### PR TITLE
Ship a signed DMG instead of a zip 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
           persist-credentials: false
       - name: Install XcodeGen
         run: brew install xcodegen
-      - name: Build release app
+      - name: Build and package release DMG
         run: |
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO
-          cd "DerivedData/Build/Products/Release" && zip -r -y "Droidective-${GITHUB_REF_NAME}.zip" "Droidective.app"
+          ./scripts/package-dmg.sh "${GITHUB_REF_NAME}"
       - name: Publish release with build
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
         with:
-          files: DerivedData/Build/Products/Release/Droidective-*.zip
+          files: DerivedData/Build/Products/Release/Droidective-*.dmg
           body_path: RELEASE_NOTES.md
           fail_on_unmatched_files: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate build test run clean
+.PHONY: generate build test run dmg clean
 
 generate:
 	xcodegen generate
@@ -11,6 +11,10 @@ test:
 
 run: build
 	open "DerivedData/Build/Products/Debug/Droidective.app"
+
+dmg: generate
+	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build
+	./scripts/package-dmg.sh $(VERSION)
 
 clean:
 	rm -rf DerivedData ADBKit/.build *.xcodeproj

--- a/README.md
+++ b/README.md
@@ -70,15 +70,18 @@ The app runs **without the App Sandbox** (it must spawn `adb`, `scrcpy`,
 
 ## Install a release build
 
-Release `.app` zips are attached to each [GitHub release](../../releases) and
-built by CI. Because the build is unsigned/unnotarized, macOS Gatekeeper will
-quarantine it on first download — clear it once:
+Each [GitHub release](../../releases) ships a `Droidective-<version>.dmg` built
+by CI. Open it and drag **Droidective** into **Applications**.
+
+The build is ad-hoc signed but not notarized (no paid Apple Developer account),
+so on first launch macOS quarantine shows *"Droidective is damaged and can't be
+opened."* Clear the quarantine once:
 
 ```sh
-xattr -d com.apple.quarantine "Droidective.app"
+xattr -dr com.apple.quarantine "/Applications/Droidective.app"
 ```
 
-Or just build from source, which avoids the quarantine entirely.
+Then open it normally. Building from source avoids the quarantine entirely.
 
 ## Architecture
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,12 +44,16 @@ device asks where to save.
 
 ### Install
 
-Download `Droidective-v1.0.0.zip` below and unzip. The build is ad-hoc signed
-(not notarized), so clear the Gatekeeper quarantine once:
+Download the `.dmg` below, open it, and drag **Droidective** into
+**Applications**.
+
+The build is ad-hoc signed but not notarized, so on first launch macOS shows
+*"Droidective is damaged and can't be opened."* Clear the Gatekeeper quarantine
+once:
 
 ```sh
-xattr -d com.apple.quarantine "Droidective.app"
+xattr -dr com.apple.quarantine "/Applications/Droidective.app"
 ```
 
-Or build from source (`brew install xcodegen && make run`), which avoids the
-quarantine entirely.
+Then open it normally. Building from source (`brew install xcodegen && make run`)
+avoids the quarantine entirely.

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Ad-hoc sign the built Release app and package it into a drag-to-Applications DMG.
+# Assumes the Release configuration has already been built into DerivedData.
+set -euo pipefail
+
+VERSION="${1:-dev}"
+APP_DIR="DerivedData/Build/Products/Release"
+APP="$APP_DIR/Droidective.app"
+DMG="$APP_DIR/Droidective-${VERSION}.dmg"
+
+if [[ ! -d "$APP" ]]; then
+  echo "error: $APP not found — build the Release configuration first" >&2
+  exit 1
+fi
+
+# Re-sign the whole bundle ad-hoc so the signature is internally valid. This
+# does not bypass Gatekeeper (no Developer ID) but prevents a broken/missing
+# signature from compounding the quarantine "damaged" message.
+codesign --force --deep --sign - "$APP"
+codesign --verify --deep --strict "$APP"
+
+# Stage the app next to an /Applications symlink so the DMG offers drag-install.
+staging="$(mktemp -d)"
+trap 'rm -rf "$staging"' EXIT
+cp -R "$APP" "$staging/"
+ln -s /Applications "$staging/Applications"
+
+rm -f "$DMG"
+hdiutil create -volname "Droidective" -srcfolder "$staging" -ov -format UDZO "$DMG"
+
+echo "created $DMG"


### PR DESCRIPTION
Releases now build a drag-to-Applications DMG and re-sign the app ad-hoc so the bundle signature is internally valid, replacing the raw .app zip that reached users unsigned and quarantined (the 'damaged and can't be opened' error).

- scripts/package-dmg.sh: ad-hoc sign + hdiutil DMG with /Applications symlink
- Makefile: make dmg target (reuses the script)
- CI release job: build, package DMG, publish the .dmg
- README / RELEASE_NOTES: DMG install steps + xattr quarantine fix

Without a paid Apple Developer ID the build still can't be notarized, so first launch needs a one-time 'xattr -dr com.apple.quarantine'.