### PR TITLE
v2.5.0: role launchpad, palette rework, sidebar reorder, refreshed screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,9 @@ jobs:
           DMG="DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg"
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/Droidective-${GITHUB_REF_NAME}.dmg"
           ./scripts/fetch-sparkle-tools.sh
-          ./scripts/update-appcast.sh "$DMG" "$VERSION" "${{ github.run_number }}" "${GITHUB_REF_NAME}" "$DOWNLOAD_URL" "site/appcast.xml"
+          # release-body.md (the GitHub release notes, extracted above) is
+          # rendered to HTML and embedded in the appcast's <description>.
+          ./scripts/update-appcast.sh "$DMG" "$VERSION" "${{ github.run_number }}" "$DOWNLOAD_URL" release-body.md "site/appcast.xml"
           # Commit the regenerated appcast back to main; the resulting push runs
           # the pages job, which deploys it. (GitHub Pages only serves deploys
           # from the source branch, so a tag-ref deploy here would never go live.)

--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -51,6 +51,49 @@ public enum FeatureCategory: String, Sendable, Codable, CaseIterable {
     }
 }
 
+/// The persona a user picks on first launch to get a focused, curated set of
+/// features instead of all of them. Drives `FeatureRegistry.featuresByRole`.
+/// UI strings and the icon (an SF Symbol *name*) live here so the picker stays
+/// declarative and ADBKit stays free of UI frameworks. A `nil` selected role
+/// means "show everything".
+public enum UserRole: String, Sendable, Codable, CaseIterable, Identifiable {
+    case androidDeveloper = "android-dev"
+    case reactNativeDeveloper = "rn-dev"
+    case qaTester = "qa"
+    case supportTriage = "support"
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .androidDeveloper: return "Android Developer"
+        case .reactNativeDeveloper: return "React Native Developer"
+        case .qaTester: return "QA / Tester"
+        case .supportTriage: return "Support / Triage"
+        }
+    }
+
+    /// One line shown under the role name on its picker card.
+    public var blurb: String {
+        switch self {
+        case .androidDeveloper: return "Logs, app internals, files, and device connection."
+        case .reactNativeDeveloper: return "Metro reload, dev menu, logs, and performance."
+        case .qaTester: return "Capture, recording, crash hunting, and state simulation."
+        case .supportTriage: return "Device diagnostics, connection, and quick checks."
+        }
+    }
+
+    /// SF Symbol name (ADBKit stays UI-framework free).
+    public var icon: String {
+        switch self {
+        case .androidDeveloper: return "hammer"
+        case .reactNativeDeveloper: return "atom"
+        case .qaTester: return "checkmark.seal"
+        case .supportTriage: return "lifepreserver"
+        }
+    }
+}
+
 public enum OverrideKind: String, Sendable, Codable, CaseIterable {
     case proxy
     case layout

--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -274,7 +274,7 @@ public struct FeatureDef: Sendable, Identifiable {
     /// Links (whose subtitle merely mentions "app"). Used to order search
     /// results in the palette and sidebar.
     public func relevance(for query: String) -> Int {
-        let q = query.lowercased()
+        let q = query.lowercased().trimmingCharacters(in: .whitespaces)
         if q.isEmpty { return 1 }
         let titleLower = title.lowercased()
         if titleLower == q { return 100 }
@@ -283,6 +283,15 @@ public struct FeatureDef: Sendable, Identifiable {
         if keywords.contains(where: { $0.lowercased().hasPrefix(q) }) { return 40 }
         if keywords.contains(where: { $0.lowercased().contains(q) }) { return 30 }
         if let subtitle, subtitle.lowercased().contains(q) { return 10 }
+
+        // Multi-word query: match when every word appears somewhere searchable,
+        // even if not contiguous — so "copy ip" finds "Copy Device IP". Ranks
+        // below any contiguous match above.
+        let tokens = q.split(separator: " ").map(String.init)
+        guard tokens.count > 1 else { return 0 }
+        if tokens.allSatisfy({ titleLower.contains($0) }) { return 50 }
+        let haystacks = keywords.map { $0.lowercased() } + [titleLower, subtitle?.lowercased() ?? ""]
+        if tokens.allSatisfy({ token in haystacks.contains { $0.contains(token) } }) { return 20 }
         return 0
     }
 }

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -387,7 +387,7 @@ public enum FeatureRegistry {
             id: "bug-report", num: 34, title: "Bug Report",
             subtitle: "Zip screenshot + logs + device info + version",
             keywords: ["bug report", "zip", "bundle", "diagnostics", "export"],
-            category: .logs, icon: "doc.zipper", kind: .instantAction
+            category: .logs, icon: "doc.zipper", kind: .view
         ),
         FeatureDef(
             id: "performance", num: 35, title: "Performance Monitor",
@@ -443,6 +443,40 @@ public enum FeatureRegistry {
     /// Features the user manages individually in the catalog and sidebar:
     /// everything except hub members. The hub screens themselves are included.
     public static let catalogFeatureIDs: [String] = all.map(\.id).filter { !absorbedFeatureIDs.contains($0) }
+
+    /// Curated, ordered catalog features per role — the focused set a newcomer
+    /// gets after picking a role on first launch. The order is the recommended
+    /// sidebar order; the launchpad re-ranks it by real usage over time. Roles
+    /// reference hub ids (`react-native`, `simulate`, `connection`, `apps`), not
+    /// the members folded into them. Every non-system catalog feature appears in
+    /// at least one role (enforced by `FeatureRegistryTests`).
+    public static let featuresByRole: [UserRole: [String]] = [
+        .androidDeveloper: [
+            "logcat", "crash-catcher", "device-info", "current-activity", "foreground-package",
+            "file-explorer", "sandbox-browser", "apps", "connection", "get-ip",
+            "meminfo", "monkey", "scrcpy", "screenshot", "send-text", "custom-commands",
+        ],
+        .reactNativeDeveloper: [
+            "react-native", "logcat", "crash-catcher", "performance", "network-speed",
+            "apps", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
+        ],
+        .qaTester: [
+            "screenshot", "screen-record", "scrcpy", "video-editor", "bug-report",
+            "crash-catcher", "logcat", "simulate", "performance", "apps",
+            "device-info", "demo-mode", "monkey",
+        ],
+        .supportTriage: [
+            "device-info", "connection", "wifi", "get-ip", "network-speed",
+            "root-status", "system-restrictions", "scrcpy", "screenshot", "bug-report", "logcat",
+            "apps", "emulators",
+        ],
+    ]
+
+    /// The curated, ordered catalog ids for a role (validated to exist in the
+    /// registry). Empty for an unknown role.
+    public static func featureIDs(for role: UserRole) -> [String] {
+        (featuresByRole[role] ?? []).filter { byID[$0] != nil }
+    }
 }
 
 public extension FeatureDef {

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -81,6 +81,15 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// nil on layouts written before the switch, so they catch up once. Optional
     /// so older files decode.
     public var didEnableAll: Bool?
+    /// The role the user picked on first launch (`UserRole` raw value), or nil
+    /// for "show everything". Drives the curated enabled set + sidebar order.
+    /// Optional so older files decode.
+    public var selectedRole: String?
+    /// True once the user has been through the role picker (picked a role or
+    /// chose "everything"). Gates the one-time picker; set together with
+    /// `didEnableAll`/`knownIds` so the legacy migrations can't re-expand a
+    /// curated role back to all-on. Optional so older files decode.
+    public var roleChosen: Bool?
 
     public init(
         enabledIds: [String]? = nil,
@@ -90,7 +99,9 @@ public struct LayoutState: Codable, Sendable, Equatable {
         categoryOrder: [String]? = nil,
         collapsedCategories: [String]? = nil,
         menuBarItems: [String]? = nil,
-        didEnableAll: Bool? = nil
+        didEnableAll: Bool? = nil,
+        selectedRole: String? = nil,
+        roleChosen: Bool? = nil
     ) {
         self.enabledIds = enabledIds
         self.favorites = favorites
@@ -100,6 +111,8 @@ public struct LayoutState: Codable, Sendable, Equatable {
         self.collapsedCategories = collapsedCategories
         self.menuBarItems = menuBarItems
         self.didEnableAll = didEnableAll
+        self.selectedRole = selectedRole
+        self.roleChosen = roleChosen
     }
 
     /// The effective enabled set: explicit user choice or registry defaults,
@@ -147,6 +160,31 @@ public struct LayoutState: Codable, Sendable, Equatable {
         }
         return true
     }
+
+    /// Curate the layout to a role: enable exactly the role's features (system
+    /// features stay on regardless via `effectiveEnabledIDs`) and match the
+    /// sidebar order to the curated order. Marks `knownIds`/`didEnableAll` so
+    /// `adoptNewDefaults`/`adoptAllEnabled` can't re-expand the set back to
+    /// all-on. Used at first-run pick and when changing role later.
+    public mutating func seedRole(_ role: UserRole) {
+        let ids = FeatureRegistry.featureIDs(for: role)
+        selectedRole = role.rawValue
+        roleChosen = true
+        enabledIds = ids
+        sidebarOrder = ids
+        knownIds = FeatureRegistry.all.map(\.id)
+        didEnableAll = true
+    }
+
+    /// The "show me everything" choice: leave every feature on, just record that
+    /// the user has been through the picker. Clears any prior role curation.
+    public mutating func seedEverything() {
+        selectedRole = nil
+        roleChosen = true
+        enabledIds = nil
+        knownIds = FeatureRegistry.all.map(\.id)
+        didEnableAll = true
+    }
 }
 
 public struct Presets: Codable, Sendable, Equatable {
@@ -178,24 +216,19 @@ public struct Prefs: Codable, Sendable, Equatable {
     public var runOnAll: Bool
     /// The active saved bundle id (used by every app-scoped feature).
     public var selectedBundleId: String?
-    /// Feature id selected when the app was last used (restored at launch).
-    /// Optional so files written before the field existed still decode.
-    public var lastFeatureId: String?
 
     public init(
         selectedSerial: String? = nil,
         runOnAll: Bool = false,
-        selectedBundleId: String? = nil,
-        lastFeatureId: String? = nil
+        selectedBundleId: String? = nil
     ) {
         self.selectedSerial = selectedSerial
         self.runOnAll = runOnAll
         self.selectedBundleId = selectedBundleId
-        self.lastFeatureId = lastFeatureId
     }
 }
 
-/// All seven durable stores, built once at app startup.
+/// All eight durable stores, built once at app startup.
 public struct AppStores: Sendable {
     public let bundles: JSONStore<[AppBundle]>
     public let deepLinks: JSONStore<DeepLinksMap>
@@ -204,6 +237,7 @@ public struct AppStores: Sendable {
     public let presets: JSONStore<Presets>
     public let overrides: JSONStore<OverridesMap>
     public let prefs: JSONStore<Prefs>
+    public let usage: JSONStore<UsageStats>
 
     public init(directory: URL = AppPaths.supportDir) {
         bundles = JSONStore(filename: "bundles.json", default: [], directory: directory)
@@ -213,5 +247,6 @@ public struct AppStores: Sendable {
         presets = JSONStore(filename: "presets.json", default: Presets(), directory: directory)
         overrides = JSONStore(filename: "overrides.json", default: [:], directory: directory)
         prefs = JSONStore(filename: "prefs.json", default: Prefs(), directory: directory)
+        usage = JSONStore(filename: "usage.json", default: UsageStats(), directory: directory)
     }
 }

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -70,6 +70,12 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// not listed fall back to `displayOrder` after the listed ones. Optional
     /// so older files decode.
     public var categoryOrder: [String]?
+    /// User's custom order for the *ungrouped* (flat) sidebar — kept separate
+    /// from `sidebarOrder` (which drives grouped/within-group order) so the two
+    /// layouts are independent. nil until the user reorders the flat list, at
+    /// which point the flat sidebar seeds from the grouped order. Optional so
+    /// older files decode.
+    public var flatOrder: [String]?
     /// Categories the user collapsed in the sidebar (`FeatureCategory` raw
     /// values) — only their header shows. Optional so older files decode.
     public var collapsedCategories: [String]?
@@ -97,6 +103,7 @@ public struct LayoutState: Codable, Sendable, Equatable {
         knownIds: [String]? = nil,
         sidebarOrder: [String]? = nil,
         categoryOrder: [String]? = nil,
+        flatOrder: [String]? = nil,
         collapsedCategories: [String]? = nil,
         menuBarItems: [String]? = nil,
         didEnableAll: Bool? = nil,
@@ -108,6 +115,7 @@ public struct LayoutState: Codable, Sendable, Equatable {
         self.knownIds = knownIds
         self.sidebarOrder = sidebarOrder
         self.categoryOrder = categoryOrder
+        self.flatOrder = flatOrder
         self.collapsedCategories = collapsedCategories
         self.menuBarItems = menuBarItems
         self.didEnableAll = didEnableAll

--- a/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Per-feature usage tally, persisted to `usage.json`. Used to re-rank a role's
+/// curated feature order on the Home launchpad by how the user actually works,
+/// so "frequently used" becomes personal over time.
+///
+/// `CommandLog` is session-only (an in-memory actor), so cross-launch ranking
+/// needs this durable store rather than the command log.
+public struct UsageStat: Codable, Sendable, Equatable {
+    public var count: Int
+    public var lastUsed: Date
+
+    public init(count: Int = 0, lastUsed: Date = .distantPast) {
+        self.count = count
+        self.lastUsed = lastUsed
+    }
+}
+
+public struct UsageStats: Codable, Sendable, Equatable {
+    /// Tally keyed by feature id.
+    public var byFeature: [String: UsageStat]
+
+    public init(byFeature: [String: UsageStat] = [:]) {
+        self.byFeature = byFeature
+    }
+
+    public func count(for featureID: String) -> Int { byFeature[featureID]?.count ?? 0 }
+
+    /// Record one user-initiated use of a feature at `date`.
+    public mutating func record(_ featureID: String, at date: Date) {
+        var stat = byFeature[featureID] ?? UsageStat()
+        stat.count += 1
+        stat.lastUsed = date
+        byFeature[featureID] = stat
+    }
+
+    /// Re-rank `ids` (a curated, ordered list) by real usage: most-used first,
+    /// most-recent use breaks count ties, and the original curated order is the
+    /// stable fallback for unused or otherwise-tied features. The comparator is
+    /// a total order (curated index is the final tiebreak), so the result is
+    /// deterministic regardless of `sorted`'s stability guarantees.
+    public func rank(_ ids: [String]) -> [String] {
+        ids.enumerated()
+            .sorted { lhs, rhs in
+                let a = byFeature[lhs.element]
+                let b = byFeature[rhs.element]
+                let countA = a?.count ?? 0
+                let countB = b?.count ?? 0
+                if countA != countB { return countA > countB }
+                if countA > 0, let lastA = a?.lastUsed, let lastB = b?.lastUsed, lastA != lastB {
+                    return lastA > lastB
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -237,4 +237,50 @@ import Testing
         #expect(layout.effectiveEnabledIDs.contains("custom-commands"))
         #expect(!layout.effectiveEnabledIDs.contains("fake-battery"))
     }
+
+    @Test func everyRoleMapsValidFeatureIDsAndCoversTheCatalog() {
+        for role in UserRole.allCases {
+            for id in FeatureRegistry.featuresByRole[role] ?? [] {
+                #expect(FeatureRegistry.byID[id] != nil, "role \(role.rawValue): unknown feature \(id)")
+                #expect(
+                    !(FeatureRegistry.byID[id]?.isAbsorbedByHub ?? false),
+                    "role \(role.rawValue): \(id) is a hub member; reference its hub instead"
+                )
+            }
+        }
+        // Every non-system catalog feature must be reachable from some role, so
+        // curation never orphans a feature. System features are always on
+        // regardless of role, so they're exempt.
+        let covered = Set(UserRole.allCases.flatMap { FeatureRegistry.featuresByRole[$0] ?? [] })
+        let mustCover = Set(FeatureRegistry.catalogFeatureIDs)
+            .subtracting(FeatureRegistry.systemFeatureIDs)
+        #expect(mustCover.isSubset(of: covered), "uncovered catalog features: \(mustCover.subtracting(covered))")
+    }
+
+    @Test func seedRoleCuratesEnabledSetAndOrder() {
+        var layout = LayoutState()
+        layout.seedRole(.qaTester)
+        let curated = FeatureRegistry.featureIDs(for: .qaTester)
+        #expect(layout.selectedRole == UserRole.qaTester.rawValue)
+        #expect(layout.roleChosen == true)
+        #expect(layout.enabledIds == curated)
+        #expect(layout.sidebarOrder == curated)
+        #expect(layout.effectiveEnabledIDs.isSuperset(of: Set(curated)))
+        #expect(layout.effectiveEnabledIDs.contains("custom-commands"))  // system stays on
+        #expect(!layout.effectiveEnabledIDs.contains("wifi"))            // curated out for QA
+        // The legacy migrations must not re-expand a curated role back to all-on.
+        #expect(layout.adoptAllEnabled() == false)
+        #expect(layout.adoptNewDefaults() == false)
+        #expect(layout.enabledIds == curated)
+    }
+
+    @Test func seedEverythingLeavesEverythingOn() {
+        var layout = LayoutState()
+        layout.seedRole(.qaTester)
+        layout.seedEverything()
+        #expect(layout.roleChosen == true)
+        #expect(layout.selectedRole == nil)
+        #expect(layout.enabledIds == nil)
+        #expect(Set(FeatureRegistry.catalogFeatureIDs).isSubset(of: layout.effectiveEnabledIDs))
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import ADBKit
 
@@ -213,6 +214,18 @@ import Testing
         #expect(!logcat.matches("battery"))
     }
 
+    @Test func multiWordSearchMatchesNonContiguousTokens() {
+        // "copy ip" must surface Copy Device IP even though "Device" sits between
+        // the two words; it should outrank the Connection hub, whose subtitle
+        // only mentions "Copy IP".
+        let copyIP = FeatureRegistry.byID["get-ip"]!
+        let connection = FeatureRegistry.byID["connection"]!
+        #expect(copyIP.matches("copy ip"))
+        #expect(copyIP.relevance(for: "copy ip") > connection.relevance(for: "copy ip"))
+        // Every word still has to appear somewhere — gibberish doesn't match.
+        #expect(!copyIP.matches("copy battery"))
+    }
+
     @Test func hubsStaySearchableByTheirMembersPrimaryKeyword() {
         // Absorbed members no longer surface as standalone search results, so
         // each hub must carry its members' identity: searching a member's
@@ -272,6 +285,18 @@ import Testing
         #expect(layout.adoptAllEnabled() == false)
         #expect(layout.adoptNewDefaults() == false)
         #expect(layout.enabledIds == curated)
+    }
+
+    @Test func flatOrderPersistsIndependentlyOfGroupedOrder() throws {
+        var layout = LayoutState()
+        layout.sidebarOrder = ["a", "b", "c"]
+        layout.flatOrder = ["c", "a", "b"]
+        let decoded = try JSONDecoder().decode(LayoutState.self, from: JSONEncoder().encode(layout))
+        #expect(decoded.sidebarOrder == ["a", "b", "c"])
+        #expect(decoded.flatOrder == ["c", "a", "b"])
+        // A fresh layout has no flat order, so the flat sidebar mirrors the
+        // grouped order until the user reorders it.
+        #expect(LayoutState().flatOrder == nil)
     }
 
     @Test func seedEverythingLeavesEverythingOn() {

--- a/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct UsageStatsTests {
+    private func date(_ seconds: Double) -> Date { Date(timeIntervalSince1970: seconds) }
+
+    @Test func recordIncrementsCountAndStampsLastUsed() {
+        var stats = UsageStats()
+        stats.record("logcat", at: date(100))
+        stats.record("logcat", at: date(200))
+        #expect(stats.count(for: "logcat") == 2)
+        #expect(stats.byFeature["logcat"]?.lastUsed == date(200))
+        #expect(stats.count(for: "screenshot") == 0)
+    }
+
+    @Test func rankPutsMostUsedFirstThenRecencyThenCuratedOrder() {
+        var stats = UsageStats()
+        // screenshot used most; logcat and apps tie on count, apps more recent.
+        for t in [10.0, 20, 30] { stats.record("screenshot", at: date(t)) }
+        stats.record("logcat", at: date(40))
+        stats.record("apps", at: date(50))
+        let curated = ["send-text", "logcat", "apps", "screenshot", "device-info"]
+        #expect(stats.rank(curated) == ["screenshot", "apps", "logcat", "send-text", "device-info"])
+    }
+
+    @Test func rankPreservesCuratedOrderWhenUnused() {
+        let stats = UsageStats()
+        let curated = ["a", "b", "c", "d"]
+        #expect(stats.rank(curated) == curated)
+    }
+}

--- a/App/Resources/Assets.xcassets/BgRoot.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/BgRoot.colorset/Contents.json
@@ -6,7 +6,7 @@
     },
     {
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
-      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x16", "green" : "0x19", "blue" : "0x1C" } },
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x1A", "green" : "0x1A", "blue" : "0x1A" } },
       "idiom" : "universal"
     }
   ],

--- a/App/Resources/Assets.xcassets/BgSurface.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/BgSurface.colorset/Contents.json
@@ -6,7 +6,7 @@
     },
     {
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
-      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x1E", "green" : "0x22", "blue" : "0x28" } },
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x23", "green" : "0x23", "blue" : "0x23" } },
       "idiom" : "universal"
     }
   ],

--- a/App/Resources/Assets.xcassets/BorderSubtle.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/BorderSubtle.colorset/Contents.json
@@ -6,7 +6,7 @@
     },
     {
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
-      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x2B", "green" : "0x30", "blue" : "0x37" } },
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x33", "green" : "0x33", "blue" : "0x33" } },
       "idiom" : "universal"
     }
   ],

--- a/App/Resources/Assets.xcassets/TextMain.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/TextMain.colorset/Contents.json
@@ -6,7 +6,7 @@
     },
     {
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
-      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xE9", "green" : "0xEC", "blue" : "0xEE" } },
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0xEC", "green" : "0xEC", "blue" : "0xEC" } },
       "idiom" : "universal"
     }
   ],

--- a/App/Resources/Assets.xcassets/TextMuted.colorset/Contents.json
+++ b/App/Resources/Assets.xcassets/TextMuted.colorset/Contents.json
@@ -6,7 +6,7 @@
     },
     {
       "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
-      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x8E", "green" : "0x93", "blue" : "0x98" } },
+      "color" : { "color-space" : "srgb", "components" : { "alpha" : "1.000", "red" : "0x92", "green" : "0x92", "blue" : "0x92" } },
       "idiom" : "universal"
     }
   ],

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -95,16 +95,6 @@ struct ADTApp: App {
             }
         }
 
-        Window("Search", id: "palette") {
-            PaletteWindowView()
-                .environment(appState)
-                .tint(.brandAccent)
-        }
-        .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentSize)
-        .defaultPosition(.center)
-        .commandsRemoved()
-
         Settings {
             SettingsView()
                 .environment(appState)

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -11,7 +11,11 @@ struct ADTApp: App {
         // hot-key registration needs a running event loop, which App.init
         // predates.
         _appState = State(initialValue: AppState(env: AppEnvironment()))
-        // Start crash reporting as early as possible; analytics only if opted in.
+        // Count this launch so the first-run privacy disclosure can be deferred
+        // (gated in RootView). Telemetry is anonymous and on by default; start
+        // it as early as possible.
+        let defaults = UserDefaults.standard
+        defaults.set(defaults.integer(forKey: "launchCount") + 1, forKey: "launchCount")
         Telemetry.shared.start()
     }
 

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -96,6 +96,8 @@ struct FeatureDetailView: View {
                 VideoEditorView()
             case "crash-catcher":
                 CrashView()
+            case "bug-report":
+                BugReportView()
             case "wireless-adb":
                 WirelessAdbView()
             case "custom-commands":

--- a/App/Sources/FeatureDetail/HubKit.swift
+++ b/App/Sources/FeatureDetail/HubKit.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// Building blocks for hub / multi-section screens (Connection, Wireless ADB,
+/// Private DNS, and future hubs). They replace the macOS grouped `Form` — whose
+/// inset bars, wide leading gutter, and right-aligned value rows read as busy
+/// and ambiguous — with a uniform, scannable card layout.
+
+/// A titled content card: a header (title + optional one-line subtitle) above
+/// its controls, on a single lifted surface. The consistent container for every
+/// section, so the whole screen reads as one rhythm instead of mismatched bars.
+struct HubSection<Content: View>: View {
+    private let title: String
+    private let subtitle: String?
+    @ViewBuilder private let content: () -> Content
+
+    init(_ title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.headline).foregroundStyle(.textMain)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.bgSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(.borderSubtle, lineWidth: 1))
+    }
+}
+
+/// A labeled text input: a quiet caption above a brand-focus field, so a field
+/// always reads as "type here" rather than a static value row.
+struct HubField: View {
+    private let label: String
+    private let prompt: String?
+    @Binding private var text: String
+
+    init(_ label: String, prompt: String? = nil, text: Binding<String>) {
+        self.label = label
+        self.prompt = prompt
+        self._text = text
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(label).font(.caption).foregroundStyle(.textMuted)
+            TextField("", text: $text, prompt: prompt.map(Text.init))
+                .brandField()
+                .labelsHidden()
+        }
+    }
+}
+
+/// The standard scrollable, centered column that holds a screen's `HubSection`s
+/// — a readable max width so content never sprawls across the pane or strands
+/// in a side gutter.
+struct HubColumn<Content: View>: View {
+    @ViewBuilder private let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                content()
+            }
+            .frame(maxWidth: 600, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// A read-only label / value row for data inside a `HubSection` (e.g. device
+/// properties) — label at the leading edge, selectable value trailing.
+struct HubRow: View {
+    private let label: String
+    private let value: String
+
+    init(_ label: String, _ value: String) {
+        self.label = label
+        self.value = value
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).foregroundStyle(.textMain)
+            Spacer(minLength: 16)
+            Text(value)
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/HubKit.swift
+++ b/App/Sources/FeatureDetail/HubKit.swift
@@ -8,27 +8,47 @@ import SwiftUI
 /// A titled content card: a header (title + optional one-line subtitle) above
 /// its controls, on a single lifted surface. The consistent container for every
 /// section, so the whole screen reads as one rhythm instead of mismatched bars.
-struct HubSection<Content: View>: View {
+struct HubSection<Content: View, Accessory: View>: View {
     private let title: String
     private let subtitle: String?
+    @ViewBuilder private let accessory: () -> Accessory
     @ViewBuilder private let content: () -> Content
 
-    init(_ title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+    init(_ title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content)
+        where Accessory == EmptyView {
         self.title = title
         self.subtitle = subtitle
+        self.accessory = { EmptyView() }
+        self.content = content
+    }
+
+    /// Variant with a trailing accessory in the header (e.g. a refresh button).
+    init(
+        _ title: String,
+        subtitle: String? = nil,
+        @ViewBuilder accessory: @escaping () -> Accessory,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.accessory = accessory
         self.content = content
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title).font(.headline).foregroundStyle(.textMain)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.callout)
-                        .foregroundStyle(.textMuted)
-                        .fixedSize(horizontal: false, vertical: true)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title).font(.headline).foregroundStyle(.textMain)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.callout)
+                            .foregroundStyle(.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
+                Spacer(minLength: 12)
+                accessory()
             }
             content()
         }
@@ -104,6 +124,23 @@ struct HubRow: View {
                 .foregroundStyle(.textMuted)
                 .multilineTextAlignment(.trailing)
                 .textSelection(.enabled)
+        }
+    }
+}
+
+/// A divider-separated list of label/value `HubRow`s — the read-only data block
+/// inside a `HubSection` (device properties, app info, …).
+struct HubRowList: View {
+    private let rows: [(String, String)]
+
+    init(_ rows: [(String, String)]) { self.rows = rows }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                if index > 0 { Divider() }
+                HubRow(row.0, row.1).padding(.vertical, 7)
+            }
         }
     }
 }

