### PR TITLE
Prepare v2.2.1 release: bump version and add release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+## Droidective v2.2.1
+
+A fix for the accent color on Macs set to a specific system accent.
+
+### Fixes
+
+- Buttons, toggles, sliders, and other standard controls now always use the
+  brand green. They previously followed the macOS system accent color, so on a
+  Mac set to a specific accent (for example Blue) they rendered in that color
+  instead of green.
+
+### Install
+
+Download the `.dmg` below and drag **Droidective** into **Applications**. The
+build is ad-hoc signed but not notarized, so clear the quarantine once:
+
+```sh
+xattr -dr com.apple.quarantine "/Applications/Droidective.app"
+```
+
+Installed copies from v2.1.0+ update in place via Sparkle.
+
 ## Droidective v2.2.0
 
 A UI overhaul: a refreshed theme, feature hubs that keep the sidebar short, a

--- a/project.yml
+++ b/project.yml
@@ -57,7 +57,7 @@ targets:
       base:
         PRODUCT_NAME: Droidective
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
-        MARKETING_VERSION: "2.2.0"
+        MARKETING_VERSION: "2.2.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
Release prep for v2.2.1 (the accent-tint fix from #10 already merged to `main`).

- Bump `MARKETING_VERSION` to `2.2.1` in `project.yml`.
- Add a `## Droidective v2.2.1` section to the top of `RELEASE_NOTES.md` so the CI release job publishes the correct notes.

No code changes. Needed before tagging `v2.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)