### PR TITLE
Inject telemetry keys at build time instead of committing them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,16 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Build and package release DMG
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release \
             -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO \
-            MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="${{ github.run_number }}"
+            MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
+            SENTRY_DSN="$SENTRY_DSN" POSTHOG_KEY="$POSTHOG_KEY"
           ./scripts/package-dmg.sh "${GITHUB_REF_NAME}"
       - name: Extract notes for this release
         run: awk '/^## /{c++} c==1{print} c==2{exit}' RELEASE_NOTES.md > release-body.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ xcuserdata/
 App/Info.plist
 .sparkle/
 sparkle-private-key.txt
+.env.telemetry
 .claude/

--- a/App/Sources/Telemetry/TelemetryConfig.swift
+++ b/App/Sources/Telemetry/TelemetryConfig.swift
@@ -1,16 +1,23 @@
 import Foundation
 
 /// Telemetry endpoints. These are client-side write keys (designed to ship in
-/// the app binary). Leave a placeholder to keep that channel disabled — the
-/// SDK is never started until a real value is present.
+/// the app binary), but they're injected at build time from the `SENTRY_DSN` and
+/// `POSTHOG_KEY` build settings into Info.plist (see project.yml / RELEASING.md)
+/// rather than committed, so forks don't report to the upstream projects and the
+/// values can be rotated without a code change. A build without the keys leaves
+/// each value empty, which keeps that SDK from ever starting.
 enum TelemetryConfig {
     /// Sentry DSN — Project Settings → Client Keys (DSN). Client-side write key.
-    static let sentryDSN = "https://b1623c7ab30b0b7c0297cf880979b9b1@o4511598359609344.ingest.de.sentry.io/4511598365835344"
+    static let sentryDSN = infoValue("SentryDSN")
 
     /// PostHog project token (starts with `phc_`) and cloud host. Client-side key.
-    static let postHogKey = "phc_pBw3mRbMGvFHTZV5ipCHo5WwQUkiwFpqVrBaq9jdkFkV"
+    static let postHogKey = infoValue("PostHogKey")
     static let postHogHost = "https://us.i.posthog.com"  // US project (verified)
 
     static var sentryConfigured: Bool { sentryDSN.hasPrefix("https://") }
     static var analyticsConfigured: Bool { postHogKey.hasPrefix("phc_") }
+
+    private static func infoValue(_ key: String) -> String {
+        (Bundle.main.object(forInfoDictionaryKey: key) as? String) ?? ""
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 .PHONY: generate build test run dmg clean
 
+# Optional telemetry keys for local builds. Create .env.telemetry (gitignored)
+# with SENTRY_DSN=... and POSTHOG_KEY=... to enable crash/analytics locally.
+# Without it both stay empty, so neither SDK starts — fine for development.
+-include .env.telemetry
+TELEMETRY := SENTRY_DSN="$(SENTRY_DSN)" POSTHOG_KEY="$(POSTHOG_KEY)"
+
 generate:
 	xcodegen generate
 
 build: generate
-	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Debug -derivedDataPath DerivedData build
+	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Debug -derivedDataPath DerivedData build $(TELEMETRY)
 
 test:
 	cd ADBKit && swift test
@@ -15,7 +21,7 @@ run: build
 	open "DerivedData/Build/Products/Debug/Droidective.app"
 
 dmg: generate
-	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build
+	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build $(TELEMETRY)
 	./scripts/package-dmg.sh $(VERSION)
 
 clean:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,20 +80,40 @@ Ranking for competitive terms still needs links and time:
 ### 5. Configure telemetry (optional)
 
 Crash reporting (Sentry) and opt-in analytics (PostHog) stay disabled until you
-add keys in `App/Sources/Telemetry/TelemetryConfig.swift`:
+supply keys. They are **not** committed to source — they're injected at build
+time from the `SENTRY_DSN` and `POSTHOG_KEY` build settings into Info.plist
+(`project.yml` → `info.properties`), so forks don't report to your projects and
+the values can be rotated without a code change. Any build without them leaves
+both empty, and neither SDK starts.
 
-- **Sentry** — paste your DSN (Sentry → Project Settings → Client Keys) into
-  `sentryDSN`. Crash + performance monitoring; anonymous (no PII); on by default
-  for users, opt-out in Settings → Privacy.
-- **PostHog** — paste your project token (starts with `phc_`) into `postHogKey`
-  and set `postHogHost` to your region (`us` or `eu`). Product analytics;
-  anonymous (`personProfiles = .never`, never identified); **opt-in only**.
+- **Sentry** — your DSN (Sentry → Project Settings → Client Keys). Crash +
+  performance monitoring; anonymous (no PII); on by default for users, opt-out in
+  Settings → Privacy.
+- **PostHog** — your project token (starts with `phc_`). Product analytics;
+  anonymous (`personProfiles = .never`, never identified); **opt-in only**. The
+  host is hardcoded to the US endpoint in `TelemetryConfig.swift` — change it
+  there if you're on EU.
 
-Both are client-side write keys, safe to ship in the binary; with the
-placeholders left in place neither SDK starts. Users get a one-time privacy
-disclosure on first launch, managed afterward in Settings → Privacy. Analytics
-sends only the feature id — never device serials, package names, paths, IPs, or
-command contents. Sentry owns crash handling (PostHog's `autoCapture` is off).
+**For CI release builds:** add two repository secrets under **Settings → Secrets
+and variables → Actions** — `SENTRY_DSN` and `POSTHOG_KEY`. The `release` job
+passes them to `xcodebuild`; the plain PR/`main` `build` job leaves them empty on
+purpose (throwaway builds, and fork PRs can't read secrets anyway).
+
+**For local builds:** create `.env.telemetry` (gitignored) in the repo root:
+
+```sh
+SENTRY_DSN=https://…@…ingest.sentry.io/…
+POSTHOG_KEY=phc_…
+```
+
+`make build` / `make dmg` pick it up automatically. Without it, local builds run
+with telemetry disabled — fine for development.
+
+Both are client-side write keys, safe to ship in the binary. Users get a one-time
+privacy disclosure on first launch, managed afterward in Settings → Privacy.
+Analytics sends only the feature id — never device serials, package names, paths,
+IPs, or command contents. Sentry owns crash handling (PostHog's `autoCapture` is
+off).
 
 ## Cutting a release
 

--- a/project.yml
+++ b/project.yml
@@ -50,6 +50,8 @@ targets:
         LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
         LSApplicationCategoryType: public.app-category.developer-tools
         NSHumanReadableCopyright: ""
+        SentryDSN: $(SENTRY_DSN)
+        PostHogKey: $(POSTHOG_KEY)
         SUFeedURL: https://rohindh-r.github.io/Droidective/appcast.xml
         SUPublicEDKey: "ma0kTe35r55/PKmemQOEBX7n6SuZPZjOBo973SdJqJ8="
         SUEnableAutomaticChecks: true
@@ -57,6 +59,8 @@ targets:
       base:
         PRODUCT_NAME: Droidective
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
+        SENTRY_DSN: ""
+        POSTHOG_KEY: ""
         MARKETING_VERSION: "2.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"


### PR DESCRIPTION
Moves the Sentry DSN and PostHog project token out of `TelemetryConfig.swift` so they no longer live in committed source on a public repo.

## What changed
- `TelemetryConfig.swift` reads `SentryDSN`/`PostHogKey` from `Info.plist` instead of hardcoded literals. Empty values keep each SDK from starting.
- `project.yml` adds `SENTRY_DSN`/`POSTHOG_KEY` build settings (empty default) and maps them to the `SentryDSN`/`PostHogKey` Info.plist entries — same pattern already used for `MARKETING_VERSION`.
- CI `release` job injects the keys from repository secrets `SENTRY_DSN`/`POSTHOG_KEY`. The PR/`main` `build` job leaves them empty (throwaway builds; fork PRs can't read secrets anyway).
- `Makefile` reads an optional gitignored `.env.telemetry` for local builds via the `TELEMETRY` var (`build` and `dmg`).
- `.gitignore` ignores `.env.telemetry`.
- `RELEASING.md` documents the new flow and the two repository secrets.

## Required before next release
Add two repository secrets under Settings → Secrets and variables → Actions: `SENTRY_DSN` and `POSTHOG_KEY`. Without them, release DMGs build with telemetry disabled (no build failure).

## Verification
- Build with `.env.telemetry` present → keys land in the built app's `Info.plist`.
- Build with empty values → `Info.plist` entries blank → `sentryConfigured`/`analyticsConfigured` are false → neither SDK starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)