### PR TITLE
v2.3.0 — Screenshot editor overhaul, Apps uninstall fix, UI fixes

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# gitleaks configuration. Extends the default ruleset and allowlists strings in
+# this repo that look like secrets but aren't.
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Known non-secrets (public by design or not credentials)"
+regexes = [
+  # Sparkle EdDSA *public* key — embedded in the app to verify updates; meant to ship publicly.
+  '''ma0kTe35r55/PKmemQOEBX7n6SuZPZjOBo973SdJqJ8=''',
+  # UserDefaults migration key, not a credential.
+  '''didMigrateDefaultsV2''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Pre-commit hooks. Install with `prek install`; run manually with `prek run --all-files`.
+# Blocks commits that contain secrets (API keys, tokens, DSNs) using the system gitleaks.
+repos:
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: gitleaks (block committing secrets)
+        entry: gitleaks protect --staged --redact --no-banner
+        language: system
+        pass_filenames: false

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -327,9 +327,9 @@ public enum FeatureRegistry {
             category: .appManagement, icon: "shippingbox", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "current-activity", num: 28, title: "Current Activity",
+            id: "current-activity", num: 28, title: "Copy Current Activity",
             subtitle: "Show the foreground Activity right now",
-            keywords: ["activity", "foreground", "screen", "resumed", "dumpsys"],
+            keywords: ["activity", "foreground", "screen", "resumed", "dumpsys", "copy"],
             category: .appManagement, icon: "square.stack.3d.up", kind: .instantAction
         ),
         FeatureDef(

--- a/ADBKit/Sources/ADBKit/Services/SystemAppsService.swift
+++ b/ADBKit/Sources/ADBKit/Services/SystemAppsService.swift
@@ -17,6 +17,17 @@ public struct AppLifecycle: Sendable, Equatable {
     }
 }
 
+/// How an uninstall-for-user attempt resolved, read back from the package's
+/// post-attempt lifecycle.
+public enum UninstallOutcome: Sendable, Equatable {
+    /// Gone from the device entirely — a user app, removed for good.
+    case removed
+    /// Still on the system image but uninstalled for this user (restorable).
+    case removedForUser
+    /// Still installed — the package manager refused (a protected package).
+    case stillInstalled
+}
+
 /// App lifecycle control behind the Apps view: disable, uninstall-for-user, or
 /// restore any package. All actions are reversible (`pm enable` /
 /// `cmd package install-existing`) and per-user — they never touch the system
@@ -81,5 +92,13 @@ public struct SystemAppsService: Sendable {
             map[package] = AppLifecycle(disabled: disabled.contains(package), removed: !installed.contains(package))
         }
         return map
+    }
+
+    /// Classify an uninstall-for-user attempt from the package's post-attempt
+    /// lifecycle. A `nil` entry means the package is no longer known to the
+    /// device — a user app removed for good, which is success, not a failure.
+    public static func uninstallOutcome(for entry: AppLifecycle?) -> UninstallOutcome {
+        guard let entry else { return .removed }
+        return entry.removed ? .removedForUser : .stillInstalled
     }
 }

--- a/ADBKit/Tests/ADBKitTests/SystemAppsServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SystemAppsServiceTests.swift
@@ -23,4 +23,16 @@ import Testing
         #expect(map["com.c"] == AppLifecycle(disabled: false, removed: true))
         #expect(map["com.c"]?.label == "Removed")
     }
+
+    @Test func uninstallOutcomeTreatsAbsentPackageAsRemoved() {
+        // A user app fully uninstalled drops out of the lifecycle map entirely;
+        // that's success, not a protected-package failure.
+        #expect(SystemAppsService.uninstallOutcome(for: nil) == .removed)
+        #expect(SystemAppsService.uninstallOutcome(
+            for: AppLifecycle(disabled: false, removed: true)) == .removedForUser)
+        #expect(SystemAppsService.uninstallOutcome(
+            for: AppLifecycle(disabled: false, removed: false)) == .stillInstalled)
+        #expect(SystemAppsService.uninstallOutcome(
+            for: AppLifecycle(disabled: true, removed: false)) == .stillInstalled)
+    }
 }

--- a/App/Sources/BrandField.swift
+++ b/App/Sources/BrandField.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// A rounded-border text field whose focus ring is the brand green on every
+/// Mac, not the user's system accent color.
+///
+/// macOS draws the focus ring on a *bezeled* text field (`.roundedBorder`) from
+/// the *system* accent color (System Settings → Appearance → Accent color).
+/// That path ignores the app's `.tint(.brandAccent)`, the `AccentColor` asset,
+/// and even `.focusEffectDisabled()`, so on a Mac whose accent is a specific
+/// color the ring renders in that color (e.g. blue) instead of green. A
+/// `.plain` field draws no ring at all, so this styles the field ourselves —
+/// a subtle resting border that turns brand-green on focus — giving an
+/// identical result regardless of the machine's accent setting.
+///
+/// Each application carries its own `@FocusState`; it composes with any
+/// external `.focused(_:)` a call site already has (both reflect the same
+/// focus). The two pre-existing `.plain` fields (palette search, screenshot
+/// canvas text) keep their own chrome and don't use this.
+///
+/// The ring is gated on `controlActiveState` so it dims to the resting border
+/// when the window goes inactive — `@FocusState` stays set while another app is
+/// frontmost, and `.brandAccent` (a named asset color) doesn't desaturate on
+/// its own, so without this the ring would stay bright green after the user
+/// clicks away. A native focus ring dims when the window loses key; this mirrors
+/// that.
+private struct BrandFieldModifier: ViewModifier {
+    @FocusState private var focused: Bool
+    @Environment(\.controlActiveState) private var controlActive
+
+    private var ringVisible: Bool { focused && controlActive != .inactive }
+
+    func body(content: Content) -> some View {
+        content
+            .textFieldStyle(.plain)
+            .focused($focused)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .strokeBorder(ringVisible ? Color.brandAccent : Color.borderSubtle, lineWidth: ringVisible ? 2 : 1)
+            }
+    }
+}
+
+extension View {
+    /// Rounded-border text-field style with a brand-green focus ring that is
+    /// consistent across Macs (see ``BrandFieldModifier``).
+    func brandField() -> some View { modifier(BrandFieldModifier()) }
+}

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -105,7 +105,7 @@ struct FormActionView: View {
         let values = presetValues(for: field.presetKey ?? "")
         HStack(spacing: 4) {
             TextField("", text: binding(for: field), prompt: field.placeholder.map(Text.init))
-                .textFieldStyle(.roundedBorder)
+                .brandField()
                 .focused($focusedField, equals: field.name)
             if !values.isEmpty {
                 Menu {
@@ -137,7 +137,7 @@ struct FormActionView: View {
         switch field.control {
         case .text, .number, .bundle:
             TextField("", text: binding(for: field), prompt: field.placeholder.map(Text.init))
-                .textFieldStyle(.roundedBorder)
+                .brandField()
                 .focused($focusedField, equals: field.name)
         case .preset:
             presetField(for: field)

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -60,7 +60,7 @@ struct AppsExplorerView: View {
             VStack(spacing: 0) {
                 HStack(spacing: 8) {
                     TextField("Search name, version, or bundle…", text: $search)
-                        .textFieldStyle(.roundedBorder)
+                        .brandField()
                     Picker("", selection: $scope) {
                         ForEach(Scope.allCases, id: \.self) { scope in
                             Text(scope.rawValue).tag(scope)

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -184,8 +184,14 @@ struct AppsExplorerView: View {
             return await (listing, lifecycle)
         }
         guard !Task.isCancelled else { return }
-        apps = listing ?? []
+        let newApps = listing ?? []
+        apps = newApps
         states = lifecycle
+        // Drop a selection whose package no longer exists (e.g. just
+        // uninstalled) so the detail pane doesn't linger on an app that's gone.
+        if let selectedPackage, !newApps.contains(where: { $0.packageId == selectedPackage }) {
+            self.selectedPackage = nil
+        }
     }
 }
 
@@ -383,19 +389,23 @@ private struct AppDetailPane: View {
         }
     }
 
-    /// Uninstall-for-user, then verify it actually went away — protected system
-    /// apps report success but the package manager keeps them. When it didn't
-    /// stick, flag it non-removable so the button disappears.
+    /// Uninstall-for-user, then read back the lifecycle to see what happened: a
+    /// user app vanishes from the device (success), a system app stays on the
+    /// image removed-for-user (success, restorable), and a protected package is
+    /// still installed — flag it non-removable so the button disappears.
     private func uninstall() {
         managing = true
         Task {
             await CommandLog.userInitiated(feature: "apps") {
                 do {
                     _ = try await state.env.engine.systemApps.setRemoved(serial: serial, packageId: packageId, true)
-                    let removed = await state.env.engine.systemApps.states(serial: serial)[packageId]?.removed ?? false
-                    if removed {
+                    let entry = await state.env.engine.systemApps.states(serial: serial)[packageId]
+                    switch SystemAppsService.uninstallOutcome(for: entry) {
+                    case .removed:
+                        state.showToast(Toast(message: "\(packageId) uninstalled", ok: true, important: true))
+                    case .removedForUser:
                         state.showToast(Toast(message: "\(packageId) uninstalled for this user", ok: true, important: true))
-                    } else {
+                    case .stillInstalled:
                         onNotRemovable(packageId)
                         state.showToast(Toast(message: "Can't uninstall \(packageId) — it's protected. Disable it instead.", ok: false))
                     }

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -92,7 +92,9 @@ struct CustomCommandsView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(editing == nil ? "New Command" : "Edit Command").font(.headline)
             TextField("Name", text: $draftName)
+                .brandField()
             TextField("Command (e.g. shell am force-stop {bundleId})", text: $draftCommand)
+                .brandField()
                 .font(.system(.body, design: .monospaced))
             SwitchRow("Requires a saved bundle", isOn: $draftNeedsBundle)
             HStack {

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -72,7 +72,9 @@ struct DeepLinksSection: View {
             Text(editingLink == nil ? "Add Deep Link" : "Edit Deep Link")
                 .font(.headline)
             TextField("URL (e.g. myapp://orders/123)", text: $draftURL)
+                .brandField()
             TextField("Label (optional)", text: $draftLabel)
+                .brandField()
             HStack {
                 Spacer()
                 Button("Cancel") { showEditor = false }

--- a/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
@@ -56,7 +56,7 @@ struct DeviceInfoView: View {
     private func content(_ props: [String: String]) -> some View {
         VStack(spacing: 0) {
             TextField("Filter properties…", text: $search)
-                .textFieldStyle(.roundedBorder)
+                .brandField()
                 .padding(10)
 
             Divider()

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -68,7 +68,7 @@ struct LogcatView: View {
             .font(.callout)
 
             TextField("Search lines…", text: $search)
-                .textFieldStyle(.roundedBorder)
+                .brandField()
                 .frame(maxWidth: 220)
 
             Spacer()

--- a/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
@@ -24,7 +24,7 @@ struct NetworkConnectionView: View {
             Section("Reverse port") {
                 HStack(spacing: 8) {
                     TextField("Port", text: $reversePort, prompt: Text("8081"))
-                        .textFieldStyle(.roundedBorder)
+                        .brandField()
                         .labelsHidden()
                         .frame(maxWidth: 140)
                     Button("Forward") {

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -388,7 +388,7 @@ struct PerformanceView: View {
             VStack(spacing: 6) {
                 HStack {
                     TextField("Filter by name…", text: $filter)
-                        .textFieldStyle(.roundedBorder)
+                        .brandField()
                     Picker("Sort", selection: $sortKey) {
                         ForEach(SortKey.allCases, id: \.self) { Text($0.rawValue).tag($0) }
                     }

--- a/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
+++ b/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
@@ -23,7 +23,7 @@ struct PrivateDnsSection: View {
 
             if mode == .hostname {
                 TextField("dns.google", text: $hostname)
-                    .textFieldStyle(.roundedBorder)
+                    .brandField()
                     .frame(maxWidth: 280)
             }
 

--- a/App/Sources/FeatureDetail/Views/ReactNativeView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactNativeView.swift
@@ -27,7 +27,7 @@ struct ReactNativeView: View {
             Section("Dev server host") {
                 HStack(spacing: 8) {
                     TextField("Dev server host", text: $devHost, prompt: Text("192.168.1.10:8081"))
-                        .textFieldStyle(.roundedBorder)
+                        .brandField()
                         .labelsHidden()
                         .frame(maxWidth: 240)
                     Button("Set") {

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -32,6 +32,17 @@ struct ScreenshotEditorView: View {
     @State private var editingText = ""
     @State private var lastSavedURL: URL?
     @FocusState private var textFocused: Bool
+    /// Select-mode editing: tap an existing annotation to select it, drag its
+    /// body to move it, drag a handle to resize it.
+    @State private var selecting = false
+    @State private var selectedID: Annotation.ID?
+    @State private var selectDragActive = false
+    @State private var selectDragMode: SelectDragMode = .none
+    /// The selected annotation as it was when the drag began, so each frame
+    /// transforms from the original rather than accumulating drift.
+    @State private var selectDragOrigin: Annotation?
+    @State private var selectDragStart: CGPoint = .zero
+    @State private var selectDidEdit = false
 
     private static let palette: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .black, .white]
     private static let widths: [(String, CGFloat)] = [("Thin", 3), ("Medium", 6), ("Thick", 12)]
@@ -45,6 +56,11 @@ struct ScreenshotEditorView: View {
     }
 
     private var pixelSize: CGSize { ScreenshotMarkup.pixelSize(of: image) }
+
+    private var selectedAnnotation: Annotation? {
+        guard let selectedID else { return nil }
+        return annotations.first { $0.id == selectedID }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -78,16 +94,31 @@ struct ScreenshotEditorView: View {
     private var toolbar: some View {
         HStack(spacing: 12) {
             HStack(spacing: 2) {
+                Button {
+                    selecting = true
+                    cropping = false
+                } label: {
+                    Image(systemName: "cursorarrow")
+                        .frame(width: 26, height: 24)
+                        .background(selecting ? AnyShapeStyle(.brandAccent.opacity(0.18)) : AnyShapeStyle(.clear),
+                                   in: RoundedRectangle(cornerRadius: 6))
+                        .foregroundStyle(selecting ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMain))
+                }
+                .buttonStyle(.plain)
+                .help("Select, move & resize")
+
                 ForEach(MarkupTool.allCases) { item in
                     Button {
                         tool = item
                         cropping = false
+                        selecting = false
+                        selectedID = nil
                     } label: {
                         Image(systemName: item.systemImage)
                             .frame(width: 26, height: 24)
-                            .background(tool == item && !cropping ? AnyShapeStyle(.brandAccent.opacity(0.18)) : AnyShapeStyle(.clear),
+                            .background(tool == item && !cropping && !selecting ? AnyShapeStyle(.brandAccent.opacity(0.18)) : AnyShapeStyle(.clear),
                                        in: RoundedRectangle(cornerRadius: 6))
-                            .foregroundStyle(tool == item && !cropping ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMain))
+                            .foregroundStyle(tool == item && !cropping && !selecting ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMain))
                     }
                     .buttonStyle(.plain)
                     .help(item.label)
@@ -120,7 +151,7 @@ struct ScreenshotEditorView: View {
             .fixedSize()
             .help("Stroke width")
 
-            if tool == .redact {
+            if tool == .redact && !selecting {
                 Picker("", selection: $redactStyle) {
                     ForEach(RedactStyle.allCases) { Text($0.label).tag($0) }
                 }
@@ -131,7 +162,14 @@ struct ScreenshotEditorView: View {
 
             Spacer()
 
-            Button { cropping.toggle(); cropRect = nil } label: {
+            Button { rotate(clockwise: false) } label: { Image(systemName: "rotate.left") }
+                .buttonStyle(.bordered)
+                .help("Rotate left 90°")
+            Button { rotate(clockwise: true) } label: { Image(systemName: "rotate.right") }
+                .buttonStyle(.bordered)
+                .help("Rotate right 90°")
+
+            Button { cropping.toggle(); cropRect = nil; selecting = false; selectedID = nil } label: {
                 Label("Crop", systemImage: "crop")
             }
             .buttonStyle(.bordered)
@@ -146,10 +184,12 @@ struct ScreenshotEditorView: View {
                 .buttonStyle(.bordered)
                 .disabled(!canRedo)
                 .help("Redo (⇧⌘Z)")
-            Button { clearAll() } label: { Image(systemName: "trash") }
+            Button {
+                if selecting, selectedID != nil { deleteSelected() } else { clearAll() }
+            } label: { Image(systemName: "trash") }
                 .buttonStyle(.bordered)
-                .disabled(annotations.isEmpty)
-                .help("Clear all markup")
+                .disabled(selecting ? selectedID == nil : annotations.isEmpty)
+                .help(selecting && selectedID != nil ? "Delete selection" : "Clear all markup")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -189,6 +229,7 @@ struct ScreenshotEditorView: View {
                     ScreenshotMarkup.draw(annotations, draft: draft, in: context, size: size)
                 }
             }
+            .overlay { if selecting { selectionOverlay(display: display) } }
             .overlay { if cropping { cropOverlay(display: display) } }
             .overlay { textEditor(display: display) }
             .contentShape(Rectangle())
@@ -205,6 +246,30 @@ struct ScreenshotEditorView: View {
             context.fill(Path(CGRect(x: 0, y: r.minY, width: r.minX, height: r.height)), with: dim)
             context.fill(Path(CGRect(x: r.maxX, y: r.minY, width: size.width - r.maxX, height: r.height)), with: dim)
             context.stroke(Path(r), with: .color(.white), style: StrokeStyle(lineWidth: 1.5, dash: [6, 4]))
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// Dashed bounding box plus resize handles around the selected annotation.
+    private func selectionOverlay(display: CGSize) -> some View {
+        Canvas { context, size in
+            guard let annotation = selectedAnnotation else { return }
+            let b = annotation.boundingBox
+            let box = CGRect(
+                x: b.minX * size.width, y: b.minY * size.height,
+                width: b.width * size.width, height: b.height * size.height
+            ).insetBy(dx: -5, dy: -5)
+            context.stroke(
+                Path(roundedRect: box, cornerRadius: 5),
+                with: .color(.white.opacity(0.95)),
+                style: StrokeStyle(lineWidth: 1.5, dash: [5, 3])
+            )
+            for handle in annotation.handlePoints {
+                let center = CGPoint(x: handle.x * size.width, y: handle.y * size.height)
+                let rect = CGRect(x: center.x - 5, y: center.y - 5, width: 10, height: 10)
+                context.fill(Path(ellipseIn: rect), with: .color(.white))
+                context.stroke(Path(ellipseIn: rect), with: .color(.black.opacity(0.65)), style: StrokeStyle(lineWidth: 1))
+            }
         }
         .allowsHitTesting(false)
     }
@@ -242,6 +307,8 @@ struct ScreenshotEditorView: View {
                     let start = cropStart ?? normalize(value.startLocation, in: display)
                     cropStart = start
                     cropRect = CGRect(origin: start, size: .zero).expanded(to: norm)
+                } else if selecting {
+                    selectChanged(value: value, display: display)
                 } else if tool.isDragShape {
                     let start = normalize(value.startLocation, in: display)
                     draft = Annotation(tool: tool, color: color, width: width, points: [start, norm], redactStyle: redactStyle)
@@ -256,6 +323,7 @@ struct ScreenshotEditorView: View {
             .onEnded { value in
                 if textPoint != nil { commitText(); return }
                 if cropping { cropStart = nil; return }
+                if selecting { selectEnded(); return }
                 if tool == .text {
                     placeText(at: normalize(value.startLocation, in: display))
                     return
@@ -299,6 +367,89 @@ struct ScreenshotEditorView: View {
         pushUndo()
         annotations.removeAll()
         draft = nil
+        selectedID = nil
+    }
+
+    // MARK: - Select / move / resize
+
+    private func selectChanged(value: DragGesture.Value, display: CGSize) {
+        let current = normalize(value.location, in: display)
+        if !selectDragActive {
+            selectDragActive = true
+            selectDidEdit = false
+            selectDragStart = normalize(value.startLocation, in: display)
+            beginSelectDrag(atDisplay: value.startLocation, display: display)
+        }
+        guard let origin = selectDragOrigin else { return }
+        let delta = CGPoint(x: current.x - selectDragStart.x, y: current.y - selectDragStart.y)
+        if !selectDidEdit {
+            guard abs(delta.x) > 0.002 || abs(delta.y) > 0.002 else { return }
+            pushUndo()
+            selectDidEdit = true
+        }
+        guard let index = annotations.firstIndex(where: { $0.id == origin.id }) else { return }
+        switch selectDragMode {
+        case .move: annotations[index] = origin.moved(by: delta)
+        case .resize(let handle): annotations[index] = origin.resizing(handle: handle, to: current)
+        case .none: break
+        }
+    }
+
+    /// On drag start, decide what was grabbed: a handle of the current selection,
+    /// the body of an annotation (selecting it), or empty space (deselect).
+    private func beginSelectDrag(atDisplay point: CGPoint, display: CGSize) {
+        if let selected = selectedAnnotation {
+            for (handle, position) in selected.handlePoints.enumerated() {
+                let inPixels = CGPoint(x: position.x * display.width, y: position.y * display.height)
+                if hypot(point.x - inPixels.x, point.y - inPixels.y) <= 12 {
+                    selectDragMode = .resize(handle)
+                    selectDragOrigin = selected
+                    return
+                }
+            }
+        }
+        if let index = ScreenshotMarkup.hitTest(annotations, atDisplay: point, display: display, tolerance: 10) {
+            selectedID = annotations[index].id
+            selectDragMode = .move
+            selectDragOrigin = annotations[index]
+        } else {
+            selectedID = nil
+            selectDragMode = .none
+            selectDragOrigin = nil
+        }
+    }
+
+    private func selectEnded() {
+        selectDragActive = false
+        selectDragMode = .none
+        selectDragOrigin = nil
+        selectDidEdit = false
+    }
+
+    private func deleteSelected() {
+        guard let id = selectedID, annotations.contains(where: { $0.id == id }) else { return }
+        pushUndo()
+        annotations.removeAll { $0.id == id }
+        selectedID = nil
+    }
+
+    /// Rotate the image 90°. Current markup is flattened in first (like Crop), so
+    /// shapes and text rotate correctly without per-annotation transforms.
+    private func rotate(clockwise: Bool) {
+        let source = annotations.isEmpty ? image : (flattened() ?? image)
+        guard let rotated = ScreenshotMarkup.rotated(source, clockwise: clockwise) else {
+            state.showToast(Toast(message: "Couldn't rotate the image", ok: false))
+            return
+        }
+        pushUndo()
+        image = rotated
+        annotations.removeAll()
+        draft = nil
+        selectedID = nil
+        cropping = false
+        cropRect = nil
+        zoom = 1
+        pinchAnchor = 1
     }
 
     // MARK: - Undo / redo
@@ -330,6 +481,10 @@ struct ScreenshotEditorView: View {
         textPoint = nil
         cropping = false
         cropRect = nil
+        selectedID = nil
+        selectDragActive = false
+        selectDragMode = .none
+        selectDragOrigin = nil
     }
 
     // MARK: - Bottom bar
@@ -446,6 +601,14 @@ private extension CGPoint {
 struct EditorSnapshot {
     var image: NSImage
     var annotations: [Annotation]
+}
+
+/// What a select-mode drag is doing: nothing, moving the selection, or dragging
+/// one of its resize handles.
+private enum SelectDragMode {
+    case none
+    case move
+    case resize(Int)
 }
 
 /// Undo/redo actions the editor publishes to the app's Edit menu while its

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -345,25 +345,45 @@ struct ScreenshotEditorView: View {
         .allowsHitTesting(false)
     }
 
-    /// Dashed bounding box plus resize handles around the selected annotation.
+    /// Dashed bounding box, resize handles, and a rotation handle around the
+    /// selected annotation. The box and handles follow the annotation's rotation.
     private func selectionOverlay(display: CGSize) -> some View {
         Canvas { context, size in
             guard let annotation = selectedAnnotation else { return }
-            let b = ScreenshotMarkup.bounds(annotation, in: size)
-            let box = CGRect(
-                x: b.minX * size.width, y: b.minY * size.height,
-                width: b.width * size.width, height: b.height * size.height
-            ).insetBy(dx: -5, dy: -5)
-            context.stroke(
-                Path(roundedRect: box, cornerRadius: 5),
-                with: .color(.white.opacity(0.95)),
-                style: StrokeStyle(lineWidth: 1.5, dash: [5, 3])
-            )
-            for handle in annotation.handlePoints(in: size) {
-                let center = CGPoint(x: handle.x * size.width, y: handle.y * size.height)
-                let rect = CGRect(x: center.x - 5, y: center.y - 5, width: 10, height: 10)
+            func dot(_ p: CGPoint) {
+                let rect = CGRect(x: p.x - 5, y: p.y - 5, width: 10, height: 10)
                 context.fill(Path(ellipseIn: rect), with: .color(.white))
                 context.stroke(Path(ellipseIn: rect), with: .color(.black.opacity(0.65)), style: StrokeStyle(lineWidth: 1))
+            }
+
+            let b = ScreenshotMarkup.bounds(annotation, in: size)
+            let center = CGPoint(x: b.midX * size.width, y: b.midY * size.height)
+            let pad: CGFloat = 5
+            var corners = [
+                CGPoint(x: b.minX * size.width - pad, y: b.minY * size.height - pad),
+                CGPoint(x: b.maxX * size.width + pad, y: b.minY * size.height - pad),
+                CGPoint(x: b.maxX * size.width + pad, y: b.maxY * size.height + pad),
+                CGPoint(x: b.minX * size.width - pad, y: b.maxY * size.height + pad),
+            ]
+            if annotation.rotation != 0 {
+                corners = corners.map { ScreenshotMarkup.rotate($0, around: center, by: annotation.rotation) }
+            }
+            var boxPath = Path()
+            boxPath.move(to: corners[0])
+            corners.dropFirst().forEach { boxPath.addLine(to: $0) }
+            boxPath.closeSubpath()
+            context.stroke(boxPath, with: .color(.white.opacity(0.95)), style: StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+
+            if let rotationHandle = annotation.rotationHandle(in: size) {
+                let topMid = CGPoint(x: (corners[0].x + corners[1].x) / 2, y: (corners[0].y + corners[1].y) / 2)
+                let point = CGPoint(x: rotationHandle.x * size.width, y: rotationHandle.y * size.height)
+                var line = Path(); line.move(to: topMid); line.addLine(to: point)
+                context.stroke(line, with: .color(.white.opacity(0.8)), style: StrokeStyle(lineWidth: 1.5))
+                dot(point)
+            }
+
+            for handle in annotation.handlePoints(in: size) {
+                dot(CGPoint(x: handle.x * size.width, y: handle.y * size.height))
             }
         }
         .allowsHitTesting(false)
@@ -516,6 +536,7 @@ struct ScreenshotEditorView: View {
         switch selectDragMode {
         case .move: annotations[index] = origin.moved(by: delta)
         case .resize(let handle): annotations[index] = origin.resizing(handle: handle, to: current, in: display)
+        case .rotate: annotations[index] = origin.rotated(toward: current, in: display)
         case .none: break
         }
     }
@@ -524,6 +545,14 @@ struct ScreenshotEditorView: View {
     /// the body of an annotation (selecting it), or empty space (deselect).
     private func beginSelectDrag(atDisplay point: CGPoint, display: CGSize) {
         if let selected = selectedAnnotation {
+            if let rotationHandle = selected.rotationHandle(in: display) {
+                let inPixels = CGPoint(x: rotationHandle.x * display.width, y: rotationHandle.y * display.height)
+                if hypot(point.x - inPixels.x, point.y - inPixels.y) <= 14 {
+                    selectDragMode = .rotate
+                    selectDragOrigin = selected
+                    return
+                }
+            }
             for (handle, position) in selected.handlePoints(in: display).enumerated() {
                 let inPixels = CGPoint(x: position.x * display.width, y: position.y * display.height)
                 if hypot(point.x - inPixels.x, point.y - inPixels.y) <= 12 {
@@ -742,6 +771,7 @@ private enum SelectDragMode {
     case none
     case move
     case resize(Int)
+    case rotate
 }
 
 /// Undo/redo actions the editor publishes to the app's Edit menu while its

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -136,9 +136,23 @@ struct ScreenshotEditorView: View {
                         .overlay(Circle().strokeBorder(.brandAccent, lineWidth: color == swatch ? 2.5 : 0).padding(-2))
                         .onTapGesture { color = swatch }
                 }
+                // Native color picker, masked behind a color-wheel "logo" so it
+                // reads as "pick any color" instead of a plain swatch. The wheel
+                // is non-interactive, so taps fall through to the picker.
                 ColorPicker("", selection: $color, supportsOpacity: false)
                     .labelsHidden()
-                    .frame(width: 36)
+                    .frame(width: 20, height: 20)
+                    .clipShape(Circle())
+                    .overlay {
+                        Circle()
+                            .fill(AngularGradient(
+                                colors: [.red, .orange, .yellow, .green, .cyan, .blue, .purple, .red],
+                                center: .center
+                            ))
+                            .overlay(Circle().strokeBorder(.white.opacity(0.7), lineWidth: 1))
+                            .allowsHitTesting(false)
+                    }
+                    .padding(.leading, 6)
                     .help("Custom color")
             }
 

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -43,6 +43,11 @@ struct ScreenshotEditorView: View {
     @State private var selectDragOrigin: Annotation?
     @State private var selectDragStart: CGPoint = .zero
     @State private var selectDidEdit = false
+    /// Redact defaults for new regions (per-annotation values live on `Annotation`).
+    @State private var blurStrength: Double = 0.4
+    @State private var fillOpacity: Double = 1
+    /// The text annotation currently being re-edited (nil = placing new text).
+    @State private var editingTextID: Annotation.ID?
 
     private static let palette: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .black, .white]
     private static let widths: [(String, CGFloat)] = [("Thin", 3), ("Medium", 6), ("Thick", 12)]
@@ -60,6 +65,61 @@ struct ScreenshotEditorView: View {
     private var selectedAnnotation: Annotation? {
         guard let selectedID else { return nil }
         return annotations.first { $0.id == selectedID }
+    }
+
+    /// Annotations drawn on the canvas — minus the text being re-edited, which
+    /// shows in the live text field instead.
+    private var visibleAnnotations: [Annotation] {
+        guard let editingTextID else { return annotations }
+        return annotations.filter { $0.id != editingTextID }
+    }
+
+    private var editingAnnotation: Annotation? {
+        guard let editingTextID else { return nil }
+        return annotations.first { $0.id == editingTextID }
+    }
+    private var activeTextColor: Color { editingAnnotation?.color ?? color }
+    private var activeTextWidth: CGFloat { editingAnnotation?.width ?? width }
+
+    // Redact controls drive the selected redact when one is selected, else the
+    // defaults applied to new redactions.
+    private var editingRedact: Annotation? {
+        guard selecting, let annotation = selectedAnnotation, annotation.tool == .redact else { return nil }
+        return annotation
+    }
+    private var showsRedactControls: Bool { (tool == .redact && !selecting) || editingRedact != nil }
+    private var activeRedactStyle: RedactStyle { editingRedact?.redactStyle ?? redactStyle }
+
+    private var redactStyleBinding: Binding<RedactStyle> {
+        Binding(
+            get: { activeRedactStyle },
+            set: { value in
+                if let id = editingRedact?.id { pushUndo(); updateAnnotation(id) { $0.redactStyle = value } }
+                else { redactStyle = value }
+            }
+        )
+    }
+    private var blurBinding: Binding<Double> {
+        Binding(
+            get: { editingRedact?.blurStrength ?? blurStrength },
+            set: { value in
+                if let id = editingRedact?.id { updateAnnotation(id) { $0.blurStrength = value } }
+                else { blurStrength = value }
+            }
+        )
+    }
+    private var opacityBinding: Binding<Double> {
+        Binding(
+            get: { editingRedact?.fillOpacity ?? fillOpacity },
+            set: { value in
+                if let id = editingRedact?.id { updateAnnotation(id) { $0.fillOpacity = value } }
+                else { fillOpacity = value }
+            }
+        )
+    }
+    private func updateAnnotation(_ id: Annotation.ID, _ mutate: (inout Annotation) -> Void) {
+        guard let index = annotations.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&annotations[index])
     }
 
     var body: some View {
@@ -165,13 +225,34 @@ struct ScreenshotEditorView: View {
             .fixedSize()
             .help("Stroke width")
 
-            if tool == .redact && !selecting {
-                Picker("", selection: $redactStyle) {
+            if showsRedactControls {
+                Picker("", selection: redactStyleBinding) {
                     ForEach(RedactStyle.allCases) { Text($0.label).tag($0) }
                 }
                 .pickerStyle(.segmented)
                 .fixedSize()
                 .help("Redaction style")
+
+                HStack(spacing: 5) {
+                    Image(systemName: activeRedactStyle == .blur ? "drop.fill" : "circle.lefthalf.filled")
+                        .font(.caption)
+                        .foregroundStyle(.textMuted)
+                    Slider(
+                        value: activeRedactStyle == .blur ? blurBinding : opacityBinding,
+                        in: activeRedactStyle == .blur ? 0.0...1.0 : 0.1...1.0,
+                        onEditingChanged: { editing in if editing, editingRedact != nil { pushUndo() } }
+                    )
+                    .frame(width: 88)
+                }
+                .help(activeRedactStyle == .blur ? "Blur amount" : "Fill opacity")
+            }
+
+            if selecting, selectedAnnotation?.tool == .text {
+                Button { beginEditingSelectedText() } label: {
+                    Label("Edit Text", systemImage: "pencil")
+                }
+                .buttonStyle(.bordered)
+                .help("Edit the selected text")
             }
 
             Spacer()
@@ -236,14 +317,14 @@ struct ScreenshotEditorView: View {
             .interpolation(.high)
             .frame(width: display.width, height: display.height)
             .overlay {
-                RedactBlurLayer(image: image, rects: ScreenshotMarkup.blurRects(annotations, draft: draft))
+                RedactBlurLayer(image: image, regions: ScreenshotMarkup.blurRegions(annotations, draft: draft))
             }
             .overlay {
                 Canvas { context, size in
-                    ScreenshotMarkup.draw(annotations, draft: draft, in: context, size: size)
+                    ScreenshotMarkup.draw(visibleAnnotations, draft: draft, in: context, size: size)
                 }
             }
-            .overlay { if selecting { selectionOverlay(display: display) } }
+            .overlay { if selecting, textPoint == nil { selectionOverlay(display: display) } }
             .overlay { if cropping { cropOverlay(display: display) } }
             .overlay { textEditor(display: display) }
             .contentShape(Rectangle())
@@ -295,12 +376,12 @@ struct ScreenshotEditorView: View {
             // Mirror the committed annotation's font and top-leading anchor
             // (ScreenshotMarkup.drawOne) so the text doesn't jump in size or
             // position the moment it's committed.
-            let fontSize = max(11, display.width * 0.03 * (width / 6))
+            let fontSize = max(11, display.width * 0.03 * (activeTextWidth / 6))
             let fieldWidth = max(120, display.width - point.x - 8)
             TextField("Type, then ⏎", text: $editingText)
                 .textFieldStyle(.plain)
                 .font(.system(size: fontSize, weight: .semibold))
-                .foregroundStyle(color)
+                .foregroundStyle(activeTextColor)
                 .focused($textFocused)
                 .frame(width: fieldWidth, alignment: .leading)
                 .position(x: point.x + fieldWidth / 2, y: point.y + fontSize / 2)
@@ -325,7 +406,7 @@ struct ScreenshotEditorView: View {
                     selectChanged(value: value, display: display)
                 } else if tool.isDragShape {
                     let start = normalize(value.startLocation, in: display)
-                    draft = Annotation(tool: tool, color: color, width: width, points: [start, norm], redactStyle: redactStyle)
+                    draft = Annotation(tool: tool, color: color, width: width, points: [start, norm], redactStyle: redactStyle, blurStrength: blurStrength, fillOpacity: fillOpacity)
                 } else if tool != .text {
                     if draft == nil {
                         draft = Annotation(tool: tool, color: color, width: width, points: [norm])
@@ -368,15 +449,42 @@ struct ScreenshotEditorView: View {
         editingText = ""
     }
 
+    /// Re-open the selected text annotation for editing (its content only —
+    /// color and size are preserved).
+    private func beginEditingSelectedText() {
+        guard let annotation = selectedAnnotation, annotation.tool == .text,
+              let point = annotation.points.first else { return }
+        editingTextID = annotation.id
+        editingText = annotation.text
+        textPoint = point
+        textFocused = true
+    }
+
     private func commitText() {
-        defer { textPoint = nil; textFocused = false }
-        guard let point = textPoint else { return }
+        let committedPoint = textPoint
+        let editID = editingTextID
+        textPoint = nil
+        textFocused = false
+        editingTextID = nil
+        guard let committedPoint else { return }
         let trimmed = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        pushUndo()
-        let annotation = Annotation(tool: .text, color: color, width: width, points: [point], text: trimmed)
-        annotations.append(annotation)
-        selectAfterDrawing(annotation.id)
+        if let editID, let index = annotations.firstIndex(where: { $0.id == editID }) {
+            // Editing existing text: update content (or delete if emptied).
+            pushUndo()
+            if trimmed.isEmpty {
+                annotations.remove(at: index)
+                selectedID = nil
+            } else {
+                annotations[index].text = trimmed
+                selectedID = editID
+            }
+        } else {
+            guard !trimmed.isEmpty else { return }
+            pushUndo()
+            let annotation = Annotation(tool: .text, color: color, width: width, points: [committedPoint], text: trimmed)
+            annotations.append(annotation)
+            selectAfterDrawing(annotation.id)
+        }
     }
 
     private func clearAll() {
@@ -503,6 +611,7 @@ struct ScreenshotEditorView: View {
         annotations = snapshot.annotations
         draft = nil
         textPoint = nil
+        editingTextID = nil
         cropping = false
         cropRect = nil
         selectedID = nil

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -265,7 +265,7 @@ struct ScreenshotEditorView: View {
                 .help("Rotate right 90°")
 
             Button { cropping.toggle(); cropRect = nil; selecting = false; selectedID = nil } label: {
-                Label("Crop", systemImage: "crop")
+                Image(systemName: "crop")
             }
             .buttonStyle(.bordered)
             .tint(cropping ? .brandAccent : nil)

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -27,6 +27,9 @@ struct ScreenshotEditorView: View {
     @State private var cropping = false
     @State private var cropStart: CGPoint?
     @State private var cropRect: CGRect?
+    /// Crop-box rotation in radians; the drag is rotating the box (vs drawing it).
+    @State private var cropRotation: Double = 0
+    @State private var cropRotating = false
     /// Normalized location of the text field currently being typed (nil = none).
     @State private var textPoint: CGPoint?
     @State private var editingText = ""
@@ -264,7 +267,7 @@ struct ScreenshotEditorView: View {
                 .buttonStyle(.bordered)
                 .help("Rotate right 90°")
 
-            Button { cropping.toggle(); cropRect = nil; selecting = false; selectedID = nil } label: {
+            Button { cropping.toggle(); cropRect = nil; cropRotation = 0; cropRotating = false; selecting = false; selectedID = nil } label: {
                 Image(systemName: "crop")
             }
             .buttonStyle(.bordered)
@@ -334,15 +337,81 @@ struct ScreenshotEditorView: View {
 
     private func cropOverlay(display: CGSize) -> some View {
         Canvas { context, size in
-            let r = (cropRect ?? CGRect(x: 0, y: 0, width: 1, height: 1)).scaled(to: size)
-            let dim = GraphicsContext.Shading.color(.black.opacity(0.5))
-            context.fill(Path(CGRect(x: 0, y: 0, width: size.width, height: r.minY)), with: dim)
-            context.fill(Path(CGRect(x: 0, y: r.maxY, width: size.width, height: size.height - r.maxY)), with: dim)
-            context.fill(Path(CGRect(x: 0, y: r.minY, width: r.minX, height: r.height)), with: dim)
-            context.fill(Path(CGRect(x: r.maxX, y: r.minY, width: size.width - r.maxX, height: r.height)), with: dim)
-            context.stroke(Path(r), with: .color(.white), style: StrokeStyle(lineWidth: 1.5, dash: [6, 4]))
+            let normRect = cropRect ?? CGRect(x: 0, y: 0, width: 1, height: 1)
+            let r = normRect.scaled(to: size)
+            let center = CGPoint(x: normRect.midX * size.width, y: normRect.midY * size.height)
+            var corners = [
+                CGPoint(x: r.minX, y: r.minY), CGPoint(x: r.maxX, y: r.minY),
+                CGPoint(x: r.maxX, y: r.maxY), CGPoint(x: r.minX, y: r.maxY),
+            ]
+            if cropRotation != 0 {
+                corners = corners.map { ScreenshotMarkup.rotate($0, around: center, by: cropRotation) }
+            }
+            var cropPath = Path()
+            cropPath.move(to: corners[0])
+            corners.dropFirst().forEach { cropPath.addLine(to: $0) }
+            cropPath.closeSubpath()
+
+            // Dim everything outside the (rotated) crop region via even-odd fill.
+            var dimPath = Path()
+            dimPath.addRect(CGRect(x: 0, y: 0, width: size.width, height: size.height))
+            dimPath.addPath(cropPath)
+            context.fill(dimPath, with: .color(.black.opacity(0.5)), style: FillStyle(eoFill: true))
+            context.stroke(cropPath, with: .color(.white), style: StrokeStyle(lineWidth: 1.5, dash: [6, 4]))
+
+            if cropRect != nil {
+                let handleNorm = cropRotationHandle(normRect, display: size)
+                let handle = CGPoint(x: handleNorm.x * size.width, y: handleNorm.y * size.height)
+                let topMid = CGPoint(x: (corners[0].x + corners[1].x) / 2, y: (corners[0].y + corners[1].y) / 2)
+                var line = Path(); line.move(to: topMid); line.addLine(to: handle)
+                context.stroke(line, with: .color(.white.opacity(0.85)), style: StrokeStyle(lineWidth: 1.5))
+                let dot = CGRect(x: handle.x - 5, y: handle.y - 5, width: 10, height: 10)
+                context.fill(Path(ellipseIn: dot), with: .color(.white))
+                context.stroke(Path(ellipseIn: dot), with: .color(.black.opacity(0.65)), style: StrokeStyle(lineWidth: 1))
+            }
         }
         .allowsHitTesting(false)
+    }
+
+    /// Normalized rotation-handle position for the crop box (above its top edge).
+    private func cropRotationHandle(_ r: CGRect, display: CGSize) -> CGPoint {
+        let offset = 26 / max(display.height, 1)
+        let raw = CGPoint(x: r.midX, y: r.minY - offset)
+        guard cropRotation != 0 else { return raw }
+        let center = CGPoint(x: r.midX * display.width, y: r.midY * display.height)
+        let rawPx = CGPoint(x: raw.x * display.width, y: raw.y * display.height)
+        let rotated = ScreenshotMarkup.rotate(rawPx, around: center, by: cropRotation)
+        return CGPoint(x: rotated.x / display.width, y: rotated.y / display.height)
+    }
+
+    private func cropRotationAngle(toward target: CGPoint, rect r: CGRect, display: CGSize) -> Double {
+        let cx = r.midX * display.width, cy = r.midY * display.height
+        let tx = target.x * display.width, ty = target.y * display.height
+        return atan2(ty - cy, tx - cx) + .pi / 2
+    }
+
+    /// In crop mode: dragging the rotation handle rotates the box; any other drag
+    /// draws a fresh (un-rotated) crop rectangle.
+    private func cropChanged(value: DragGesture.Value, display: CGSize) {
+        let norm = normalize(value.location, in: display)
+        if cropStart == nil && !cropRotating {
+            if let r = cropRect {
+                let handleNorm = cropRotationHandle(r, display: display)
+                let hpx = CGPoint(x: handleNorm.x * display.width, y: handleNorm.y * display.height)
+                if hypot(value.startLocation.x - hpx.x, value.startLocation.y - hpx.y) <= 14 {
+                    cropRotating = true
+                }
+            }
+            if !cropRotating {
+                cropStart = normalize(value.startLocation, in: display)
+                cropRotation = 0
+            }
+        }
+        if cropRotating, let r = cropRect {
+            cropRotation = cropRotationAngle(toward: norm, rect: r, display: display)
+        } else if let start = cropStart {
+            cropRect = CGRect(origin: start, size: .zero).expanded(to: norm)
+        }
     }
 
     /// Dashed bounding box, resize handles, and a rotation handle around the
@@ -419,9 +488,7 @@ struct ScreenshotEditorView: View {
                 if textPoint != nil { return }
                 let norm = normalize(value.location, in: display)
                 if cropping {
-                    let start = cropStart ?? normalize(value.startLocation, in: display)
-                    cropStart = start
-                    cropRect = CGRect(origin: start, size: .zero).expanded(to: norm)
+                    cropChanged(value: value, display: display)
                 } else if selecting {
                     selectChanged(value: value, display: display)
                 } else if tool.isDragShape {
@@ -437,7 +504,7 @@ struct ScreenshotEditorView: View {
             }
             .onEnded { value in
                 if textPoint != nil { commitText(); return }
-                if cropping { cropStart = nil; return }
+                if cropping { cropStart = nil; cropRotating = false; return }
                 if selecting { selectEnded(); return }
                 if tool == .text {
                     placeText(at: normalize(value.startLocation, in: display))
@@ -643,6 +710,8 @@ struct ScreenshotEditorView: View {
         editingTextID = nil
         cropping = false
         cropRect = nil
+        cropRotation = 0
+        cropRotating = false
         selectedID = nil
         selectDragActive = false
         selectDragMode = .none
@@ -658,7 +727,7 @@ struct ScreenshotEditorView: View {
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
                 Spacer()
-                Button("Cancel") { cropping = false; cropRect = nil }
+                Button("Cancel") { cropping = false; cropRect = nil; cropRotation = 0; cropRotating = false }
                 Button("Apply Crop") { applyCrop() }
                     .buttonStyle(.borderedProminent)
                     .disabled((cropRect?.width ?? 0) < 0.02 || (cropRect?.height ?? 0) < 0.02)
@@ -698,13 +767,17 @@ struct ScreenshotEditorView: View {
     // MARK: - Output
 
     private func applyCrop() {
-        guard let rect = cropRect, let cropped = ScreenshotMarkup.crop(image, annotations: annotations, to: rect) else { return }
+        guard let rect = cropRect,
+              let cropped = ScreenshotMarkup.crop(image, annotations: annotations, to: rect, rotation: cropRotation) else { return }
         pushUndo()
         image = cropped
         annotations.removeAll()
         draft = nil
+        selectedID = nil
         cropping = false
         cropRect = nil
+        cropRotation = 0
+        cropRotating = false
         zoom = 1
         pinchAnchor = 1
     }

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -337,6 +337,7 @@ struct ScreenshotEditorView: View {
                     pushUndo()
                     annotations.append(finished)
                     draft = nil
+                    selectAfterDrawing(finished.id)
                 }
             }
     }
@@ -359,7 +360,9 @@ struct ScreenshotEditorView: View {
         let trimmed = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         pushUndo()
-        annotations.append(Annotation(tool: .text, color: color, width: width, points: [point], text: trimmed))
+        let annotation = Annotation(tool: .text, color: color, width: width, points: [point], text: trimmed)
+        annotations.append(annotation)
+        selectAfterDrawing(annotation.id)
     }
 
     private func clearAll() {
@@ -424,6 +427,13 @@ struct ScreenshotEditorView: View {
         selectDragMode = .none
         selectDragOrigin = nil
         selectDidEdit = false
+    }
+
+    /// After a shape/stroke/text is drawn, switch to Select mode with it selected
+    /// so it can be moved or resized right away.
+    private func selectAfterDrawing(_ id: Annotation.ID) {
+        selecting = true
+        selectedID = id
     }
 
     private func deleteSelected() {

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -254,7 +254,7 @@ struct ScreenshotEditorView: View {
     private func selectionOverlay(display: CGSize) -> some View {
         Canvas { context, size in
             guard let annotation = selectedAnnotation else { return }
-            let b = annotation.boundingBox
+            let b = ScreenshotMarkup.bounds(annotation, in: size)
             let box = CGRect(
                 x: b.minX * size.width, y: b.minY * size.height,
                 width: b.width * size.width, height: b.height * size.height
@@ -264,7 +264,7 @@ struct ScreenshotEditorView: View {
                 with: .color(.white.opacity(0.95)),
                 style: StrokeStyle(lineWidth: 1.5, dash: [5, 3])
             )
-            for handle in annotation.handlePoints {
+            for handle in annotation.handlePoints(in: size) {
                 let center = CGPoint(x: handle.x * size.width, y: handle.y * size.height)
                 let rect = CGRect(x: center.x - 5, y: center.y - 5, width: 10, height: 10)
                 context.fill(Path(ellipseIn: rect), with: .color(.white))
@@ -393,7 +393,7 @@ struct ScreenshotEditorView: View {
         guard let index = annotations.firstIndex(where: { $0.id == origin.id }) else { return }
         switch selectDragMode {
         case .move: annotations[index] = origin.moved(by: delta)
-        case .resize(let handle): annotations[index] = origin.resizing(handle: handle, to: current)
+        case .resize(let handle): annotations[index] = origin.resizing(handle: handle, to: current, in: display)
         case .none: break
         }
     }
@@ -402,7 +402,7 @@ struct ScreenshotEditorView: View {
     /// the body of an annotation (selecting it), or empty space (deselect).
     private func beginSelectDrag(atDisplay point: CGPoint, display: CGSize) {
         if let selected = selectedAnnotation {
-            for (handle, position) in selected.handlePoints.enumerated() {
+            for (handle, position) in selected.handlePoints(in: display).enumerated() {
                 let inPixels = CGPoint(x: position.x * display.width, y: position.y * display.height)
                 if hypot(point.x - inPixels.x, point.y - inPixels.y) <= 12 {
                     selectDragMode = .resize(handle)

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -25,11 +25,13 @@ struct ScreenshotEditorView: View {
     @State private var zoom: CGFloat = 1
     @State private var pinchAnchor: CGFloat = 1
     @State private var cropping = false
-    @State private var cropStart: CGPoint?
     @State private var cropRect: CGRect?
-    /// Crop-box rotation in radians; the drag is rotating the box (vs drawing it).
+    /// Crop-box rotation in radians.
     @State private var cropRotation: Double = 0
-    @State private var cropRotating = false
+    /// What the current crop-mode drag is doing, and the box when it began.
+    @State private var cropDrag: CropDragMode = .none
+    @State private var cropDragOrigin: CGRect?
+    @State private var cropDragStart: CGPoint = .zero
     /// Normalized location of the text field currently being typed (nil = none).
     @State private var textPoint: CGPoint?
     @State private var editingText = ""
@@ -267,7 +269,7 @@ struct ScreenshotEditorView: View {
                 .buttonStyle(.bordered)
                 .help("Rotate right 90°")
 
-            Button { cropping.toggle(); cropRect = nil; cropRotation = 0; cropRotating = false; selecting = false; selectedID = nil } label: {
+            Button { cropping.toggle(); cropRect = nil; cropRotation = 0; cropDrag = .none; cropDragOrigin = nil; selecting = false; selectedID = nil } label: {
                 Image(systemName: "crop")
             }
             .buttonStyle(.bordered)
@@ -368,6 +370,12 @@ struct ScreenshotEditorView: View {
                 let dot = CGRect(x: handle.x - 5, y: handle.y - 5, width: 10, height: 10)
                 context.fill(Path(ellipseIn: dot), with: .color(.white))
                 context.stroke(Path(ellipseIn: dot), with: .color(.black.opacity(0.65)), style: StrokeStyle(lineWidth: 1))
+                // Corner resize handles.
+                for corner in corners {
+                    let cornerDot = CGRect(x: corner.x - 5, y: corner.y - 5, width: 10, height: 10)
+                    context.fill(Path(ellipseIn: cornerDot), with: .color(.white))
+                    context.stroke(Path(ellipseIn: cornerDot), with: .color(.black.opacity(0.65)), style: StrokeStyle(lineWidth: 1))
+                }
             }
         }
         .allowsHitTesting(false)
@@ -390,28 +398,109 @@ struct ScreenshotEditorView: View {
         return atan2(ty - cy, tx - cx) + .pi / 2
     }
 
-    /// In crop mode: dragging the rotation handle rotates the box; any other drag
-    /// draws a fresh (un-rotated) crop rectangle.
+    /// In crop mode a drag rotates the box (rotation handle), resizes it (corner
+    /// handle), moves it (inside the box), or draws a fresh box (empty area).
     private func cropChanged(value: DragGesture.Value, display: CGSize) {
-        let norm = normalize(value.location, in: display)
-        if cropStart == nil && !cropRotating {
-            if let r = cropRect {
-                let handleNorm = cropRotationHandle(r, display: display)
-                let hpx = CGPoint(x: handleNorm.x * display.width, y: handleNorm.y * display.height)
-                if hypot(value.startLocation.x - hpx.x, value.startLocation.y - hpx.y) <= 14 {
-                    cropRotating = true
-                }
+        let current = normalize(value.location, in: display)
+        if cropDrag == .none {
+            cropDragStart = normalize(value.startLocation, in: display)
+            beginCropDrag(atDisplay: value.startLocation, display: display)
+        }
+        let delta = CGPoint(x: current.x - cropDragStart.x, y: current.y - cropDragStart.y)
+        switch cropDrag {
+        case .draw:
+            cropRect = CGRect(origin: cropDragStart, size: .zero).expanded(to: current)
+        case .move:
+            if let origin = cropDragOrigin {
+                let dx = min(max(delta.x, -origin.minX), 1 - origin.maxX)
+                let dy = min(max(delta.y, -origin.minY), 1 - origin.maxY)
+                cropRect = origin.offsetBy(dx: dx, dy: dy)
             }
-            if !cropRotating {
-                cropStart = normalize(value.startLocation, in: display)
-                cropRotation = 0
+        case .resize(let corner):
+            if let origin = cropDragOrigin {
+                cropRect = resizedCropRect(origin, corner: corner, toward: current, display: display)
+            }
+        case .rotate:
+            if let r = cropRect { cropRotation = cropRotationAngle(toward: current, rect: r, display: display) }
+        case .none:
+            break
+        }
+    }
+
+    /// Decide what a crop drag does from where it starts: rotation handle,
+    /// corner handle (resize), inside the box (move), or empty area (draw new).
+    private func beginCropDrag(atDisplay point: CGPoint, display: CGSize) {
+        guard let r = cropRect else {
+            cropDrag = .draw
+            cropRotation = 0
+            return
+        }
+        let handle = cropRotationHandle(r, display: display)
+        let handlePx = CGPoint(x: handle.x * display.width, y: handle.y * display.height)
+        if hypot(point.x - handlePx.x, point.y - handlePx.y) <= 14 {
+            cropDrag = .rotate
+            return
+        }
+        for (corner, position) in cropCornerHandles(r, display: display).enumerated() {
+            let cornerPx = CGPoint(x: position.x * display.width, y: position.y * display.height)
+            if hypot(point.x - cornerPx.x, point.y - cornerPx.y) <= 12 {
+                cropDrag = .resize(corner)
+                cropDragOrigin = r
+                return
             }
         }
-        if cropRotating, let r = cropRect {
-            cropRotation = cropRotationAngle(toward: norm, rect: r, display: display)
-        } else if let start = cropStart {
-            cropRect = CGRect(origin: start, size: .zero).expanded(to: norm)
+        if cropContains(point, rect: r, display: display) {
+            cropDrag = .move
+            cropDragOrigin = r
+            return
         }
+        cropDrag = .draw
+        cropRotation = 0
+    }
+
+    /// The crop box's four corner handles (normalized), following its rotation.
+    private func cropCornerHandles(_ r: CGRect, display: CGSize) -> [CGPoint] {
+        var corners = [
+            CGPoint(x: r.minX, y: r.minY), CGPoint(x: r.maxX, y: r.minY),
+            CGPoint(x: r.maxX, y: r.maxY), CGPoint(x: r.minX, y: r.maxY),
+        ]
+        guard cropRotation != 0 else { return corners }
+        let center = CGPoint(x: r.midX * display.width, y: r.midY * display.height)
+        corners = corners.map {
+            let px = CGPoint(x: $0.x * display.width, y: $0.y * display.height)
+            let rotated = ScreenshotMarkup.rotate(px, around: center, by: cropRotation)
+            return CGPoint(x: rotated.x / display.width, y: rotated.y / display.height)
+        }
+        return corners
+    }
+
+    private func cropContains(_ point: CGPoint, rect r: CGRect, display: CGSize) -> Bool {
+        var p = point
+        if cropRotation != 0 {
+            let center = CGPoint(x: r.midX * display.width, y: r.midY * display.height)
+            p = ScreenshotMarkup.rotate(point, around: center, by: -cropRotation)
+        }
+        let px = CGRect(x: r.minX * display.width, y: r.minY * display.height,
+                        width: r.width * display.width, height: r.height * display.height)
+        return px.contains(p)
+    }
+
+    private func resizedCropRect(_ origin: CGRect, corner: Int, toward target: CGPoint, display: CGSize) -> CGRect {
+        var local = target
+        if cropRotation != 0 {
+            let center = CGPoint(x: origin.midX * display.width, y: origin.midY * display.height)
+            let targetPx = CGPoint(x: target.x * display.width, y: target.y * display.height)
+            let unrotated = ScreenshotMarkup.rotate(targetPx, around: center, by: -cropRotation)
+            local = CGPoint(x: unrotated.x / display.width, y: unrotated.y / display.height)
+        }
+        let corners = [
+            CGPoint(x: origin.minX, y: origin.minY), CGPoint(x: origin.maxX, y: origin.minY),
+            CGPoint(x: origin.maxX, y: origin.maxY), CGPoint(x: origin.minX, y: origin.maxY),
+        ]
+        let opposite = corners[(corner + 2) % 4]
+        let p = CGPoint(x: min(1, max(0, local.x)), y: min(1, max(0, local.y)))
+        return CGRect(x: min(opposite.x, p.x), y: min(opposite.y, p.y),
+                      width: abs(p.x - opposite.x), height: abs(p.y - opposite.y))
     }
 
     /// Dashed bounding box, resize handles, and a rotation handle around the
@@ -504,7 +593,7 @@ struct ScreenshotEditorView: View {
             }
             .onEnded { value in
                 if textPoint != nil { commitText(); return }
-                if cropping { cropStart = nil; cropRotating = false; return }
+                if cropping { cropDrag = .none; cropDragOrigin = nil; return }
                 if selecting { selectEnded(); return }
                 if tool == .text {
                     placeText(at: normalize(value.startLocation, in: display))
@@ -711,7 +800,8 @@ struct ScreenshotEditorView: View {
         cropping = false
         cropRect = nil
         cropRotation = 0
-        cropRotating = false
+        cropDrag = .none
+        cropDragOrigin = nil
         selectedID = nil
         selectDragActive = false
         selectDragMode = .none
@@ -727,7 +817,7 @@ struct ScreenshotEditorView: View {
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
                 Spacer()
-                Button("Cancel") { cropping = false; cropRect = nil; cropRotation = 0; cropRotating = false }
+                Button("Cancel") { cropping = false; cropRect = nil; cropRotation = 0; cropDrag = .none; cropDragOrigin = nil }
                 Button("Apply Crop") { applyCrop() }
                     .buttonStyle(.borderedProminent)
                     .disabled((cropRect?.width ?? 0) < 0.02 || (cropRect?.height ?? 0) < 0.02)
@@ -777,7 +867,8 @@ struct ScreenshotEditorView: View {
         cropping = false
         cropRect = nil
         cropRotation = 0
-        cropRotating = false
+        cropDrag = .none
+        cropDragOrigin = nil
         zoom = 1
         pinchAnchor = 1
     }
@@ -842,6 +933,16 @@ struct EditorSnapshot {
 /// one of its resize handles.
 private enum SelectDragMode {
     case none
+    case move
+    case resize(Int)
+    case rotate
+}
+
+/// What a crop-mode drag is doing: drawing a new box, moving it, resizing a
+/// corner, or rotating it.
+private enum CropDragMode: Equatable {
+    case none
+    case draw
     case move
     case resize(Int)
     case rotate

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -1,4 +1,6 @@
 import AppKit
+import CoreImage
+import ImageIO
 import SwiftUI
 
 /// A markup tool in the screenshot editor.
@@ -63,6 +65,83 @@ struct Annotation: Identifiable {
     var text: String = ""
     /// Only meaningful for `.redact`.
     var redactStyle: RedactStyle = .solid
+}
+
+extension Annotation {
+    /// Normalized (0...1) bounding box. Text gets an approximate extent (its real
+    /// size depends on the render width) so it's still selectable and movable.
+    var boundingBox: CGRect {
+        guard let first = points.first else { return .zero }
+        if tool == .text {
+            let w = max(0.06, CGFloat(max(text.count, 4)) * 0.011 * (width / 6))
+            let h = max(0.03, 0.05 * (width / 6))
+            return CGRect(x: first.x, y: first.y, width: w, height: h)
+        }
+        var minX = first.x, minY = first.y, maxX = first.x, maxY = first.y
+        for p in points {
+            minX = min(minX, p.x); minY = min(minY, p.y)
+            maxX = max(maxX, p.x); maxY = max(maxY, p.y)
+        }
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    /// Normalized resize-handle positions. Two-point shapes expose their two
+    /// defining points; freehand strokes expose bounding-box corners; text has
+    /// none (move only).
+    var handlePoints: [CGPoint] {
+        switch tool {
+        case .line, .arrow, .rectangle, .ellipse, .redact:
+            return points.count >= 2 ? [points[0], points[1]] : []
+        case .pen, .highlighter:
+            let b = boundingBox
+            return [
+                CGPoint(x: b.minX, y: b.minY), CGPoint(x: b.maxX, y: b.minY),
+                CGPoint(x: b.maxX, y: b.maxY), CGPoint(x: b.minX, y: b.maxY),
+            ]
+        case .text:
+            return []
+        }
+    }
+
+    /// Translate every point, clamped so the bounding box stays within 0...1
+    /// (the shape moves rigidly and stops at the edge).
+    func moved(by delta: CGPoint) -> Annotation {
+        let b = boundingBox
+        let dx = min(max(delta.x, -b.minX), 1 - b.maxX)
+        let dy = min(max(delta.y, -b.minY), 1 - b.maxY)
+        var copy = self
+        copy.points = points.map { CGPoint(x: $0.x + dx, y: $0.y + dy) }
+        return copy
+    }
+
+    /// Move handle `index` to `target` (normalized). Two-point shapes move that
+    /// endpoint; freehand strokes scale every point from the opposite corner.
+    func resizing(handle index: Int, to target: CGPoint) -> Annotation {
+        let p = CGPoint(x: min(1, max(0, target.x)), y: min(1, max(0, target.y)))
+        var copy = self
+        switch tool {
+        case .line, .arrow, .rectangle, .ellipse, .redact:
+            if copy.points.indices.contains(index) { copy.points[index] = p }
+        case .pen, .highlighter:
+            let b = boundingBox
+            let corners = [
+                CGPoint(x: b.minX, y: b.minY), CGPoint(x: b.maxX, y: b.minY),
+                CGPoint(x: b.maxX, y: b.maxY), CGPoint(x: b.minX, y: b.maxY),
+            ]
+            let anchor = corners[(index + 2) % 4]
+            let sx = abs(p.x - anchor.x) / max(b.width, 0.0001)
+            let sy = abs(p.y - anchor.y) / max(b.height, 0.0001)
+            copy.points = points.map {
+                CGPoint(
+                    x: min(1, max(0, anchor.x + ($0.x - anchor.x) * sx)),
+                    y: min(1, max(0, anchor.y + ($0.y - anchor.y) * sy))
+                )
+            }
+        case .text:
+            break
+        }
+        return copy
+    }
 }
 
 /// Stateless drawing + rasterization for the screenshot editor. Drawing routines
@@ -162,7 +241,58 @@ enum ScreenshotMarkup {
         return result
     }
 
+    // MARK: - Hit-testing (display-pixel space, so it's isotropic)
+
+    /// Index of the top-most annotation under `point` (display px), or nil. Area
+    /// shapes hit inside their box; strokes/lines hit near their path.
+    static func hitTest(_ annotations: [Annotation], atDisplay point: CGPoint, display: CGSize, tolerance: CGFloat) -> Int? {
+        for index in annotations.indices.reversed() where hits(annotations[index], point, display, tolerance) {
+            return index
+        }
+        return nil
+    }
+
+    private static func hits(_ a: Annotation, _ p: CGPoint, _ display: CGSize, _ tol: CGFloat) -> Bool {
+        switch a.tool {
+        case .rectangle, .ellipse, .redact, .text:
+            let b = a.boundingBox
+            let box = CGRect(
+                x: b.minX * display.width, y: b.minY * display.height,
+                width: b.width * display.width, height: b.height * display.height
+            )
+            return box.insetBy(dx: -tol, dy: -tol).contains(p)
+        case .pen, .highlighter, .line, .arrow:
+            let pts = a.points.map { CGPoint(x: $0.x * display.width, y: $0.y * display.height) }
+            return distanceToPolyline(pts, p) <= tol
+        }
+    }
+
+    private static func distanceToPolyline(_ pts: [CGPoint], _ p: CGPoint) -> CGFloat {
+        guard let first = pts.first else { return .greatestFiniteMagnitude }
+        if pts.count == 1 { return hypot(p.x - first.x, p.y - first.y) }
+        var best = CGFloat.greatestFiniteMagnitude
+        for i in 0..<(pts.count - 1) { best = min(best, distance(p, segment: pts[i], pts[i + 1])) }
+        return best
+    }
+
+    private static func distance(_ p: CGPoint, segment a: CGPoint, _ b: CGPoint) -> CGFloat {
+        let dx = b.x - a.x, dy = b.y - a.y
+        let lengthSquared = dx * dx + dy * dy
+        if lengthSquared < 1e-9 { return hypot(p.x - a.x, p.y - a.y) }
+        let t = min(1, max(0, ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSquared))
+        return hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy))
+    }
+
     // MARK: - Rasterization
+
+    /// Rotate an image 90° (clockwise or counter-clockwise) at pixel resolution.
+    @MainActor
+    static func rotated(_ image: NSImage, clockwise: Bool) -> NSImage? {
+        guard let cg = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }
+        let oriented = CIImage(cgImage: cg).oriented(clockwise ? .right : .left)
+        guard let out = CIContext().createCGImage(oriented, from: oriented.extent) else { return nil }
+        return NSImage(cgImage: out, size: NSSize(width: out.width, height: out.height))
+    }
 
     /// Flatten the base image + annotations into a new image at the base's pixel
     /// resolution.

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -65,6 +65,10 @@ struct Annotation: Identifiable {
     var text: String = ""
     /// Only meaningful for `.redact`.
     var redactStyle: RedactStyle = .solid
+    /// Blur intensity (0...1) for a blur-style redact.
+    var blurStrength: Double = 0.4
+    /// Fill opacity (0...1) for a solid-style redact.
+    var fillOpacity: Double = 1
 }
 
 extension Annotation {
@@ -203,7 +207,7 @@ enum ScreenshotMarkup {
             // Solid fills here; blur regions are drawn by `RedactBlurLayer`
             // beneath this canvas (a 2-D context can't sample the image).
             guard pts.count >= 2, a.redactStyle == .solid else { return }
-            context.fill(Path(rect(first, pts[1])), with: .color(a.color))
+            context.fill(Path(rect(first, pts[1])), with: .color(a.color.opacity(a.fillOpacity)))
         case .text:
             let fontSize = max(11, size.width * 0.03 * (a.width / 6))
             let label = Text(a.text.isEmpty ? "Text" : a.text)
@@ -238,15 +242,21 @@ enum ScreenshotMarkup {
         CGRect(x: min(a.x, b.x), y: min(a.y, b.y), width: abs(a.x - b.x), height: abs(a.y - b.y))
     }
 
-    /// Normalized rects of every blur-style redact region (plus an in-progress
-    /// draft) — drawn by `RedactBlurLayer`, not the 2-D canvas.
-    static func blurRects(_ annotations: [Annotation], draft: Annotation?) -> [CGRect] {
-        var result: [CGRect] = []
+    /// A blur-style redact region: a normalized rect plus blur strength (0...1).
+    struct BlurRegion {
+        let rect: CGRect
+        let strength: Double
+    }
+
+    /// Blur-style redact regions (plus an in-progress draft) — drawn by
+    /// `RedactBlurLayer`, not the 2-D canvas. Each carries its own blur strength.
+    static func blurRegions(_ annotations: [Annotation], draft: Annotation?) -> [BlurRegion] {
+        var result: [BlurRegion] = []
         for a in annotations where a.tool == .redact && a.redactStyle == .blur && a.points.count >= 2 {
-            result.append(rect(a.points[0], a.points[1]))
+            result.append(BlurRegion(rect: rect(a.points[0], a.points[1]), strength: a.blurStrength))
         }
         if let d = draft, d.tool == .redact, d.redactStyle == .blur, d.points.count >= 2 {
-            result.append(rect(d.points[0], d.points[1]))
+            result.append(BlurRegion(rect: rect(d.points[0], d.points[1]), strength: d.blurStrength))
         }
         return result
     }
@@ -326,7 +336,7 @@ enum ScreenshotMarkup {
         let size = pixelSize(of: image)
         let composite = ZStack(alignment: .topLeading) {
             Image(nsImage: image).resizable().interpolation(.high).frame(width: size.width, height: size.height)
-            RedactBlurLayer(image: image, rects: blurRects(annotations, draft: nil))
+            RedactBlurLayer(image: image, regions: blurRegions(annotations, draft: nil))
                 .frame(width: size.width, height: size.height)
             Canvas { context, canvasSize in
                 draw(annotations, draft: nil, in: context, size: canvasSize)
@@ -367,29 +377,31 @@ enum ScreenshotMarkup {
 /// the export renderer so blur is WYSIWYG. `rects` are normalized (0...1).
 struct RedactBlurLayer: View {
     let image: NSImage
-    let rects: [CGRect]
+    let regions: [ScreenshotMarkup.BlurRegion]
 
     var body: some View {
-        if rects.isEmpty {
+        if regions.isEmpty {
             Color.clear
         } else {
             GeometryReader { geo in
-                Image(nsImage: image)
-                    .resizable()
-                    .interpolation(.high)
-                    .frame(width: geo.size.width, height: geo.size.height)
-                    .blur(radius: max(8, geo.size.width * 0.02))
-                    .mask {
-                        Canvas { context, size in
-                            for r in rects {
-                                let scaled = CGRect(
-                                    x: r.minX * size.width, y: r.minY * size.height,
-                                    width: r.width * size.width, height: r.height * size.height
+                // One blurred copy per region, each masked to its rect, so every
+                // region can carry its own blur strength.
+                ForEach(Array(regions.enumerated()), id: \.offset) { _, region in
+                    Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.high)
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .blur(radius: max(2, region.strength * geo.size.width * 0.06))
+                        .mask {
+                            let r = region.rect
+                            Rectangle()
+                                .frame(width: r.width * geo.size.width, height: r.height * geo.size.height)
+                                .position(
+                                    x: (r.minX + r.width / 2) * geo.size.width,
+                                    y: (r.minY + r.height / 2) * geo.size.height
                                 )
-                                context.fill(Path(scaled), with: .color(.white))
-                            }
                         }
-                    }
+                }
             }
             .allowsHitTesting(false)
         }

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -423,11 +423,13 @@ enum ScreenshotMarkup {
         return renderer.nsImage
     }
 
-    /// Flatten, then crop to a normalized rectangle. Returns a new image.
+    /// Flatten, then crop to a normalized rectangle. A non-zero `rotation`
+    /// extracts the tilted region, straightened. Returns a new image.
     @MainActor
-    static func crop(_ image: NSImage, annotations: [Annotation], to normalized: CGRect) -> NSImage? {
-        guard let flat = flatten(image, annotations: annotations),
-              let cg = flat.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }
+    static func crop(_ image: NSImage, annotations: [Annotation], to normalized: CGRect, rotation: Double = 0) -> NSImage? {
+        guard let flat = flatten(image, annotations: annotations) else { return nil }
+        if rotation != 0 { return straightenedCrop(flat, to: normalized, rotation: rotation) }
+        guard let cg = flat.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }
         let w = CGFloat(cg.width), h = CGFloat(cg.height)
         let pxRect = CGRect(
             x: (normalized.minX * w).rounded(),
@@ -437,6 +439,29 @@ enum ScreenshotMarkup {
         ).intersection(CGRect(x: 0, y: 0, width: w, height: h))
         guard pxRect.width >= 1, pxRect.height >= 1, let cropped = cg.cropping(to: pxRect) else { return nil }
         return NSImage(cgImage: cropped, size: NSSize(width: cropped.width, height: cropped.height))
+    }
+
+    /// Extract a rotated crop region, straightened: render the flattened image
+    /// rotated by −angle around the crop center, clipped to the output frame.
+    @MainActor
+    private static func straightenedCrop(_ flat: NSImage, to normalized: CGRect, rotation: Double) -> NSImage? {
+        let size = pixelSize(of: flat)
+        let w = size.width, h = size.height
+        let outW = max(1, (normalized.width * w).rounded())
+        let outH = max(1, (normalized.height * h).rounded())
+        let content = ZStack(alignment: .topLeading) {
+            Image(nsImage: flat)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: w, height: h)
+                .rotationEffect(.radians(-rotation), anchor: UnitPoint(x: normalized.midX, y: normalized.midY))
+                .offset(x: outW / 2 - normalized.midX * w, y: outH / 2 - normalized.midY * h)
+        }
+        .frame(width: outW, height: outH, alignment: .topLeading)
+        .clipped()
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 1
+        return renderer.nsImage
     }
 
     /// PNG bytes for an image at its pixel resolution.

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -69,6 +69,8 @@ struct Annotation: Identifiable {
     var blurStrength: Double = 0.4
     /// Fill opacity (0...1) for a solid-style redact.
     var fillOpacity: Double = 1
+    /// Rotation in radians around the annotation's bounding-box center.
+    var rotation: Double = 0
 }
 
 extension Annotation {
@@ -93,19 +95,41 @@ extension Annotation {
     /// defining points; freehand strokes expose bounding-box corners; text has
     /// none (move only).
     func handlePoints(in size: CGSize) -> [CGPoint] {
+        let raw: [CGPoint]
         switch tool {
         case .line, .arrow, .rectangle, .ellipse, .redact:
-            return points.count >= 2 ? [points[0], points[1]] : []
+            raw = points.count >= 2 ? [points[0], points[1]] : []
         case .pen, .highlighter:
             let b = boundingBox
-            return [
+            raw = [
                 CGPoint(x: b.minX, y: b.minY), CGPoint(x: b.maxX, y: b.minY),
                 CGPoint(x: b.maxX, y: b.maxY), CGPoint(x: b.minX, y: b.maxY),
             ]
         case .text:
             let b = ScreenshotMarkup.bounds(self, in: size)
-            return [CGPoint(x: b.maxX, y: b.maxY)]
+            raw = [CGPoint(x: b.maxX, y: b.maxY)]
         }
+        return raw.map { rotatedHandle($0, in: size) }
+    }
+
+    /// A handle dragged to rotate the annotation, sitting above its top edge
+    /// (nil when the annotation is empty).
+    func rotationHandle(in size: CGSize) -> CGPoint? {
+        let b = ScreenshotMarkup.bounds(self, in: size)
+        guard b.width > 0 || b.height > 0 else { return nil }
+        let offset = 26 / max(size.height, 1)
+        return rotatedHandle(CGPoint(x: b.midX, y: b.minY - offset), in: size)
+    }
+
+    /// Apply the annotation's rotation to a normalized point, rotating in pixel
+    /// space (isotropic) around the bounding-box center.
+    private func rotatedHandle(_ normalized: CGPoint, in size: CGSize) -> CGPoint {
+        guard rotation != 0 else { return normalized }
+        let b = ScreenshotMarkup.bounds(self, in: size)
+        let center = CGPoint(x: b.midX * size.width, y: b.midY * size.height)
+        let px = CGPoint(x: normalized.x * size.width, y: normalized.y * size.height)
+        let rotated = ScreenshotMarkup.rotate(px, around: center, by: rotation)
+        return CGPoint(x: rotated.x / size.width, y: rotated.y / size.height)
     }
 
     /// Translate every point, clamped so the bounding box stays within 0...1
@@ -122,7 +146,17 @@ extension Annotation {
     /// Move handle `index` to `target` (normalized). Two-point shapes move that
     /// endpoint; freehand strokes scale every point from the opposite corner.
     func resizing(handle index: Int, to target: CGPoint, in size: CGSize) -> Annotation {
-        let p = CGPoint(x: min(1, max(0, target.x)), y: min(1, max(0, target.y)))
+        // Resize handles live on the rotated shape, so map the cursor back into
+        // the un-rotated frame before applying the (rotation-agnostic) edit.
+        var localTarget = target
+        if rotation != 0 {
+            let b = ScreenshotMarkup.bounds(self, in: size)
+            let center = CGPoint(x: b.midX * size.width, y: b.midY * size.height)
+            let targetPx = CGPoint(x: target.x * size.width, y: target.y * size.height)
+            let unrotated = ScreenshotMarkup.rotate(targetPx, around: center, by: -rotation)
+            localTarget = CGPoint(x: unrotated.x / size.width, y: unrotated.y / size.height)
+        }
+        let p = CGPoint(x: min(1, max(0, localTarget.x)), y: min(1, max(0, localTarget.y)))
         var copy = self
         switch tool {
         case .line, .arrow, .rectangle, .ellipse, .redact:
@@ -156,6 +190,17 @@ extension Annotation {
         }
         return copy
     }
+
+    /// Rotate so the rotation handle (which sits above the shape) points toward
+    /// `target` (normalized). Angle is computed in pixel space (isotropic).
+    func rotated(toward target: CGPoint, in size: CGSize) -> Annotation {
+        let b = ScreenshotMarkup.bounds(self, in: size)
+        let cx = b.midX * size.width, cy = b.midY * size.height
+        let tx = target.x * size.width, ty = target.y * size.height
+        var copy = self
+        copy.rotation = atan2(ty - cy, tx - cx) + .pi / 2
+        return copy
+    }
 }
 
 /// Stateless drawing + rasterization for the screenshot editor. Drawing routines
@@ -184,36 +229,47 @@ enum ScreenshotMarkup {
         let weight = max(1, a.width * size.width / 1000)
         let solid = StrokeStyle(lineWidth: weight, lineCap: .round, lineJoin: .round)
 
+        // Rotate a copy of the context around the annotation's center; the
+        // original context is untouched for the next annotation.
+        var ctx = context
+        if a.rotation != 0 {
+            let b = bounds(a, in: size)
+            let cx = b.midX * size.width, cy = b.midY * size.height
+            ctx.translateBy(x: cx, y: cy)
+            ctx.rotate(by: Angle(radians: a.rotation))
+            ctx.translateBy(x: -cx, y: -cy)
+        }
+
         switch a.tool {
         case .pen:
-            context.stroke(freehandPath(pts), with: .color(a.color), style: solid)
+            ctx.stroke(freehandPath(pts), with: .color(a.color), style: solid)
         case .highlighter:
             let thick = StrokeStyle(lineWidth: weight * 3.5, lineCap: .round, lineJoin: .round)
-            context.stroke(freehandPath(pts), with: .color(a.color.opacity(0.35)), style: thick)
+            ctx.stroke(freehandPath(pts), with: .color(a.color.opacity(0.35)), style: thick)
         case .line:
             guard pts.count >= 2 else { return }
             var path = Path(); path.move(to: first); path.addLine(to: pts[1])
-            context.stroke(path, with: .color(a.color), style: solid)
+            ctx.stroke(path, with: .color(a.color), style: solid)
         case .arrow:
             guard pts.count >= 2 else { return }
-            drawArrow(from: first, to: pts[1], weight: weight, color: a.color, in: context)
+            drawArrow(from: first, to: pts[1], weight: weight, color: a.color, in: ctx)
         case .rectangle:
             guard pts.count >= 2 else { return }
-            context.stroke(Path(roundedRect: rect(first, pts[1]), cornerRadius: weight), with: .color(a.color), style: solid)
+            ctx.stroke(Path(roundedRect: rect(first, pts[1]), cornerRadius: weight), with: .color(a.color), style: solid)
         case .ellipse:
             guard pts.count >= 2 else { return }
-            context.stroke(Path(ellipseIn: rect(first, pts[1])), with: .color(a.color), style: solid)
+            ctx.stroke(Path(ellipseIn: rect(first, pts[1])), with: .color(a.color), style: solid)
         case .redact:
             // Solid fills here; blur regions are drawn by `RedactBlurLayer`
             // beneath this canvas (a 2-D context can't sample the image).
             guard pts.count >= 2, a.redactStyle == .solid else { return }
-            context.fill(Path(rect(first, pts[1])), with: .color(a.color.opacity(a.fillOpacity)))
+            ctx.fill(Path(rect(first, pts[1])), with: .color(a.color.opacity(a.fillOpacity)))
         case .text:
             let fontSize = max(11, size.width * 0.03 * (a.width / 6))
             let label = Text(a.text.isEmpty ? "Text" : a.text)
                 .font(.system(size: fontSize, weight: .semibold))
                 .foregroundColor(a.color)
-            context.draw(label, at: first, anchor: .topLeading)
+            ctx.draw(label, at: first, anchor: .topLeading)
         }
     }
 
@@ -242,21 +298,23 @@ enum ScreenshotMarkup {
         CGRect(x: min(a.x, b.x), y: min(a.y, b.y), width: abs(a.x - b.x), height: abs(a.y - b.y))
     }
 
-    /// A blur-style redact region: a normalized rect plus blur strength (0...1).
+    /// A blur-style redact region: a normalized rect, blur strength (0...1), and
+    /// rotation in radians around its center.
     struct BlurRegion {
         let rect: CGRect
         let strength: Double
+        let rotation: Double
     }
 
     /// Blur-style redact regions (plus an in-progress draft) — drawn by
-    /// `RedactBlurLayer`, not the 2-D canvas. Each carries its own blur strength.
+    /// `RedactBlurLayer`, not the 2-D canvas. Each carries its own blur + rotation.
     static func blurRegions(_ annotations: [Annotation], draft: Annotation?) -> [BlurRegion] {
         var result: [BlurRegion] = []
         for a in annotations where a.tool == .redact && a.redactStyle == .blur && a.points.count >= 2 {
-            result.append(BlurRegion(rect: rect(a.points[0], a.points[1]), strength: a.blurStrength))
+            result.append(BlurRegion(rect: rect(a.points[0], a.points[1]), strength: a.blurStrength, rotation: a.rotation))
         }
         if let d = draft, d.tool == .redact, d.redactStyle == .blur, d.points.count >= 2 {
-            result.append(BlurRegion(rect: rect(d.points[0], d.points[1]), strength: d.blurStrength))
+            result.append(BlurRegion(rect: rect(d.points[0], d.points[1]), strength: d.blurStrength, rotation: d.rotation))
         }
         return result
     }
@@ -276,6 +334,14 @@ enum ScreenshotMarkup {
         return CGRect(x: origin.x, y: origin.y, width: measured.width / size.width, height: measured.height / size.height)
     }
 
+    /// Rotate `p` around `center` by `angle` radians. Use a consistent space —
+    /// pixels — so it's isotropic.
+    static func rotate(_ p: CGPoint, around center: CGPoint, by angle: Double) -> CGPoint {
+        let s = sin(angle), c = cos(angle)
+        let dx = p.x - center.x, dy = p.y - center.y
+        return CGPoint(x: center.x + dx * c - dy * s, y: center.y + dx * s + dy * c)
+    }
+
     // MARK: - Hit-testing (display-pixel space, so it's isotropic)
 
     /// Index of the top-most annotation under `point` (display px), or nil. Area
@@ -287,7 +353,15 @@ enum ScreenshotMarkup {
         return nil
     }
 
-    private static func hits(_ a: Annotation, _ p: CGPoint, _ display: CGSize, _ tol: CGFloat) -> Bool {
+    private static func hits(_ a: Annotation, _ point: CGPoint, _ display: CGSize, _ tol: CGFloat) -> Bool {
+        // Map the cursor into the annotation's un-rotated frame, then test the
+        // upright geometry.
+        var p = point
+        if a.rotation != 0 {
+            let b = bounds(a, in: display)
+            let center = CGPoint(x: b.midX * display.width, y: b.midY * display.height)
+            p = rotate(point, around: center, by: -a.rotation)
+        }
         switch a.tool {
         case .rectangle, .ellipse, .redact, .text:
             let b = bounds(a, in: display)
@@ -399,6 +473,7 @@ struct RedactBlurLayer: View {
                             let r = region.rect
                             Rectangle()
                                 .frame(width: r.width * geo.size.width, height: r.height * geo.size.height)
+                                .rotationEffect(.radians(region.rotation))
                                 .position(
                                     x: (r.minX + r.width / 2) * geo.size.width,
                                     y: (r.minY + r.height / 2) * geo.size.height

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -99,7 +99,8 @@ extension Annotation {
                 CGPoint(x: b.maxX, y: b.maxY), CGPoint(x: b.minX, y: b.maxY),
             ]
         case .text:
-            return []
+            let b = boundingBox
+            return [CGPoint(x: b.maxX, y: b.maxY)]
         }
     }
 
@@ -138,7 +139,12 @@ extension Annotation {
                 )
             }
         case .text:
-            break
+            // Drag the corner handle to scale the text: its distance below the
+            // top-left anchor sets the font scale (`width`, which drives font size).
+            if let anchor = points.first {
+                let height = max(0.012, p.y - anchor.y)
+                copy.width = min(60, max(2, height * 120))
+            }
         }
         return copy
     }

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -391,7 +391,10 @@ struct RedactBlurLayer: View {
                         .resizable()
                         .interpolation(.high)
                         .frame(width: geo.size.width, height: geo.size.height)
-                        .blur(radius: max(2, region.strength * geo.size.width * 0.06))
+                        // `opaque: true` clamps the edges; without it the blur
+                        // fades to transparent at the borders and the sharp
+                        // original leaks through (corners/edges look unblurred).
+                        .blur(radius: max(2, region.strength * geo.size.width * 0.06), opaque: true)
                         .mask {
                             let r = region.rect
                             Rectangle()

--- a/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotMarkup.swift
@@ -88,7 +88,7 @@ extension Annotation {
     /// Normalized resize-handle positions. Two-point shapes expose their two
     /// defining points; freehand strokes expose bounding-box corners; text has
     /// none (move only).
-    var handlePoints: [CGPoint] {
+    func handlePoints(in size: CGSize) -> [CGPoint] {
         switch tool {
         case .line, .arrow, .rectangle, .ellipse, .redact:
             return points.count >= 2 ? [points[0], points[1]] : []
@@ -99,7 +99,7 @@ extension Annotation {
                 CGPoint(x: b.maxX, y: b.maxY), CGPoint(x: b.minX, y: b.maxY),
             ]
         case .text:
-            let b = boundingBox
+            let b = ScreenshotMarkup.bounds(self, in: size)
             return [CGPoint(x: b.maxX, y: b.maxY)]
         }
     }
@@ -117,7 +117,7 @@ extension Annotation {
 
     /// Move handle `index` to `target` (normalized). Two-point shapes move that
     /// endpoint; freehand strokes scale every point from the opposite corner.
-    func resizing(handle index: Int, to target: CGPoint) -> Annotation {
+    func resizing(handle index: Int, to target: CGPoint, in size: CGSize) -> Annotation {
         let p = CGPoint(x: min(1, max(0, target.x)), y: min(1, max(0, target.y)))
         var copy = self
         switch tool {
@@ -139,11 +139,15 @@ extension Annotation {
                 )
             }
         case .text:
-            // Drag the corner handle to scale the text: its distance below the
-            // top-left anchor sets the font scale (`width`, which drives font size).
+            // Scale the font so the handle tracks the cursor: grow `width` by the
+            // ratio of the new box height (cursor below the anchor) to the current
+            // measured height.
             if let anchor = points.first {
-                let height = max(0.012, p.y - anchor.y)
-                copy.width = min(60, max(2, height * 120))
+                let currentHeight = ScreenshotMarkup.bounds(self, in: size).height
+                let newHeight = max(0.01, p.y - anchor.y)
+                if currentHeight > 0.0001 {
+                    copy.width = min(80, max(2, width * newHeight / currentHeight))
+                }
             }
         }
         return copy
@@ -247,6 +251,21 @@ enum ScreenshotMarkup {
         return result
     }
 
+    // MARK: - Geometry
+
+    /// Normalized bounding box of an annotation at a given render size. Text is
+    /// measured with its real font so the box wraps the glyphs; other tools use
+    /// their point-based box (render-independent).
+    static func bounds(_ a: Annotation, in size: CGSize) -> CGRect {
+        guard a.tool == .text, let origin = a.points.first, size.width > 0, size.height > 0 else {
+            return a.boundingBox
+        }
+        let fontSize = max(11, size.width * 0.03 * (a.width / 6))
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
+        let measured = ((a.text.isEmpty ? "Text" : a.text) as NSString).size(withAttributes: [.font: font])
+        return CGRect(x: origin.x, y: origin.y, width: measured.width / size.width, height: measured.height / size.height)
+    }
+
     // MARK: - Hit-testing (display-pixel space, so it's isotropic)
 
     /// Index of the top-most annotation under `point` (display px), or nil. Area
@@ -261,7 +280,7 @@ enum ScreenshotMarkup {
     private static func hits(_ a: Annotation, _ p: CGPoint, _ display: CGSize, _ tol: CGFloat) -> Bool {
         switch a.tool {
         case .rectangle, .ellipse, .redact, .text:
-            let b = a.boundingBox
+            let b = bounds(a, in: display)
             let box = CGRect(
                 x: b.minX * display.width, y: b.minY * display.height,
                 width: b.width * display.width, height: b.height * display.height

--- a/App/Sources/FeatureDetail/Views/SimulateView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulateView.swift
@@ -61,6 +61,7 @@ struct SimulateView: View {
                     Slider(value: $fontScale, in: 0.85...1.3, step: 0.05)
                 }
                 TextField("Density (dpi, blank = keep)", text: $density)
+                    .brandField()
                     .frame(maxWidth: 200)
                 Button("Apply") {
                     var params: [String: FeatureValue] = ["fontScale": .number(fontScale)]
@@ -90,6 +91,7 @@ struct SimulateView: View {
 
             Section("Proxy") {
                 TextField("Proxy (host:port)", text: $proxy)
+                    .brandField()
                     .frame(maxWidth: 200)
                 HStack {
                     Button("Set") { run("http-proxy", ["proxy": .string(proxy.trimmingCharacters(in: .whitespaces))]) }

--- a/App/Sources/FeatureDetail/Views/WiFiView.swift
+++ b/App/Sources/FeatureDetail/Views/WiFiView.swift
@@ -83,7 +83,7 @@ struct WiFiView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Connect to a network").font(.headline)
             HStack {
-                TextField("SSID", text: $newSSID).textFieldStyle(.roundedBorder)
+                TextField("SSID", text: $newSSID).brandField()
                 Picker("", selection: $newSecurity) {
                     Text("WPA2").tag("wpa2")
                     Text("WPA3").tag("wpa3")
@@ -92,7 +92,7 @@ struct WiFiView: View {
                 .labelsHidden()
                 .frame(width: 110)
             }
-            SecureField("Password (blank for open)", text: $newPassword).textFieldStyle(.roundedBorder)
+            SecureField("Password (blank for open)", text: $newPassword).brandField()
             HStack {
                 Text("`cmd wifi connect-network` (Android 11+); some ROMs block it over adb.")
                     .font(.caption)

--- a/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
+++ b/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
@@ -36,14 +36,18 @@ struct WirelessAdbSection: View {
 
         Section("Pair (Android 11+)") {
             TextField("Host / IP", text: $host, prompt: Text("192.168.1.42"))
+                .brandField()
             TextField("Pairing port", text: $pairingPort, prompt: Text("37123"))
+                .brandField()
             TextField("Pairing code", text: $pairingCode, prompt: Text("123456"))
+                .brandField()
             Button("Pair") {
                 pair()
             }
             .disabled(busy || host.isEmpty || pairingPort.isEmpty || pairingCode.isEmpty)
 
             TextField("Connection port", text: $connectionPort, prompt: Text("5555"))
+                .brandField()
             Button("Connect") {
                 connect()
             }

--- a/App/Sources/Root/BundleManagerView.swift
+++ b/App/Sources/Root/BundleManagerView.swift
@@ -55,7 +55,9 @@ struct BundleManagerView: View {
             Text(editingBundle == nil ? "Add new bundle" : "Edit bundle")
                 .font(.subheadline.bold())
             TextField("Nickname (e.g. My App)", text: $nickname)
+                .brandField()
             TextField("Package id (e.g. com.myapp)", text: $packageId)
+                .brandField()
 
             HStack {
                 Spacer()

--- a/App/Sources/Root/InstalledAppsPickerView.swift
+++ b/App/Sources/Root/InstalledAppsPickerView.swift
@@ -30,7 +30,7 @@ struct InstalledAppsPickerView: View {
 
             HStack(spacing: 10) {
                 TextField("Filter…", text: $filter)
-                    .textFieldStyle(.roundedBorder)
+                    .brandField()
                 Toggle("System apps", isOn: $includeSystem)
                     .toggleStyle(.checkbox)
             }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -63,21 +63,22 @@ struct RootView: View {
 
     /// macOS ignores SwiftUI dynamic type, so ⌘=/⌘- zoom is done by scaling the
     /// content: it's laid out at size/scale, then scaled up to fill the window,
-    /// which enlarges every font and reflows the layout. The transform breaks
-    /// `.help` tooltips, so at 1.0× (the default) the content renders untouched.
-    @ViewBuilder
+    /// which enlarges every font and reflows the layout. The GeometryReader and
+    /// scaleEffect wrap `split` unconditionally — at 1.0× it's an identity
+    /// transform (no coordinate offset, so `.help`/hover/chart selection keep
+    /// working) — so `split` holds one stable view identity across zoom steps.
+    /// Branching on the scale (plain `split` at 1.0×, wrapped otherwise) moved
+    /// `split` between two conditional branches, which rebuilt the subtree and
+    /// wiped descendants' @State (e.g. a captured screenshot) on every zoom
+    /// across 1.0×.
     private var zoomedContent: some View {
-        if state.fontScale == 1.0 {
+        GeometryReader { geo in
             split
-        } else {
-            GeometryReader { geo in
-                split
-                    .frame(
-                        width: geo.size.width / state.fontScale,
-                        height: geo.size.height / state.fontScale
-                    )
-                    .scaleEffect(state.fontScale, anchor: .topLeading)
-            }
+                .frame(
+                    width: geo.size.width / state.fontScale,
+                    height: geo.size.height / state.fontScale
+                )
+                .scaleEffect(state.fontScale, anchor: .topLeading)
         }
     }
 

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -6,10 +6,13 @@ import UniformTypeIdentifiers
 
 extension FeatureDef {
     /// Instant actions taking no input fire immediately (click or ⏎) and show
-    /// only a toast — no detail screen. Screenshot keeps its panel (delay +
-    /// preview); an unimplemented action falls back to its placeholder.
+    /// only a toast — no detail screen. Toggle actions flip in place too (the
+    /// sidebar switch shows state, so they need no screen); Screenshot keeps its
+    /// panel (delay + preview); an unimplemented action falls back to its
+    /// placeholder.
     var firesWithoutScreen: Bool {
-        kind == .instantAction && id != "screenshot" && FeatureEngine.implementedIDs.contains(id)
+        (kind == .instantAction || kind == .toggleAction)
+            && id != "screenshot" && FeatureEngine.implementedIDs.contains(id)
     }
 }
 

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -117,7 +117,7 @@ struct SidebarPaletteView: View {
         @Bindable var state = state
         VStack(spacing: 0) {
             TextField("Search features…", text: $state.searchText)
-                .textFieldStyle(.roundedBorder)
+                .brandField()
                 .controlSize(.large)
                 .font(.title3)
                 .focused($searchFocused)

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -536,6 +536,12 @@ final class AppState {
         }
 
         var params = params
+        // A state-override fired without an explicit target flips its current
+        // state — so a sidebar tap, hotkey, or ⌘K toggles it in place with no
+        // detail screen (the sidebar switch reflects the result).
+        if feature.isStateOverride, params["on"] == nil, let kind = feature.overrideKind {
+            params["on"] = .bool(!activeOverrides.contains { $0.kind == kind })
+        }
         if feature.needsBundle {
             guard let bundle = selectedBundle else {
                 showToast(Toast(message: "Pick a saved bundle first.", ok: false))

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -591,7 +591,7 @@ final class AppState {
 
     private func show(_ result: FeatureResult) {
         // A result that carries copyText (Copy Device IP, Copy Foreground
-        // Bundle ID, Current Activity) lands on the clipboard immediately — the
+        // Bundle ID, Copy Current Activity) lands on the clipboard immediately — the
         // point of these actions — so a sidebar click is all it takes.
         var message = result.message
         if let copyText = result.copyText {

--- a/App/Sources/State/HotkeyManager.swift
+++ b/App/Sources/State/HotkeyManager.swift
@@ -45,7 +45,7 @@ enum HotkeyManager {
         for feature in FeatureRegistry.all {
             KeyboardShortcuts.onKeyUp(for: featureName(feature.id)) { [weak state] in
                 guard let state else { return }
-                if feature.kind == .instantAction {
+                if feature.kind == .instantAction || feature.kind == .toggleAction {
                     Task { await state.run(feature: feature, params: [:]) }
                 } else {
                     state.activateMainWindow()

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ test:
 	cd ADBKit && swift test
 
 run: build
+	-pkill -x Droidective
+	@sleep 0.3
 	open "DerivedData/Build/Products/Debug/Droidective.app"
 
 dmg: generate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+## Droidective v2.3.0
+
+A big screenshot-editor update — annotations you can move, resize, and rotate
+after drawing, blur and opacity controls, editable text, and a rotatable crop —
+plus a handful of fixes.
+
+### New features
+
+- **Editable annotations** — select any markup (shapes, arrows, pen, text,
+  redactions) to move, resize, or delete it; a freshly drawn one is selected
+  automatically so you can adjust it right away.
+- **Rotate** — rotate any annotation, the crop box, or the whole screenshot
+  (90°) with a drag handle.
+- **Redaction controls** — adjustable blur strength for blur redactions, and
+  fill opacity for solid ones.
+- **Editable text** — re-open a text label to change it, and drag a handle to
+  resize it.
+- **Rotatable crop** — tilt the crop box to straighten as you crop.
+
+### Fixes
+
+- Text fields now show the brand-green focus ring on every Mac (it followed the
+  macOS system accent before) and dim when the window is inactive.
+- Blur redaction no longer leaks the original image at its edges.
+- ⌘= / ⌘- zoom no longer discards in-progress work, such as a captured
+  screenshot.
+- **Apps** — uninstalling a user app no longer reports a false "protected"
+  error, and the detail pane clears once the app is removed.
+- Demo Mode is a sidebar toggle instead of a separate screen.
+- Renamed **Current Activity** to **Copy Current Activity**.
+
+### Install
+
+Download the `.dmg` below and drag **Droidective** into **Applications**. The
+build is ad-hoc signed but not notarized, so clear the quarantine once:
+
+```sh
+xattr -dr com.apple.quarantine "/Applications/Droidective.app"
+```
+
+Installed copies from v2.1.0+ update in place via Sparkle.
+
 ## Droidective v2.2.1
 
 A fix for the accent color on Macs set to a specific system accent.

--- a/project.yml
+++ b/project.yml
@@ -57,7 +57,7 @@ targets:
       base:
         PRODUCT_NAME: Droidective
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
-        MARKETING_VERSION: "2.2.1"
+        MARKETING_VERSION: "2.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
## Screenshot editor

- **Edit annotations after drawing** — a Select tool to move/resize anything; freshly drawn items auto-select; the trash deletes the selection.
- **Rotation** — rotate any annotation (and the crop box) with a drag handle; rotate the whole image 90° (left/right).
- **Redaction** — per-region **blur strength** and per-region solid **fill opacity** sliders; blur no longer leaks the original at its edges (rendered `opaque`).
- **Text** — re-editable (Edit Text button), a resize handle, and a selection box that fits the actual glyphs.
- **Crop** — icon-only button; a **rotatable crop** that straightens the tilted region on Apply.
- **Color** — the custom picker shows a color-wheel logo with a bit of spacing.

## Apps

- Fix the false "protected" error when uninstalling a **user** app (`pm uninstall --user 0` fully removes it, so `states()` is nil — no longer misread as a failure), and clear the stale detail pane after an uninstall. Adds `SystemAppsService.uninstallOutcome` with a test.

## Other UI fixes

- Text-field focus ring is brand-green on every Mac (it followed the system accent before), and dims when the window goes inactive.
- ⌘= / ⌘- zoom no longer wipes feature state (e.g. a captured screenshot) — the content keeps a stable view identity.
- Demo Mode is a sidebar toggle, not a redundant detail screen.
- Rename **Current Activity → Copy Current Activity**.
- `make run` relaunches the app (kills the old instance first) instead of focusing a stale one.

Tests: 187 ADBKit tests green; build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
