### PR TITLE
Publish the Sparkle appcast through main, not a tag-ref deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Debug -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO
 
-  # Publish the marketing site to GitHub Pages on every push to main, preserving
-  # the appcast the release job last published (so site edits don't wipe the
-  # Sparkle update feed).
+  # Publish the marketing site (and the committed Sparkle appcast) to GitHub
+  # Pages on every push to main. The appcast in site/ is the single source of
+  # truth — the release job commits each new version's entry back to main, which
+  # re-triggers this job to deploy it.
   pages:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -51,16 +52,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
-      - name: Assemble site (refresh appcast from the live feed when present)
+      - name: Assemble site
         run: |
           mkdir -p _site
           cp -R site/. _site/
-          # Prefer the live feed (kept fresh by releases); fall back to the
-          # committed site/appcast.xml. Fetch to a temp file so a 404 never
-          # truncates the committed copy.
-          if curl -fsSL https://droidective.github.io/Droidective/appcast.xml -o /tmp/appcast.xml; then
-            cp /tmp/appcast.xml _site/appcast.xml
-          fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: _site
@@ -73,14 +68,6 @@ jobs:
     runs-on: macos-15
     permissions:
       contents: write
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    concurrency:
-      group: pages
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
@@ -140,17 +127,20 @@ jobs:
           files: DerivedData/Build/Products/Release/Droidective-*.dmg
           body_path: release-body.md
           fail_on_unmatched_files: true
-      - name: Sign update and assemble site + appcast
+      - name: Sign update and publish appcast to main
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           DMG="DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg"
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/Droidective-${GITHUB_REF_NAME}.dmg"
           ./scripts/fetch-sparkle-tools.sh
-          mkdir -p _site
-          cp -R site/. _site/
-          ./scripts/update-appcast.sh "$DMG" "$VERSION" "${{ github.run_number }}" "${GITHUB_REF_NAME}" "$DOWNLOAD_URL" "_site/appcast.xml"
+          ./scripts/update-appcast.sh "$DMG" "$VERSION" "${{ github.run_number }}" "${GITHUB_REF_NAME}" "$DOWNLOAD_URL" "site/appcast.xml"
+          # Commit the regenerated appcast back to main; the resulting push runs
+          # the pages job, which deploys it. (GitHub Pages only serves deploys
+          # from the source branch, so a tag-ref deploy here would never go live.)
+          ./scripts/commit-appcast.sh "site/appcast.xml" "${{ github.repository }}" main "${GITHUB_REF_NAME}"
       - name: Update Homebrew cask
         continue-on-error: true
         env:
@@ -168,8 +158,3 @@ jobs:
           git add Casks/droidective.rb
           git diff --cached --quiet || git commit -m "droidective ${VERSION}"
           git push
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
-        with:
-          path: _site
-      - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,9 +58,13 @@ delete the file (`trash sparkle-private-key.txt`).
 
 **Settings → Pages → Build and deployment → Source = GitHub Actions.**
 
