### PR TITLE
Fix CRLF parsing and false-success network toggles

### DIFF
--- a/ADBKit/Sources/ADBKit/Devices/DeviceListParser.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceListParser.swift
@@ -4,12 +4,12 @@ import Foundation
 /// daemon-startup noise.
 public enum DeviceListParser {
     public static func parse(_ output: String) -> [Device] {
-        output.split(separator: "\n", omittingEmptySubsequences: true)
+        output.split(omittingEmptySubsequences: true, whereSeparator: \.isNewline)
             .compactMap { parseLine(String($0)) }
     }
 
     public static func parseLine(_ line: String) -> Device? {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
         if trimmed.hasPrefix("List of devices") { return nil }
         if trimmed.hasPrefix("*") || trimmed.hasPrefix("adb server") { return nil }

--- a/ADBKit/Sources/ADBKit/Devices/DeviceOverview.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceOverview.swift
@@ -34,9 +34,11 @@ public struct DeviceOverview: Sendable, Equatable {
 
     /// `df -k /data` → (totalKb, usedKb, availableKb).
     public static func parseDf(_ output: String) -> (total: Int?, used: Int?, available: Int?) {
-        let lines = output.split(separator: "\n")
+        let lines = output.split(whereSeparator: \.isNewline)
         guard lines.count >= 2 else { return (nil, nil, nil) }
-        let fields = lines[1].split(separator: " ", omittingEmptySubsequences: true)
+        // Split on any whitespace (incl. a trailing CR on CRLF output) so the
+        // last numeric column parses cleanly.
+        let fields = lines[1].split(whereSeparator: \.isWhitespace)
         guard fields.count >= 4 else { return (nil, nil, nil) }
         return (Int(fields[1]), Int(fields[2]), Int(fields[3]))
     }
@@ -61,7 +63,7 @@ public struct DeviceOverview: Sendable, Equatable {
     }
 
     static func countPackages(_ output: String) -> Int {
-        output.split(separator: "\n").filter { $0.hasPrefix("package:") }.count
+        output.split(whereSeparator: \.isNewline).filter { $0.hasPrefix("package:") }.count
     }
 
     // MARK: - Fetch

--- a/ADBKit/Sources/ADBKit/Devices/DeviceProps.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceProps.swift
@@ -5,8 +5,8 @@ public enum DeviceProps {
     /// Parse a full `getprop` dump (`[key]: [value]` lines) into a map.
     public static func parse(_ output: String) -> [String: String] {
         var props: [String: String] = [:]
-        for line in output.split(separator: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+        for line in output.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard let match = trimmed.wholeMatch(of: /\[(.+?)\]:\s*\[(.*?)\]/) else { continue }
             props[String(match.1)] = String(match.2)
         }

--- a/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
+++ b/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
@@ -103,9 +103,9 @@ public actor ToolLocator {
         )
         guard output.exitCode == 0 else { return nil }
         let resolved = output.stdoutText
-            .split(separator: "\n")
+            .split(whereSeparator: \.isNewline)
             .last
-            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         guard let resolved, fileManager.isExecutableFile(atPath: resolved) else { return nil }
         return resolved
     }

--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -253,11 +253,21 @@ public struct FeatureEngine: Sendable {
             let wifi = params["wifi"]?.boolValue ?? true
             let data = params["data"]?.boolValue ?? true
             let airplane = params["airplane"]?.boolValue ?? false
-            _ = try await client.run(on: serial, ["shell", "svc", "wifi", wifi ? "enable" : "disable"])
-            _ = try await client.run(on: serial, ["shell", "svc", "data", data ? "enable" : "disable"])
-            _ = try await client.run(on: serial, [
+            let wifiResult = try await client.run(on: serial, ["shell", "svc", "wifi", wifi ? "enable" : "disable"])
+            let dataResult = try await client.run(on: serial, ["shell", "svc", "data", data ? "enable" : "disable"])
+            let airplaneResult = try await client.run(on: serial, [
                 "shell", "cmd", "connectivity", "airplane-mode", airplane ? "enable" : "disable",
             ])
+            var failed: [String] = []
+            if !wifiResult.succeeded { failed.append("Wi-Fi") }
+            if !dataResult.succeeded { failed.append("data") }
+            if !airplaneResult.succeeded { failed.append("airplane") }
+            guard failed.isEmpty else {
+                return FeatureResult(
+                    ok: false,
+                    message: "Couldn't set \(failed.joined(separator: ", ")) — the ROM may not allow it over adb."
+                )
+            }
             return FeatureResult(
                 ok: true,
                 message: "Wi-Fi \(wifi ? "on" : "off") · data \(data ? "on" : "off") · airplane \(airplane ? "on" : "off")"

--- a/ADBKit/Sources/ADBKit/Services/AppControlService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppControlService.swift
@@ -69,8 +69,8 @@ public struct AppControlService: Sendable {
         }
         let result = try await client.run(on: serial, args)
         return result.stdout
-            .split(separator: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "package:", with: "") }
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "package:", with: "") }
             .filter { !$0.isEmpty }
             .sorted()
     }

--- a/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
@@ -61,7 +61,7 @@ public struct AppInspectionService: Sendable {
     public static func parsePermissions(_ dump: String) -> [PermissionEntry] {
         var permissions: [PermissionEntry] = []
         var inRuntime = false
-        for line in dump.split(separator: "\n", omittingEmptySubsequences: false) {
+        for line in dump.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
             if line.range(of: "runtime permissions:", options: .caseInsensitive) != nil {
                 inRuntime = true
                 continue
@@ -136,8 +136,8 @@ public struct AppInspectionService: Sendable {
 
     func firstApkPath(serial: String, packageId: String) async throws(AdbError) -> String? {
         let output = try await client.run(on: serial, ["shell", "pm", "path", packageId])
-        return output.stdout.split(separator: "\n")
-            .map { $0.replacingOccurrences(of: "package:", with: "").trimmingCharacters(in: .whitespaces) }
+        return output.stdout.split(whereSeparator: \.isNewline)
+            .map { $0.replacingOccurrences(of: "package:", with: "").trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
     }
 
@@ -234,8 +234,8 @@ public struct AppInspectionService: Sendable {
 
     public static func parseLsOutput(_ output: String) -> [FsEntry] {
         var entries: [FsEntry] = []
-        for line in output.split(separator: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
+        for line in output.split(whereSeparator: \.isNewline) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.isEmpty || trimmed.hasPrefix("total ") { continue }
             let parts = trimmed.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
             guard parts.count >= 8 else { continue }

--- a/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
@@ -34,7 +34,7 @@ public struct AppsExplorerService: Sendable {
     public static func parseVersions(_ dump: String) -> [String: String] {
         var versions: [String: String] = [:]
         var currentPackage: String?
-        for line in dump.split(separator: "\n") {
+        for line in dump.split(whereSeparator: \.isNewline) {
             if let match = line.firstMatch(of: /Package \[([\w.]+)\]/) {
                 currentPackage = String(match.1)
             } else if let package = currentPackage,
@@ -55,14 +55,14 @@ public struct AppsExplorerService: Sendable {
 
         let userList = try await client.run(on: serial, ["shell", "pm", "list", "packages", "-3"])
         let userPackages = Set(
-            userList.stdout.split(separator: "\n")
-                .map { $0.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "package:", with: "") }
+            userList.stdout.split(whereSeparator: \.isNewline)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "package:", with: "") }
                 .filter { !$0.isEmpty }
         )
 
         let allList = try await client.run(on: serial, ["shell", "pm", "list", "packages"])
-        let allPackages = allList.stdout.split(separator: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "package:", with: "") }
+        let allPackages = allList.stdout.split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "package:", with: "") }
             .filter { !$0.isEmpty }
 
         return allPackages

--- a/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
+++ b/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
@@ -27,7 +27,7 @@ public struct CrashExtractor: Sendable {
     }
 
     public static func extractLastCrash(_ text: String) -> String {
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
         var index = -1
         for i in stride(from: lines.count - 1, through: 0, by: -1) {
             if lines[i].range(of: crashPattern, options: .regularExpression) != nil {

--- a/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
@@ -38,7 +38,7 @@ public struct ToolDetectionService: Sendable {
             executable: path, arguments: versionArgs, timeout: .seconds(8), maxOutputBytes: 1024 * 1024
         )
         let text = output.stdoutText.isEmpty ? output.stderrText : output.stdoutText
-        let version = text.split(separator: "\n").first.map { $0.trimmingCharacters(in: .whitespaces) }
+        let version = text.split(whereSeparator: \.isNewline).first.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         return ToolStatus(installed: true, path: path, version: version, installHint: hint)
     }
 
@@ -62,7 +62,7 @@ public struct ToolDetectionService: Sendable {
             await locator.clearCache()
             return FeatureResult(ok: true, message: "\(tool.rawValue) installed successfully.")
         }
-        let reason = output.stderrText.split(separator: "\n").last.map(String.init) ?? "brew failed"
+        let reason = output.stderrText.split(whereSeparator: \.isNewline).last.map(String.init) ?? "brew failed"
         return FeatureResult(ok: false, message: "Couldn't install \(tool.rawValue): \(reason)")
     }
 }

--- a/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
@@ -55,6 +55,21 @@ import Testing
         #expect(packages == ["com.alpha", "com.middle", "com.zebra"])
     }
 
+    @Test func listInstalledPackagesStripsCarriageReturns() async throws {
+        // CRLF device-shell output must not leave a trailing \r on package ids,
+        // or downstream force-stop/clear/uninstall silently fail to match.
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "pm", "list", "packages", "-3"],
+            stdout: "package:com.zebra\r\npackage:com.alpha\r\n"
+        )
+        let service = await makeService(runner)
+
+        let packages = try await service.listInstalledPackages(serial: "S1")
+        #expect(packages == ["com.alpha", "com.zebra"])
+        #expect(!packages.contains { $0.contains("\r") })
+    }
+
     @Test func deepLinkLaunchDetectsActivityErrors() async throws {
         let runner = MockProcessRunner()
         runner.script(

--- a/ADBKit/Tests/ADBKitTests/DeviceListParserTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceListParserTests.swift
@@ -27,6 +27,20 @@ import Testing
         #expect(devices[0].serial == "192.168.1.42:5555")
     }
 
+    @Test func parsesCrlfOutputWithoutStrandedCarriageReturns() {
+        // `\r\n` is a single grapheme, so splitting on "\n" leaves the whole
+        // dump as one line. The reader must split on any newline so a CRLF
+        // device is still recognized as wireless and ready.
+        let output = "List of devices attached\r\n192.168.1.42:5555   device model:Pixel_7\r\n"
+        let devices = DeviceListParser.parse(output)
+        #expect(devices.count == 1)
+        let device = try! #require(devices.first)
+        #expect(device.serial == "192.168.1.42:5555")
+        #expect(device.state == "device")
+        #expect(device.isWireless)
+        #expect(device.isReady)
+    }
+
     @Test func parsesUnauthorizedAndOffline() {
         let output = """
         List of devices attached

--- a/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
@@ -24,6 +24,15 @@ import Testing
         #expect(available == 34_057_940)
     }
 
+    @Test func parsesDfWithCrlf() {
+        // A trailing \r on the data row must not break the last (Available) column.
+        let output = "Filesystem 1K-blocks Used Available Use% Mounted on\r\n/dev/block/dm-5 56371708 22152504 34057940 40% /data\r\n"
+        let (total, used, available) = DeviceOverview.parseDf(output)
+        #expect(total == 56_371_708)
+        #expect(used == 22_152_504)
+        #expect(available == 34_057_940)
+    }
+
     @Test func parsesBatteryWithHealthAndCycles() {
         let output = """
         Current Battery Service state:
@@ -117,5 +126,24 @@ import Testing
         #expect(listing.matches("2.4"))
         #expect(listing.matches("example"))
         #expect(!listing.matches("nomatch"))
+    }
+
+    @Test func listAllResolvesVersionsAcrossCrlfOutput() async throws {
+        // With CRLF output the package-list ids must be trimmed so they match
+        // the clean keys from parseVersions — otherwise every app shows nil.
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "dumpsys", "package", "packages"],
+            stdout: "Package [com.foo] (x):\r\n    versionName=1.0\r\n"
+        )
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "list", "packages"], stdout: "package:com.foo\r\n")
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "list", "packages", "-3"], stdout: "package:com.foo\r\n")
+        let service = AppsExplorerService(client: await makeTestClient(runner: runner))
+
+        let listing = try await service.listAll(serial: "S1")
+        #expect(listing.count == 1)
+        #expect(listing.first?.packageId == "com.foo")
+        #expect(listing.first?.versionName == "1.0")
+        #expect(listing.first?.isSystem == false)
     }
 }

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -107,6 +107,34 @@ import Testing
         #expect(result.message.contains("ADBKeyboard"))
     }
 
+    @Test func networkTogglesReportsSuccessWhenAllCommandsSucceed() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let engine = await makeEngine(runner)
+
+        let result = await engine.run(
+            featureID: "network-toggles", serial: "S1",
+            params: ["wifi": .bool(false), "data": .bool(true), "airplane": .bool(false)]
+        )
+        #expect(result.ok)
+        #expect(result.message.contains("Wi-Fi off"))
+    }
+
+    @Test func networkTogglesReportsFailureInsteadOfFalseSuccess() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        // `svc data disable` is rejected on this ROM.
+        runner.script(argsPrefix: ["-s", "S1", "shell", "svc", "data"], stderr: "Permission denial", exitCode: 1)
+        let engine = await makeEngine(runner)
+
+        let result = await engine.run(
+            featureID: "network-toggles", serial: "S1",
+            params: ["wifi": .bool(true), "data": .bool(false), "airplane": .bool(false)]
+        )
+        #expect(!result.ok)
+        #expect(result.message.contains("data"))
+    }
+
     @Test func unimplementedFeatureReportsPlaceholder() async {
         let runner = MockProcessRunner()
         let engine = await makeEngine(runner)

--- a/ADBKit/Tests/ADBKitTests/ParserTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ParserTests.swift
@@ -15,6 +15,16 @@ import Testing
         #expect(props["ro.empty"] == "")
         #expect(props.count == 3)
     }
