### PR TITLE
Centralize every color into Theme tokens

### DIFF
--- a/App/Resources/Assets.xcassets/Chart1.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Chart1.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x2E", "green" : "0x6F", "blue" : "0xE0" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x5B", "green" : "0x9B", "blue" : "0xF5" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Chart2.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Chart2.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x0E", "green" : "0x8C", "blue" : "0x8C" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x35", "green" : "0xBD", "blue" : "0xBD" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Chart3.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Chart3.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x7A", "green" : "0x52", "blue" : "0xCC" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xA7", "green" : "0x7E", "blue" : "0xF2" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Chart4.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Chart4.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xC2", "green" : "0x74", "blue" : "0x0A" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xE0", "green" : "0xA3", "blue" : "0x3A" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Danger.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Danger.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xCC", "green" : "0x3B", "blue" : "0x30" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xFF", "green" : "0x6B", "blue" : "0x60" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Success.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Success.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x2E", "green" : "0x9E", "blue" : "0x44" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x5F", "green" : "0xD0", "blue" : "0x6E" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/TextFaint.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/TextFaint.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x9D", "green" : "0xA1", "blue" : "0xA6" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x66", "green" : "0x6B", "blue" : "0x70" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Resources/Assets.xcassets/Warning.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/Warning.colorset/Contents.json
@@ -1,0 +1,14 @@
+{
+  "colors" : [
+    {
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xB2", "green" : "0x6B", "blue" : "0x0E" } },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xE6", "green" : "0xA2", "blue" : "0x3C" } },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/App/Sources/FeatureDetail/CommandReferenceViews.swift
+++ b/App/Sources/FeatureDetail/CommandReferenceViews.swift
@@ -44,7 +44,7 @@ struct CommandReferenceList: View {
                         if let note = command.note {
                             Text(note)
                                 .font(.caption2)
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(.textFaint)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }
@@ -79,7 +79,7 @@ struct CommandLogRow: View {
                     Spacer(minLength: 6)
                     Text(Self.exitLabel(entry))
                         .font(.caption)
-                        .foregroundStyle(entry.exitCode == 0 ? Color.brandAccent : Color.red)
+                        .foregroundStyle(entry.exitCode == 0 ? Color.success : Color.danger)
                     Text(entry.timestamp, style: .time)
                         .font(.caption)
                         .foregroundStyle(.textMuted)
@@ -93,12 +93,12 @@ struct CommandLogRow: View {
                     outputBlock(entry.stdout, tint: nil)
                 }
                 if !entry.stderr.isEmpty {
-                    outputBlock(entry.stderr, tint: .red)
+                    outputBlock(entry.stderr, tint: .danger)
                 }
                 if entry.stdout.isEmpty && entry.stderr.isEmpty {
                     Text("(no output)")
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.textFaint)
                         .padding(.leading, 18)
                 }
             }
@@ -109,7 +109,7 @@ struct CommandLogRow: View {
     private func outputBlock(_ text: String, tint: Color?) -> some View {
         Text(text)
             .font(.system(.caption, design: .monospaced))
-            .foregroundStyle(tint ?? .primary)
+            .foregroundStyle(tint ?? .textMain)
             .textSelection(.enabled)
             .padding(6)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -167,7 +167,7 @@ struct FeatureCommandLog: View {
             if entries.isEmpty {
                 Text("No runs yet — run this feature to see its commands and output here.")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.textFaint)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 ForEach(entries) { entry in

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -146,7 +146,7 @@ struct FeatureDescription: View {
                 withAnimation(.easeInOut(duration: 0.15)) { showFeatureNotes = false }
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.textFaint)
             }
             .buttonStyle(.plain)
             .help("Hide this note (toggle back with ⓘ in the bar below)")

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -32,7 +32,7 @@ struct FormActionView: View {
 
                 Text("⌘⏎ to run")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.textFaint)
             }
             .padding(.top, 4)
 

--- a/App/Sources/FeatureDetail/LastResultCard.swift
+++ b/App/Sources/FeatureDetail/LastResultCard.swift
@@ -12,13 +12,13 @@ struct LastResultCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 6) {
                     Image(systemName: entry.result.ok ? "checkmark.circle.fill" : "xmark.circle.fill")
-                        .foregroundStyle(entry.result.ok ? .brandAccent : .red)
+                        .foregroundStyle(entry.result.ok ? .success : .danger)
                     Text(entry.result.message)
                         .textSelection(.enabled)
                     Spacer()
                     Text(entry.at, style: .time)
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.textFaint)
                 }
 
                 HStack(spacing: 8) {

--- a/App/Sources/FeatureDetail/Views/AppManagementView.swift
+++ b/App/Sources/FeatureDetail/Views/AppManagementView.swift
@@ -92,7 +92,7 @@ struct AppManagementView: View {
             confirmingAction = action
         } label: {
             Label(title, systemImage: "trash")
-                .foregroundStyle(.red)
+                .foregroundStyle(.danger)
         }
         .disabled(pendingAction != nil)
     }

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -112,7 +112,7 @@ struct AppsExplorerView: View {
                     HStack {
                         Text("\(visibleApps.count) of \(apps.count) apps")
                             .font(.caption)
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.textFaint)
                         Spacer()
                     }
                     .padding(6)
@@ -148,9 +148,9 @@ struct AppsExplorerView: View {
     @ViewBuilder
     private func lifecycleBadge(for packageId: String) -> some View {
         if let lifecycle = states[packageId], lifecycle.removed {
-            badge("removed", .red)
+            badge("removed", .danger)
         } else if let lifecycle = states[packageId], lifecycle.disabled {
-            badge("disabled", .orange)
+            badge("disabled", .warning)
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/CatalogView.swift
+++ b/App/Sources/FeatureDetail/Views/CatalogView.swift
@@ -114,7 +114,7 @@ struct GroupHeaderView: View {
             }
         }
         .font(compact ? .caption : nil)
-        .foregroundStyle(compact ? AnyShapeStyle(.textMuted) : AnyShapeStyle(.primary))
+        .foregroundStyle(compact ? AnyShapeStyle(.textMuted) : AnyShapeStyle(.textMain))
         .textCase(compact ? .uppercase : nil)
         // Breathing room so the drop guideline (drawn at the row's top/bottom
         // edge during a drag) sits clear of the label instead of touching it.

--- a/App/Sources/FeatureDetail/Views/CrashView.swift
+++ b/App/Sources/FeatureDetail/Views/CrashView.swift
@@ -46,7 +46,7 @@ struct CrashView: View {
                 ScrollView {
                     Text(crash)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(.danger)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(8)

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -71,7 +71,7 @@ struct CustomCommandsView: View {
                             commands.removeAll { $0.id == command.id }
                             persist()
                         } label: {
-                            Image(systemName: "trash").foregroundStyle(.red)
+                            Image(systemName: "trash").foregroundStyle(.danger)
                         }
                         .buttonStyle(.plain)
                     }

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -48,7 +48,7 @@ struct DeepLinksSection: View {
                         }
                         .buttonStyle(.borderless)
                         Button { remove(link) } label: {
-                            Image(systemName: "trash").foregroundStyle(.red)
+                            Image(systemName: "trash").foregroundStyle(.danger)
                         }
                         .buttonStyle(.borderless)
                     }

--- a/App/Sources/FeatureDetail/Views/FileExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/FileExplorerView.swift
@@ -398,7 +398,7 @@ struct FileExplorerView: View {
                     }
                     Text("Android doesn't record file creation time — Modified is the closest signal.")
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.textFaint)
                 } else {
                     HStack {
                         ProgressView().controlSize(.small)

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -188,7 +188,7 @@ struct HomeView: View {
             if state.adbMissing {
                 Label("adb isn't installed yet — use the Install button in the device bar first.", systemImage: "exclamationmark.triangle")
                     .font(.footnote)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(.warning)
             }
         }
         .padding(16)

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -134,7 +134,7 @@ struct LogcatView: View {
             } else {
                 Text("\(lines.count) lines")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.textFaint)
             }
         }
         .padding(.horizontal, 10)
@@ -144,8 +144,8 @@ struct LogcatView: View {
 
     private var statusColor: Color {
         if state.targetSerials.isEmpty { return .textMuted }
-        if waitingForPackage != nil { return .orange }
-        return paused ? .yellow : .brandAccent
+        if waitingForPackage != nil { return .warning }
+        return paused ? .warning : .success
     }
 
     private var statusText: String {
@@ -294,9 +294,9 @@ struct LogcatView: View {
 
     private func color(for level: String) -> Color {
         switch level {
-        case "E", "F": return .red
-        case "W": return .orange
-        case "I": return .primary
+        case "E", "F": return .danger
+        case "W": return .warning
+        case "I": return .textMain
         default: return .textMuted
         }
     }

--- a/App/Sources/FeatureDetail/Views/MeminfoView.swift
+++ b/App/Sources/FeatureDetail/Views/MeminfoView.swift
@@ -60,7 +60,7 @@ struct MeminfoView: View {
                 }
                 Text("Refreshes every 2 seconds.")
                     .font(.footnote)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.textFaint)
             }
             .centeredColumn(maxWidth: 640)
             .padding(20)

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -72,7 +72,7 @@ struct NetworkView: View {
                             .frame(minWidth: 84)
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(isRecording ? .red : .brandAccent)
+                    .tint(isRecording ? .danger : .brandAccent)
                     .disabled(!isLive)
                     .help(isRecording ? "Stop recording" : "Record a session to export")
 
@@ -84,7 +84,7 @@ struct NetworkView: View {
                 }
                 if let last = liveSamples.last {
                     HStack(spacing: 0) {
-                        readout("Download", last.downloadBps, "arrow.down", .blue)
+                        readout("Download", last.downloadBps, "arrow.down", .chart1)
                         Divider().frame(height: 54)
                         readout("Upload", last.uploadBps, "arrow.up", .brandAccent)
                     }
@@ -101,7 +101,7 @@ struct NetworkView: View {
     @ViewBuilder
     private var statusDot: some View {
         if isRecording {
-            Circle().fill(.red).frame(width: 8, height: 8)
+            Circle().fill(.danger).frame(width: 8, height: 8)
         } else if isLive {
             Circle().fill(.brandAccent).frame(width: 8, height: 8)
         }
@@ -169,7 +169,7 @@ struct NetworkView: View {
                 .foregroundStyle(by: .value("Series", "Upload"))
                 .interpolationMethod(.monotone)
             }
-            .chartForegroundStyleScale(["Download": Color.blue, "Upload": Color.brandAccent])
+            .chartForegroundStyleScale(["Download": Color.chart1, "Upload": Color.brandAccent])
             .chartXAxisLabel("seconds")
             .chartLegend(position: .bottom, spacing: 6)
             .frame(height: 170)
@@ -179,7 +179,7 @@ struct NetworkView: View {
     private var totalsCard: some View {
         card("This session", subtitle: statusText) {
             HStack(spacing: 0) {
-                total("Downloaded", sessionRx, .blue)
+                total("Downloaded", sessionRx, .chart1)
                 Divider().frame(height: 36)
                 total("Uploaded", sessionTx, .brandAccent)
             }

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -93,7 +93,7 @@ struct PerformanceView: View {
                 Label(recordTitle, systemImage: recordIcon).frame(minWidth: 78)
             }
             .buttonStyle(.borderedProminent)
-            .tint(phase == .recording ? .orange : .red)
+            .tint(phase == .recording ? .warning : .danger)
             .disabled(serial == nil)
             .help("Start, pause, or resume sampling")
 
@@ -165,11 +165,11 @@ struct PerformanceView: View {
 
     private func summaryChips(_ sample: Sample) -> some View {
         HStack(spacing: 8) {
-            chip("CPU", sample.totalCpu.map { String(format: "%.0f%%", $0) } ?? "—", .blue)
+            chip("CPU", sample.totalCpu.map { String(format: "%.0f%%", $0) } ?? "—", .chart1)
             chip("RAM", sample.ramUsedKb.map { "\(mb($0)) MB" } ?? "—", .brandAccent)
-            chip("NET", "↓\(speedCompact(sample.downloadBps)) ↑\(speedCompact(sample.uploadBps))", .teal)
+            chip("NET", "↓\(speedCompact(sample.downloadBps)) ↑\(speedCompact(sample.uploadBps))", .chart2)
             if packageId != nil {
-                chip("FPS", sample.appFps.map { String(format: "%.0f", $0) } ?? "—", .purple)
+                chip("FPS", sample.appFps.map { String(format: "%.0f", $0) } ?? "—", .chart3)
             }
         }
     }
@@ -271,7 +271,7 @@ struct PerformanceView: View {
                         x: .value("Time", sample.elapsed),
                         y: .value("MB", Double(pss) / 1024.0)
                     )
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(.chart4)
                     .interpolationMethod(.monotone)
                 }
                 hoverRule { "\(Int($0.elapsed))s · \($0.appPssKb.map { "\(mb($0)) MB" } ?? "—")" }
@@ -297,7 +297,7 @@ struct PerformanceView: View {
                             x: .value("Time", sample.elapsed),
                             y: .value("FPS", fps)
                         )
-                        .foregroundStyle(.purple)
+                        .foregroundStyle(.chart3)
                         .interpolationMethod(.monotone)
                     }
                 }
@@ -347,7 +347,7 @@ struct PerformanceView: View {
                 }
                 hoverRule { "\(Int($0.elapsed))s · ↓\(self.speedShort($0.downloadBps)) ↑\(self.speedShort($0.uploadBps))" }
             }
-            .chartForegroundStyleScale(["Download": Color.blue, "Upload": Color.brandAccent])
+            .chartForegroundStyleScale(["Download": Color.chart1, "Upload": Color.brandAccent])
             .chartXSelection(value: $selectedElapsed)
             .chartXAxisLabel("seconds")
             .chartLegend(position: .bottom, spacing: 6)

--- a/App/Sources/FeatureDetail/Views/RootStatusView.swift
+++ b/App/Sources/FeatureDetail/Views/RootStatusView.swift
@@ -93,7 +93,7 @@ struct RootStatusView: View {
 
     private func tint(_ status: RootStatus) -> Color {
         if status.hasRootShell { return .brandAccent }
-        return status.likelyRooted ? .orange : .textMuted
+        return status.likelyRooted ? .warning : .textMuted
     }
 
     private func load() async {

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -33,7 +33,7 @@ struct ScreenRecordView: View {
                 HStack(spacing: 10) {
                     Image(systemName: "video")
                         .font(.title2)
-                        .foregroundStyle(isRecording ? .red : .textMuted)
+                        .foregroundStyle(isRecording ? .danger : .textMuted)
                         .symbolEffect(.pulse, isActive: isRecording)
                     if isRecording, let startedAt {
                         Text(startedAt, style: .timer)
@@ -82,7 +82,7 @@ struct ScreenRecordView: View {
                     .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(isRecording ? .red : .brandAccent)
+                .tint(isRecording ? .danger : .brandAccent)
                 .controlSize(.large)
                 .disabled(isStarting || isSaving || state.targetSerials.isEmpty)
 

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -92,7 +92,7 @@ struct TourView: View {
             HStack(spacing: 7) {
                 ForEach(steps.indices, id: \.self) { i in
                     Circle()
-                        .fill(i == index ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.quaternary))
+                        .fill(i == index ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.borderSubtle))
                         .frame(width: 7, height: 7)
                 }
             }

--- a/App/Sources/Root/BundleManagerView.swift
+++ b/App/Sources/Root/BundleManagerView.swift
@@ -42,7 +42,7 @@ struct BundleManagerView: View {
                             state.removeBundle(id: bundle.id)
                         } label: {
                             Image(systemName: "trash")
-                                .foregroundStyle(.red)
+                                .foregroundStyle(.danger)
                         }
                         .buttonStyle(.plain)
                     }

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -45,7 +45,7 @@ struct DeviceBarView: View {
                     if state.adbMissing {
                         Label("adb not found", systemImage: "exclamationmark.triangle.fill")
                             .font(.footnote)
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(.warning)
                         Button(state.installingTool == .adb ? "Installing…" : "Install") {
                             state.installTool(.adb)
                         }
@@ -167,9 +167,9 @@ struct DeviceBarView: View {
 
     private var deviceStatusColor: Color {
         guard let device = selectedDevice else { return Color("TextMuted") }
-        if device.isReady { return .green }
-        if device.state == "unauthorized" { return .orange }
-        return .red
+        if device.isReady { return .success }
+        if device.state == "unauthorized" { return .warning }
+        return .danger
     }
 
     private var bundleIconColor: Color {
@@ -202,7 +202,7 @@ struct DeviceBarView: View {
         }
         .fixedSize()
         .controlSize(.large)
-        .tint(.red)
+        .tint(.danger)
         .help("Disconnect \(device.label)")
         .disabled(state.recordingActive)
     }
@@ -272,13 +272,13 @@ struct DeviceBarView: View {
                     .fontWeight(.semibold)
                     .lineLimit(1)
                 Text(bundle.packageId)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.textMuted)
                     .lineLimit(1)
             } else {
                 Image(systemName: "shippingbox")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.textMuted)
                 Text("Choose app bundle…")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.textMuted)
             }
         }
     }

--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -154,7 +154,7 @@ struct NotificationBell: View {
                             .padding(.horizontal, 3)
                             .frame(minWidth: 9)
                             .padding(.vertical, 1)
-                            .background(.red, in: Capsule())
+                            .background(.danger, in: Capsule())
                             .offset(x: 6, y: -5)
                     }
                 }

--- a/App/Sources/Root/OverridesPillView.swift
+++ b/App/Sources/Root/OverridesPillView.swift
@@ -28,8 +28,8 @@ struct OverridesPillView: View {
             .fixedSize()
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(.orange.opacity(0.18), in: Capsule())
-            .foregroundStyle(.orange)
+            .background(.warning.opacity(0.18), in: Capsule())
+            .foregroundStyle(.warning)
             .help("Device-state overrides are active")
         }
     }

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -117,7 +117,7 @@ struct PaletteWindowView: View {
                 if let subtitle = feature.subtitle {
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .secondary)
+                        .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .textMuted)
                         .lineLimit(1)
                 }
             }
@@ -125,7 +125,7 @@ struct PaletteWindowView: View {
             if !state.layout.effectiveEnabledIDs.contains(feature.id) {
                 Text("disabled")
                     .font(.caption2)
-                    .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .secondary)
+                    .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .textMuted)
             }
             if index < 8 {
                 KeyHint("⌘\(index + 1)", prominent: isHighlighted)
@@ -137,7 +137,7 @@ struct PaletteWindowView: View {
             isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.clear),
             in: RoundedRectangle(cornerRadius: 8)
         )
-        .foregroundStyle(isHighlighted ? .white : .primary)
+        .foregroundStyle(isHighlighted ? .white : .textMain)
         .contentShape(Rectangle())
     }
 
@@ -197,7 +197,7 @@ struct KeyHint: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
-                prominent ? AnyShapeStyle(.white.opacity(0.22)) : AnyShapeStyle(.quaternary),
+                prominent ? AnyShapeStyle(.white.opacity(0.22)) : AnyShapeStyle(.borderSubtle),
                 in: RoundedRectangle(cornerRadius: 4)
             )
     }

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -539,7 +539,7 @@ struct FeatureRowView: View {
             state.toggleFavorite(feature.id)
         } label: {
             Image(systemName: isPinned ? "pin.fill" : "pin")
-                .foregroundStyle(isPinned ? AnyShapeStyle(.orange) : AnyShapeStyle(.textMuted))
+                .foregroundStyle(isPinned ? AnyShapeStyle(.warning) : AnyShapeStyle(.textMuted))
         }
         .buttonStyle(.plain)
         .help(isPinned ? "Unpin from top" : "Pin to top")
