### PR TITLE
Fix sandboxPull: pass the raw path to exec-out

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
@@ -265,8 +265,11 @@ public struct AppInspectionService: Sendable {
     }
 
     public func sandboxPull(serial: String, packageId: String, filePath: String, to destination: URL? = nil) async throws -> URL {
+        // `exec-out` escapes each argument itself (unlike `adb shell`, which runs the
+        // joined command through a device shell), so the path goes raw — a shellQuote'd
+        // path would reach `cat` with the literal quotes and fail to resolve.
         let output = try await client.runBinary(
-            on: serial, ["exec-out", "run-as", packageId, "cat", shellQuote(filePath)], timeout: .seconds(120)
+            on: serial, ["exec-out", "run-as", packageId, "cat", filePath], timeout: .seconds(120)
         )
         if Self.isNotDebuggable(output.stderrText) {
             throw PullError.notDebuggable


### PR DESCRIPTION
## What & why

The run-as sandbox file pull never worked: `sandboxPull` passed a `shellQuote`'d path to `adb exec-out`, but `exec-out` escapes each argument itself (unlike `adb shell`, which runs the joined command through a device shell). So `cat` received the literal single-quotes and failed to resolve the file. Fix is to pass the raw path.

## How it was tested

Verified against an Android 16 emulator (the quoted form fails with `cat: 'files/…': No such file`; the raw form returns the bytes). All 111 ADBKit unit tests pass.