+
+    @Test func parsesPropDumpWithCrlf() {
+        // `adb shell getprop` over a CRLF device shell leaves a trailing \r;
+        // `wholeMatch` fails unless it's trimmed off.
+        let output = "[ro.product.model]: [Pixel 7]\r\n[ro.build.version.release]: [14]\r\n"
+        let props = DeviceProps.parse(output)
+        #expect(props["ro.product.model"] == "Pixel 7")
+        #expect(props["ro.build.version.release"] == "14")
+        #expect(props.count == 2)
+    }
 }
 
 @Suite struct IpParseTests {


### PR DESCRIPTION
A read-through of the ADBKit layer surfaced two real bugs.

## CRLF newline splitting (systemic)

`\r\n` is a single Swift grapheme, so `split(separator: "\n")` finds no separator on CRLF device-shell output and returns the whole dump as one line. Every parser that split on `"\n"` silently failed on a CRLF device:

- `getprop` → empty prop map (device-info panel blank)
- `dumpsys package packages` → version lookups returned nil for every app
- `pm list packages` → package ids carried a stray `\r` into force-stop / clear / uninstall, which then no-matched
- `df -k /data` → the Available column failed to parse
- `ls -la` → file explorer / sandbox browser
- `adb devices -l` → a CRLF device wasn't recognized as ready or wireless
- brew/version output and crash extraction

Fix: split on `\.isNewline` (the `\r\n` grapheme satisfies it) and trim with `.whitespacesAndNewlines`. Both are exact supersets of the previous behavior for LF input, so LF devices are unaffected. This is the gotcha already documented in CLAUDE.md ("`\r\n` is ONE Swift Character").

## network-toggles false success

The runner discarded the result of all three `svc`/`cmd` calls and always returned `ok: true`. A rejected `svc data disable` (common on ROMs that restrict it over adb) was reported as success. Now each result is checked and failures are surfaced.

## Tests

Added CRLF regression tests for the device list, getprop, df, the apps explorer (full `listAll` version resolution), and the installed-package list, plus success/failure tests for network-toggles. **118 tests pass** (was 111); `make build` is clean.

## Reviewed but not changed

A parallel review also flagged some App-layer items (logcat pause via `@State` in a `.task` loop; a redundant overrides refresh on device-list changes). On inspection these were either lower-impact than first rated (`DeviceMonitor` only yields on actual list changes, not every poll) or not safely verifiable without running UI automation on this machine, so they're left for a follow-up rather than risk a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)