### PR TITLE
Release v2.4.0: Developer ID signing, notarization, and self-contained bundling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,20 +85,54 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
-      - name: Install XcodeGen
-        run: brew install xcodegen
-      - name: Build and package release DMG
+      - name: Install build tools
+        run: brew install xcodegen dylibbundler
+      - name: Import Developer ID certificate
+        env:
+          DEVELOPER_ID_CERT_P12: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
+          DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          echo "$DEVELOPER_ID_CERT_P12" | openssl base64 -d -A > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$DEVELOPER_ID_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/cert.p12"
+      - name: Build, bundle tools, sign, and package DMG
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          SIGN_IDENTITY: ${{ secrets.DEVELOPER_ID_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release \
-            -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO \
+            -derivedDataPath DerivedData build \
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
-            SENTRY_DSN="$SENTRY_DSN" POSTHOG_KEY="$POSTHOG_KEY"
-          ./scripts/package-dmg.sh "${GITHUB_REF_NAME}"
+            SENTRY_DSN="$SENTRY_DSN" POSTHOG_KEY="$POSTHOG_KEY" \
+            CODE_SIGN_IDENTITY="$SIGN_IDENTITY" DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            CODE_SIGN_STYLE=Manual ENABLE_HARDENED_RUNTIME=YES OTHER_CODE_SIGN_FLAGS="--timestamp"
+          ./scripts/bundle-tools.sh "DerivedData/Build/Products/Release/Droidective.app"
+          SIGN_IDENTITY="$SIGN_IDENTITY" ./scripts/package-dmg.sh "${GITHUB_REF_NAME}"
+      - name: Notarize and staple
+        env:
+          AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+        run: |
+          echo "$AC_API_KEY_P8" | openssl base64 -d -A > "$RUNNER_TEMP/ac_api.p8"
+          AC_API_KEY_PATH="$RUNNER_TEMP/ac_api.p8" \
+          AC_API_KEY_ID="$AC_API_KEY_ID" \
+          AC_API_ISSUER_ID="$AC_API_ISSUER_ID" \
+            ./scripts/notarize.sh "DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg"
+          rm -f "$RUNNER_TEMP/ac_api.p8"
       - name: Extract notes for this release
         run: awk '/^## /{c++} c==1{print} c==2{exit}' RELEASE_NOTES.md > release-body.md
       - name: Publish release with build
@@ -118,6 +152,23 @@ jobs:
           mkdir -p _site
           cp -R site/. _site/
           ./scripts/update-appcast.sh "$DMG" "$VERSION" "${{ github.run_number }}" "${GITHUB_REF_NAME}" "$DOWNLOAD_URL" "_site/appcast.xml"
+      - name: Update Homebrew cask
+        continue-on-error: true
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          [[ -n "${HOMEBREW_TAP_TOKEN:-}" ]] || { echo "no HOMEBREW_TAP_TOKEN — skipping cask update"; exit 0; }
+          VERSION="${GITHUB_REF_NAME#v}"
+          DMG="DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg"
+          URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/Droidective-${GITHUB_REF_NAME}.dmg"
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Rohindh-R/homebrew-tap.git" tap
+          ./scripts/update-cask.sh "$VERSION" "$DMG" "$URL" "tap/Casks/droidective.rb"
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/droidective.rb
+          git diff --cached --quiet || git commit -m "droidective ${VERSION}"
+          git push
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: _site

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@ App/Info.plist
 .sparkle/
 sparkle-private-key.txt
 .env.telemetry
+.env.signing
+*.p12
+AuthKey_*.p8
 .claude/

--- a/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
+++ b/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
@@ -30,14 +30,20 @@ public actor ToolLocator {
     private var cache: [Tool: String?] = [:]
     private let runner: any ProcessRunning
     private let environment: [String: String]
+    /// Directory holding tool copies shipped inside the app bundle (scrcpy,
+    /// ffmpeg). When set, a bundled copy is preferred over any system install,
+    /// so a self-contained build never depends on Homebrew.
+    private let bundledToolsDirectory: URL?
     private let fileManager = FileManager.default
 
     public init(
         runner: any ProcessRunning = SystemProcessRunner(),
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundledToolsDirectory: URL? = nil
     ) {
         self.runner = runner
         self.environment = environment
+        self.bundledToolsDirectory = bundledToolsDirectory
     }
 
     public func resolve(_ tool: Tool) async -> String? {
@@ -82,16 +88,20 @@ public actor ToolLocator {
             "\(home)/Library/Android/sdk",
         ].compactMap(\.self)
 
+        let system: [String]
         switch tool {
         case .adb:
-            return sdkRoots.map { "\($0)/platform-tools/adb" }
+            system = sdkRoots.map { "\($0)/platform-tools/adb" }
                 + brewPrefixes.map { "\($0)/adb" }
         case .emulator:
             // The emulator launcher only ships with the SDK, not Homebrew.
-            return sdkRoots.map { "\($0)/emulator/emulator" }
+            system = sdkRoots.map { "\($0)/emulator/emulator" }
         case .scrcpy, .brew, .ffmpeg:
-            return brewPrefixes.map { "\($0)/\(tool.rawValue)" }
+            system = brewPrefixes.map { "\($0)/\(tool.rawValue)" }
         }
+
+        guard let bundledToolsDirectory else { return system }
+        return [bundledToolsDirectory.appendingPathComponent(tool.rawValue).path] + system
     }
 
     private func resolveViaLoginShell(_ tool: Tool) async -> String? {

--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -347,6 +347,16 @@ public struct FeatureEngine: Sendable {
         process.arguments = ["-s", serial] + options.args(recordingPath: recordingPath)
         var environment = ProcessInfo.processInfo.environment
         environment["ADB"] = adbPath
+        // A bundled scrcpy (Contents/Helpers/scrcpy) ships its server alongside
+        // it under Contents/Resources; point scrcpy at it. A Homebrew scrcpy
+        // finds its own server, so this is skipped when the file isn't present.
+        let bundledServer = URL(fileURLWithPath: scrcpyPath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/scrcpy-server")
+        if FileManager.default.fileExists(atPath: bundledServer.path) {
+            environment["SCRCPY_SERVER_PATH"] = bundledServer.path
+        }
         let extraPaths = [
             (adbPath as NSString).deletingLastPathComponent,
             (scrcpyPath as NSString).deletingLastPathComponent,

--- a/ADBKit/Tests/ADBKitTests/ToolLocatorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ToolLocatorTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct ToolLocatorTests {
+    private func makeBundledDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("adbkit-bundled-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func writeExecutable(_ url: URL) {
+        FileManager.default.createFile(
+            atPath: url.path, contents: Data(), attributes: [.posixPermissions: 0o755]
+        )
+    }
+
+    @Test func bundledToolIsPreferredOverSystemInstalls() async {
+        let dir = makeBundledDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let scrcpy = dir.appendingPathComponent("scrcpy")
+        writeExecutable(scrcpy)
+
+        let locator = ToolLocator(
+            runner: MockProcessRunner(),
+            environment: ["ANDROID_HOME": "/opt/android"],
+            bundledToolsDirectory: dir
+        )
+        #expect(await locator.resolve(.scrcpy) == scrcpy.path)
+    }
+
+    @Test func emptyBundledDirectoryIsNotFalselyMatched() async {
+        let dir = makeBundledDir() // empty — no binaries inside
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // With no bundled copy present, resolution must skip the bundled
+        // directory (the path inside it doesn't exist) and fall through to the
+        // normal system search — it must never return the non-existent
+        // bundled path itself.
+        let locator = ToolLocator(
+            runner: MockProcessRunner(),
+            environment: [:],
+            bundledToolsDirectory: dir
+        )
+        let resolved = await locator.resolve(.ffmpeg)
+        #expect(resolved != dir.appendingPathComponent("ffmpeg").path)
+    }
+}

--- a/App/Sources/State/AppEnvironment.swift
+++ b/App/Sources/State/AppEnvironment.swift
@@ -11,11 +11,17 @@ struct AppEnvironment: Sendable {
     let stores: AppStores
 
     init() {
-        locator = ToolLocator()
+        locator = ToolLocator(bundledToolsDirectory: Self.bundledToolsDirectory)
         commandLog = CommandLog()
         client = AdbClient(locator: locator, log: commandLog)
         monitor = DeviceMonitor(client: client)
         stores = AppStores()
         engine = FeatureEngine(client: client, locator: locator, monitor: monitor, overridesStore: stores.overrides)
     }
+
+    /// scrcpy/ffmpeg copies shipped inside the app bundle (injected at packaging
+    /// time by scripts/bundle-tools.sh). Absent in dev builds, where the locator
+    /// falls back to the developer's Homebrew/SDK installs.
+    private static let bundledToolsDirectory = Bundle.main.bundleURL
+        .appendingPathComponent("Contents/Helpers", isDirectory: true)
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ feature for existing users via `knownIds`.
 Feature-complete across all planned milestones plus several UX rounds (latest:
 **v2.2.0** — theme/hub overhaul, screenshot annotation editor, all-features-on
 default, live memory graph); 186 tests green; builds clean with zero warnings.
-Verified live against a physical device and an Android emulator. Open gaps: no
-notarization (ad-hoc signed — see README for the Gatekeeper workaround), the Apps
-list/detail divider isn't drag-resizable.
+Verified live against a physical device and an Android emulator. Release builds
+are Developer ID-signed + notarized and bundle scrcpy/ffmpeg
+(see `RELEASING.md`). Open gaps: the Apps list/detail divider isn't
+drag-resizable.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,18 @@
 -include .env.telemetry
 TELEMETRY := SENTRY_DSN="$(SENTRY_DSN)" POSTHOG_KEY="$(POSTHOG_KEY)"
 
+# Optional Developer ID signing for `make dmg`. Create .env.signing (gitignored)
+# with SIGN_IDENTITY="Developer ID Application: … (TEAMID)" and
+# DEVELOPMENT_TEAM=TEAMID for a notarizable build. Without it the DMG is ad-hoc
+# signed — fine for local testing, but Gatekeeper still warns.
+-include .env.signing
+SIGN_IDENTITY ?= -
+ifeq ($(SIGN_IDENTITY),-)
+SIGNING :=
+else
+SIGNING := CODE_SIGN_IDENTITY="$(SIGN_IDENTITY)" DEVELOPMENT_TEAM="$(DEVELOPMENT_TEAM)" CODE_SIGN_STYLE=Manual ENABLE_HARDENED_RUNTIME=YES OTHER_CODE_SIGN_FLAGS="--timestamp"
+endif
+
 generate:
 	xcodegen generate
 
@@ -21,8 +33,9 @@ run: build
 	open "DerivedData/Build/Products/Debug/Droidective.app"
 
 dmg: generate
-	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build $(TELEMETRY)
-	./scripts/package-dmg.sh $(VERSION)
+	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build $(TELEMETRY) $(SIGNING)
+	./scripts/bundle-tools.sh "DerivedData/Build/Products/Release/Droidective.app"
+	SIGN_IDENTITY="$(SIGN_IDENTITY)" ./scripts/package-dmg.sh $(VERSION)
 
 clean:
 	rm -rf DerivedData ADBKit/.build *.xcodeproj

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Built in Swift 6 + SwiftUI, with all logic in a platform-agnostic Swift package
 (`ADBKit`) so the engine stays testable and a future cross-platform port only
 needs a new UI layer.
 
-> Requires macOS 14+ and the Android `adb` tool. Ad-hoc signed (not notarized);
-> see [Building](#building) and [Install a release build](#install-a-release-build).
+> Requires macOS 14+ and the Android `adb` tool. Signed with a Developer ID and
+> notarized by Apple; see [Install a release build](#install-a-release-build).
 
 ## Features
 
@@ -68,8 +68,8 @@ font zoom. Files pulled from the device always ask where to save (default
 - [Android platform-tools](https://developer.android.com/tools/releases/platform-tools)
   (`adb`) — found automatically via `ANDROID_HOME`, `~/Library/Android/sdk`, or
   Homebrew; the app offers a one-click install if it's missing.
-- Optional: `scrcpy` (screen mirroring), `ffmpeg` (GIF export), the Android SDK
-  `emulator` (AVD management).
+- `scrcpy` (screen mirroring) and `ffmpeg` (GIF export) ship **inside the app** —
+  no install needed. Optional: the Android SDK `emulator` for AVD management.
 
 ## Building
 
@@ -85,22 +85,24 @@ make run                  # build and launch
 after a fresh clone if you want to open it in Xcode.
 
 The app runs **without the App Sandbox** (it must spawn `adb`, `scrcpy`,
-`emulator`, and `brew`) and is **ad-hoc signed** for local development.
+`emulator`, and `brew`). Local builds are ad-hoc signed; release builds are
+signed with a Developer ID and notarized (see [`RELEASING.md`](RELEASING.md)).
 
 ## Install a release build
 
-Each [GitHub release](../../releases) ships a `Droidective-<version>.dmg` built
-by CI. Open it and drag **Droidective** into **Applications**.
-
-The build is ad-hoc signed but not notarized (no paid Apple Developer account),
-so on first launch macOS quarantine shows *"Droidective is damaged and can't be
-opened."* Clear the quarantine once:
+**Homebrew (recommended):**
 
 ```sh
-xattr -dr com.apple.quarantine "/Applications/Droidective.app"
+brew install --cask rohindh-r/tap/droidective
 ```
 
-Then open it normally. Building from source avoids the quarantine entirely.
+**Direct download:** each [GitHub release](../../releases) ships a
+`Droidective-<version>.dmg`. Open it and drag **Droidective** into
+**Applications**.
+
+The app is signed with a Developer ID and notarized by Apple, so it opens
+normally — no Gatekeeper warning, no `xattr` workaround. It keeps itself current
+through Sparkle (and `brew upgrade` defers to that).
 
 ## Architecture
 
@@ -130,5 +132,6 @@ Issues and PRs welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 [MIT](LICENSE) © 2026 Rohindh R.
 
-scrcpy, ffmpeg, adb, and the Android emulator are separate tools with their own
-licenses; Droidective shells out to them and does not bundle them.
+adb and the Android emulator are separate tools with their own licenses and are
+not bundled — Droidective resolves your SDK install. scrcpy (Apache-2.0) and
+ffmpeg (LGPL) are bundled inside the app and shelled out to.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+## Droidective v2.4.0
+
+Droidective is now signed with a Developer ID and notarized by Apple, so it
+opens with no Gatekeeper warning — and it ships with scrcpy and ffmpeg bundled,
+so screen mirroring and GIF export work without installing anything extra.
+
+### New features
+
+- **Notarized build** — signed with a Developer ID and notarized by Apple. No
+  more "Droidective is damaged" warning and no `xattr` workaround; just open it.
+- **Self-contained** — scrcpy and ffmpeg now ship inside the app, so Mirror
+  Screen and GIF export work out of the box, with no Homebrew install needed.
+
+### Install
+
+Download the `.dmg` below and drag **Droidective** into **Applications**. It
+opens normally — no quarantine workaround needed.
+
+Installed copies from v2.1.0+ update in place via Sparkle.
+
 ## Droidective v2.3.0
 
 A big screenshot-editor update — annotations you can move, resize, and rotate

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing Droidective
 
-Droidective ships as a notarization-free DMG via GitHub Releases and updates
-itself with [Sparkle](https://sparkle-project.org). The marketing site and the
-Sparkle appcast are both served from GitHub Pages at
+Droidective ships as a Developer ID-signed, notarized DMG via GitHub Releases
+and a Homebrew cask, and updates itself with
+[Sparkle](https://sparkle-project.org). The marketing site and the Sparkle
+appcast are both served from GitHub Pages at
 `https://rohindh-r.github.io/Droidective/`.
 
 ## One-time setup
@@ -61,7 +62,56 @@ After this, every push to `main` deploys the marketing site, and each release
 deploys the site plus a freshly signed appcast. (Until Pages is enabled, the
 `pages` job and the release's deploy step will fail — that's expected.)
 
-### 4. SEO / discoverability (optional but recommended)
+### 4. Developer ID signing and notarization
+
+Release builds are signed with a Developer ID Application certificate and
+notarized by Apple, so users get no Gatekeeper warning. Set this up once:
+
+1. **Create a "Developer ID Application" certificate** — Xcode → Settings →
+   Accounts → your team → Manage Certificates → ＋. Export it from Keychain
+   Access (My Certificates → right-click → Export) as a `.p12` with a password.
+2. **Create an App Store Connect API key** (used by `notarytool`) — App Store
+   Connect → Users and Access → Integrations → App Store Connect API → generate
+   (role *Developer*). Download `AuthKey_XXXX.p8` once; note the Key ID and
+   Issuer ID.
+3. **Add these repository secrets** (Settings → Secrets and variables → Actions):
+
+   | Secret | Value |
+   | --- | --- |
+   | `DEVELOPER_ID_CERT_P12` | `base64 -i Cert.p12` |
+   | `DEVELOPER_ID_CERT_PASSWORD` | the `.p12` export password |
+   | `DEVELOPER_ID_IDENTITY` | `Developer ID Application: Your Name (TEAMID)` |
+   | `KEYCHAIN_PASSWORD` | any random string (throwaway CI keychain) |
+   | `AC_API_KEY_P8` | `base64 -i AuthKey_XXXX.p8` |
+   | `AC_API_KEY_ID` | the key id |
+   | `AC_API_ISSUER_ID` | the issuer id |
+   | `APPLE_TEAM_ID` | your 10-character team id |
+
+To build a notarizable DMG **locally**, create `.env.signing` (gitignored):
+
+```sh
+SIGN_IDENTITY=Developer ID Application: Your Name (TEAMID)
+DEVELOPMENT_TEAM=TEAMID
+```
+
+`make dmg` then signs and bundles scrcpy/ffmpeg; notarize the result with
+`AC_API_KEY_PATH=… AC_API_KEY_ID=… AC_API_ISSUER_ID=… ./scripts/notarize.sh <dmg>`.
+Without `.env.signing`, `make dmg` produces an ad-hoc DMG — fine for testing,
+but Gatekeeper still warns.
+
+### 5. Homebrew cask (optional)
+
+Releases publish a cask to a tap repo so users can
+`brew install --cask rohindh-r/tap/droidective`.
+
+1. Create an empty public repo **`Rohindh-R/homebrew-tap`**.
+2. Add a `HOMEBREW_TAP_TOKEN` secret — a fine-grained PAT with *contents: write*
+   on that repo.
+
+The release job renders `Casks/droidective.rb` (version + DMG sha256) and commits
+it. Without the token, the cask step is skipped.
+
+### 6. SEO / discoverability (optional but recommended)
 
 On-page SEO is already in `site/index.html` (title, meta description, Open
 Graph, Twitter card, JSON-LD `SoftwareApplication`, `sitemap.xml`, `robots.txt`).
@@ -77,7 +127,7 @@ Ranking for competitive terms still needs links and time:
 - Expect long-tail phrases ("all-in-one Android debugging tool for macOS") to
   land first; head terms like "adb tool" take sustained authority.
 
-### 5. Configure telemetry (optional)
+### 7. Configure telemetry (optional)
 
 Crash reporting (Sentry) and opt-in analytics (PostHog) stay disabled until you
 supply keys. They are **not** committed to source — they're injected at build
@@ -130,9 +180,12 @@ CI (the `release` job) then:
 - builds Release with `MARKETING_VERSION=X.Y.Z` and `CURRENT_PROJECT_VERSION=`
   the GitHub Actions run number (Sparkle compares this monotonically increasing
   `CFBundleVersion`);
-- packages and ad-hoc-signs `Droidective-vX.Y.Z.dmg`;
+- bundles scrcpy + ffmpeg into the app, signs it with the Developer ID, and
+  packages `Droidective-vX.Y.Z.dmg`;
+- notarizes the DMG with Apple and staples the ticket;
 - publishes the GitHub release with that DMG and the latest release notes;
-- signs the DMG with the EdDSA key and writes `appcast.xml`;
+- signs the stapled DMG with the EdDSA key and writes `appcast.xml`;
+- updates the Homebrew cask;
 - deploys the site + appcast to GitHub Pages.
 
 Installed copies pick up the new appcast and offer the update automatically.
@@ -165,12 +218,13 @@ Copy this into the release PR and tick each item.
 ### Release (CI does the build — triggered by the tag)
 
 - [ ] Tag from `main` and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-- [ ] The Actions `release` job succeeds: builds Release with `MARKETING_VERSION=X.Y.Z`, packages and ad-hoc-signs `Droidective-vX.Y.Z.dmg`, signs it with the Sparkle EdDSA key, publishes the GitHub release with the DMG + latest notes, writes `appcast.xml`, and deploys the site to GitHub Pages.
+- [ ] The Actions `release` job succeeds: builds Release with `MARKETING_VERSION=X.Y.Z`, bundles scrcpy + ffmpeg, signs with the Developer ID, packages `Droidective-vX.Y.Z.dmg`, notarizes + staples it, signs it with the Sparkle EdDSA key, updates the Homebrew cask, publishes the GitHub release with the DMG + latest notes, writes `appcast.xml`, and deploys the site to GitHub Pages.
 
 ### Verify (post-release)
 
 - [ ] GitHub release page shows the right version, the notes, and a downloadable DMG.
-- [ ] Fresh download launches: mount the DMG, copy to `/Applications`, `xattr -dr com.apple.quarantine "/Applications/Droidective.app"`, open.
+- [ ] Fresh download launches cleanly: mount the DMG, drag to `/Applications`, open — no Gatekeeper warning. `spctl -a -vvv -t install Droidective-vX.Y.Z.dmg` reports *accepted, source=Notarized Developer ID*.
+- [ ] `brew install --cask rohindh-r/tap/droidective` installs the new version.
 - [ ] `https://rohindh-r.github.io/Droidective/` shows the new screenshots and copy.
 - [ ] `https://rohindh-r.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature`.
 - [ ] A prior install (v2.1.0+) offers the update via Sparkle and applies it in place.
@@ -178,10 +232,11 @@ Copy this into the release PR and tick each item.
 
 ## Mac App Store builds
 
-Sparkle is wrapped in `#if !APPSTORE` (App Store apps update through the App
-Store and can't bundle a self-updater). For a MAS build:
+Not a supported target. The Mac App Store mandates the App Sandbox, which forbids
+spawning external executables — and Droidective's whole job is driving `adb`,
+`scrcpy`, the Android `emulator`, and `brew`. The emulator additionally needs a
+hypervisor entitlement the App Store doesn't grant. So Droidective is distributed
+only as a Developer ID-signed, notarized build.
 
-- add `APPSTORE` to `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, and
-- remove the `Sparkle` package + dependency from `project.yml`.
-
-Everything Sparkle-related then compiles out cleanly.
+The `#if !APPSTORE` guard around Sparkle is kept (a self-updater couldn't ship in
+a MAS build anyway), but there is no MAS build to produce.

--- a/project.yml
+++ b/project.yml
@@ -61,7 +61,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.3.0"
+        MARKETING_VERSION: "2.4.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/scripts/bundle-tools.sh
+++ b/scripts/bundle-tools.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Vendor scrcpy + ffmpeg (and scrcpy's server) into the built .app so the
+# release DMG is self-contained — users don't need Homebrew. adb and the Android
+# emulator are NOT bundled (Android SDK licensing forbids redistribution); the
+# app resolves the user's own SDK copies for those.
+#
+# Run AFTER xcodebuild and BEFORE signing: this adds Contents/Helpers and loose
+# dylibs to Contents/Frameworks, which invalidates the app signature, so
+# package-dmg.sh re-signs everything afterward.
+#
+# Usage: bundle-tools.sh [path/to/Droidective.app]
+set -euo pipefail
+
+APP="${1:-DerivedData/Build/Products/Release/Droidective.app}"
+[[ -d "$APP" ]] || {
+  echo "error: app not found: $APP — build the app first" >&2
+  exit 1
+}
+
+HELPERS="$APP/Contents/Helpers"
+FRAMEWORKS="$APP/Contents/Frameworks"
+RESOURCES="$APP/Contents/Resources"
+
+command -v dylibbundler >/dev/null 2>&1 || {
+  echo "error: dylibbundler missing — run 'brew install dylibbundler'" >&2
+  exit 1
+}
+
+resolve() { # absolute path to a tool, or fail loudly
+  command -v "$1" 2>/dev/null || {
+    echo "error: '$1' not found on PATH — run 'brew install $1'" >&2
+    exit 1
+  }
+}
+
+SCRCPY="$(resolve scrcpy)"
+FFMPEG="$(resolve ffmpeg)"
+
+# scrcpy-server is a data blob scrcpy pushes to the device. Homebrew installs it
+# at <prefix>/share/scrcpy/scrcpy-server; fall back to a Cellar glob.
+prefix="$(cd "$(dirname "$SCRCPY")/.." && pwd)"
+SERVER="$prefix/share/scrcpy/scrcpy-server"
+if [[ ! -f "$SERVER" ]]; then
+  SERVER="$(/bin/ls -1 "$prefix"/Cellar/scrcpy/*/share/scrcpy/scrcpy-server 2>/dev/null | head -1 || true)"
+fi
+[[ -f "$SERVER" ]] || {
+  echo "error: scrcpy-server not found near $SCRCPY" >&2
+  exit 1
+}
+
+mkdir -p "$HELPERS" "$FRAMEWORKS" "$RESOURCES"
+cp -f "$SCRCPY" "$HELPERS/scrcpy"
+cp -f "$FFMPEG" "$HELPERS/ffmpeg"
+cp -f "$SERVER" "$RESOURCES/scrcpy-server"
+chmod +x "$HELPERS/scrcpy" "$HELPERS/ffmpeg"
+
+# dylibbundler copies each binary's full (transitive) dylib closure into
+# Frameworks and rewrites the load commands to @executable_path-relative paths.
+# Shared dependencies between scrcpy and ffmpeg are copied once.
+dylibbundler -of -cd -b \
+  -d "$FRAMEWORKS" \
+  -p "@executable_path/../Frameworks/" \
+  -x "$HELPERS/scrcpy" \
+  -x "$HELPERS/ffmpeg"
+
+echo "bundled scrcpy + ffmpeg into $APP"

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Submit a signed DMG to Apple's notary service, wait for the result, and staple
+# the ticket so first launch works offline. Run after package-dmg.sh and before
+# publishing/Sparkle-signing (stapling rewrites the DMG).
+#
+# Requires an App Store Connect API key, passed by path:
+#   AC_API_KEY_PATH   path to the AuthKey_XXXX.p8 file
+#   AC_API_KEY_ID     the key id
+#   AC_API_ISSUER_ID  the issuer id
+#
+# Usage: notarize.sh <dmg>
+set -euo pipefail
+
+DMG="${1:?dmg path required}"
+: "${AC_API_KEY_PATH:?AC_API_KEY_PATH (path to .p8) required}"
+: "${AC_API_KEY_ID:?AC_API_KEY_ID required}"
+: "${AC_API_ISSUER_ID:?AC_API_ISSUER_ID required}"
+
+[[ -f "$DMG" ]] || {
+  echo "error: DMG not found: $DMG" >&2
+  exit 1
+}
+
+echo "Submitting $DMG for notarization (waiting for Apple)…"
+xcrun notarytool submit "$DMG" \
+  --key "$AC_API_KEY_PATH" \
+  --key-id "$AC_API_KEY_ID" \
+  --issuer "$AC_API_ISSUER_ID" \
+  --wait
+
+echo "Stapling notarization ticket…"
+xcrun stapler staple "$DMG"
+xcrun stapler validate "$DMG"
+echo "notarized + stapled $DMG"

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -1,22 +1,43 @@
 #!/usr/bin/env bash
-# Ad-hoc sign the built Release app and package it into a drag-to-Applications DMG.
-# Assumes the Release configuration has already been built into DerivedData.
+# Sign the built Release app and package it into a drag-to-Applications DMG.
+# Assumes the Release app is already built and scripts/bundle-tools.sh has
+# injected scrcpy/ffmpeg.
+#
+# Signing identity comes from $SIGN_IDENTITY (default "-" = ad-hoc, for local
+# dev). A real "Developer ID Application: …" identity additionally enables the
+# hardened runtime + secure timestamp, which notarization requires.
 set -euo pipefail
 
 VERSION="${1:-dev}"
 APP_DIR="DerivedData/Build/Products/Release"
 APP="$APP_DIR/Droidective.app"
 DMG="$APP_DIR/Droidective-${VERSION}.dmg"
+IDENTITY="${SIGN_IDENTITY:--}"
 
 if [[ ! -d "$APP" ]]; then
   echo "error: $APP not found — build the Release configuration first" >&2
   exit 1
 fi
 
-# Re-sign the whole bundle ad-hoc so the signature is internally valid. This
-# does not bypass Gatekeeper (no Developer ID) but prevents a broken/missing
-# signature from compounding the quarantine "damaged" message.
-codesign --force --deep --sign - "$APP"
+opts=(--force --sign "$IDENTITY")
+if [[ "$IDENTITY" != "-" ]]; then
+  opts+=(--options runtime --timestamp)
+fi
+
+# Sign inner-out: bundle-tools added loose dylibs and helper executables after
+# xcodebuild signed the app, so re-sign those, then re-seal the whole bundle.
+# (Nested .frameworks keep the signatures xcodebuild already gave them.)
+if [[ -d "$APP/Contents/Frameworks" ]]; then
+  for lib in "$APP/Contents/Frameworks"/*.dylib; do
+    [[ -f "$lib" ]] && codesign "${opts[@]}" "$lib"
+  done
+fi
+if [[ -d "$APP/Contents/Helpers" ]]; then
+  for helper in "$APP/Contents/Helpers"/*; do
+    [[ -f "$helper" ]] && codesign "${opts[@]}" "$helper"
+  done
+fi
+codesign "${opts[@]}" "$APP"
 codesign --verify --deep --strict "$APP"
 
 # Stage the app next to an /Applications symlink so the DMG offers drag-install.
@@ -28,4 +49,9 @@ ln -s /Applications "$staging/Applications"
 rm -f "$DMG"
 hdiutil create -volname "Droidective" -srcfolder "$staging" -ov -format UDZO "$DMG"
 
-echo "created $DMG"
+# Sign the DMG itself so the download carries a Developer ID signature too.
+if [[ "$IDENTITY" != "-" ]]; then
+  codesign --force --sign "$IDENTITY" --timestamp "$DMG"
+fi
+
+echo "created $DMG (identity: $IDENTITY)"

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Render the Homebrew cask for a release. The release job runs this against a
+# checkout of the tap repo, then commits the result.
+#
+# Usage: update-cask.sh <version> <dmg> <download-url> <cask-file>
+set -euo pipefail
+
+VERSION="${1:?version required}"
+DMG="${2:?dmg path required}"
+URL="${3:?download url required}"
+OUT="${4:?output cask path required}"
+
+[[ -f "$DMG" ]] || {
+  echo "error: DMG not found: $DMG" >&2
+  exit 1
+}
+
+SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+mkdir -p "$(dirname "$OUT")"
+
+cat >"$OUT" <<RUBY
+cask "droidective" do
+  version "${VERSION}"
+  sha256 "${SHA}"
+
+  url "${URL}"
+  name "Droidective"
+  desc "Native macOS app for Android and React Native debugging over adb"
+  homepage "https://rohindh-r.github.io/Droidective/"
+
+  # Sparkle updates the app in place, so Homebrew should not fight it.
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Droidective.app"
+
+  zap trash: [
+    "~/Library/Application Support/Droidective",
+    "~/Library/Preferences/com.rohindh.droidective.plist",
+  ]
+end
+RUBY
+
+echo "wrote $OUT (v${VERSION}, sha256 ${SHA})"


### PR DESCRIPTION
Ships **v2.4.0**: Droidective is now signed with a Developer ID and notarized by Apple (no Gatekeeper warning), with scrcpy + ffmpeg bundled so it's self-contained.

## What's in it
- Bundle scrcpy + ffmpeg (and scrcpy-server) into the app via dylibbundler; ToolLocator prefers the bundled copies, falls back to the SDK/Homebrew search. adb and the emulator stay external (SDK licensing).
- package-dmg.sh signs inner-out with the Developer ID identity + hardened runtime + timestamp; notarize.sh submits to Apple and staples.
- The release workflow imports the cert, builds signed, bundles, notarizes + staples before publishing, signs the stapled DMG for Sparkle, and updates the Homebrew cask (when a tap token is set).
- Signing is injected from .env.signing / CI secrets; the repo stays identity-free.
- Bumps MARKETING_VERSION to 2.4.0 with release notes; docs updated; the old quarantine workaround is gone.

Tagging `v2.4.0` after merge runs the signed + notarized release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