-After this, every push to `main` deploys the marketing site, and each release
-deploys the site plus a freshly signed appcast. (Until Pages is enabled, the
-`pages` job and the release's deploy step will fail — that's expected.)
+After this, every push to `main` deploys the marketing site and the committed
+`site/appcast.xml`. The appcast in `site/` is the single source of truth: the
+release job signs a new version's entry and commits it back to `main` (see the
+`RELEASE_PUSH_TOKEN` secret below), which re-runs the `pages` job to deploy it.
+GitHub Pages only serves deployments from the source branch, so the release must
+publish through `main` rather than deploying from its tag ref directly. (Until
+Pages is enabled, the `pages` job will fail — that's expected.)
 
 ### 4. Developer ID signing and notarization
 
@@ -86,6 +90,17 @@ notarized by Apple, so users get no Gatekeeper warning. Set this up once:
    | `AC_API_KEY_ID` | the key id |
    | `AC_API_ISSUER_ID` | the issuer id |
    | `APPLE_TEAM_ID` | your 10-character team id |
+
+### 4b. Appcast publish token
+
+The release job commits the freshly signed `site/appcast.xml` back to `main` via
+the GitHub contents API (a verified, signed commit — which the protected branch
+requires). Add a `RELEASE_PUSH_TOKEN` secret: a fine-grained PAT with
+*Contents: read and write* on this repo, owned by an account allowed to bypass
+`main`'s protection (the repo admin). Because `main` is locked and requires
+reviews, the token must be able to bypass those rules; with admin enforcement
+off, an admin PAT does. Without this token the release publishes the DMG but the
+appcast won't update.
 
 To build a notarizable DMG **locally**, create `.env.signing` (gitignored):
 
@@ -185,11 +200,13 @@ CI (the `release` job) then:
   Developer ID, and packages `Droidective-vX.Y.Z.dmg`;
 - notarizes the DMG with Apple and staples the ticket;
 - publishes the GitHub release with that DMG and the latest release notes;
-- signs the stapled DMG with the EdDSA key and writes `appcast.xml`;
-- updates the Homebrew cask;
-- deploys the site + appcast to GitHub Pages.
+- signs the stapled DMG with the EdDSA key and commits the regenerated
+  `site/appcast.xml` to `main`;
+- updates the Homebrew cask.
 
-Installed copies pick up the new appcast and offer the update automatically.
+That commit to `main` re-runs the `pages` job, which deploys the site and the
+new appcast to GitHub Pages. Installed copies then pick up the new appcast and
+offer the update automatically.
 
 > **First Sparkle release:** existing v2.0.0 installs predate Sparkle, so they
 > won't auto-update *to* the first Sparkle-enabled build — download that one
@@ -219,7 +236,8 @@ Copy this into the release PR and tick each item.
 ### Release (CI does the build — triggered by the tag)
 
 - [ ] Tag from `main` and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-- [ ] The Actions `release` job succeeds: builds Release with `MARKETING_VERSION=X.Y.Z` (scrcpy-server + ffmpeg ship inside the app), signs with the Developer ID, packages `Droidective-vX.Y.Z.dmg`, notarizes + staples it, signs it with the Sparkle EdDSA key, updates the Homebrew cask, publishes the GitHub release with the DMG + latest notes, writes `appcast.xml`, and deploys the site to GitHub Pages.
+- [ ] The Actions `release` job succeeds: builds Release with `MARKETING_VERSION=X.Y.Z` (scrcpy-server + ffmpeg ship inside the app), signs with the Developer ID, packages `Droidective-vX.Y.Z.dmg`, notarizes + staples it, signs it with the Sparkle EdDSA key, updates the Homebrew cask, publishes the GitHub release with the DMG + latest notes, and commits the regenerated `site/appcast.xml` to `main`.
+- [ ] The follow-up `pages` run (triggered by that appcast commit) deploys the site + appcast to GitHub Pages.
 
 ### Verify (post-release)
 

--- a/scripts/commit-appcast.sh
+++ b/scripts/commit-appcast.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Commit the regenerated appcast to a branch via the GitHub contents API.
+#
+# Uses the API (not `git push`) on purpose: it produces a GitHub-signed,
+# "verified" commit, which the protected default branch requires. $GH_TOKEN
+# must be allowed to bypass that branch's protection (an admin / bypass PAT).
+#
+# Usage: commit-appcast.sh <local-appcast> <owner/repo> <branch> <tag>
+set -euo pipefail
+
+LOCAL="${1:?local appcast path required}"
+REPO="${2:?owner/repo required}"
+BRANCH="${3:?branch required}"
+TAG="${4:?tag required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+
+[[ -f "$LOCAL" ]] || {
+  echo "error: appcast not found: $LOCAL" >&2
+  exit 1
+}
+
+REMOTE_PATH="site/appcast.xml"
+content="$(base64 <"$LOCAL" | tr -d '\n')"
+# Current blob sha so the API does an update; empty (omitted) creates the file.
+sha="$(gh api "repos/$REPO/contents/$REMOTE_PATH?ref=$BRANCH" --jq '.sha' 2>/dev/null || true)"
+
+gh api -X PUT "repos/$REPO/contents/$REMOTE_PATH" \
+  -f message="Publish appcast for $TAG" \
+  -f content="$content" \
+  -f branch="$BRANCH" \
+  ${sha:+-f sha="$sha"}
+
+echo "committed $REMOTE_PATH to $BRANCH ($TAG)"

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -49,7 +49,7 @@ cat >"$APPCAST" <<XML
       <sparkle:version>${BUILD_VERSION}</sparkle:version>
       <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <sparkle:releaseNotesLink>https://github.com/Rohindh-R/Droidective/releases/tag/${TAG}</sparkle:releaseNotesLink>
+      <sparkle:releaseNotesLink>https://github.com/Droidective/Droidective/releases/tag/${TAG}</sparkle:releaseNotesLink>
       <pubDate>${pub_date}</pubDate>
       <enclosure url="${DOWNLOAD_URL}" ${enclosure_attrs} type="application/octet-stream" />
     </item>

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -6,13 +6,13 @@
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>
-      <title>Droidective 2.1.0</title>
-      <sparkle:version>22</sparkle:version>
-      <sparkle:shortVersionString>2.1.0</sparkle:shortVersionString>
+      <title>Droidective 2.4.0</title>
+      <sparkle:version>69</sparkle:version>
+      <sparkle:shortVersionString>2.4.0</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <sparkle:releaseNotesLink>https://github.com/Rohindh-R/Droidective/releases/tag/v2.1.0</sparkle:releaseNotesLink>
-      <pubDate>Sat, 20 Jun 2026 16:36:53 +0000</pubDate>
-      <enclosure url="https://github.com/Rohindh-R/Droidective/releases/download/v2.1.0/Droidective-v2.1.0.dmg" sparkle:edSignature="PktlZJSxnwZ8VufMueUnpUyTHiIxGG3aiKPNSRDWj2Q9b7EPKvgo/aRcGQxwM1dzhWVahKynAVHh/2ad2Kp/DQ==" length="7117209" type="application/octet-stream" />
+      <sparkle:releaseNotesLink>https://github.com/Droidective/Droidective/releases/tag/v2.4.0</sparkle:releaseNotesLink>
+      <pubDate>Wed, 24 Jun 2026 09:11:44 +0000</pubDate>
+      <enclosure url="https://github.com/Droidective/Droidective/releases/download/v2.4.0/Droidective-v2.4.0.dmg" sparkle:edSignature="H+IwWl3NkKrdp2Wue5bJ+gTsfWGLxOmBI62+QEqjh9DnlK1mjRFaJWja8qFnzbATnY9ca6wwokUZ5O+fPoDNDA==" length="44317257" type="application/octet-stream" />
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
## Problem

The live Sparkle feed at `droidective.github.io/Droidective/appcast.xml` was frozen at v2.1.0 — no release (including v2.4.0) ever advanced it. Two compounding causes:

1. **Fetch-and-overwrite loop:** the `pages` job (every push to main) curled the *live* feed and redeployed it, perpetually overwriting both the committed `site/appcast.xml` and whatever a release had just published.
2. **Tag-ref deploys don't serve:** GitHub Pages only serves deployments from the source branch (`main`). The release job ran on a `v*` tag, so its Pages deploys succeeded but never became the live site (verified: two successful release deploys for v2.4.0 left the origin serving the older `main`-ref artifact).

## Fix

`site/appcast.xml` becomes the single source of truth:

- **`pages` job:** drop the fetch-and-overwrite; deploy `site/` verbatim.
- **`release` job:** sign the new entry, write `site/appcast.xml`, and commit it back to `main` via the GitHub contents API (a verified/signed commit, which the protected branch requires). That commit re-runs `pages`, which deploys the feed. The release job no longer deploys Pages itself — so it also no longer holds the `pages` concurrency lock (which previously let a stuck run block releases).
- Commit the current signed **v2.4.0** entry so the feed is correct as soon as this merges (a `main`-ref deploy, which *does* serve).
- Fix `update-appcast.sh`'s release-notes link to the `Droidective` org.

## Required setup

Add a **`RELEASE_PUSH_TOKEN`** secret — a fine-grained PAT with *Contents: read and write* on this repo, owned by an admin who can bypass `main`'s protection (lock + required reviews). Without it the release still ships the DMG, but the appcast won't update. Documented in `RELEASING.md` §4b.

`actionlint` + `shellcheck` + `shfmt` clean.