--- a/App/Sources/FeatureDetail/Views/AppInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/AppInfoView.swift
@@ -38,27 +38,31 @@ struct AppInfoView: View {
     }
 
     private func details(_ info: AppInfo) -> some View {
-        Form {
-            LabeledContent("Version", value: info.versionName)
-            LabeledContent("Version Code", value: info.versionCode)
-            LabeledContent("Target SDK", value: info.targetSdk)
-            LabeledContent("Min SDK", value: info.minSdk)
-            LabeledContent("First Install", value: info.firstInstall)
-            LabeledContent("Last Update", value: info.lastUpdate)
-            if let size = info.apkSizeBytes {
-                LabeledContent("APK Size", value: ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file))
+        HubColumn {
+            HubSection("App info") {
+                HubRowList(
+                    [
+                        ("Version", info.versionName),
+                        ("Version Code", info.versionCode),
+                        ("Target SDK", info.targetSdk),
+                        ("Min SDK", info.minSdk),
+                        ("First Install", info.firstInstall),
+                        ("Last Update", info.lastUpdate),
+                    ]
+                    + (info.apkSizeBytes.map {
+                        [("APK Size", ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .file))]
+                    } ?? [])
+                )
             }
 
-            Button {
-                pullApk()
-            } label: {
-                Label(pulling ? "Pulling…" : "Pull APK", systemImage: "arrow.down.circle")
+            HubSection("APK") {
+                Button { pullApk() } label: {
+                    Label(pulling ? "Pulling…" : "Pull APK", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(pulling)
             }
-            .disabled(pulling)
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn(maxWidth: 460)
     }
 
     private func load() async {

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -220,8 +220,8 @@ private struct AppDetailPane: View {
     private var serial: String { state.targetSerials.first ?? "" }
 
     var body: some View {
-        Form {
-            Section {
+        HubColumn {
+            HubSection("App info") {
                 HStack(spacing: 12) {
                     AppIconView(packageId: packageId, name: derivedName, serial: state.targetSerials.first ?? "")
                         .frame(width: 40, height: 40)
@@ -230,15 +230,17 @@ private struct AppDetailPane: View {
                         .textSelection(.enabled)
                 }
                 if let info, info.installed {
-                    LabeledContent("Version", value: info.versionName)
-                    LabeledContent("Target SDK", value: info.targetSdk)
-                    LabeledContent("Min SDK", value: info.minSdk)
-                    LabeledContent("Last Update", value: info.lastUpdate)
-                    if let size = info.apkSizeBytes {
-                        LabeledContent("APK Size", value: ByteCountFormatter.string(
-                            fromByteCount: Int64(size), countStyle: .file
-                        ))
-                    }
+                    HubRowList(
+                        [
+                            ("Version", info.versionName),
+                            ("Target SDK", info.targetSdk),
+                            ("Min SDK", info.minSdk),
+                            ("Last Update", info.lastUpdate),
+                        ]
+                        + (info.apkSizeBytes.map {
+                            [("APK Size", ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .file))]
+                        } ?? [])
+                    )
                 } else if info == nil {
                     HStack {
                         ProgressView().controlSize(.small)
@@ -247,7 +249,7 @@ private struct AppDetailPane: View {
                 }
             }
 
-            Section("Controls") {
+            HubSection("Controls") {
                 HStack(spacing: 8) {
                     Button { runControl(.open) } label: {
                         Label("Open", systemImage: "play.fill")
@@ -265,7 +267,7 @@ private struct AppDetailPane: View {
                 .disabled(managing)
             }
 
-            Section {
+            HubSection("Permissions") {
                 if let permissions {
                     Toggle(isOn: $showPermissions) {
                         Text("Runtime permissions (\(permissions.count))")
@@ -308,7 +310,7 @@ private struct AppDetailPane: View {
                 }
             }
 
-            Section {
+            HubSection("Files & APK") {
                 Button {
                     pullApk()
                 } label: {
@@ -322,7 +324,7 @@ private struct AppDetailPane: View {
                 }
             }
 
-            Section("Manage") {
+            HubSection("Manage") {
                 if lifecycle?.removed == true {
                     Button {
                         manage { try await $0.setRemoved(serial: serial, packageId: packageId, false) }
@@ -358,8 +360,6 @@ private struct AppDetailPane: View {
                 }
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
         .confirmationDialog(
             "Clear all data for \(packageId)? This signs you out and wipes local storage.",
             isPresented: $confirmingClearData

--- a/App/Sources/FeatureDetail/Views/BugReportView.swift
+++ b/App/Sources/FeatureDetail/Views/BugReportView.swift
@@ -1,0 +1,83 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// Bug Report — assemble a shareable zip (screenshot + recent logcat + device
+/// info, plus the app version when a bundle is selected) and reveal it in
+/// Finder, ready to attach to a ticket.
+struct BugReportView: View {
+    @Environment(AppState.self) private var state
+
+    private var bundle: AppBundle? { state.selectedBundle }
+    private var lastReport: (result: FeatureResult, at: Date)? { state.lastResults["bug-report"] }
+
+    var body: some View {
+        HubColumn {
+            HubSection("What's included", subtitle: "A single zip you can drop straight into a bug ticket.") {
+                VStack(spacing: 0) {
+                    contentRow("camera", "Screenshot", "The current screen")
+                    Divider()
+                    contentRow("scroll", "Logcat", "The last 2,000 log lines")
+                    Divider()
+                    contentRow("info.circle", "Device info", "Model, Android version, ABI, serial")
+                    Divider()
+                    contentRow(
+                        "shippingbox", "App version",
+                        bundle.map { "Included for \($0.nickname)" } ?? "Select a bundle in the bar to include it"
+                    )
+                }
+            }
+
+            HubSection("Generate") {
+                Button { generate() } label: {
+                    Label("Generate bug report", systemImage: "doc.zipper")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
+
+                if state.isRunningFeature {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.small)
+                        Text("Collecting screenshot, logs, and device info…").foregroundStyle(.textMuted)
+                    }
+                } else if state.targetSerials.isEmpty {
+                    Text("Connect a device first.").font(.footnote).foregroundStyle(.textMuted)
+                }
+
+                if let last = lastReport, last.result.ok, let path = last.result.revealPath {
+                    Divider()
+                    HStack(spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill").foregroundStyle(.brandAccent)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Bug report saved").foregroundStyle(.textMain)
+                            Text((path as NSString).lastPathComponent)
+                                .font(.footnote).foregroundStyle(.textMuted)
+                        }
+                        Spacer()
+                        Button("Reveal in Finder") {
+                            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func contentRow(_ icon: String, _ title: String, _ detail: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon).foregroundStyle(.textMuted).frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).foregroundStyle(.textMain)
+                Text(detail).font(.footnote).foregroundStyle(.textMuted)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 7)
+    }
+
+    private func generate() {
+        guard let feature = FeatureRegistry.byID["bug-report"] else { return }
+        Task { await state.run(feature: feature, params: [:]) }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/CatalogView.swift
+++ b/App/Sources/FeatureDetail/Views/CatalogView.swift
@@ -64,14 +64,15 @@ struct GroupHeaderView: View {
     var compact = false
     /// Show the grip glyph that hints the row can be dragged (sidebar only).
     var showsDragHandle = false
+    /// Sidebar reorder mode — the grip shows and the group becomes draggable only
+    /// while this holds, so headers stay clean the rest of the time.
+    var reordering = false
     var collapsed = false
     /// When set, a single click toggles collapse and a disclosure chevron shows.
     var onToggleCollapse: (() -> Void)?
     /// When set, dragging the grip reorders this group (sidebar only). Kept on
     /// the grip, not the whole header, so it never competes with the tap.
     var dragProvider: (() -> NSItemProvider)?
-
-    @State private var hovering = false
 
     var body: some View {
         if state.canToggleGroup(category) {
@@ -96,21 +97,15 @@ struct GroupHeaderView: View {
             }
             Text(category.label)
             Spacer(minLength: 0)
-            if showsDragHandle {
+            if showsDragHandle, reordering {
                 let grip = Image(systemName: "line.3.horizontal")
-                    .foregroundStyle(.textMuted)
+                    .foregroundStyle(.brandAccent)
                     .font(.body)
-                Group {
-                    if let dragProvider {
-                        grip.onDrag(dragProvider).help("Drag to reorder this group")
-                    } else {
-                        grip
-                    }
+                if let dragProvider {
+                    grip.onDrag(dragProvider).help("Drag to reorder this group")
+                } else {
+                    grip
                 }
-                // Only hint the grip while hovering the header, so it isn't
-                // always-on clutter next to every group title.
-                .opacity(hovering ? 1 : 0)
-                .allowsHitTesting(hovering)
             }
         }
         .font(compact ? .caption : nil)
@@ -120,7 +115,6 @@ struct GroupHeaderView: View {
         // edge during a drag) sits clear of the label instead of touching it.
         .padding(.vertical, compact ? 6 : 0)
         .contentShape(Rectangle())
-        .onHover { hovering = $0 }
         .onTapGesture { onToggleCollapse?() }
         .help(onToggleCollapse != nil
             ? "Click to collapse · drag to reorder · right-click to enable/disable the group"

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -1,9 +1,8 @@
 import ADBKit
 import SwiftUI
 
-/// Saved deep links for the selected bundle, as a `Form` section so it composes
-/// into both the standalone screen and the React Native hub (and scrolls with
-/// the rest of the form).
+/// Saved deep links for the selected bundle, as a reusable card so it composes
+/// into both the standalone screen and the React Native hub.
 struct DeepLinksSection: View {
     @Environment(AppState.self) private var state
     @State private var links: [DeepLink] = []
@@ -13,7 +12,7 @@ struct DeepLinksSection: View {
     @State private var draftURL = ""
 
     var body: some View {
-        Section("Deep links") {
+        HubSection("Deep links", subtitle: "Saved per app — launch a URL on the device in one click.") {
             if state.selectedBundle == nil {
                 Text("Select a bundle in the bar above — deep links are saved per app.")
                     .foregroundStyle(.textMuted)
@@ -21,36 +20,12 @@ struct DeepLinksSection: View {
                 if links.isEmpty {
                     Text("No deep links yet. Add one like myapp://orders/123 to launch it in a click.")
                         .foregroundStyle(.textMuted)
-                }
-                ForEach(links) { link in
-                    HStack {
-                        Image(systemName: "link").foregroundStyle(.textMuted)
-                        VStack(alignment: .leading) {
-                            if !link.label.isEmpty { Text(link.label) }
-                            Text(link.url)
-                                .font(.footnote)
-                                .foregroundStyle(.textMuted)
-                                .textSelection(.enabled)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(links) { link in
+                            if link.id != links.first?.id { Divider() }
+                            linkRow(link)
                         }
-                        Spacer()
-                        Button { launch(link) } label: {
-                            Image(systemName: "play.fill").foregroundStyle(.brandAccent)
-                        }
-                        .buttonStyle(.borderless)
-                        .help("Launch on device")
-                        Button {
-                            editingLink = link
-                            draftLabel = link.label
-                            draftURL = link.url
-                            showEditor = true
-                        } label: {
-                            Image(systemName: "pencil")
-                        }
-                        .buttonStyle(.borderless)
-                        Button { remove(link) } label: {
-                            Image(systemName: "trash").foregroundStyle(.red)
-                        }
-                        .buttonStyle(.borderless)
                     }
                 }
                 Button {
@@ -61,10 +36,44 @@ struct DeepLinksSection: View {
                 } label: {
                     Label("Add deep link", systemImage: "plus")
                 }
+                .buttonStyle(.bordered)
             }
         }
         .task(id: state.selectedBundleId) { await loadLinks() }
         .sheet(isPresented: $showEditor) { editor }
+    }
+
+    private func linkRow(_ link: DeepLink) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "link").foregroundStyle(.textMuted)
+            VStack(alignment: .leading, spacing: 1) {
+                if !link.label.isEmpty { Text(link.label).foregroundStyle(.textMain) }
+                Text(link.url)
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            Button { launch(link) } label: {
+                Image(systemName: "play.fill").foregroundStyle(.brandAccent)
+            }
+            .buttonStyle(.borderless)
+            .help("Launch on device")
+            Button {
+                editingLink = link
+                draftLabel = link.label
+                draftURL = link.url
+                showEditor = true
+            } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.borderless)
+            Button { remove(link) } label: {
+                Image(systemName: "trash").foregroundStyle(.red)
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, 7)
     }
 
     private var editor: some View {
@@ -143,14 +152,9 @@ struct DeepLinksSection: View {
     }
 }
 
-/// Standalone Deep Links screen — the section on its own in a grouped form.
+/// Standalone Deep Links screen — the section on its own in the hub column.
 struct DeepLinksView: View {
     var body: some View {
-        Form {
-            DeepLinksSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { DeepLinksSection() }
     }
 }

--- a/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
@@ -57,7 +57,7 @@ struct DeviceInfoView: View {
         VStack(spacing: 0) {
             TextField("Filter properties…", text: $search)
                 .brandField()
-                .padding(10)
+                .padding(12)
 
             Divider()
 
@@ -70,36 +70,35 @@ struct DeviceInfoView: View {
     }
 
     private func curated(_ props: [String: String]) -> some View {
-        Form {
+        HubColumn {
             if let overview {
-                Section("Memory") {
-                    LabeledContent("Total RAM", value: formatKb(overview.ramTotalKb))
-                    LabeledContent("Used RAM", value: formatKb(overview.ramUsedKb))
-                    LabeledContent("Available RAM", value: formatKb(overview.ramAvailableKb))
+                HubSection("Memory") {
+                    infoRows([
+                        ("Total RAM", formatKb(overview.ramTotalKb)),
+                        ("Used RAM", formatKb(overview.ramUsedKb)),
+                        ("Available RAM", formatKb(overview.ramAvailableKb)),
+                    ])
                 }
-                Section("Storage") {
-                    LabeledContent("Total", value: formatKb(overview.storageTotalKb))
-                    LabeledContent("Used", value: formatKb(overview.storageUsedKb))
-                    LabeledContent("Available", value: formatKb(overview.storageAvailableKb))
+                HubSection("Storage") {
+                    infoRows([
+                        ("Total", formatKb(overview.storageTotalKb)),
+                        ("Used", formatKb(overview.storageUsedKb)),
+                        ("Available", formatKb(overview.storageAvailableKb)),
+                    ])
                 }
-                Section("Battery") {
-                    LabeledContent("Level", value: overview.batteryLevel.map { "\($0)%" } ?? "—")
-                    LabeledContent("Health", value: overview.batteryHealth ?? "—")
-                    if let cycles = overview.batteryCycleCount {
-                        LabeledContent("Cycle Count", value: "\(cycles)")
-                    }
-                }
-                Section("Apps & CPU") {
-                    LabeledContent("CPU Architecture", value: overview.cpuAbi ?? "—")
-                    LabeledContent("Installed Apps", value: overview.userAppCount.map(String.init) ?? "—")
-                    LabeledContent("System Apps", value: overview.systemAppCount.map(String.init) ?? "—")
+                HubSection("Battery") { infoRows(batteryRows) }
+                HubSection("Apps & CPU") {
+                    infoRows([
+                        ("CPU Architecture", overview.cpuAbi ?? "—"),
+                        ("Installed Apps", overview.userAppCount.map(String.init) ?? "—"),
+                        ("System Apps", overview.systemAppCount.map(String.init) ?? "—"),
+                    ])
                 }
             } else {
-                Section("Overview") {
-                    HStack {
+                HubSection("Overview") {
+                    HStack(spacing: 8) {
                         ProgressView().controlSize(.small)
-                        Text("Reading memory, storage, and battery…")
-                            .foregroundStyle(.textMuted)
+                        Text("Reading memory, storage, and battery…").foregroundStyle(.textMuted)
                     }
                 }
             }
@@ -110,25 +109,37 @@ struct DeviceInfoView: View {
                     return (item.label, value)
                 }
                 if !rows.isEmpty {
-                    Section(group.section) {
-                        ForEach(rows, id: \.0) { row in
-                            LabeledContent(row.0) {
-                                Text(row.1)
-                                    .textSelection(.enabled)
-                                    .foregroundStyle(.textMuted)
-                            }
-                        }
-                    }
+                    HubSection(group.section) { infoRows(rows) }
                 }
             }
-            Section("All properties (\(props.count))") {
+
+            HubSection("All properties (\(props.count))") {
                 Text("Type in the filter box above to search every raw getprop value.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
+    }
+
+    private var batteryRows: [(String, String)] {
+        guard let overview else { return [] }
+        var rows: [(String, String)] = [
+            ("Level", overview.batteryLevel.map { "\($0)%" } ?? "—"),
+            ("Health", overview.batteryHealth ?? "—"),
+        ]
+        if let cycles = overview.batteryCycleCount {
+            rows.append(("Cycle Count", "\(cycles)"))
+        }
+        return rows
+    }
+
+    private func infoRows(_ pairs: [(String, String)]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(pairs.enumerated()), id: \.offset) { index, pair in
+                if index > 0 { Divider() }
+                HubRow(pair.0, pair.1).padding(.vertical, 7)
+            }
+        }
     }
 
     private func filtered(_ props: [String: String]) -> some View {
@@ -155,6 +166,7 @@ struct DeviceInfoView: View {
                             .textSelection(.enabled)
                     }
                 }
+                .scrollContentBackground(.hidden)
             }
         }
     }

--- a/App/Sources/FeatureDetail/Views/EmulatorsView.swift
+++ b/App/Sources/FeatureDetail/Views/EmulatorsView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import AppKit
 import SwiftUI
 
 /// Android Studio AVDs: launch (normal / cold boot / wipe data), see which
@@ -96,6 +97,9 @@ struct EmulatorsView: View {
                     }
                 }
                 .padding(.vertical, 3)
+                .contentShape(Rectangle())
+                .onTapGesture { if let serial = avd.runningSerial { focus(serial: serial) } }
+                .help(avd.runningSerial != nil ? "Click to bring the emulator window to the front" : "")
             }
         }
         .confirmationDialog(
@@ -126,12 +130,75 @@ struct EmulatorsView: View {
     }
 
     private func launch(_ avd: Avd, options: EmulatorService.LaunchOptions) {
+        // Remember the emulator windows already up, so post-launch focus targets
+        // the one we're starting rather than an existing emulator.
+        let existing = Set(emulatorApps().map(\.processIdentifier))
         Task {
-            await CommandLog.userInitiated(feature: "emulators") {
+            let ok = await CommandLog.userInitiated(feature: "emulators") {
                 let result = await state.env.engine.emulators.launch(avd: avd.name, options: options)
                 state.showToast(Toast(message: result.message, ok: result.ok))
                 // The device monitor picks the emulator up once adb sees it.
+                return result.ok
             }
+            if ok { await focusNewEmulator(excluding: existing) }
+        }
+    }
+
+    /// Running Android-emulator GUI processes. The emulator runs as a
+    /// `qemu-system-*` binary under the SDK's `emulator/` directory.
+    private func emulatorApps() -> [NSRunningApplication] {
+        NSWorkspace.shared.runningApplications.filter { app in
+            let path = app.executableURL?.path.lowercased() ?? ""
+            let name = app.localizedName?.lowercased() ?? ""
+            return path.contains("/emulator/") || path.contains("qemu-system") || name.contains("qemu")
+        }
+    }
+
+    /// Focus the specific emulator for `serial`. Its console port (the number in
+    /// `emulator-5554`) is held by exactly that qemu process, so `lsof` maps the
+    /// serial to the right pid — and the right window — even with several
+    /// emulators running. Falls back to any emulator if the lookup misses.
+    private func focus(serial: String) {
+        Task {
+            let pid = await Self.consolePortPID(serial: serial)
+            if let pid, let app = NSRunningApplication(processIdentifier: pid) {
+                app.activate(options: .activateAllWindows)
+            } else {
+                for app in emulatorApps() { app.activate(options: .activateAllWindows) }
+            }
+        }
+    }
+
+    /// pid of the process listening on the emulator's console port. Runs `lsof`
+    /// off the main actor so the tap handler never blocks.
+    nonisolated private static func consolePortPID(serial: String) async -> pid_t? {
+        guard let port = serial.split(separator: "-").last.flatMap({ Int($0) }) else { return nil }
+        return await Task.detached {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+            task.arguments = ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = FileHandle.nullDevice
+            do { try task.run() } catch { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            task.waitUntilExit()
+            return String(data: data, encoding: .utf8)?
+                .split(whereSeparator: \.isNewline)
+                .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+                .first
+        }.value
+    }
+
+    /// The emulator window appears a few seconds after launch — poll briefly and
+    /// focus the freshly-spawned process (one not in `existing`).
+    private func focusNewEmulator(excluding existing: Set<pid_t>) async {
+        for _ in 0..<25 {
+            if let fresh = emulatorApps().first(where: { !existing.contains($0.processIdentifier) }) {
+                fresh.activate(options: .activateAllWindows)
+                return
+            }
+            try? await Task.sleep(for: .seconds(1))
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -2,12 +2,14 @@ import ADBKit
 import AppKit
 import SwiftUI
 
-/// The landing screen: what Droidective is, the keyboard shortcuts that drive
-/// it, how to customize features and theme, and an overview of every feature
-/// category. Doubles as the no-device onboarding when nothing is connected.
+/// The landing screen, now a role-aware launchpad: a grid of the user's curated
+/// tools (sorted by what they use most), an expandable "More features" section
+/// to add the rest, the keyboard shortcuts that drive the app, and the
+/// no-device onboarding when nothing is connected.
 struct HomeView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
+    @State private var showMore = false
 
     var body: some View {
         ScrollView {
@@ -16,9 +18,9 @@ struct HomeView: View {
                 if state.devices.isEmpty {
                     connectCard
                 }
+                launchpadSection
+                moreFeaturesSection
                 shortcutsSection
-                customizeSection
-                categoriesSection
                 tourFooter
             }
             .frame(maxWidth: 760, alignment: .leading)
@@ -42,7 +44,124 @@ struct HomeView: View {
                     .font(.title3)
                     .foregroundStyle(.textMuted)
             }
+            Spacer(minLength: 12)
+            roleBadge
         }
+    }
+
+    /// Current role as a pill that opens the picker — the "change this anytime"
+    /// affordance the first-run picker promises.
+    private var roleBadge: some View {
+        Button { state.presentRolePicker = true } label: {
+            HStack(spacing: 6) {
+                Image(systemName: state.selectedRole?.icon ?? "square.grid.2x2")
+                Text(state.selectedRole?.label ?? "All features")
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.textMuted)
+            }
+            .font(.callout)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color.bgSurface, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.borderSubtle, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .help("Your role decides which tools start here — change it anytime")
+    }
+
+    // MARK: - Launchpad
+
+    private var launchpadSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("Your tools")
+            Text("Your most-used features, front and center. Add more below or from the sidebar.")
+                .font(.callout)
+                .foregroundStyle(.textMuted)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 210), spacing: 12)],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                ForEach(state.launchpadFeatures) { feature in
+                    FeatureCard(feature: feature) { state.openFeature(feature) }
+                }
+            }
+        }
+    }
+
+    // MARK: - More features
+
+    /// Catalog features the user hasn't enabled yet — the "show me other
+    /// features so I can pick" path, addable in one click. System features are
+    /// always on, so they never appear here.
+    private var addableFeatures: [FeatureDef] {
+        let enabled = Set(state.enabledFeatures.map(\.id))
+        let catalog = Set(FeatureRegistry.catalogFeatureIDs)
+        return state.orderedCategories.flatMap { state.catalogFeatures(in: $0) }
+            .filter { catalog.contains($0.id) && !enabled.contains($0.id) && $0.kind != .system }
+    }
+
+    @ViewBuilder private var moreFeaturesSection: some View {
+        let addable = addableFeatures
+        if !addable.isEmpty {
+            DisclosureGroup(isExpanded: $showMore) {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 210), spacing: 12)],
+                    alignment: .leading,
+                    spacing: 12
+                ) {
+                    ForEach(addable) { feature in
+                        addCard(feature)
+                    }
+                }
+                .padding(.top, 10)
+                Button("Manage all features…") { state.selectedFeatureID = "catalog" }
+                    .buttonStyle(.link)
+                    .font(.callout)
+                    .padding(.top, 8)
+            } label: {
+                HStack(spacing: 8) {
+                    Text("More features")
+                        .font(.title2.bold())
+                    Text("\(addable.count)")
+                        .font(.callout.monospacedDigit())
+                        .foregroundStyle(.textMuted)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { withAnimation { showMore.toggle() } }
+            }
+            .tint(.textMuted)
+        }
+    }
+
+    private func addCard(_ feature: FeatureDef) -> some View {
+        Button { state.setFeatureEnabled(feature.id, enabled: true) } label: {
+            HStack(spacing: 10) {
+                Image(systemName: feature.icon)
+                    .frame(width: 22)
+                    .foregroundStyle(.textMuted)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(feature.title).foregroundStyle(.textMain)
+                    if let subtitle = feature.subtitle {
+                        Text(subtitle)
+                            .font(.footnote)
+                            .foregroundStyle(.textMuted)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 6)
+                Image(systemName: "plus.circle")
+                    .foregroundStyle(.brandAccent)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help("Add \(feature.title) to your tools")
     }
 
     // MARK: - Shortcuts
@@ -102,69 +221,6 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10))
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.borderSubtle, lineWidth: 1))
-    }
-
-    // MARK: - Customize
-
-    private var customizeSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionTitle("Make it yours")
-
-            infoRow(
-                icon: "pin",
-                title: "Enable, disable & pin features",
-                detail: "Right-click any feature in the sidebar to pin it to the top, or enable/disable it. The Feature Catalog manages them all at once."
-            ) {
-                Button("Open Feature Catalog") { state.selectedFeatureID = "catalog" }
-            }
-
-            infoRow(
-                icon: "paintbrush",
-                title: "Theme",
-                detail: "Match the system appearance, or force light or dark."
-            ) {
-                ThemePicker()
-            }
-        }
-    }
-
-    // MARK: - Categories
-
-    private var categoriesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionTitle("All \(FeatureRegistry.catalogFeatureIDs.count) features")
-            Text("Grouped into \(FeatureCategory.displayOrder.count) categories — browse and toggle every tool in the catalog.")
-                .font(.callout)
-                .foregroundStyle(.textMuted)
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 220), spacing: 12)],
-                alignment: .leading,
-                spacing: 12
-            ) {
-                ForEach(FeatureCategory.displayOrder, id: \.self) { category in
-                    categoryChip(category)
-                }
-            }
-        }
-    }
-
-    private func categoryChip(_ category: FeatureCategory) -> some View {
-        let count = FeatureRegistry.all.filter { $0.category == category && !$0.isAbsorbedByHub }.count
-        return HStack(spacing: 10) {
-            Image(systemName: category.icon)
-                .foregroundStyle(.textMuted)
-                .frame(width: 22)
-            Text(category.label)
-                .lineLimit(1)
-            Spacer(minLength: 6)
-            Text("\(count)")
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.textMuted)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 8))
-        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle, lineWidth: 1))
     }
 
     // MARK: - Connect card (no device)
@@ -228,48 +284,50 @@ struct HomeView: View {
         Text(text)
             .font(.title2.bold())
     }
-
-    private func infoRow(
-        icon: String,
-        title: String,
-        detail: String,
-        @ViewBuilder action: () -> some View
-    ) -> some View {
-        HStack(alignment: .center, spacing: 12) {
-            Image(systemName: icon)
-                .font(.title2)
-                .foregroundStyle(.textMuted)
-                .frame(width: 26)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.headline)
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(.textMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 12)
-            action()
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10))
-        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.borderSubtle, lineWidth: 1))
-    }
 }
 
-/// The Light / Dark / Auto segmented control, reused on Home and Settings.
-struct ThemePicker: View {
-    @AppStorage("theme") private var theme = "auto"
+/// One tappable tool on the launchpad grid — icon, title, and subtitle, with the
+/// brand-green hover border used across the app. Opens or runs the feature.
+private struct FeatureCard: View {
+    let feature: FeatureDef
+    let action: () -> Void
+    @State private var hovering = false
 
     var body: some View {
-        Picker("", selection: $theme) {
-            Text("Auto").tag("auto")
-            Text("Light").tag("light")
-            Text("Dark").tag("dark")
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: feature.icon)
+                    .font(.title2)
+                    .foregroundStyle(hovering ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(feature.title)
+                        .font(.headline)
+                        .foregroundStyle(.textMain)
+                    if let subtitle = feature.subtitle {
+                        Text(subtitle)
+                            .font(.callout)
+                            .foregroundStyle(.textMuted)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+            .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(
+                        hovering ? Color.brandAccent : Color.borderSubtle,
+                        lineWidth: hovering ? 2 : 1
+                    )
+            }
         }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .frame(width: 200)
-        .onChange(of: theme) { applyStoredTheme() }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(.easeInOut(duration: 0.15), value: hovering)
+        .help(feature.subtitle ?? feature.title)
     }
 }

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -203,7 +203,7 @@ struct HomeView: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: shortcut.icon)
                 .font(.title2)
-                .foregroundStyle(.textMuted)
+                .foregroundStyle(.brandAccent)
                 .frame(width: 26)
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
@@ -298,7 +298,7 @@ private struct FeatureCard: View {
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: feature.icon)
                     .font(.title2)
-                    .foregroundStyle(hovering ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                    .foregroundStyle(.brandAccent)
                     .frame(width: 26)
                 VStack(alignment: .leading, spacing: 3) {
                     Text(feature.title)

--- a/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
@@ -1,35 +1,34 @@
 import ADBKit
 import SwiftUI
 
-/// Connection hub — copy the device IP, forward a port, drop a wireless
-/// connection, set Private DNS, and run the wireless ADB pairing flow on one
-/// scrollable screen. Copy IP also stays a one-click sidebar action; the other
-/// gathered features stay searchable and hotkey-able. Wi-Fi, Network Speed, and
-/// Emulators remain their own screens.
+/// Connection hub — copy the device IP, forward a port, set Private DNS, and run
+/// the wireless ADB pairing flow on one scrollable screen. Copy IP also stays a
+/// one-click sidebar action; the other gathered features stay searchable and
+/// hotkey-able. Wi-Fi, Network Speed, and Emulators remain their own screens.
 struct NetworkConnectionView: View {
     @Environment(AppState.self) private var state
     @State private var reversePort = "8081"
 
     var body: some View {
-        Form {
-            Section("Quick") {
-                Button {
-                    run("get-ip")
-                } label: {
+        HubColumn {
+            HubSection("Device IP") {
+                Button { run("get-ip") } label: {
                     Label("Copy device IP", systemImage: "globe")
                 }
+                .buttonStyle(.bordered)
                 .disabled(state.targetSerials.isEmpty)
             }
 
-            Section("Reverse port") {
-                HStack(spacing: 8) {
-                    TextField("Port", text: $reversePort, prompt: Text("8081"))
+            HubSection("Reverse port", subtitle: "Forward a device port to your Mac — e.g. Metro on 8081.") {
+                HStack(spacing: 10) {
+                    TextField("", text: $reversePort, prompt: Text("8081"))
                         .brandField()
                         .labelsHidden()
                         .frame(maxWidth: 140)
                     Button("Forward") {
                         run("reverse-port", ["port": .string(reversePort.trimmingCharacters(in: .whitespaces))])
                     }
+                    .buttonStyle(.borderedProminent)
                     .disabled(state.targetSerials.isEmpty || reversePort.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
@@ -37,8 +36,6 @@ struct NetworkConnectionView: View {
             PrivateDnsSection()
             WirelessAdbSection()
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
     }
 
     private func run(_ id: String, _ params: [String: FeatureValue] = [:]) {

--- a/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
+++ b/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
@@ -1,7 +1,7 @@
 import ADBKit
 import SwiftUI
 
-/// Private DNS (DNS-over-TLS) controls as a `Form` section, so it composes into
+/// Private DNS (DNS-over-TLS) controls as a reusable card, so it composes into
 /// both the standalone screen and the Connection hub.
 struct PrivateDnsSection: View {
     @Environment(AppState.self) private var state
@@ -13,22 +13,22 @@ struct PrivateDnsSection: View {
     private var serial: String { state.targetSerials.first ?? "" }
 
     var body: some View {
-        Section("Private DNS") {
+        HubSection("Private DNS", subtitle: "Set DNS-over-TLS mode for this device.") {
             Picker("Mode", selection: $mode) {
                 Text("Off").tag(DnsStatus.Mode.off)
                 Text("Automatic").tag(DnsStatus.Mode.automatic)
-                Text("Provider hostname").tag(DnsStatus.Mode.hostname)
+                Text("Hostname").tag(DnsStatus.Mode.hostname)
             }
-            .pickerStyle(.radioGroup)
+            .pickerStyle(.segmented)
+            .labelsHidden()
 
             if mode == .hostname {
-                TextField("dns.google", text: $hostname)
-                    .brandField()
-                    .frame(maxWidth: 280)
+                HubField("Provider hostname", prompt: "dns.google", text: $hostname)
             }
 
-            HStack {
+            HStack(spacing: 10) {
                 Button("Apply") { Task { await apply() } }
+                    .buttonStyle(.borderedProminent)
                     .disabled(busy || !loaded || state.targetSerials.isEmpty
                         || (mode == .hostname && hostname.trimmingCharacters(in: .whitespaces).isEmpty))
                 Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
@@ -77,14 +77,9 @@ struct PrivateDnsSection: View {
     }
 }
 
-/// Standalone Private DNS screen — the section on its own in a grouped form.
+/// Standalone Private DNS screen — the section on its own in the hub column.
 struct PrivateDnsView: View {
     var body: some View {
-        Form {
-            PrivateDnsSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { PrivateDnsSection() }
     }
 }

--- a/App/Sources/FeatureDetail/Views/ReactNativeView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactNativeView.swift
@@ -1,21 +1,24 @@
 import ADBKit
 import SwiftUI
 
-/// React Native hub — dev menu, JS reload, process death, dev-server host, and
-/// saved deep links on one scrollable screen. The individual actions stay
-/// available from search and global hotkeys; this just gathers them so the
-/// sidebar isn't five rows of RN tools.
+/// React Native hub — dev menu, JS reload, process death, Metro forwarding,
+/// dev-server host, saved deep links, and quick links to the logs/perf tools RN
+/// work leans on. The individual actions stay available from search and global
+/// hotkeys; this just gathers them so the sidebar isn't a wall of RN tools.
 struct ReactNativeView: View {
     @Environment(AppState.self) private var state
     @AppStorage("rnDevHost") private var devHost = ""
 
+    private let actionColumns = [GridItem(.adaptive(minimum: 150), spacing: 10)]
+
     var body: some View {
-        Form {
-            Section("Quick actions") {
-                HStack(spacing: 10) {
+        HubColumn {
+            HubSection("Quick actions", subtitle: "Drive the in-app dev menu and Metro over adb.") {
+                LazyVGrid(columns: actionColumns, spacing: 10) {
                     actionButton("reload-js", "Reload JS", "arrow.clockwise", prominent: true)
                     actionButton("open-dev-menu", "Dev Menu", "filemenu.and.selection")
                     actionButton("process-death", "Process Death", "xmark.octagon")
+                    metroButton
                 }
                 if state.targetSerials.isEmpty {
                     Text("Connect a device to use these.")
@@ -24,39 +27,78 @@ struct ReactNativeView: View {
                 }
             }
 
-            Section("Dev server host") {
-                HStack(spacing: 8) {
-                    TextField("Dev server host", text: $devHost, prompt: Text("192.168.1.10:8081"))
+            HubSection("Dev server host", subtitle: "Point the app at your Metro bundler and reverse-tunnel its port.") {
+                HStack(spacing: 10) {
+                    TextField("", text: $devHost, prompt: Text("192.168.1.10:8081"))
                         .brandField()
                         .labelsHidden()
-                        .frame(maxWidth: 240)
                     Button("Set") {
                         run("rn-dev-host", ["host": .string(devHost.trimmingCharacters(in: .whitespaces))])
                     }
+                    .buttonStyle(.borderedProminent)
                     .disabled(state.targetSerials.isEmpty || devHost.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
 
             DeepLinksSection()
+
+            HubSection("Related tools") {
+                VStack(spacing: 0) {
+                    relatedRow("logcat", "Logcat", "Live JS & native logs", "scroll")
+                    Divider()
+                    relatedRow("crash-catcher", "Crash Catcher", "Catches ReactNativeJS crashes", "exclamationmark.triangle")
+                    Divider()
+                    relatedRow("performance", "Performance Monitor", "Live CPU, RAM & FPS", "chart.line.uptrend.xyaxis")
+                }
+            }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
     }
 
     @ViewBuilder
     private func actionButton(_ id: String, _ title: String, _ icon: String, prominent: Bool = false) -> some View {
-        let content = Label(title, systemImage: icon)
+        let label = Label(title, systemImage: icon).frame(maxWidth: .infinity)
         if prominent {
-            Button { run(id) } label: { content }
+            Button { run(id) } label: { label }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
         } else {
-            Button { run(id) } label: { content }
+            Button { run(id) } label: { label }
                 .buttonStyle(.bordered)
                 .controlSize(.large)
                 .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
         }
+    }
+
+    /// Reverse-tunnel Metro's 8081 so a USB device reaches the local bundler —
+    /// the one adb step every RN-on-device session needs (reuses Reverse Port).
+    private var metroButton: some View {
+        Button { run("reverse-port", ["port": .string("8081")]) } label: {
+            Label("Forward Metro", systemImage: "arrow.left.arrow.right").frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+        .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
+        .help("adb reverse tcp:8081 — reach your local Metro bundler from a USB device")
+    }
+
+    private func relatedRow(_ id: String, _ title: String, _ detail: String, _ icon: String) -> some View {
+        Button {
+            if let feature = FeatureRegistry.byID[id] { state.openFeature(feature) }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon).foregroundStyle(.textMuted).frame(width: 22)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title).foregroundStyle(.textMain)
+                    Text(detail).font(.footnote).foregroundStyle(.textMuted)
+                }
+                Spacer()
+                Image(systemName: "chevron.right").font(.caption).foregroundStyle(.textMuted)
+            }
+            .contentShape(Rectangle())
+            .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
     }
 
     private func run(_ id: String, _ params: [String: FeatureValue] = [:]) {

--- a/App/Sources/FeatureDetail/Views/RolePickerView.swift
+++ b/App/Sources/FeatureDetail/Views/RolePickerView.swift
@@ -1,0 +1,98 @@
+import ADBKit
+import SwiftUI
+
+/// First-launch full-window takeover: the user picks a role and gets a focused
+/// set of features instead of all of them — the answer to "this app is
+/// overwhelming". Skippable ("Show me everything") and changeable later from
+/// Settings. Selecting a role seeds the curated set via `AppState.chooseRole`.
+///
+/// Presented as a full-bleed overlay (not a sheet) so it genuinely takes over
+/// the window; macOS has no `fullScreenCover`.
+struct RolePickerView: View {
+    @Environment(AppState.self) private var state
+    @AppStorage("hasChosenRole") private var hasChosenRole = false
+
+    private let columns = [GridItem(.adaptive(minimum: 240), spacing: 16)]
+
+    var body: some View {
+        VStack(spacing: 28) {
+            header
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(UserRole.allCases) { role in
+                    RoleCard(role: role) { choose(role) }
+                }
+            }
+            .frame(maxWidth: 560)
+            Button("Show me everything") { choose(nil) }
+                .buttonStyle(.plain)
+                .foregroundStyle(.textMuted)
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.bgRoot)
+    }
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "square.grid.2x2.fill")
+                .font(.system(size: 42))
+                .foregroundStyle(.brandAccent)
+                .symbolRenderingMode(.hierarchical)
+            Text("What do you do?")
+                .font(.largeTitle.bold())
+                .foregroundStyle(.textMain)
+            Text("Pick a role and we'll start you with the tools you'll use most. "
+                + "Everything else is one click away — and you can change this anytime.")
+                .font(.body)
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 480)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func choose(_ role: UserRole?) {
+        hasChosenRole = true
+        state.chooseRole(role)
+    }
+}
+
+/// One selectable role tile — icon, name, and a one-line description, with the
+/// brand-green hover border used elsewhere in the app.
+private struct RoleCard: View {
+    let role: UserRole
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 10) {
+                Image(systemName: role.icon)
+                    .font(.system(size: 26))
+                    .foregroundStyle(.brandAccent)
+                    .symbolRenderingMode(.hierarchical)
+                Text(role.label)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.textMain)
+                Text(role.blurb)
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+            .padding(18)
+            .background(.bgSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(
+                        hovering ? Color.brandAccent : Color.borderSubtle,
+                        lineWidth: hovering ? 2 : 1
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(.easeInOut(duration: 0.15), value: hovering)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -139,6 +139,9 @@ struct ScreenshotEditorView: View {
         // its window is key. Nil while typing a text label, so ⌘Z falls through
         // to the text field's own undo.
         .focusedSceneValue(\.screenshotEdit, editCommands)
+        // Delete / Backspace removes the selected annotation. Skipped while a text
+        // label is being edited so the field's own deletion keeps working.
+        .onDeleteCommand { if editingTextID == nil { deleteSelected() } }
     }
 
     /// Undo/redo are unavailable while a text label is being typed, so ⌘Z falls

--- a/App/Sources/FeatureDetail/Views/SimulateView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulateView.swift
@@ -18,25 +18,25 @@ struct SimulateView: View {
     @State private var proxy = ""
 
     var body: some View {
-        Form {
+        HubColumn {
             if !state.activeOverrides.isEmpty {
-                Section {
-                    Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
-                }
+                Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
+                    .buttonStyle(.bordered)
             }
 
-            Section("Battery") {
-                VStack(alignment: .leading) {
-                    Text("Level: \(Int(batteryLevel))%")
+            HubSection("Battery") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Level: \(Int(batteryLevel))%").foregroundStyle(.textMain)
                     Slider(value: $batteryLevel, in: 0...100, step: 1)
                 }
                 SwitchRow("Simulate unplugged", isOn: $batteryUnplugged)
                 Button("Apply") {
                     run("fake-battery", ["level": .number(batteryLevel), "unplugged": .bool(batteryUnplugged)])
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Appearance & Motion") {
+            HubSection("Appearance & motion") {
                 if let darkMode = FeatureRegistry.byID["dark-mode"] {
                     HStack {
                         Text("Dark mode")
@@ -55,55 +55,58 @@ struct SimulateView: View {
                 }
             }
 
-            Section("Layout") {
-                VStack(alignment: .leading) {
-                    Text("Font scale: \(fontScale, specifier: "%.2f")")
+            HubSection("Layout") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Font scale: \(fontScale, specifier: "%.2f")").foregroundStyle(.textMain)
                     Slider(value: $fontScale, in: 0.85...1.3, step: 0.05)
                 }
-                TextField("Density (dpi, blank = keep)", text: $density)
-                    .brandField()
-                    .frame(maxWidth: 200)
+                HubField("Display density", prompt: "dpi — blank to keep", text: $density)
                 Button("Apply") {
                     var params: [String: FeatureValue] = ["fontScale": .number(fontScale)]
                     let raw = density.trimmingCharacters(in: .whitespaces)
                     if !raw.isEmpty, let value = Double(raw) { params["density"] = .number(value) }
                     run("layout-overrides", params)
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Locale") {
-                Picker("Language", selection: $locale) {
-                    ForEach(localeOptions, id: \.value) { option in
-                        Text(option.label).tag(option.value)
+            HubSection("Locale") {
+                HStack {
+                    Text("Language")
+                    Spacer(minLength: 12)
+                    Picker("", selection: $locale) {
+                        ForEach(localeOptions, id: \.value) { option in
+                            Text(option.label).tag(option.value)
+                        }
                     }
+                    .labelsHidden()
+                    .fixedSize()
                 }
                 Button("Apply") { run("locale", ["locale": .string(locale)]) }
+                    .buttonStyle(.borderedProminent)
             }
 
-            Section("Network") {
+            HubSection("Network") {
                 SwitchRow("Wi-Fi", isOn: $wifi)
                 SwitchRow("Mobile data", isOn: $data)
                 SwitchRow("Airplane mode", isOn: $airplane)
                 Button("Apply") {
                     run("network-toggles", ["wifi": .bool(wifi), "data": .bool(data), "airplane": .bool(airplane)])
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Proxy") {
-                TextField("Proxy (host:port)", text: $proxy)
-                    .brandField()
-                    .frame(maxWidth: 200)
-                HStack {
+            HubSection("HTTP proxy", subtitle: "Route traffic through Charles, Proxyman, or mitmproxy.") {
+                HubField("Proxy", prompt: "10.0.0.5:8888", text: $proxy)
+                HStack(spacing: 10) {
                     Button("Set") { run("http-proxy", ["proxy": .string(proxy.trimmingCharacters(in: .whitespaces))]) }
+                        .buttonStyle(.borderedProminent)
                         .disabled(proxy.trimmingCharacters(in: .whitespaces).isEmpty)
-                    // Clear via the feature (empty proxy → engine resets it) so it
-                    // lands in the command log like Set, instead of a silent reset.
                     Button("Clear") { run("http-proxy", ["proxy": .string("")]) }
+                        .buttonStyle(.bordered)
                 }
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
         .disabled(state.targetSerials.isEmpty)
         .overlay {
             if state.targetSerials.isEmpty {

--- a/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
+++ b/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
@@ -29,8 +29,13 @@ struct SystemRestrictionsView: View {
     }
 
     private func form(_ state0: RestrictionsState) -> some View {
-        Form {
-            Section {
+        HubColumn {
+            HubSection("Installs & APIs", accessory: {
+                Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
+                    .buttonStyle(.borderless)
+                    .help("Refresh")
+                    .disabled(busy)
+            }) {
                 SwitchRow("Verify apps installed via ADB", isOn: binding(state0.adbInstallVerification) {
                     try await engine.restrictions.setAdbInstallVerification(serial: serial, $0)
                 })
@@ -43,16 +48,9 @@ struct SystemRestrictionsView: View {
                 SwitchRow("Stay awake while charging", isOn: binding(state0.stayAwake) {
                     try await engine.restrictions.setStayAwake(serial: serial, $0)
                 })
-            } header: {
-                HStack {
-                    Text("Installs & APIs")
-                    Spacer()
-                    Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
-                        .buttonStyle(.borderless)
-                        .help("Refresh")
-                }
             }
-            Section("Root") {
+
+            HubSection("Root") {
                 if hasRoot {
                     SwitchRow("SELinux enforcing", isOn: binding(state0.selinuxEnforcing ?? true) {
                         try await engine.restrictions.setSelinuxEnforcing(serial: serial, $0)
@@ -60,6 +58,7 @@ struct SystemRestrictionsView: View {
                     Button("Remount /system read-write") {
                         Task { await apply { try await engine.restrictions.remountSystemReadWrite(serial: serial) } }
                     }
+                    .buttonStyle(.bordered)
                 } else {
                     Text("Connect a rooted device to relax SELinux or remount the system partition.")
                         .font(.callout)
@@ -67,9 +66,6 @@ struct SystemRestrictionsView: View {
                 }
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
     }
 
     private var engine: FeatureEngine { state.env.engine }

--- a/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
+++ b/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
@@ -2,7 +2,7 @@ import ADBKit
 import SwiftUI
 
 /// Wireless ADB wizard (USB→tcpip bootstrap, Android 11+ pair, connect, and
-/// per-device disconnect) as `Form` sections, so it composes into both the
+/// per-device disconnect) as reusable cards, so it composes into both the
 /// standalone screen and the Connection hub.
 struct WirelessAdbSection: View {
     @Environment(AppState.self) private var state
@@ -16,62 +16,55 @@ struct WirelessAdbSection: View {
     private var wirelessDevices: [Device] { state.devices.filter(\.isWireless) }
 
     var body: some View {
-        Section("Wireless ADB — over USB") {
+        HubSection("Wireless ADB", subtitle: "Switch a USB-connected device to debugging over Wi-Fi.") {
             if usbDevices.isEmpty {
-                Text("Connect a device over USB to bootstrap wireless ADB.")
+                Text("Connect a device over USB to start.")
                     .foregroundStyle(.textMuted)
             } else {
                 ForEach(usbDevices) { device in
                     HStack {
                         Text(device.label)
                         Spacer()
-                        Button("Enable Wi-Fi & Connect") {
-                            enableTcpip(device.serial)
-                        }
-                        .disabled(busy)
+                        Button("Enable Wi-Fi & Connect") { enableTcpip(device.serial) }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(busy)
                     }
                 }
             }
         }
 
-        Section("Pair (Android 11+)") {
-            TextField("Host / IP", text: $host, prompt: Text("192.168.1.42"))
-                .brandField()
-            TextField("Pairing port", text: $pairingPort, prompt: Text("37123"))
-                .brandField()
-            TextField("Pairing code", text: $pairingCode, prompt: Text("123456"))
-                .brandField()
-            Button("Pair") {
-                pair()
+        HubSection("Pair a device", subtitle: "Android 11+ — pair with a code, then connect.") {
+            HubField("Host / IP", prompt: "192.168.1.42", text: $host)
+            HStack(spacing: 12) {
+                HubField("Pairing port", prompt: "37123", text: $pairingPort)
+                HubField("Pairing code", prompt: "123456", text: $pairingCode)
             }
-            .disabled(busy || host.isEmpty || pairingPort.isEmpty || pairingCode.isEmpty)
+            Button("Pair") { pair() }
+                .buttonStyle(.bordered)
+                .disabled(busy || host.isEmpty || pairingPort.isEmpty || pairingCode.isEmpty)
 
-            TextField("Connection port", text: $connectionPort, prompt: Text("5555"))
-                .brandField()
-            Button("Connect") {
-                connect()
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(busy || host.isEmpty || connectionPort.isEmpty)
+            Divider().padding(.vertical, 2)
 
-            Text("The pairing port (from \"Pair device with pairing code\") differs from the connection port on the Wireless Debugging screen.")
+            HubField("Connection port", prompt: "5555", text: $connectionPort)
+            Button("Connect") { connect() }
+                .buttonStyle(.borderedProminent)
+                .disabled(busy || host.isEmpty || connectionPort.isEmpty)
+
+            Text("The pairing port (from \"Pair device with pairing code\") differs from the connection port shown on the device's Wireless debugging screen.")
                 .font(.footnote)
                 .foregroundStyle(.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
         }
 
-        Section("Connected over Wi-Fi") {
-            if wirelessDevices.isEmpty {
-                Text("No wireless devices.")
-                    .foregroundStyle(.textMuted)
-            } else {
+        if !wirelessDevices.isEmpty {
+            HubSection("Connected over Wi-Fi") {
                 ForEach(wirelessDevices) { device in
                     HStack {
                         Text(device.label)
                         Spacer()
-                        Button("Disconnect") {
-                            disconnect(device.serial)
-                        }
-                        .disabled(busy)
+                        Button("Disconnect") { disconnect(device.serial) }
+                            .buttonStyle(.bordered)
+                            .disabled(busy)
                     }
                 }
             }
@@ -116,14 +109,9 @@ struct WirelessAdbSection: View {
     }
 }
 
-/// Standalone Wireless ADB screen — the sections on their own in a grouped form.
+/// Standalone Wireless ADB screen — the cards on their own in the hub column.
 struct WirelessAdbView: View {
     var body: some View {
-        Form {
-            WirelessAdbSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { WirelessAdbSection() }
     }
 }

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -275,8 +275,6 @@ struct DeviceBarView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             } else {
-                Image(systemName: "shippingbox")
-                    .foregroundStyle(.secondary)
                 Text("Choose app bundle…")
                     .foregroundStyle(.secondary)
             }

--- a/App/Sources/Root/PalettePanel.swift
+++ b/App/Sources/Root/PalettePanel.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftUI
+
+/// A borderless panel that can still take key focus. Borderless `NSWindow`s
+/// return `false` from `canBecomeKey`/`canBecomeMain` by default, which would
+/// stop the palette's search field from receiving input; overriding them keeps
+/// the panel chromeless yet focusable. A panel we own (vs. a SwiftUI `Window`
+/// scene) can do this without colliding with SwiftUI's window constraints.
+final class KeyablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+/// Owns the ⌘K command palette as a borderless `NSPanel`. Borderless removes the
+/// 32pt title-bar region a hidden-title-bar `Window` scene always reserves, so
+/// the content sizes the panel exactly — flush at top and bottom. The panel
+/// hosts `PaletteWindowView`, resizes to its content, keeps its top edge anchored
+/// as results grow/shrink, and closes when it loses key (click-away) or on Esc.
+@MainActor
+final class PaletteController {
+    static let shared = PaletteController()
+
+    private var panel: KeyablePanel?
+    private var anchorMaxY: CGFloat = 0
+    private var resignObserver: NSObjectProtocol?
+    private var resizeObserver: NSObjectProtocol?
+
+    func show(appState: AppState) {
+        if let panel {
+            panel.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let root = PaletteWindowView(onClose: { [weak self] in self?.close() })
+            .environment(appState)
+            .tint(.brandAccent)
+        let hosting = NSHostingController(rootView: root)
+        hosting.sizingOptions = [.preferredContentSize]
+
+        let panel = KeyablePanel(contentViewController: hosting)
+        panel.styleMask = [.borderless]
+        panel.identifier = NSUserInterfaceItemIdentifier("palette")
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.isMovableByWindowBackground = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        positionInitially(panel)
+        panel.makeKeyAndOrderFront(nil)
+
+        resignObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification, object: panel, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.close() } }
+        resizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification, object: panel, queue: .main
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.keepTopAnchored() } }
+
+        self.panel = panel
+    }
+
+    func close() {
+        if let resignObserver { NotificationCenter.default.removeObserver(resignObserver) }
+        if let resizeObserver { NotificationCenter.default.removeObserver(resizeObserver) }
+        resignObserver = nil
+        resizeObserver = nil
+        panel?.orderOut(nil)
+        panel?.close()
+        panel = nil
+    }
+
+    /// Center on screen, and remember the top edge so later resizes grow
+    /// downward from there instead of drifting up off the bottom-left origin.
+    private func positionInitially(_ panel: NSPanel) {
+        guard let screen = panel.screen ?? NSScreen.main else { return }
+        let frame = panel.frame
+        let visible = screen.visibleFrame
+        let x = visible.midX - frame.width / 2
+        let y = visible.midY - frame.height / 2
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+        anchorMaxY = panel.frame.maxY
+    }
+
+    private func keepTopAnchored() {
+        guard let panel else { return }
+        var frame = panel.frame
+        if abs(frame.maxY - anchorMaxY) > 0.5 {
+            frame.origin.y = anchorMaxY - frame.height
+            panel.setFrameOrigin(frame.origin)
+        }
+    }
+}

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -8,7 +8,8 @@ import SwiftUI
 /// closes.
 struct PaletteWindowView: View {
     @Environment(AppState.self) private var state
-    @Environment(\.dismissWindow) private var dismissWindow
+
+    let onClose: () -> Void
 
     @State private var query = ""
     @State private var highlighted = 0
@@ -50,44 +51,40 @@ struct PaletteWindowView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
-            // Full-bleed material fills the whole window (incl. under the hidden
-            // title bar). Kept as its own layer so it doesn't inflate the
-            // content's measured height — the content respects the safe area and
-            // ends at the window's bottom, with no dead strip.
-            Color.clear.background(.regularMaterial).ignoresSafeArea()
+        VStack(spacing: 0) {
+            searchField
 
-            VStack(spacing: 0) {
-                searchField
-
-                if !visibleMatches.isEmpty {
-                    Divider()
-                    VStack(spacing: 0) {
-                        ForEach(Array(visibleMatches.enumerated()), id: \.element.id) { index, feature in
-                            paletteRow(feature, index: index, isHighlighted: index == highlighted)
-                                .onTapGesture { open(at: index) }
-                        }
+            if !visibleMatches.isEmpty {
+                Divider()
+                VStack(spacing: 0) {
+                    ForEach(Array(visibleMatches.enumerated()), id: \.element.id) { index, feature in
+                        paletteRow(feature, index: index, isHighlighted: index == highlighted)
+                            .onTapGesture { open(at: index) }
                     }
-                    .padding(6)
-                    Divider()
-                    footer
-                } else if !query.isEmpty {
-                    Divider()
-                    Text("No matching features")
-                        .font(.callout)
-                        .foregroundStyle(.textMuted)
-                        .padding(14)
                 }
+                .padding(6)
+                Divider()
+                footer
+            } else if !query.isEmpty {
+                Divider()
+                Text("No matching features")
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .padding(14)
             }
         }
         .frame(width: 520)
+        // Borderless window has no title bar and a clear backing, so the content
+        // sizes the window exactly — flush at top and bottom. The material is the
+        // content's own background, clipped to rounded corners.
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .background { shortcutButtons }
         .onExitCommand { close() }
         .onAppear {
             query = ""
             highlighted = 0
-            configureWindow()
-            // Focus must land after the window becomes key — setting it
+            // Focus must land after the panel becomes key — setting it
             // synchronously in onAppear loses the race.
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(250))
@@ -95,13 +92,6 @@ struct PaletteWindowView: View {
             }
         }
         .onChange(of: query) { highlighted = 0 }
-        // Spotlight behavior: clicking anywhere else dismisses the palette.
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) { note in
-            if let window = note.object as? NSWindow,
-               window.identifier?.rawValue.contains("palette") == true {
-                close()
-            }
-        }
     }
 
     private var searchField: some View {
@@ -223,26 +213,7 @@ struct PaletteWindowView: View {
     }
 
     private func close() {
-        dismissWindow(id: "palette")
-    }
-
-    /// Float above everything, minimal chrome, centered — Spotlight-like.
-    /// The window keeps its normal opaque backing: a clear background plus a
-    /// clipped view leaves transparent corners and a see-through title strip.
-    private func configureWindow() {
-        guard let window = NSApp.windows.first(where: { $0.identifier?.rawValue.contains("palette") == true }) else {
-            return
-        }
-        window.level = .floating
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.styleMask.insert(.fullSizeContentView)
-        window.standardWindowButton(.closeButton)?.isHidden = true
-        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
-        window.isMovableByWindowBackground = true
-        window.center()
-        window.makeKeyAndOrderFront(nil)
+        onClose()
     }
 }
 

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -2,8 +2,10 @@ import ADBKit
 import AppKit
 import SwiftUI
 
-/// Spotlight-style floating search palette (⌘K): type, arrow through
-/// matches, ⏎ jumps to the feature in the main window. Esc closes.
+/// Spotlight-style floating search palette (⌘K): type, arrow through matches,
+/// ⏎ opens the feature in the main window. ⌘P pins / ⌘E enables-disables the
+/// highlighted feature. Pinned features lead the list when not searching. Esc
+/// closes.
 struct PaletteWindowView: View {
     @Environment(AppState.self) private var state
     @Environment(\.dismissWindow) private var dismissWindow
@@ -14,77 +16,72 @@ struct PaletteWindowView: View {
 
     private static let digitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8"]
 
+    private var searching: Bool { !query.isEmpty }
+
+    /// Results in display order. When not searching, pinned features lead; once
+    /// the user types, the pinned section drops and results rank by relevance.
     private var matches: [FeatureDef] {
         let enabled = state.layout.effectiveEnabledIDs
-        // Rank by relevance (best match first), registry order as tiebreak. Hub
-        // members are excluded — they're used from their hub (which matches the
-        // same keywords), not as standalone palette rows.
-        let ranked = FeatureRegistry.all.enumerated()
-            .filter { $0.element.matches(query) && !$0.element.isAbsorbedByHub }
-            .sorted { lhs, rhs in
-                let rl = lhs.element.relevance(for: query)
-                let rr = rhs.element.relevance(for: query)
-                return rl != rr ? rl > rr : lhs.offset < rhs.offset
-            }
-            .map(\.element)
-        // Enabled features first, then disabled matches.
-        return ranked.filter { enabled.contains($0.id) } + ranked.filter { !enabled.contains($0.id) }
+        if searching {
+            let ranked = FeatureRegistry.all.enumerated()
+                .filter { $0.element.matches(query) && !$0.element.isAbsorbedByHub }
+                .sorted { lhs, rhs in
+                    let rl = lhs.element.relevance(for: query)
+                    let rr = rhs.element.relevance(for: query)
+                    return rl != rr ? rl > rr : lhs.offset < rhs.offset
+                }
+                .map(\.element)
+            return ranked.filter { enabled.contains($0.id) } + ranked.filter { !enabled.contains($0.id) }
+        }
+        let pinned = state.layout.favorites
+            .compactMap { FeatureRegistry.byID[$0] }
+            .filter { !$0.isAbsorbedByHub }
+        let pinnedIDs = Set(pinned.map(\.id))
+        let rest = FeatureRegistry.all.filter { !$0.isAbsorbedByHub && !pinnedIDs.contains($0.id) }
+        return pinned
+            + rest.filter { enabled.contains($0.id) }
+            + rest.filter { !enabled.contains($0.id) }
     }
 
-    private var visibleMatches: [FeatureDef] {
-        Array(matches.prefix(8))
+    private var visibleMatches: [FeatureDef] { Array(matches.prefix(8)) }
+
+    private var highlightedFeature: FeatureDef? {
+        visibleMatches.indices.contains(highlighted) ? visibleMatches[highlighted] : nil
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 12) {
-                Image(systemName: "magnifyingglass")
-                    .font(.title)
-                    .foregroundStyle(.textMuted)
-                TextField("Search features…", text: $query)
-                    .textFieldStyle(.plain)
-                    .font(.title)
-                    .focused($fieldFocused)
-                    .onSubmit { open(at: highlighted) }
-                    .onKeyPress(.downArrow) { move(1); return .handled }
-                    .onKeyPress(.upArrow) { move(-1); return .handled }
-            }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 16)
+        ZStack(alignment: .top) {
+            // Full-bleed material fills the whole window (incl. under the hidden
+            // title bar). Kept as its own layer so it doesn't inflate the
+            // content's measured height — the content respects the safe area and
+            // ends at the window's bottom, with no dead strip.
+            Color.clear.background(.regularMaterial).ignoresSafeArea()
 
-            if !visibleMatches.isEmpty {
-                Divider()
-                VStack(spacing: 0) {
-                    ForEach(Array(visibleMatches.enumerated()), id: \.element.id) { index, feature in
-                        paletteRow(feature, index: index, isHighlighted: index == highlighted)
-                            .onTapGesture { open(at: index) }
+            VStack(spacing: 0) {
+                searchField
+
+                if !visibleMatches.isEmpty {
+                    Divider()
+                    VStack(spacing: 0) {
+                        ForEach(Array(visibleMatches.enumerated()), id: \.element.id) { index, feature in
+                            paletteRow(feature, index: index, isHighlighted: index == highlighted)
+                                .onTapGesture { open(at: index) }
+                        }
                     }
+                    .padding(6)
+                    Divider()
+                    footer
+                } else if !query.isEmpty {
+                    Divider()
+                    Text("No matching features")
+                        .font(.callout)
+                        .foregroundStyle(.textMuted)
+                        .padding(14)
                 }
-                .padding(6)
-            } else if !query.isEmpty {
-                Divider()
-                Text("No matching features")
-                    .font(.callout)
-                    .foregroundStyle(.textMuted)
-                    .padding(14)
             }
         }
-        // Natural height so the window tracks content (.windowResizability
-        // .contentSize) — it shrinks to the search row alone when nothing
-        // matches and grows with results. ignoresSafeArea lets the material
-        // fill under the hidden title bar so there's no dead strip on top.
         .frame(width: 520)
-        .background(.regularMaterial)
-        .ignoresSafeArea()
-        .background {
-            // ⌘1–⌘8 jump straight to the Nth visible result.
-            ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
-                Button("") { open(at: index) }
-                    .keyboardShortcut(key, modifiers: .command)
-                    .frame(width: 0, height: 0)
-                    .opacity(0)
-            }
-        }
+        .background { shortcutButtons }
         .onExitCommand { close() }
         .onAppear {
             query = ""
@@ -107,6 +104,61 @@ struct PaletteWindowView: View {
         }
     }
 
+    private var searchField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.title)
+                .foregroundStyle(.textMuted)
+            TextField("Search features…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.title)
+                .focused($fieldFocused)
+                .onSubmit { open(at: highlighted) }
+                .onKeyPress(.downArrow) { move(1); return .handled }
+                .onKeyPress(.upArrow) { move(-1); return .handled }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+    }
+
+    /// Hidden buttons backing the palette's keyboard shortcuts: ⌘1–8 jump,
+    /// ⌘P pin/unpin, ⌘E enable/disable — all acting on the highlighted row.
+    private var shortcutButtons: some View {
+        ZStack {
+            ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
+                Button("") { open(at: index) }
+                    .keyboardShortcut(key, modifiers: .command)
+            }
+            Button("") { togglePinHighlighted() }.keyboardShortcut("p", modifiers: .command)
+            Button("") { toggleEnabledHighlighted() }.keyboardShortcut("e", modifiers: .command)
+        }
+        .frame(width: 0, height: 0)
+        .opacity(0)
+    }
+
+    private var footer: some View {
+        let pinned = highlightedFeature.map { state.layout.favorites.contains($0.id) } ?? false
+        let isEnabled = highlightedFeature.map { state.layout.effectiveEnabledIDs.contains($0.id) } ?? true
+        return HStack(spacing: 14) {
+            footerHint("⏎", "Open")
+            footerHint("⌘P", pinned ? "Unpin" : "Pin")
+            if highlightedFeature?.kind != .system {
+                footerHint("⌘E", isEnabled ? "Disable" : "Enable")
+            }
+            Spacer()
+            footerHint("⌘1–8", "Jump")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    private func footerHint(_ key: String, _ label: String) -> some View {
+        HStack(spacing: 5) {
+            KeyHint(key)
+            Text(label).font(.caption2).foregroundStyle(.textMuted)
+        }
+    }
+
     private func paletteRow(_ feature: FeatureDef, index: Int, isHighlighted: Bool) -> some View {
         HStack(spacing: 10) {
             Image(systemName: feature.icon)
@@ -122,6 +174,11 @@ struct PaletteWindowView: View {
                 }
             }
             Spacer()
+            if state.layout.favorites.contains(feature.id) {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(.white.opacity(0.8)) : AnyShapeStyle(.brandAccent))
+            }
             if !state.layout.effectiveEnabledIDs.contains(feature.id) {
                 Text("disabled")
                     .font(.caption2)
@@ -153,6 +210,16 @@ struct PaletteWindowView: View {
         close()
         state.activateMainWindow()
         state.selectedFeatureID = feature.id
+    }
+
+    private func togglePinHighlighted() {
+        guard let feature = highlightedFeature else { return }
+        state.toggleFavorite(feature.id)
+    }
+
+    private func toggleEnabledHighlighted() {
+        guard let feature = highlightedFeature, feature.kind != .system else { return }
+        state.setFeatureEnabled(feature.id, enabled: !state.layout.effectiveEnabledIDs.contains(feature.id))
     }
 
     private func close() {

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -7,11 +7,16 @@ struct RootView: View {
     @Environment(\.openWindow) private var openWindow
     @AppStorage("sidebarWidth") private var sidebarWidth = 280.0
     @AppStorage("hasSeenTour") private var hasSeenTour = false
+    @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
     @AppStorage("launchCount") private var launchCount = 0
     @AppStorage("starPromptShown") private var starPromptShown = false
     @State private var presentConsent = false
     @State private var presentStar = false
+    /// True only while the *first-run* role picker is up, so its dismissal
+    /// chains into the welcome tour. Changing role later (pill / Settings)
+    /// leaves this false, so the tour never reappears.
+    @State private var pickerIsFirstRun = false
     @Environment(\.colorScheme) private var colorScheme
 
     /// Launches to allow before the first-run privacy disclosure appears.
@@ -33,6 +38,22 @@ struct RootView: View {
     var body: some View {
         @Bindable var state = state
         zoomedContent
+            .background(WindowAccessor { window in
+                // Fill the screen's usable area on launch — a regular maximized
+                // window, not a native full-screen Space.
+                if let screen = window.screen ?? NSScreen.main {
+                    window.setFrame(screen.visibleFrame, display: true)
+                }
+            })
+            .overlay {
+                // Full-window takeover (macOS has no fullScreenCover), shown
+                // before the tour for brand-new users and from "Change role".
+                if state.presentRolePicker {
+                    RolePickerView()
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: state.presentRolePicker)
             .sheet(isPresented: $state.presentTour) {
                 TourView()
             }
@@ -56,12 +77,24 @@ struct RootView: View {
                 applyStoredTheme()
                 updateDockIcon()
                 HotkeyManager.install(state: state)
-                if !hasSeenTour {
+                if !hasChosenRole && !hasSeenTour {
+                    // Brand-new user: pick a role first, then run the tour.
+                    pickerIsFirstRun = true
+                    state.presentRolePicker = true
+                } else if !hasSeenTour {
                     state.presentTour = true
                 } else if shouldPromptConsent {
                     presentConsent = true
                 } else if shouldPromptStar {
                     presentStar = true
+                }
+            }
+            .onChange(of: state.presentRolePicker) { _, showing in
+                // Only the first-run picker chains into the tour; changing role
+                // later (pill / Settings) must not reopen it.
+                if !showing && pickerIsFirstRun {
+                    pickerIsFirstRun = false
+                    if !hasSeenTour { state.presentTour = true }
                 }
             }
             .onChange(of: state.presentTour) { _, showing in
@@ -147,6 +180,33 @@ struct RootView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)
     }
+}
+
+/// Reads the hosting `NSWindow` once it attaches, so the main window can be
+/// sized to fill the screen on launch. `viewDidMoveToWindow` runs on the main
+/// actor with the window in place — no async hop, so it stays Swift-6 clean.
+private final class WindowReaderView: NSView {
+    var onWindow: ((NSWindow) -> Void)?
+    private var resolved = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard !resolved, let window else { return }
+        resolved = true
+        onWindow?(window)
+    }
+}
+
+private struct WindowAccessor: NSViewRepresentable {
+    let onResolve: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> WindowReaderView {
+        let view = WindowReaderView()
+        view.onWindow = onResolve
+        return view
+    }
+
+    func updateNSView(_ nsView: WindowReaderView, context: Context) {}
 }
 
 /// A draggable divider that resizes an adjacent pane. `value` is the pane's

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -8,8 +8,18 @@ struct RootView: View {
     @AppStorage("sidebarWidth") private var sidebarWidth = 280.0
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
+    @AppStorage("launchCount") private var launchCount = 0
     @State private var presentConsent = false
     @Environment(\.colorScheme) private var colorScheme
+
+    /// Launches to allow before the first-run privacy disclosure appears.
+    /// Telemetry is anonymous and on by default in the meantime (opt-out in
+    /// Settings → Privacy); the modal then lets the user confirm or opt out.
+    private let consentPromptAfterLaunches = 5
+
+    private var shouldPromptConsent: Bool {
+        !consentAsked && launchCount >= consentPromptAfterLaunches
+    }
 
     var body: some View {
         @Bindable var state = state
@@ -19,7 +29,7 @@ struct RootView: View {
             }
             .background {
                 // Separate host view: two .sheet modifiers on one view can drop
-                // one, and first-run privacy consent must always show.
+                // one, and the deferred privacy consent must still reliably show.
                 Color.clear.sheet(isPresented: $presentConsent) {
                     TelemetryConsentView()
                 }
@@ -33,12 +43,12 @@ struct RootView: View {
                 HotkeyManager.install(state: state)
                 if !hasSeenTour {
                     state.presentTour = true
-                } else if !consentAsked {
+                } else if shouldPromptConsent {
                     presentConsent = true
                 }
             }
             .onChange(of: state.presentTour) { _, showing in
-                if !showing && !consentAsked { presentConsent = true }
+                if !showing && shouldPromptConsent { presentConsent = true }
             }
             .onChange(of: colorScheme) { _, _ in updateDockIcon() }
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct RootView: View {
     @Environment(AppState.self) private var state
     @Environment(\.openWindow) private var openWindow
-    @AppStorage("sidebarWidth") private var sidebarWidth = 280.0
+    @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
@@ -72,7 +72,7 @@ struct RootView: View {
             }
             .onAppear {
                 state.openMainWindow = { openWindow(id: "main") }
-                state.openPalette = { openWindow(id: "palette") }
+                state.openPalette = { PaletteController.shared.show(appState: state) }
                 migrateDefaultsIfNeeded()
                 applyStoredTheme()
                 updateDockIcon()
@@ -148,9 +148,9 @@ struct RootView: View {
         HStack(spacing: 0) {
             if state.sidebarVisible {
                 SidebarPaletteView()
-                    .frame(width: min(max(sidebarWidth, 250), 460))
+                    .frame(width: min(max(sidebarWidth, 300), 460))
                     .transition(.move(edge: .leading).combined(with: .opacity))
-                ResizeHandle(value: $sidebarWidth, range: 250...460)
+                ResizeHandle(value: $sidebarWidth, range: 300...460)
             }
             VStack(spacing: 0) {
                 // The catalog has no device context, so its device bar is hidden.

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -9,7 +9,9 @@ struct RootView: View {
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
     @AppStorage("launchCount") private var launchCount = 0
+    @AppStorage("starPromptShown") private var starPromptShown = false
     @State private var presentConsent = false
+    @State private var presentStar = false
     @Environment(\.colorScheme) private var colorScheme
 
     /// Launches to allow before the first-run privacy disclosure appears.
@@ -17,8 +19,15 @@ struct RootView: View {
     /// Settings → Privacy); the modal then lets the user confirm or opt out.
     private let consentPromptAfterLaunches = 5
 
+    /// Launches before the one-time GitHub-star nudge (shown after consent).
+    private let starPromptAfterLaunches = 10
+
     private var shouldPromptConsent: Bool {
         !consentAsked && launchCount >= consentPromptAfterLaunches
+    }
+
+    private var shouldPromptStar: Bool {
+        !starPromptShown && launchCount >= starPromptAfterLaunches
     }
 
     var body: some View {
@@ -34,6 +43,12 @@ struct RootView: View {
                     TelemetryConsentView()
                 }
             }
+            .background {
+                // Its own host view for the same reason as the consent sheet.
+                Color.clear.sheet(isPresented: $presentStar) {
+                    StarPromptView(onStar: { state.openRepository() })
+                }
+            }
             .onAppear {
                 state.openMainWindow = { openWindow(id: "main") }
                 state.openPalette = { openWindow(id: "palette") }
@@ -45,6 +60,8 @@ struct RootView: View {
                     state.presentTour = true
                 } else if shouldPromptConsent {
                     presentConsent = true
+                } else if shouldPromptStar {
+                    presentStar = true
                 }
             }
             .onChange(of: state.presentTour) { _, showing in

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -230,7 +230,6 @@ struct SidebarPaletteView: View {
         .background(.bgSurface)
         .background { shortcutButtons }
         .onChange(of: state.focusSearchToken) { searchFocused = true }
-        .onChange(of: state.selectedFeatureID) { state.persistLastFeature() }
         .onAppear {
             // Track ⌘ so the row hints can appear/disappear as it's held.
             flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
@@ -500,11 +499,7 @@ struct FeatureRowView: View {
     /// a screen, which just runs (feedback is the toast + clipboard) and leaves
     /// the current detail pane untouched.
     private func activate() {
-        if feature.firesWithoutScreen {
-            Task { await state.run(feature: feature, params: [:]) }
-        } else {
-            state.selectedFeatureID = feature.id
-        }
+        state.openFeature(feature)
     }
 
     /// Trailing edge of a row: a hover-revealed pin button, then a live switch

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -50,6 +50,9 @@ private struct SidebarDrop: DropDelegate {
     /// The target is the last feature row in its group — its lower half maps to
     /// `.afterRow` (end of group), the one slot a top guideline can't reach.
     let isLastFeature: Bool
+    /// Flat (ungrouped) sidebar — any row drops above/below any other, no group
+    /// constraint and no header targets.
+    var isFlat = false
     /// Measured height of the target row (0 if not yet measured).
     let rowHeight: CGFloat
     let setSlot: (DropSlot?) -> Void
@@ -71,6 +74,11 @@ private struct SidebarDrop: DropDelegate {
 
     private func slot(_ info: DropInfo) -> DropSlot? {
         guard let dragID else { return nil }
+        if isFlat {
+            guard dragID.hasPrefix("feature:"), case .feature(let feature) = target else { return nil }
+            if rowHeight > 0, info.location.y > rowHeight / 2 { return .afterRow(feature.id) }
+            return .beforeRow(feature.id)
+        }
         let draggingGroup = dragID.hasPrefix("group:")
         switch target {
         case .header(let category):
@@ -99,8 +107,12 @@ private struct SidebarDrop: DropDelegate {
 /// and ⌘<n> jumps to that row.
 struct SidebarPaletteView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var searchFocused: Bool
     @AppStorage("groupSidebar") private var groupSidebar = true
+    /// Transient "edit" mode: rows jiggle and become draggable, controlled by the
+    /// reorder button. Not persisted — every launch starts calm.
+    @State private var reorderMode = false
     @State private var commandHeld = false
     @State private var flagsMonitor: Any?
     /// Active sidebar drag: "feature:<id>" or "group:<rawValue>", nil when idle.
@@ -119,36 +131,41 @@ struct SidebarPaletteView: View {
     var body: some View {
         @Bindable var state = state
         VStack(spacing: 0) {
-            TextField("Search features…", text: $state.searchText)
-                .brandField()
-                .controlSize(.large)
-                .font(.title3)
-                .focused($searchFocused)
-                .overlay(alignment: .trailing) {
-                    if state.searchText.isEmpty {
-                        KeyHint("⌘K")
+            HStack(spacing: 6) {
+                TextField("Search features…", text: $state.searchText)
+                    .brandField()
+                    .controlSize(.large)
+                    .font(.title3)
+                    .focused($searchFocused)
+                    .overlay(alignment: .trailing) {
+                        if state.searchText.isEmpty {
+                            KeyHint("⌘K")
+                                .padding(.trailing, 6)
+                                .allowsHitTesting(false)
+                                .help("⌘K opens the full search")
+                        } else {
+                            Button {
+                                state.searchText = ""
+                                searchFocused = true
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.textMuted)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
                             .padding(.trailing, 6)
-                            .allowsHitTesting(false)
-                            .help("⌘K opens the full search")
-                    } else {
-                        Button {
-                            state.searchText = ""
-                            searchFocused = true
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.textMuted)
-                                .contentShape(Rectangle())
+                            .help("Clear search")
                         }
-                        .buttonStyle(.plain)
-                        .padding(.trailing, 6)
-                        .help("Clear search")
                     }
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .onSubmit { runTopMatch() }
-                .onKeyPress(.downArrow) { moveSelection(by: 1); return .handled }
-                .onKeyPress(.upArrow) { moveSelection(by: -1); return .handled }
+                    .onSubmit { runTopMatch() }
+                    .onKeyPress(.downArrow) { moveSelection(by: 1); return .handled }
+                    .onKeyPress(.upArrow) { moveSelection(by: -1); return .handled }
+
+                groupToggleButton
+                reorderToggleButton
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
 
             ScrollViewReader { proxy in
             List {
@@ -182,24 +199,22 @@ struct SidebarPaletteView: View {
                     }
                 } else if groupSidebar {
                     // Custom drag-and-drop (not List.onMove, which raced the row
-                    // tap gestures and dropped intermittently). Drag a feature to
-                    // reorder within its group; drag a header to move the whole
-                    // group. The guideline is drawn between rows for a feature
-                    // drag and only at group boundaries for a group drag.
+                    // tap gestures and dropped intermittently). In reorder mode a
+                    // feature drags to reorder within its group and a header drags
+                    // to move the whole group; the guideline is drawn between rows
+                    // for a feature drag and only at group boundaries for a group.
                     Section {
                         ForEach(groupedRows) { row in
                             groupedRow(row, shortcutRank: shortcutRank)
                         }
                     }
                 } else {
-                    // Ungrouped: the user's custom order, drag to reorder.
+                    // Ungrouped: the flat order (its own `flatOrder`, independent
+                    // of groups). Same custom drag/drop as grouped — List.onMove
+                    // fights the jiggle rotation and the row tap gestures.
                     Section {
-                        let ordered = state.orderedEnabledFeatures
-                        ForEach(ordered) { feature in
-                            FeatureRowView(feature: feature, shortcutIndex: shortcutRank[feature.id])
-                        }
-                        .onMove { source, destination in
-                            state.reorderFeatures(ordered, from: source, to: destination)
+                        ForEach(state.orderedEnabledFeatures) { feature in
+                            flatRow(feature, shortcutRank: shortcutRank)
                         }
                     }
                 }
@@ -310,6 +325,49 @@ struct SidebarPaletteView: View {
         }
     }
 
+    /// Toggles category grouping in the sidebar. Accent-tinted when grouping is
+    /// on; switching off reveals the user's flat drag-to-reorder list.
+    private var groupToggleButton: some View {
+        Button {
+            groupSidebar.toggle()
+        } label: {
+            Image(systemName: groupSidebar ? "list.bullet.indent" : "list.bullet")
+                .font(.title3)
+                .foregroundStyle(groupSidebar ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                .frame(width: 30, height: 30)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(reorderMode)
+        .opacity(reorderMode ? 0.4 : 1)
+        .help(reorderMode
+            ? "Finish reordering to switch grouping"
+            : (groupSidebar
+                ? "Grouped by category — click for a flat, reorderable list"
+                : "Flat list — click to group by category"))
+    }
+
+    /// Enters/leaves reorder mode. While on, rows jiggle and can be dragged to
+    /// reorder (grouped and flat keep separate orders); off keeps rows calm and
+    /// clutter-free.
+    private var reorderToggleButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) { reorderMode.toggle() }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+                .font(.title3)
+                .foregroundStyle(reorderMode ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                .frame(width: 30, height: 30)
+                .background(
+                    reorderMode ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear),
+                    in: RoundedRectangle(cornerRadius: 7)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(reorderMode ? "Done reordering" : "Reorder features — drag rows to rearrange")
+    }
+
     /// The grouped sidebar flattened to a single list: each non-empty category
     /// contributes a header row then its (shown) feature rows.
     private var groupedRows: [SidebarRow] {
@@ -318,18 +376,18 @@ struct SidebarPaletteView: View {
         }
     }
 
-    /// Renders one flattened sidebar row. The drag starts from the row's grip
-    /// handle (not the whole row), so it never competes with the tap-to-open /
-    /// click-to-collapse gesture; the whole row is the drop target.
+    /// Renders one flattened sidebar row. In reorder mode the whole row/header is
+    /// draggable (no per-row grip) and tap-to-open is suspended, so the drag never
+    /// competes with a tap; the whole row is the drop target.
     @ViewBuilder
     private func groupedRow(_ row: SidebarRow, shortcutRank: [String: Int]) -> some View {
         switch row {
         case .header(let category):
             GroupHeaderView(
-                category: category, compact: true, showsDragHandle: true,
+                category: category, compact: true, showsDragHandle: true, reordering: reorderMode,
                 collapsed: state.isCategoryCollapsed(category),
                 onToggleCollapse: { state.toggleCategoryCollapsed(category) },
-                dragProvider: { startDrag("group:" + category.rawValue) }
+                dragProvider: reorderMode ? { startDrag("group:" + category.rawValue) } : nil
             )
             .overlay(alignment: .top) { guideline(dropSlot == .beforeGroup(category.rawValue)).offset(y: -6) }
             .overlay(alignment: .bottom) { guideline(dropSlot == .topOfGroup(category.rawValue)).offset(y: 6) }
@@ -337,7 +395,8 @@ struct SidebarPaletteView: View {
         case .feature(let feature):
             FeatureRowView(
                 feature: feature, shortcutIndex: shortcutRank[feature.id],
-                dragProvider: { startDrag("feature:" + feature.id) }
+                reordering: reorderMode,
+                dragProvider: reorderMode ? { startDrag("feature:" + feature.id) } : nil
             )
             .background(
                 GeometryReader { geo in
@@ -350,6 +409,28 @@ struct SidebarPaletteView: View {
             .overlay(alignment: .bottom) { guideline(dropSlot == .afterRow(feature.id)).offset(y: 6) }
             .onDrop(of: [.text], delegate: dropDelegate(for: row))
         }
+    }
+
+    /// One row of the flat (ungrouped) sidebar. Mirrors `groupedRow`'s feature
+    /// case but with a flat drop delegate — any row can drop above or below any
+    /// other, with no group constraint.
+    @ViewBuilder
+    private func flatRow(_ feature: FeatureDef, shortcutRank: [String: Int]) -> some View {
+        FeatureRowView(
+            feature: feature, shortcutIndex: shortcutRank[feature.id],
+            reordering: reorderMode,
+            dragProvider: reorderMode ? { startDrag("feature:" + feature.id) } : nil
+        )
+        .background(
+            GeometryReader { geo in
+                Color.clear.onChange(of: geo.size.height, initial: true) { _, height in
+                    rowHeights[feature.id] = height
+                }
+            }
+        )
+        .overlay(alignment: .top) { guideline(dropSlot == .beforeRow(feature.id)).offset(y: -6) }
+        .overlay(alignment: .bottom) { guideline(dropSlot == .afterRow(feature.id)).offset(y: 6) }
+        .onDrop(of: [.text], delegate: dropDelegate(for: .feature(feature), isFlat: true))
     }
 
     /// The accent insertion indicator shown at a drop slot — a thin line capped
@@ -377,11 +458,12 @@ struct SidebarPaletteView: View {
         return NSItemProvider(object: payload as NSString)
     }
 
-    private func dropDelegate(for row: SidebarRow) -> SidebarDrop {
+    private func dropDelegate(for row: SidebarRow, isFlat: Bool = false) -> SidebarDrop {
         SidebarDrop(
             target: row,
             dragID: dragID,
             isLastFeature: isLastFeature(row),
+            isFlat: isFlat,
             rowHeight: rowHeight(for: row),
             setSlot: { dropSlot = $0 },
             perform: { slot, dragged in performSidebarDrop(slot, dragged) }
@@ -409,6 +491,17 @@ struct SidebarPaletteView: View {
             return
         }
         let fid = String(dragged.dropFirst("feature:".count))
+        if !groupSidebar {
+            let flat = state.orderedEnabledFeatures
+            let toIndex: Int
+            switch slot {
+            case .beforeRow(let targetID): toIndex = flat.firstIndex { $0.id == targetID } ?? flat.count
+            case .afterRow(let targetID): toIndex = flat.firstIndex { $0.id == targetID }.map { $0 + 1 } ?? flat.count
+            default: return
+            }
+            state.moveFlatFeature(fid, toIndex: toIndex)
+            return
+        }
         guard let category = FeatureRegistry.byID[fid]?.category else { return }
         let group = state.enabledFeatures(in: category)
         let toIndex: Int
@@ -481,15 +574,32 @@ struct SidebarPaletteView: View {
 
 struct FeatureRowView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let feature: FeatureDef
     /// 0-based ⌘<n> hint to show trailing (nil = none).
     var shortcutIndex: Int?
     var dimmed = false
-    /// When set, a hover-revealed grip drags this row to reorder it (grouped
-    /// sidebar only). Kept off the row body so it never competes with the tap.
+    /// True while the sidebar is in reorder mode — the row jiggles and tap-to-open
+    /// is suspended so dragging never competes with a tap.
+    var reordering = false
+    /// Set only in reorder mode (grouped sidebar): makes the whole row draggable
+    /// to reorder it. nil otherwise, which is how the drag stays gated.
     var dragProvider: (() -> NSItemProvider)?
     @State private var showingHotkey = false
-    @State private var hovering = false
+
+    private static let jiggleTilt = 1.3
+
+    private var jiggleActive: Bool { reordering && !reduceMotion }
+
+    /// iOS-style edit jiggle as a continuous function of the clock, so it can't
+    /// stall the way a `repeatForever` animation does when the sidebar re-renders.
+    /// Each row gets a stable phase offset from its id so they don't sway in
+    /// lockstep. Off (angle 0) under Reduce Motion — the accent button is the cue.
+    private func jiggleAngle(at date: Date) -> Double {
+        guard jiggleActive else { return 0 }
+        let phase = Double(abs(feature.id.hashValue % 360)) * .pi / 180
+        return sin(date.timeIntervalSinceReferenceDate * 8.5 + phase) * Self.jiggleTilt
+    }
 
     private var isPinned: Bool { state.layout.favorites.contains(feature.id) }
     private var isEnabled: Bool { state.layout.effectiveEnabledIDs.contains(feature.id) }
@@ -502,53 +612,27 @@ struct FeatureRowView: View {
         state.openFeature(feature)
     }
 
-    /// Trailing edge of a row: a hover-revealed pin button, then a live switch
-    /// for toggle features (flip the override without opening a screen) or the
-    /// ⌘<n> jump hint.
+    /// Trailing edge of a row: a live switch for toggle features (flip the
+    /// override without opening a screen) or the ⌘<n> jump hint. Pinning and
+    /// reordering moved off the row — pin lives on the right-click menu (and ⌘P
+    /// in the palette), reordering is the sidebar's reorder mode.
     @ViewBuilder private var trailingControl: some View {
-        HStack(spacing: 4) {
-            if let dragProvider {
-                Image(systemName: "line.3.horizontal")
-                    .foregroundStyle(.textMuted)
-                    .opacity(hovering ? 1 : 0)
-                    .onDrag(dragProvider)
-                    .help("Drag to reorder")
-            }
-            if !dimmed {
-                pinButton
-                    .opacity(hovering ? 1 : 0)
-                    .allowsHitTesting(hovering)
-            }
-            if feature.kind == .toggleAction {
-                OverrideToggleControl(feature: feature) { _ in EmptyView() }
-                    .labelsHidden()
-                    .controlSize(.mini)
-            } else if let shortcutIndex {
-                KeyHint("⌘\(shortcutIndex + 1)")
-            }
+        if feature.kind == .toggleAction {
+            OverrideToggleControl(feature: feature) { _ in EmptyView() }
+                .labelsHidden()
+                .controlSize(.mini)
+                .padding(.leading, 6)
+        } else if let shortcutIndex {
+            KeyHint("⌘\(shortcutIndex + 1)")
+                .padding(.leading, 6)
         }
-        .padding(.leading, 6)
     }
 
-    /// Pin/unpin this feature to the top of the sidebar. Hidden until the row
-    /// is hovered (the pinned rows live in their own section, so the filled pin
-    /// is only needed as the unpin affordance on hover).
-    private var pinButton: some View {
-        Button {
-            state.toggleFavorite(feature.id)
-        } label: {
-            Image(systemName: isPinned ? "pin.fill" : "pin")
-                .foregroundStyle(isPinned ? AnyShapeStyle(.orange) : AnyShapeStyle(.textMuted))
-        }
-        .buttonStyle(.plain)
-        .help(isPinned ? "Unpin from top" : "Pin to top")
-    }
-
-    /// Icon tint: brand green for the active row, quiet gray otherwise. Static
-    /// asset colors (not `.tint`), so they keep their color when the window is
-    /// inactive.
+    /// Icon tint: brand green for every live feature, quiet gray only when the
+    /// row is dimmed (disabled). Static asset colors (not `.tint`), so they keep
+    /// their color when the window is inactive.
     private var iconStyle: AnyShapeStyle {
-        (isSelected && !dimmed) ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted)
+        dimmed ? AnyShapeStyle(.textMuted) : AnyShapeStyle(.brandAccent)
     }
 
     /// Selection highlight drawn by us, not the system list. The native sidebar
@@ -565,6 +649,25 @@ struct FeatureRowView: View {
     }
 
     var body: some View {
+        // Paused (no ticks, zero cost) unless reordering; the row keeps a stable
+        // identity either way so toggling the mode doesn't recreate it.
+        TimelineView(.animation(paused: !jiggleActive)) { timeline in
+            rowContent
+                .rotationEffect(.degrees(jiggleAngle(at: timeline.date)))
+        }
+    }
+
+    /// The row itself, made draggable as a whole only when `dragProvider` is set
+    /// (reorder mode, grouped sidebar) — no per-row grip.
+    @ViewBuilder private var rowContent: some View {
+        if let dragProvider {
+            row.onDrag(dragProvider)
+        } else {
+            row
+        }
+    }
+
+    private var row: some View {
         HStack(spacing: 0) {
             Label {
                 VStack(alignment: .leading, spacing: 1) {
@@ -583,17 +686,17 @@ struct FeatureRowView: View {
                     .foregroundStyle(iconStyle)
             }
             // Tap target is the label/icon only, so a toggle row's switch keeps
-            // its own taps and flips without navigating.
+            // its own taps and flips without navigating. Tap is suspended in
+            // reorder mode so it never competes with the drag.
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
-            .onTapGesture { activate() }
+            .onTapGesture { if !reordering { activate() } }
 
             trailingControl
         }
         .opacity(dimmed ? 0.75 : 1)
         .listRowBackground(rowBackground)
         .padding(.vertical, 2)
-        .onHover { hovering = $0 }
         .contextMenu {
             // Hub members live in their hub, so pinning/enabling them as
             // standalone rows doesn't apply — only the hotkey does.

--- a/App/Sources/Root/StarPromptView.swift
+++ b/App/Sources/Root/StarPromptView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// One-time nudge to star the project on GitHub, shown once the app has been
+/// launched several times (gated in RootView, after the privacy consent). Marks
+/// itself shown the moment it appears, so it never nags twice — whatever the
+/// user does with it.
+struct StarPromptView: View {
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("starPromptShown") private var starPromptShown = false
+
+    /// Opens the GitHub repository (routed through AppState so views stay thin).
+    let onStar: () -> Void
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "star.fill")
+                .font(.system(size: 34, weight: .semibold))
+                .foregroundStyle(.brandAccent)
+                .frame(width: 64, height: 64)
+                .background(Color.brandAccent.opacity(0.12), in: RoundedRectangle(cornerRadius: 16))
+
+            VStack(spacing: 7) {
+                Text("Enjoying Droidective?")
+                    .font(.title2.bold())
+                Text("A star on GitHub helps other Android and React Native developers find it. It takes a moment and genuinely helps.")
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 10) {
+                Button {
+                    onStar()
+                    dismiss()
+                } label: {
+                    Label("Star on GitHub", systemImage: "star.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .controlSize(.large)
+                .keyboardShortcut(.defaultAction)
+                .tint(.brandAccent)
+
+                Button("Maybe Later") { dismiss() }
+                    .buttonStyle(.plain)
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+            }
+        }
+        .padding(28)
+        .frame(width: 380)
+        .background(Color.bgRoot)
+        .onAppear { starPromptShown = true }
+    }
+}

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -43,7 +43,6 @@ struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("theme") private var theme = "auto"
     @AppStorage("groupSidebar") private var groupSidebar = true
-    @AppStorage("restoreLastFeature") private var restoreLastFeature = true
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
     @AppStorage(ScreenCaptureService.captureFolderDefaultsKey) private var captureFolderPath = ""
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
@@ -92,6 +91,10 @@ struct GeneralSettingsView: View {
         )
     }
 
+    private var roleBinding: Binding<UserRole?> {
+        Binding(get: { state.selectedRole }, set: { state.chooseRole($0) })
+    }
+
     var body: some View {
         Form {
             Section("Appearance") {
@@ -116,8 +119,23 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.textMuted)
             }
 
+            Section("Role") {
+                Picker("Role", selection: roleBinding) {
+                    Text("All features").tag(Optional<UserRole>.none)
+                    ForEach(UserRole.allCases) { role in
+                        Text(role.label).tag(Optional(role))
+                    }
+                }
+                Text("Curates which features start visible — switching re-curates your set. Nothing is deleted; add any feature back from Home or the catalog.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+                Button("Open the role picker…") {
+                    state.activateMainWindow()
+                    state.presentRolePicker = true
+                }
+            }
+
             Section("Startup") {
-                Toggle("Reopen the last used feature", isOn: $restoreLastFeature)
                 Toggle("Open at login", isOn: openAtLogin)
             }
 

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -42,7 +42,6 @@ func applyStoredTheme() {
 struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("theme") private var theme = "auto"
-    @AppStorage("groupSidebar") private var groupSidebar = true
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
     @AppStorage(ScreenCaptureService.captureFolderDefaultsKey) private var captureFolderPath = ""
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
@@ -108,13 +107,6 @@ struct GeneralSettingsView: View {
 
                 Toggle("Show how-it-works notes", isOn: $showFeatureNotes)
                 Text("The info text beneath each feature, above the command bar.")
-                    .font(.footnote)
-                    .foregroundStyle(.textMuted)
-            }
-
-            Section("Sidebar") {
-                Toggle("Group features by category", isOn: $groupSidebar)
-                Text("Turn off to drag features into your own order.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -60,6 +60,9 @@ final class AppState {
     var searchText = ""
     var selectedFeatureID: String?
     var layout = LayoutState()
+    /// Per-feature usage tally (persisted), used to re-rank the launchpad's
+    /// curated feature order by how the user actually works.
+    var usageStats = UsageStats()
     var toasts: [Toast] = []
     /// History of important notifications (errors, warnings, key wins), newest
     /// first. Routine success toasts are not kept.
@@ -76,6 +79,9 @@ final class AppState {
     var commandBarTab: CommandBarTab = .recent
     /// Drives the first-launch / replayable welcome tour sheet.
     var presentTour = false
+    /// Drives the first-launch role picker (a full-window takeover) and the
+    /// "Change role" flow. Picking a role seeds a curated feature set.
+    var presentRolePicker = false
     /// True while a performance/network recording is in flight — locks the
     /// device and bundle pickers so the captured series stays consistent.
     var recordingActive = false
@@ -215,6 +221,9 @@ final class AppState {
     var adbMissing: Bool { adbStatus?.installed == false }
 
     private var deviceStreamTask: Task<Void, Never>?
+    /// Set the moment the user picks a role this session, so `bootstrap`'s
+    /// async layout load can't overwrite the just-seeded curation.
+    private var roleChosenThisSession = false
 
     init(env: AppEnvironment) {
         self.env = env
@@ -228,16 +237,21 @@ final class AppState {
         selectedSerial = prefs.selectedSerial
         runOnAll = prefs.runOnAll
         selectedBundleId = prefs.selectedBundleId
-        let restoreLast = UserDefaults.standard.object(forKey: "restoreLastFeature") as? Bool ?? true
-        if restoreLast, let last = prefs.lastFeatureId, FeatureRegistry.byID[last] != nil {
-            selectedFeatureID = last
+        // The launchpad (Home) is the consistent entry point — land there on
+        // every launch rather than reopening the last-used feature.
+        selectedFeatureID = "home"
+        let loadedLayout = await env.stores.layout.load()
+        // A brand-new user can pick a role — which seeds `layout` — while these
+        // async store loads are still in flight; don't clobber that seed.
+        if !roleChosenThisSession {
+            layout = loadedLayout
+            var layoutChanged = layout.adoptNewDefaults()
+            layoutChanged = layout.adoptAllEnabled() || layoutChanged
+            if layoutChanged {
+                persistLayout()
+            }
         }
-        layout = await env.stores.layout.load()
-        var layoutChanged = layout.adoptNewDefaults()
-        layoutChanged = layout.adoptAllEnabled() || layoutChanged
-        if layoutChanged {
-            persistLayout()
-        }
+        usageStats = await env.stores.usage.load()
         bundles = await env.stores.bundles.load()
         await refreshToolStatus()
 
@@ -373,6 +387,15 @@ final class AppState {
     var enabledFeatures: [FeatureDef] {
         let enabled = layout.effectiveEnabledIDs
         return FeatureRegistry.all.filter { enabled.contains($0.id) && !$0.isAbsorbedByHub }
+    }
+
+    /// The launchpad grid: the role-curated enabled set in its curated order,
+    /// re-ranked by real usage (most-used first), with the curated order as the
+    /// stable fallback. Hub members stay excluded, exactly like the sidebar.
+    var launchpadFeatures: [FeatureDef] {
+        let curated = ordered(enabledFeatures)
+        let byID = Dictionary(uniqueKeysWithValues: curated.map { ($0.id, $0) })
+        return usageStats.rank(curated.map(\.id)).compactMap { byID[$0] }
     }
 
     var visibleFeatures: [FeatureDef] {
@@ -519,10 +542,31 @@ final class AppState {
 
     // MARK: - Feature running
 
+    /// Open or run a feature from a launch surface (launchpad or sidebar),
+    /// recording the engagement for adaptive ranking. Instant/toggle actions
+    /// that need no screen fire in place (recorded inside `run`); everything
+    /// else opens its detail pane.
+    func openFeature(_ feature: FeatureDef) {
+        if feature.firesWithoutScreen {
+            Task { await run(feature: feature, params: [:]) }
+        } else {
+            noteFeatureUse(feature.id)
+            selectedFeatureID = feature.id
+        }
+    }
+
+    /// Record one engagement with a feature, persisted for adaptive launchpad
+    /// ranking across launches.
+    func noteFeatureUse(_ featureID: String) {
+        usageStats.record(featureID, at: Date())
+        persistUsage()
+    }
+
     func run(feature: FeatureDef, params: [String: FeatureValue]) async {
         isRunningFeature = true
         defer { isRunningFeature = false }
         Telemetry.shared.track("feature_used", ["feature": feature.id])
+        noteFeatureUse(feature.id)
 
         // A screenshot from a quick path (sidebar ⏎, global hotkey, menu bar)
         // captures and saves straight to the capture folder; the Screenshot
@@ -642,6 +686,28 @@ final class AppState {
         notifications.removeAll { $0.id == id }
     }
 
+    // MARK: - Role
+
+    /// Apply the user's role choice (first-run or "Change role"): curate the
+    /// enabled set + sidebar order to that role, or keep everything on for
+    /// `nil` ("show me everything"). Persists and lands on the launchpad.
+    func chooseRole(_ role: UserRole?) {
+        if let role {
+            layout.seedRole(role)
+        } else {
+            layout.seedEverything()
+        }
+        roleChosenThisSession = true
+        persistLayout()
+        presentRolePicker = false
+        selectedFeatureID = "home"
+    }
+
+    /// The user's current role, nil when they chose "show me everything".
+    var selectedRole: UserRole? {
+        layout.selectedRole.flatMap(UserRole.init(rawValue:))
+    }
+
     // MARK: - Layout (catalog customization)
 
     func setFeatureEnabled(_ featureID: String, enabled: Bool) {
@@ -729,6 +795,13 @@ final class AppState {
         let snapshot = layout
         Task {
             try? await env.stores.layout.save(snapshot)
+        }
+    }
+
+    private func persistUsage() {
+        let snapshot = usageStats
+        Task {
+            try? await env.stores.usage.save(snapshot)
         }
     }
 
@@ -898,13 +971,6 @@ final class AppState {
                 let result = await env.engine.adbKeyboard.install(serial: serial)
                 showToast(Toast(message: result.message, ok: result.ok))
             }
-        }
-    }
-
-    func persistLastFeature() {
-        let id = selectedFeatureID
-        Task {
-            try? await env.stores.prefs.update { $0.lastFeatureId = id }
         }
     }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -471,10 +471,25 @@ final class AppState {
         ordered(FeatureRegistry.all.filter { $0.category == category && !$0.isAbsorbedByHub })
     }
 
-    /// Enabled, non-pinned features in the user's order. Drives the flat
-    /// (ungrouped) sidebar and its drag-to-reorder.
+    /// Enabled, non-pinned features in grouped display order, flattened — the
+    /// seed for the flat sidebar before the user reorders it.
+    private var groupedFlatFeatures: [FeatureDef] {
+        orderedCategories.flatMap { enabledFeatures(in: $0) }
+    }
+
+    /// Enabled, non-pinned features in the flat sidebar's own order. Until the
+    /// user reorders the flat list (`flatOrder` is nil), it mirrors the grouped
+    /// order so toggling grouping off doesn't reshuffle anything.
     var orderedEnabledFeatures: [FeatureDef] {
-        ordered(enabledFeatures.filter { !layout.favorites.contains($0.id) })
+        guard let flatOrder = layout.flatOrder else { return groupedFlatFeatures }
+        let rank = Dictionary(flatOrder.enumerated().map { ($1, $0) }, uniquingKeysWith: { first, _ in first })
+        let registryIndex = Dictionary(
+            uniqueKeysWithValues: FeatureRegistry.all.enumerated().map { ($1.id, $0) }
+        )
+        return enabledFeatures.filter { !layout.favorites.contains($0.id) }.sorted {
+            (rank[$0.id] ?? Int.max, registryIndex[$0.id] ?? 0)
+                < (rank[$1.id] ?? Int.max, registryIndex[$1.id] ?? 0)
+        }
     }
 
     /// Genuinely-disabled features — not on the sidebar and not folded into a
@@ -733,6 +748,15 @@ final class AppState {
         persistLayout()
     }
 
+    /// Reorder the flat (ungrouped) sidebar. `displayed` is the whole flat list,
+    /// so the moved sequence is stored verbatim as the independent `flatOrder` —
+    /// leaving the grouped order (`sidebarOrder`/`categoryOrder`) untouched.
+    func reorderFlatFeatures(_ displayed: [FeatureDef], from source: IndexSet, to destination: Int) {
+        let ids = displayed.map(\.id)
+        layout.flatOrder = SidebarOrdering.reorder(displayed: ids, from: source, to: destination, within: ids)
+        persistLayout()
+    }
+
     /// Move a feature to `toIndex` within its group (sidebar drag-and-drop).
     /// `toIndex` is the insertion position in the group's enabled-feature list
     /// (0 = top, count = end).
@@ -740,6 +764,15 @@ final class AppState {
         let group = enabledFeatures(in: category)
         guard let from = group.firstIndex(where: { $0.id == id }) else { return }
         reorderFeatures(group, from: IndexSet(integer: from), to: toIndex)
+    }
+
+    /// Move a feature to `toIndex` within the flat (ungrouped) sidebar, writing
+    /// the independent `flatOrder`. `toIndex` is the insertion position in the
+    /// flat list (0 = top, count = end).
+    func moveFlatFeature(_ id: String, toIndex: Int) {
+        let flat = orderedEnabledFeatures
+        guard let from = flat.firstIndex(where: { $0.id == id }) else { return }
+        reorderFlatFeatures(flat, from: IndexSet(integer: from), to: toIndex)
     }
 
     /// Move a whole group before `targetRawValue` (nil = to the end).

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -2,13 +2,13 @@ import Foundation
 import PostHog
 import Sentry
 
-/// Crash reporting (Sentry) and opt-in product analytics (PostHog). Lives in the
-/// App layer so ADBKit stays dependency-free and `swift test` stays clean.
+/// Crash reporting (Sentry) and product analytics (PostHog). Lives in the App
+/// layer so ADBKit stays dependency-free and `swift test` stays clean.
 ///
 /// Everything is anonymous: no device serials, package ids, file paths, IPs, or
-/// command contents are ever sent — only which tool was used. Crash reporting is
-/// on by default (disclosed on first launch, opt-out in Settings → Privacy);
-/// product analytics is opt-in.
+/// command contents are ever sent — only which tool was used. Both are on by
+/// default and opt-out in Settings → Privacy; the first-run consent disclosure
+/// is deferred for the first few launches (gated in RootView).
 @MainActor
 final class Telemetry {
     static let shared = Telemetry()
@@ -17,14 +17,14 @@ final class Telemetry {
     static let crashReportingKey = "crashReportingEnabled"
     static let analyticsKey = "analyticsEnabled"
 
-    /// Defaults ON. Disclosed at first launch; opt-out in Settings → Privacy.
+    /// Defaults ON. Opt-out in Settings → Privacy.
     var crashReportingEnabled: Bool {
         UserDefaults.standard.object(forKey: Self.crashReportingKey) as? Bool ?? true
     }
 
-    /// Defaults OFF — opt-in only.
+    /// Defaults ON. Opt-out in Settings → Privacy.
     var analyticsEnabled: Bool {
-        UserDefaults.standard.bool(forKey: Self.analyticsKey)
+        UserDefaults.standard.object(forKey: Self.analyticsKey) as? Bool ?? true
     }
 
     private var sentryRunning = false

--- a/App/Sources/Telemetry/TelemetryConsentView.swift
+++ b/App/Sources/Telemetry/TelemetryConsentView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// One-time privacy disclosure shown on first launch (after the welcome tour).
-/// Both crash reporting and analytics start ON here and are recommended; nothing
-/// is sent until Continue is pressed. Toggleable later in Settings → Privacy.
+/// Privacy disclosure shown once, after the app has been launched a few times
+/// (RootView gates it). Telemetry is anonymous and already on by default; this
+/// lets the user confirm or opt out. Toggleable later in Settings → Privacy.
 struct TelemetryConsentView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
@@ -41,7 +41,10 @@ struct TelemetryConsentView: View {
         .padding(28)
         .frame(width: 480)
         .background(Color.bgRoot)
-        .onAppear { crashReports = Telemetry.shared.crashReportingEnabled }
+        .onAppear {
+            crashReports = Telemetry.shared.crashReportingEnabled
+            analytics = Telemetry.shared.analyticsEnabled
+        }
     }
 
     private var header: some View {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,43 @@
-## Droidective v2.4.2
+## Droidective v2.5.0
 
-A fix for the in-app updater's release notes, plus a couple of first-run changes.
+A big UX release: pick your role on first launch and get a focused Home, a faster
+command palette, a sidebar you can rearrange, and refreshed screens throughout.
 
-### Fixes
+### New features
 
-- **Update notes** — the in-app updater now shows the release notes in its own
-  window instead of opening the GitHub release web page.
+- **Role-based start** — on first launch, pick a role (Android, React Native, QA,
+  Support, or "everything") and Droidective curates a focused feature set and a
+  Home launchpad of your most-used tools, ordered by real usage. Change your role
+  anytime in Settings; nothing is ever removed.
+- **Bug Report screen** — capturing a bug report now has its own screen instead
+  of firing blind.
+- **Forward Metro (React Native)** — one click runs `adb reverse tcp:8081` so the
+  device reaches Metro on your Mac.
 
 ### Improvements
 
-- **First-run privacy screen** — appears after a few launches instead of on the
-  first one. Anonymous crash reports and usage analytics are on by default in
-  the meantime; both stay opt-out anytime in Settings → Privacy.
+- **Command palette (⌘K)** — rebuilt as a tight, centered Spotlight-style panel.
+  Pin features with `⌘P` (pinned items lead the sidebar and palette), enable or
+  disable with `⌘E`, and search now matches every word you type — so "copy ip"
+  finds "Copy Device IP". Keyboard hints throughout.
+- **Reorder the sidebar** — a reorder button drops the sidebar into an edit mode
+  (rows jiggle) where you drag to rearrange. Grouped and ungrouped layouts keep
+  independent orders, and pinning moved to right-click so rows stay clean.
+- **Grouping toggle** — group-by-category is now a button next to the search
+  field instead of a Settings option.
+- **Refreshed screens** — Connection, Device Info, Simulate, React Native, Deep
+  Links, App Info, System Restrictions, and the Apps detail pane share one card
+  layout.
+- **Emulators** — click a running emulator to bring its window to the front, and
+  a freshly launched emulator comes forward on its own.
+- **Screenshot editor** — press Delete to remove the selected annotation.
+- **Theme** — a neutral charcoal dark palette (no blue cast) and brand-green
+  feature icons throughout.
+- **Update notes** — the in-app updater shows release notes in its own window
+  instead of opening the web page.
+- **First-run privacy screen** — appears after a few launches instead of the
+  first. Anonymous crash reports and usage analytics stay opt-out in
+  Settings → Privacy.
 - **Star prompt** — a one-time nudge to star the project on GitHub.
 
 Installed copies update in place via Sparkle.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+## Droidective v2.4.2
+
+A fix for the in-app updater's release notes, plus a couple of first-run changes.
+
+### Fixes
+
+- **Update notes** — the in-app updater now shows the release notes in its own
+  window instead of opening the GitHub release web page.
+
+### Improvements
+
+- **First-run privacy screen** — appears after a few launches instead of on the
+  first one. Anonymous crash reports and usage analytics are on by default in
+  the meantime; both stay opt-out anytime in Settings → Privacy.
+- **Star prompt** — a one-time nudge to star the project on GitHub.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.4.1
 
 ### Improvements

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -202,7 +202,9 @@ CI (the `release` job) then:
 - notarizes the DMG with Apple and staples the ticket;
 - publishes the GitHub release with that DMG and the latest release notes;
 - signs the stapled DMG with the EdDSA key and commits the regenerated
-  `site/appcast.xml` to `main`;
+  `site/appcast.xml` to `main` — with those notes rendered to HTML and embedded
+  in the item's `<description>`, so Sparkle shows them in its update window
+  rather than loading the GitHub release page;
 - updates the Homebrew cask.
 
 That commit to `main` re-runs the `pages` job, which deploys the site and the
@@ -246,8 +248,8 @@ Copy this into the release PR and tick each item.
 - [ ] Fresh download launches cleanly: mount the DMG, drag to `/Applications`, open — no Gatekeeper warning. `spctl -a -vvv -t install Droidective-vX.Y.Z.dmg` reports *accepted, source=Notarized Developer ID*.
 - [ ] `brew install --cask rohindh-r/tap/droidective` installs the new version.
 - [ ] `https://droidective.github.io/Droidective/` shows the new screenshots and copy.
-- [ ] `https://droidective.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature`.
-- [ ] A prior install (v2.1.0+) offers the update via Sparkle and applies it in place.
+- [ ] `https://droidective.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature` and the release notes inline in `<description>`.
+- [ ] A prior install (v2.1.0+) offers the update via Sparkle, shows the release notes in the update window (not the GitHub web page), and applies it in place.
 - [ ] Repo **About → Website** still points at the Pages URL.
 
 ## Mac App Store builds

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.4.2"
+        MARKETING_VERSION: "2.5.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.4.1"
+        MARKETING_VERSION: "2.4.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 # Sign a built DMG with Sparkle's EdDSA key and (re)write the appcast feed.
-# Produces a single-item appcast pointing at the GitHub release asset — all
-# Sparkle needs to offer the latest version to every older install.
+# Produces a single-item appcast whose enclosure points at the GitHub release
+# asset and whose <description> carries the release notes inline as HTML — so
+# Sparkle renders the notes in its update window instead of loading the GitHub
+# release web page (which dragged in the whole site chrome).
 #
 # Usage:
-#   update-appcast.sh <dmg> <short-version> <build-version> <tag> <download-url> [appcast-out]
+#   update-appcast.sh <dmg> <short-version> <build-version> <download-url> <notes-md> [appcast-out]
+#
+# <notes-md> is this release's section in Markdown (the same file used for the
+# GitHub release body). It's rendered to HTML with GitHub's /markdown API — so
+# it matches the release page — and embedded in <description>.
 #
 # The signing key is read from $SPARKLE_ED_PRIVATE_KEY (CI) or, when unset, from
-# the login Keychain (local runs).
+# the login Keychain (local runs). gh must be authenticated (GH_TOKEN in CI).
 set -euo pipefail
 
 DMG="${1:?dmg path required}"
 SHORT_VERSION="${2:?marketing version required}"
 BUILD_VERSION="${3:?build version required}"
-TAG="${4:?tag required}"
-DOWNLOAD_URL="${5:?download url required}"
+DOWNLOAD_URL="${4:?download url required}"
+NOTES_MD="${5:?release notes markdown path required}"
 APPCAST="${6:-site/appcast.xml}"
 
 SIGN_UPDATE=".sparkle/bin/sign_update"
@@ -26,6 +32,26 @@ SIGN_UPDATE=".sparkle/bin/sign_update"
   echo "error: DMG not found: $DMG" >&2
   exit 1
 }
+[[ -f "$NOTES_MD" ]] || {
+  echo "error: release notes not found: $NOTES_MD" >&2
+  exit 1
+}
+command -v gh >/dev/null || {
+  echo "error: gh (GitHub CLI) required to render release notes" >&2
+  exit 1
+}
+
+# Sparkle's notes are this version's section minus the redundant version heading
+# (Sparkle's UI already shows the version) and the "Install" subsection (its
+# "download the .dmg below" steps make no sense in an updater that installs for
+# you). Both filters are no-ops when those lines are absent.
+notes_md="$(awk 'NR==1 && /^## /{next} /^### Install/{exit} {print}' "$NOTES_MD")"
+
+# Render Markdown -> HTML with GitHub's renderer (so it matches the release
+# page), then strip GitHub's heading chrome — the permalink octicon anchors and
+# wrapper divs render as broken glyphs in Sparkle's plain web view.
+notes_html="$(gh api --method POST /markdown -f text="$notes_md" -f mode=markdown |
+  sed -E 's#<a id="user-content-[^"]*" class="anchor"[^>]*>.*</a>##g; s#<div class="markdown-heading">##g; s#</div>##g; s# class="heading-element"##g')"
 
 if [[ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]]; then
   enclosure_attrs="$(printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | "$SIGN_UPDATE" --ed-key-file - "$DMG")"
@@ -49,12 +75,39 @@ cat >"$APPCAST" <<XML
       <sparkle:version>${BUILD_VERSION}</sparkle:version>
       <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <sparkle:releaseNotesLink>https://github.com/Droidective/Droidective/releases/tag/${TAG}</sparkle:releaseNotesLink>
+      <description><![CDATA[
+<style>
+:root { color-scheme: light dark; }
+body { font: 13px/1.55 -apple-system, BlinkMacSystemFont, sans-serif; margin: 0; }
+h2 { font-size: 1.3em; margin: .2em 0 .4em; }
+h3 { font-size: 1.05em; margin: 1.1em 0 .3em; }
+p { margin: .5em 0; }
+ul { margin: .4em 0; padding-left: 1.4em; }
+li { margin: .3em 0; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em; background: color-mix(in srgb, currentColor 12%, transparent); padding: .1em .35em; border-radius: 4px; }
+pre { background: color-mix(in srgb, currentColor 8%, transparent); padding: .6em .8em; border-radius: 6px; overflow-x: auto; }
+pre code { background: none; padding: 0; }
+a { color: #2f9e44; }
+</style>
+${notes_html}
+]]></description>
       <pubDate>${pub_date}</pubDate>
       <enclosure url="${DOWNLOAD_URL}" ${enclosure_attrs} type="application/octet-stream" />
     </item>
   </channel>
 </rss>
 XML
+
+# The <description> now carries generated HTML, so confirm the feed still parses
+# before it's committed — a malformed appcast silently stops every client's
+# updates. (Skipped, with a warning, only if xmllint isn't installed.)
+if command -v xmllint >/dev/null; then
+  xmllint --noout "$APPCAST" || {
+    echo "error: generated $APPCAST is not well-formed XML" >&2
+    exit 1
+  }
+else
+  echo "warning: xmllint not found — skipping appcast validation" >&2
+fi
 
 echo "wrote $APPCAST ($SHORT_VERSION / build $BUILD_VERSION)"

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -10,7 +10,28 @@
       <sparkle:version>80</sparkle:version>
       <sparkle:shortVersionString>2.4.1</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <sparkle:releaseNotesLink>https://github.com/Droidective/Droidective/releases/tag/v2.4.1</sparkle:releaseNotesLink>
+      <description><![CDATA[
+<style>
+:root { color-scheme: light dark; }
+body { font: 13px/1.55 -apple-system, BlinkMacSystemFont, sans-serif; margin: 0; }
+h2 { font-size: 1.3em; margin: .2em 0 .4em; }
+h3 { font-size: 1.05em; margin: 1.1em 0 .3em; }
+p { margin: .5em 0; }
+ul { margin: .4em 0; padding-left: 1.4em; }
+li { margin: .3em 0; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9em; background: color-mix(in srgb, currentColor 12%, transparent); padding: .1em .35em; border-radius: 4px; }
+pre { background: color-mix(in srgb, currentColor 8%, transparent); padding: .6em .8em; border-radius: 6px; overflow-x: auto; }
+pre code { background: none; padding: 0; }
+a { color: #2f9e44; }
+</style>
+<h3>Improvements</h3>
+<ul>
+<li>
+<strong>Sidebar footer</strong> — the "Manage features" button stays on one line, and the
+sidebar has a higher minimum width so the footer no longer wraps when narrowed.</li>
+</ul>
+<p>Installed copies update in place via Sparkle.</p>
+]]></description>
       <pubDate>Wed, 24 Jun 2026 13:59:33 +0000</pubDate>
       <enclosure url="https://github.com/Droidective/Droidective/releases/download/v2.4.1/Droidective-v2.4.1.dmg" sparkle:edSignature="hWcQo0n9m0rt/KHop2aY821NrZKRKWxXgpaQ/DjSRhTJeT5SJ8CwKvJ5hsjOqtbbGE1c8jdadjLOztYY7504Bg==" length="44365721" type="application/octet-stream" />
     </item>


### PR DESCRIPTION
Ships **v2.5.0** — a UX-focused release built on top of the role-based launchpad.

## New features
- **Role-based start** — first launch picks a role (Android / React Native / QA / Support / everything) and curates a focused feature set plus a Home launchpad ordered by real usage. Changeable in Settings; nothing is ever removed.
- **Bug Report screen** — the bug-report capture has its own screen instead of a fire-and-forget action.
- **Forward Metro** — one click runs `adb reverse tcp:8081` for React Native.

## Improvements
- **Command palette (⌘K)** — rebuilt as a borderless, centered `NSPanel` (flush top and bottom). `⌘P` pins, `⌘E` enables/disables, and search matches every query word, so "copy ip" finds "Copy Device IP".
- **Sidebar reorder mode** — a reorder button jiggles rows and drags to rearrange via the shared `onDrag`/`onDrop`; grouped and flat layouts keep independent orders. Grouping moved to a sidebar button; pin/reorder icons are off the rows (pin is on right-click).
- **Refreshed screens** — Connection, Device Info, Simulate, React Native, Deep Links, App Info, System Restrictions, and the Apps detail pane share one card layout.
- **Emulators** — click a running emulator to raise its window; a launched emulator comes forward on its own.
- **Screenshot editor** — Delete removes the selected annotation.
- **Theme** — neutral charcoal dark palette and brand-green feature icons.
- Inline in-app update notes, a deferred first-run privacy screen, and a one-time GitHub-star prompt.

## Tests
- ADBKit: 268 tests green. App builds clean at `MARKETING_VERSION` 2.5.0.
