### PR TITLE
Tint controls with brand accent regardless of system accent

### DIFF
--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -20,6 +20,11 @@ struct ADTApp: App {
             RootView()
                 .environment(appState)
                 .frame(minWidth: 760, minHeight: 480)
+                // Force the brand accent on standard controls (prominent
+                // buttons, switches, sliders) so they stay green regardless of
+                // the Mac's system accent color, which otherwise overrides the
+                // AccentColor asset.
+                .tint(.brandAccent)
         }
         .windowStyle(.automatic)
         .commands {
@@ -89,6 +94,7 @@ struct ADTApp: App {
         Window("Search", id: "palette") {
             PaletteWindowView()
                 .environment(appState)
+                .tint(.brandAccent)
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
@@ -98,6 +104,7 @@ struct ADTApp: App {
         Settings {
             SettingsView()
                 .environment(appState)
+                .tint(.brandAccent)
         }
 
         MenuBarExtra("Droidective", systemImage: "iphone.gen3", isInserted: $showMenuBarExtra) {

--- a/App/Sources/FeatureDetail/Views/AppManagementView.swift
+++ b/App/Sources/FeatureDetail/Views/AppManagementView.swift
@@ -83,7 +83,7 @@ struct AppManagementView: View {
             Label(title, systemImage: icon)
         }
         .buttonStyle(BorderedButtonStyle())
-        .tint(prominent ? .accentColor : nil)
+        .tint(prominent ? .brandAccent : nil)
         .disabled(pendingAction != nil)
     }
 

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -72,7 +72,7 @@ struct NetworkView: View {
                             .frame(minWidth: 84)
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(isRecording ? .red : .accentColor)
+                    .tint(isRecording ? .red : .brandAccent)
                     .disabled(!isLive)
                     .help(isRecording ? "Stop recording" : "Record a session to export")
 

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -82,7 +82,7 @@ struct ScreenRecordView: View {
                     .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(isRecording ? .red : .accentColor)
+                .tint(isRecording ? .red : .brandAccent)
                 .controlSize(.large)
                 .disabled(isStarting || isSaving || state.targetSerials.isEmpty)
 

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -135,7 +135,7 @@ struct ScreenshotEditorView: View {
                 Label("Crop", systemImage: "crop")
             }
             .buttonStyle(.bordered)
-            .tint(cropping ? .accentColor : nil)
+            .tint(cropping ? .brandAccent : nil)
             .help("Crop the image")
 
             Button { undo() } label: { Image(systemName: "arrow.uturn.backward") }


### PR DESCRIPTION
## Problem

On a Mac whose **System Settings → Appearance → Accent color** is set to a specific color (e.g. **Blue**), Droidective's prominent buttons, switches, sliders, and segmented pickers rendered **blue** instead of the brand green. On a Mac set to **Multicolor** (the default), the same controls were green.

Cause: those are standard SwiftUI controls that follow the system accent. The green `AccentColor` asset added in v2.2.0 is honored only under "Multicolor"; a specific system accent overrides it. Explicitly `.brandAccent`-colored elements (sidebar labels, selection) were unaffected — which is why only buttons/toggles/sliders differed between machines.

## Fix

- Set `.tint(.brandAccent)` on each scene root (main window, palette, settings) so standard controls use the brand green regardless of the user's system accent.
- Replace the four hardcoded `.accentColor` (system accent) tints with `.brandAccent` (`AppManagementView`, `NetworkView`, `ScreenRecordView`, `ScreenshotEditorView`), which would otherwise stay system-accent even under the root tint.

## Verification

- `make build` — clean, zero warnings.
- Simulate hub toggles/sliders render green (regression check on a Multicolor Mac).
- The definitive case (a non-Multicolor Mac) can't be reproduced here without changing your system accent; the fix is the standard documented `.tint()` override of the system accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)