### PR TITLE
Point Sparkle feed and site URLs at the org Pages domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           # Prefer the live feed (kept fresh by releases); fall back to the
           # committed site/appcast.xml. Fetch to a temp file so a 404 never
           # truncates the committed copy.
-          if curl -fsSL https://rohindh-r.github.io/Droidective/appcast.xml -o /tmp/appcast.xml; then
+          if curl -fsSL https://droidective.github.io/Droidective/appcast.xml -o /tmp/appcast.xml; then
             cp /tmp/appcast.xml _site/appcast.xml
           fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Droidective ships as a Developer ID-signed, notarized DMG via GitHub Releases
 and a Homebrew cask, and updates itself with
 [Sparkle](https://sparkle-project.org). The marketing site and the Sparkle
 appcast are both served from GitHub Pages at
-`https://rohindh-r.github.io/Droidective/`.
+`https://droidective.github.io/Droidective/`.
 
 ## One-time setup
 
@@ -118,7 +118,7 @@ On-page SEO is already in `site/index.html` (title, meta description, Open
 Graph, Twitter card, JSON-LD `SoftwareApplication`, `sitemap.xml`, `robots.txt`).
 Ranking for competitive terms still needs links and time:
 
-- Set the repo's **About → Website** to `https://rohindh-r.github.io/Droidective/`.
+- Set the repo's **About → Website** to `https://droidective.github.io/Droidective/`.
 - Add the URL to the README and link it from anywhere you can.
 - Verify the site in **Google Search Console** (URL-prefix property; use the
   meta-tag method — add the `google-site-verification` tag to `index.html`), then
@@ -226,8 +226,8 @@ Copy this into the release PR and tick each item.
 - [ ] GitHub release page shows the right version, the notes, and a downloadable DMG.
 - [ ] Fresh download launches cleanly: mount the DMG, drag to `/Applications`, open — no Gatekeeper warning. `spctl -a -vvv -t install Droidective-vX.Y.Z.dmg` reports *accepted, source=Notarized Developer ID*.
 - [ ] `brew install --cask rohindh-r/tap/droidective` installs the new version.
-- [ ] `https://rohindh-r.github.io/Droidective/` shows the new screenshots and copy.
-- [ ] `https://rohindh-r.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature`.
+- [ ] `https://droidective.github.io/Droidective/` shows the new screenshots and copy.
+- [ ] `https://droidective.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature`.
 - [ ] A prior install (v2.1.0+) offers the update via Sparkle and applies it in place.
 - [ ] Repo **About → Website** still points at the Pages URL.
 

--- a/project.yml
+++ b/project.yml
@@ -63,7 +63,7 @@ targets:
         NSHumanReadableCopyright: ""
         SentryDSN: $(SENTRY_DSN)
         PostHogKey: $(POSTHOG_KEY)
-        SUFeedURL: https://rohindh-r.github.io/Droidective/appcast.xml
+        SUFeedURL: https://droidective.github.io/Droidective/appcast.xml
         SUPublicEDKey: "ma0kTe35r55/PKmemQOEBX7n6SuZPZjOBo973SdJqJ8="
         SUEnableAutomaticChecks: true
     settings:

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -41,7 +41,7 @@ cat >"$APPCAST" <<XML
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Droidective</title>
-    <link>https://rohindh-r.github.io/Droidective/appcast.xml</link>
+    <link>https://droidective.github.io/Droidective/appcast.xml</link>
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -26,7 +26,7 @@ cask "droidective" do
   url "${URL}"
   name "Droidective"
   desc "Native macOS app for Android and React Native debugging over adb"
-  homepage "https://rohindh-r.github.io/Droidective/"
+  homepage "https://droidective.github.io/Droidective/"
 
   # Sparkle updates the app in place, so Homebrew should not fight it.
   auto_updates true

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Droidective</title>
-    <link>https://rohindh-r.github.io/Droidective/appcast.xml</link>
+    <link>https://droidective.github.io/Droidective/appcast.xml</link>
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>

--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,7 @@
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0d0f0e" />
-  <link rel="canonical" href="https://rohindh-r.github.io/Droidective/" />
+  <link rel="canonical" href="https://droidective.github.io/Droidective/" />
 
   <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
   <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
@@ -21,14 +21,14 @@
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
   <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 45 tools, one keystroke away." />
-  <meta property="og:url" content="https://rohindh-r.github.io/Droidective/" />
-  <meta property="og:image" content="https://rohindh-r.github.io/Droidective/assets/screenshot-home.png" />
+  <meta property="og:url" content="https://droidective.github.io/Droidective/" />
+  <meta property="og:image" content="https://droidective.github.io/Droidective/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
   <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 45 tools, one keystroke away. Free & open source." />
-  <meta name="twitter:image" content="https://rohindh-r.github.io/Droidective/assets/screenshot-home.png" />
+  <meta name="twitter:image" content="https://droidective.github.io/Droidective/assets/screenshot-home.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -42,10 +42,10 @@
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS 14.0 or later",
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 45 tools in all.",
-    "url": "https://rohindh-r.github.io/Droidective/",
+    "url": "https://droidective.github.io/Droidective/",
     "downloadUrl": "https://github.com/Rohindh-R/Droidective/releases",
     "softwareVersion": "2.2.1",
-    "screenshot": "https://rohindh-r.github.io/Droidective/assets/screenshot-home.png",
+    "screenshot": "https://droidective.github.io/Droidective/assets/screenshot-home.png",
     "license": "https://github.com/Rohindh-R/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Person", "name": "Rohindh R", "url": "https://github.com/Rohindh-R" }

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://rohindh-r.github.io/Droidective/sitemap.xml
+Sitemap: https://droidective.github.io/Droidective/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://rohindh-r.github.io/Droidective/</loc>
+    <loc>https://droidective.github.io/Droidective/</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
The repo moved to the Droidective org, so GitHub Pages now serves at `droidective.github.io`, but several references still pointed at the old `rohindh-r.github.io` host, which now returns 404:

- `project.yml` `SUFeedURL` — baked into the app, so shipped builds couldn't reach any feed.
- `ci.yml` pages job — its "preserve the live feed" `curl` hit the dead URL, so it fell back to the committed v2.1.0 `site/appcast.xml` and clobbered each release's appcast on every push to main.
- `scripts/update-appcast.sh` / `site/appcast.xml` feed `<link>`, `scripts/update-cask.sh` homepage, and the `site/` SEO metadata (canonical, OG, Twitter, JSON-LD, sitemap, robots).

This repoints every reference to `droidective.github.io` so auto-update resolves and main pushes preserve the published feed.

The Homebrew tap clone (`Rohindh-R/homebrew-tap`) is a separate repo that didn't move and is left unchanged.

Note: the corrected `SUFeedURL` only reaches users once a build carries it — v2.4.0 will be re-published from the updated `main` so its DMG ships the right feed URL.