### PR TITLE
Correct how the appcast commit clears branch protection

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,14 +93,15 @@ notarized by Apple, so users get no Gatekeeper warning. Set this up once:
 
 ### 4b. Appcast publish token
 
-The release job commits the freshly signed `site/appcast.xml` back to `main` via
-the GitHub contents API (a verified, signed commit — which the protected branch
-requires). Add a `RELEASE_PUSH_TOKEN` secret: a fine-grained PAT with
-*Contents: read and write* on this repo, owned by an account allowed to bypass
-`main`'s protection (the repo admin). Because `main` is locked and requires
-reviews, the token must be able to bypass those rules; with admin enforcement
-off, an admin PAT does. Without this token the release publishes the DMG but the
-appcast won't update.
+The release job commits the freshly signed `site/appcast.xml` (its enclosure
+carries the Sparkle EdDSA signature) back to `main` via the GitHub contents API.
+Add a `RELEASE_PUSH_TOKEN` secret: a fine-grained PAT with *Contents: read and
+write* on this repo, owned by the repo admin. `main` is protected (locked,
+requires reviews, requires signed commits), and this commit is itself unsigned —
+it lands only because the admin PAT bypasses all of those rules, which works
+because **"Include administrators" (`enforce_admins`) is off**. Keep it off, or
+this step (and the auto-update feed) breaks. Without the token the release still
+publishes the DMG, but the appcast won't update.
 
 To build a notarizable DMG **locally**, create `.env.signing` (gitignored):
 

--- a/scripts/commit-appcast.sh
+++ b/scripts/commit-appcast.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Commit the regenerated appcast to a branch via the GitHub contents API.
 #
-# Uses the API (not `git push`) on purpose: it produces a GitHub-signed,
-# "verified" commit, which the protected default branch requires. $GH_TOKEN
-# must be allowed to bypass that branch's protection (an admin / bypass PAT).
+# Uses the API (not `git push`) so the job needs no git checkout-with-write or
+# credential setup — just a token. The commit it makes is unsigned; it lands on
+# the protected default branch only because $GH_TOKEN is an admin/bypass PAT and
+# "Include administrators" (enforce_admins) is off, so it bypasses the branch's
+# lock, required reviews, and required-signatures rules. Turning enforce_admins
+# on would start rejecting this commit.
 #
 # Usage: commit-appcast.sh <local-appcast> <owner/repo> <branch> <tag>
 set -euo pipefail


### PR DESCRIPTION
A test commit to `main` showed the previous explanation was wrong. `commit-appcast.sh`'s comment and `RELEASING.md` §4b said the contents API produces a *signed/verified* commit that satisfies `main`'s "require signed commits" rule.

In reality the commit lands **unsigned** (`verification: "unsigned"`) and is accepted only because the `RELEASE_PUSH_TOKEN` admin PAT bypasses branch protection wholesale — lock, required reviews, *and* required signatures — which works because **`enforce_admins` is off**.

This corrects both spots to describe the actual mechanism and flags the dependency: if "Include administrators" is ever enabled on `main`, the appcast-publish step (and thus the auto-update feed) will start failing. Comment/doc only — no behavior change.