### PR TITLE
Install scrcpy and ffmpeg in the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install build tools
-        run: brew install xcodegen dylibbundler
+        run: brew install xcodegen dylibbundler scrcpy ffmpeg
       - name: Import Developer ID certificate
         env:
           DEVELOPER_ID_CERT_P12: ${{ secrets.DEVELOPER_ID_CERT_P12 }}


### PR DESCRIPTION
Fixes the v2.4.0 release. bundle-tools.sh copies scrcpy + ffmpeg into the app, so the release runner must install them — the build and Developer ID signing already succeed; it only failed at bundling. Release-job-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)