@@ -667,6 +667,6 @@ private struct HotkeyPopover: View {
         }
         .frame(maxWidth: .infinity, minHeight: 32, alignment: .leading)
         .padding(.horizontal, 10)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+        .background(.borderSubtle, in: RoundedRectangle(cornerRadius: 6))
     }
 }

--- a/App/Sources/Root/ToastOverlay.swift
+++ b/App/Sources/Root/ToastOverlay.swift
@@ -79,8 +79,8 @@ enum ToastStyle {
         switch level {
         case .success: Color("BrandAccent")
         case .info: Color("TextMuted")
-        case .warning: .orange
-        case .error: .red
+        case .warning: .warning
+        case .error: .danger
         }
     }
 }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -279,7 +279,7 @@ struct DoctorSettingsView: View {
                 "\(n) tool\(n == 1 ? "" : "s") missing — some features won't work until installed.",
                 systemImage: "exclamationmark.triangle.fill"
             )
-            .foregroundStyle(.orange)
+            .foregroundStyle(.warning)
         }
     }
 
@@ -334,7 +334,7 @@ struct DoctorSettingsView: View {
     private func statusIcon(_ status: ToolStatus?) -> some View {
         if let status {
             Image(systemName: status.installed ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .foregroundStyle(status.installed ? Color.brandAccent : Color.orange)
+                .foregroundStyle(status.installed ? Color.success : Color.warning)
         } else {
             ProgressView().controlSize(.small)
         }

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -1,28 +1,55 @@
 import SwiftUI
 
-/// App color tokens — the "Terminal" (dark) / "Lab" (light) palette, sourced
-/// from the asset catalog with a light + dark variant per token.
+/// App color tokens — the single source of truth for every color in the UI.
+/// The "Terminal" (dark) / "Lab" (light) palette, sourced from the asset catalog
+/// with a light + dark variant per token. To re-theme the whole app, edit the
+/// matching `*.colorset` in `Assets.xcassets` (or point a token at a different
+/// asset here) — no view code changes.
 ///
 /// These are *named* asset colors, not the system accent. A named asset color
 /// resolves statically and keeps its value when the window goes inactive,
-/// whereas `.tint` / `Color.accentColor` desaturate to graphite on focus loss.
-/// So accent-colored icons, text, and highlights use `.brandAccent` here and
-/// stay put on focus change.
+/// whereas `.tint` / `Color.accentColor` follow the user's macOS accent and
+/// desaturate to graphite on focus loss. So every icon, label, fill, and chart
+/// series colors itself from a token here rather than a system/literal color.
 ///
 /// Icon usage (the matrix): static-navigation and input icons are `.textMuted`;
 /// resting-action icons inherit `.textMain`; active/selected icons, loaders, and
 /// CTAs are `.brandAccent`.
 extension ShapeStyle where Self == Color {
+    // MARK: Surfaces
     /// Deepest layer — the content background (the "graphite case").
     static var bgRoot: Color { Color("BgRoot") }
     /// Lifted surface — sidebar, cards, and bars sit one step above `bgRoot`.
     static var bgSurface: Color { Color("BgSurface") }
-    /// Thin dividers and borders.
+    /// Thin dividers, borders, and faint neutral fills.
     static var borderSubtle: Color { Color("BorderSubtle") }
+
+    // MARK: Content
     /// Primary reading text, header titles, active values, resting-action icons.
     static var textMain: Color { Color("TextMain") }
     /// Subtitles, timestamps, labels, and quiet navigation/input icons.
     static var textMuted: Color { Color("TextMuted") }
+    /// The faintest text/icons — hints, captions, placeholders.
+    static var textFaint: Color { Color("TextFaint") }
+
+    // MARK: Accent
     /// "The electricity" — CTAs, active toggles, selection, loaders, logo mark.
     static var brandAccent: Color { Color("BrandAccent") }
+
+    // MARK: Status
+    /// Positive / ready / completed — connected device, OK result, exit code 0.
+    static var success: Color { Color("Success") }
+    /// Heads-up — overrides active, unauthorized device, pinned, disabled app.
+    static var warning: Color { Color("Warning") }
+    /// Error / destructive — failed result, delete, disconnect, error badge.
+    static var danger: Color { Color("Danger") }
+
+    // MARK: Data viz
+    /// Categorical chart/metric palette. Distinct hues for legibility; the
+    /// positive series (RAM, Upload) uses `.brandAccent`. 1: blue, 2: teal,
+    /// 3: violet, 4: amber.
+    static var chart1: Color { Color("Chart1") }
+    static var chart2: Color { Color("Chart2") }
+    static var chart3: Color { Color("Chart3") }
+    static var chart4: Color { Color("Chart4") }
 }


### PR DESCRIPTION
## Problem

The theme (`Theme.swift`) was only partially adopted. Many views still used **system colors** — `.secondary`/`.tertiary`/`.primary`, `.blue`/`.accentColor`, `.red`/`.orange`/`.green`, `.teal`/`.purple`. Two consequences:

1. Controls/icons that fell through to the **system accent** rendered **blue** on Macs whose accent isn't "Multicolor" (e.g. the icon near the device dropdown).
2. There was no single place to change the palette.

## Fix — one source of truth

`Theme.swift` is now the only place colors are defined. New semantic tokens (asset colorsets, light + dark):

| Token | Role |
|---|---|
| `success` / `warning` / `danger` | status: ready/ok · heads-up · error/destructive |
| `textFaint` | the faintest text level (was `.tertiary`) |
| `chart1`–`chart4` | data-viz palette (blue / teal / violet / amber) |

(existing: `bgRoot`, `bgSurface`, `borderSubtle`, `textMain`, `textMuted`, `brandAccent`)

**~28 views migrated:** grays → `textMuted`/`textFaint`/`textMain`/`borderSubtle`; status → `success`/`warning`/`danger`; chart/metric hues → `chart1–4`; stray accent/blue chrome → `brandAccent`.

**Named exceptions (intentionally raw):** the screenshot annotation palette + canvas scrim, the logcat search highlight, `AppsExplorer`'s per-app `hash→hue` avatar tint (an identicon), on-accent white text, and translucent `.regularMaterial` overlays.

### Re-theming
To change the whole app's palette now, edit the `*.colorset`s in `Assets.xcassets` (or repoint a token in `Theme.swift`) — no view code changes.

## Verification
- `make build` — clean, zero warnings; the 8 new colorsets are bundled.
- Final sweep confirms no `.accentColor` and no raw system colors remain outside the documented exceptions.
- Screenshot check (Multicolor Mac): chrome themed green, status colors correct, no stray blue.
- Note: the device-*connected* device bar should be spot-checked on a Mac set to a **specific** (non-Multicolor) accent — every element now uses an explicit token rather than the system accent, so it should stay on-theme there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)