### PR TITLE
Release v2.4.1: keep the sidebar footer on one line

### DIFF
--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -88,9 +88,9 @@ struct RootView: View {
         HStack(spacing: 0) {
             if state.sidebarVisible {
                 SidebarPaletteView()
-                    .frame(width: sidebarWidth)
+                    .frame(width: min(max(sidebarWidth, 250), 460))
                     .transition(.move(edge: .leading).combined(with: .opacity))
-                ResizeHandle(value: $sidebarWidth, range: 200...460)
+                ResizeHandle(value: $sidebarWidth, range: 250...460)
             }
             VStack(spacing: 0) {
                 // The catalog has no device context, so its device bar is hidden.

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -266,6 +266,7 @@ struct SidebarPaletteView: View {
                     systemImage: "square.grid.2x2"
                 )
                 .font(.body)
+                .lineLimit(1)
             }
             .buttonStyle(.plain)
             .foregroundStyle(state.selectedFeatureID == "catalog" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## Droidective v2.4.1
+
+### Improvements
+
+- **Sidebar footer** — the "Manage features" button stays on one line, and the
+  sidebar has a higher minimum width so the footer no longer wraps when narrowed.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.4.0
 
 A live in-app screen mirror, a video editor, and self-contained tools — scrcpy

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.4.0"
+        MARKETING_VERSION: "2.4.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
## What changed

The sidebar footer's **Manage features** button wrapped vertically (one character per line) when the sidebar was dragged narrow.

- `SidebarPaletteView`: the footer label is now `lineLimit(1)` — single line, never wraps.
- `RootView`: sidebar minimum width raised **200 → 250** so the footer fits, and a previously-saved narrower width is clamped up into the new range.

Bumps `MARKETING_VERSION` to **2.4.1** and adds the release note.

## Why

Cuts the next release so the appcast feed advances past v2.4.0 — exercises the in-place Sparkle auto-update path end-to-end.