### PR TITLE
Fix appcast serving on GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,16 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
-      - name: Assemble site (keep the published appcast)
+      - name: Assemble site (refresh appcast from the live feed when present)
         run: |
           mkdir -p _site
           cp -R site/. _site/
-          curl -fsSL https://rohindh-r.github.io/Droidective/appcast.xml -o _site/appcast.xml \
-            || echo "no published appcast yet — first deploy"
+          # Prefer the live feed (kept fresh by releases); fall back to the
+          # committed site/appcast.xml. Fetch to a temp file so a 404 never
+          # truncates the committed copy.
+          if curl -fsSL https://rohindh-r.github.io/Droidective/appcast.xml -o /tmp/appcast.xml; then
+            cp /tmp/appcast.xml _site/appcast.xml
+          fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: _site

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Droidective</title>
+    <link>https://rohindh-r.github.io/Droidective/appcast.xml</link>
+    <description>Most recent Droidective updates.</description>
+    <language>en</language>
+    <item>
+      <title>Droidective 2.1.0</title>
+      <sparkle:version>22</sparkle:version>
+      <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:releaseNotesLink>https://github.com/Rohindh-R/Droidective/releases/tag/v2.1.0</sparkle:releaseNotesLink>
+      <pubDate>Sat, 20 Jun 2026 16:36:53 +0000</pubDate>
+      <enclosure url="https://github.com/Rohindh-R/Droidective/releases/download/v2.1.0/Droidective-v2.1.0.dmg" sparkle:edSignature="PktlZJSxnwZ8VufMueUnpUyTHiIxGG3aiKPNSRDWj2Q9b7EPKvgo/aRcGQxwM1dzhWVahKynAVHh/2ad2Kp/DQ==" length="7117209" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
appcast.xml was in the deployed artifact but 404'd at the edge. Commits the signed feed as a static site/ file, adds .nojekyll, and hardens the pages job's fetch so a 404 can't truncate the committed appcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)