### PR TITLE
Add role-based onboarding, a launchpad Home, and card-based detail screens

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -51,6 +51,49 @@ public enum FeatureCategory: String, Sendable, Codable, CaseIterable {
     }
 }
 
+/// The persona a user picks on first launch to get a focused, curated set of
+/// features instead of all of them. Drives `FeatureRegistry.featuresByRole`.
+/// UI strings and the icon (an SF Symbol *name*) live here so the picker stays
+/// declarative and ADBKit stays free of UI frameworks. A `nil` selected role
+/// means "show everything".
+public enum UserRole: String, Sendable, Codable, CaseIterable, Identifiable {
+    case androidDeveloper = "android-dev"
+    case reactNativeDeveloper = "rn-dev"
+    case qaTester = "qa"
+    case supportTriage = "support"
+
+    public var id: String { rawValue }
+
+    public var label: String {
+        switch self {
+        case .androidDeveloper: return "Android Developer"
+        case .reactNativeDeveloper: return "React Native Developer"
+        case .qaTester: return "QA / Tester"
+        case .supportTriage: return "Support / Triage"
+        }
+    }
+
+    /// One line shown under the role name on its picker card.
+    public var blurb: String {
+        switch self {
+        case .androidDeveloper: return "Logs, app internals, files, and device connection."
+        case .reactNativeDeveloper: return "Metro reload, dev menu, logs, and performance."
+        case .qaTester: return "Capture, recording, crash hunting, and state simulation."
+        case .supportTriage: return "Device diagnostics, connection, and quick checks."
+        }
+    }
+
+    /// SF Symbol name (ADBKit stays UI-framework free).
+    public var icon: String {
+        switch self {
+        case .androidDeveloper: return "hammer"
+        case .reactNativeDeveloper: return "atom"
+        case .qaTester: return "checkmark.seal"
+        case .supportTriage: return "lifepreserver"
+        }
+    }
+}
+
 public enum OverrideKind: String, Sendable, Codable, CaseIterable {
     case proxy
     case layout

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -387,7 +387,7 @@ public enum FeatureRegistry {
             id: "bug-report", num: 34, title: "Bug Report",
             subtitle: "Zip screenshot + logs + device info + version",
             keywords: ["bug report", "zip", "bundle", "diagnostics", "export"],
-            category: .logs, icon: "doc.zipper", kind: .instantAction
+            category: .logs, icon: "doc.zipper", kind: .view
         ),
         FeatureDef(
             id: "performance", num: 35, title: "Performance Monitor",
@@ -443,6 +443,40 @@ public enum FeatureRegistry {
     /// Features the user manages individually in the catalog and sidebar:
     /// everything except hub members. The hub screens themselves are included.
     public static let catalogFeatureIDs: [String] = all.map(\.id).filter { !absorbedFeatureIDs.contains($0) }
+
+    /// Curated, ordered catalog features per role — the focused set a newcomer
+    /// gets after picking a role on first launch. The order is the recommended
+    /// sidebar order; the launchpad re-ranks it by real usage over time. Roles
+    /// reference hub ids (`react-native`, `simulate`, `connection`, `apps`), not
+    /// the members folded into them. Every non-system catalog feature appears in
+    /// at least one role (enforced by `FeatureRegistryTests`).
+    public static let featuresByRole: [UserRole: [String]] = [
+        .androidDeveloper: [
+            "logcat", "crash-catcher", "device-info", "current-activity", "foreground-package",
+            "file-explorer", "sandbox-browser", "apps", "connection", "get-ip",
+            "meminfo", "monkey", "scrcpy", "screenshot", "send-text", "custom-commands",
+        ],
+        .reactNativeDeveloper: [
+            "react-native", "logcat", "crash-catcher", "performance", "network-speed",
+            "apps", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
+        ],
+        .qaTester: [
+            "screenshot", "screen-record", "scrcpy", "video-editor", "bug-report",
+            "crash-catcher", "logcat", "simulate", "performance", "apps",
+            "device-info", "demo-mode", "monkey",
+        ],
+        .supportTriage: [
+            "device-info", "connection", "wifi", "get-ip", "network-speed",
+            "root-status", "system-restrictions", "scrcpy", "screenshot", "bug-report", "logcat",
+            "apps", "emulators",
+        ],
+    ]
+
+    /// The curated, ordered catalog ids for a role (validated to exist in the
+    /// registry). Empty for an unknown role.
+    public static func featureIDs(for role: UserRole) -> [String] {
+        (featuresByRole[role] ?? []).filter { byID[$0] != nil }
+    }
 }
 
 public extension FeatureDef {

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -81,6 +81,15 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// nil on layouts written before the switch, so they catch up once. Optional
     /// so older files decode.
     public var didEnableAll: Bool?
+    /// The role the user picked on first launch (`UserRole` raw value), or nil
+    /// for "show everything". Drives the curated enabled set + sidebar order.
+    /// Optional so older files decode.
+    public var selectedRole: String?
+    /// True once the user has been through the role picker (picked a role or
+    /// chose "everything"). Gates the one-time picker; set together with
+    /// `didEnableAll`/`knownIds` so the legacy migrations can't re-expand a
+    /// curated role back to all-on. Optional so older files decode.
+    public var roleChosen: Bool?
 
     public init(
         enabledIds: [String]? = nil,
@@ -90,7 +99,9 @@ public struct LayoutState: Codable, Sendable, Equatable {
         categoryOrder: [String]? = nil,
         collapsedCategories: [String]? = nil,
         menuBarItems: [String]? = nil,
-        didEnableAll: Bool? = nil
+        didEnableAll: Bool? = nil,
+        selectedRole: String? = nil,
+        roleChosen: Bool? = nil
     ) {
         self.enabledIds = enabledIds
         self.favorites = favorites
@@ -100,6 +111,8 @@ public struct LayoutState: Codable, Sendable, Equatable {
         self.collapsedCategories = collapsedCategories
         self.menuBarItems = menuBarItems
         self.didEnableAll = didEnableAll
+        self.selectedRole = selectedRole
+        self.roleChosen = roleChosen
     }
 
     /// The effective enabled set: explicit user choice or registry defaults,
@@ -147,6 +160,31 @@ public struct LayoutState: Codable, Sendable, Equatable {
         }
         return true
     }
+
+    /// Curate the layout to a role: enable exactly the role's features (system
+    /// features stay on regardless via `effectiveEnabledIDs`) and match the
+    /// sidebar order to the curated order. Marks `knownIds`/`didEnableAll` so
+    /// `adoptNewDefaults`/`adoptAllEnabled` can't re-expand the set back to
+    /// all-on. Used at first-run pick and when changing role later.
+    public mutating func seedRole(_ role: UserRole) {
+        let ids = FeatureRegistry.featureIDs(for: role)
+        selectedRole = role.rawValue
+        roleChosen = true
+        enabledIds = ids
+        sidebarOrder = ids
+        knownIds = FeatureRegistry.all.map(\.id)
+        didEnableAll = true
+    }
+
+    /// The "show me everything" choice: leave every feature on, just record that
+    /// the user has been through the picker. Clears any prior role curation.
+    public mutating func seedEverything() {
+        selectedRole = nil
+        roleChosen = true
+        enabledIds = nil
+        knownIds = FeatureRegistry.all.map(\.id)
+        didEnableAll = true
+    }
 }
 
 public struct Presets: Codable, Sendable, Equatable {
@@ -178,24 +216,19 @@ public struct Prefs: Codable, Sendable, Equatable {
     public var runOnAll: Bool
     /// The active saved bundle id (used by every app-scoped feature).
     public var selectedBundleId: String?
-    /// Feature id selected when the app was last used (restored at launch).
-    /// Optional so files written before the field existed still decode.
-    public var lastFeatureId: String?
 
     public init(
         selectedSerial: String? = nil,
         runOnAll: Bool = false,
-        selectedBundleId: String? = nil,
-        lastFeatureId: String? = nil
+        selectedBundleId: String? = nil
     ) {
         self.selectedSerial = selectedSerial
         self.runOnAll = runOnAll
         self.selectedBundleId = selectedBundleId
-        self.lastFeatureId = lastFeatureId
     }
 }
 
-/// All seven durable stores, built once at app startup.
+/// All eight durable stores, built once at app startup.
 public struct AppStores: Sendable {
     public let bundles: JSONStore<[AppBundle]>
     public let deepLinks: JSONStore<DeepLinksMap>
@@ -204,6 +237,7 @@ public struct AppStores: Sendable {
     public let presets: JSONStore<Presets>
     public let overrides: JSONStore<OverridesMap>
     public let prefs: JSONStore<Prefs>
+    public let usage: JSONStore<UsageStats>
 
     public init(directory: URL = AppPaths.supportDir) {
         bundles = JSONStore(filename: "bundles.json", default: [], directory: directory)
@@ -213,5 +247,6 @@ public struct AppStores: Sendable {
         presets = JSONStore(filename: "presets.json", default: Presets(), directory: directory)
         overrides = JSONStore(filename: "overrides.json", default: [:], directory: directory)
         prefs = JSONStore(filename: "prefs.json", default: Prefs(), directory: directory)
+        usage = JSONStore(filename: "usage.json", default: UsageStats(), directory: directory)
     }
 }

--- a/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Per-feature usage tally, persisted to `usage.json`. Used to re-rank a role's
+/// curated feature order on the Home launchpad by how the user actually works,
+/// so "frequently used" becomes personal over time.
+///
+/// `CommandLog` is session-only (an in-memory actor), so cross-launch ranking
+/// needs this durable store rather than the command log.
+public struct UsageStat: Codable, Sendable, Equatable {
+    public var count: Int
+    public var lastUsed: Date
+
+    public init(count: Int = 0, lastUsed: Date = .distantPast) {
+        self.count = count
+        self.lastUsed = lastUsed
+    }
+}
+
+public struct UsageStats: Codable, Sendable, Equatable {
+    /// Tally keyed by feature id.
+    public var byFeature: [String: UsageStat]
+
+    public init(byFeature: [String: UsageStat] = [:]) {
+        self.byFeature = byFeature
+    }
+
+    public func count(for featureID: String) -> Int { byFeature[featureID]?.count ?? 0 }
+
+    /// Record one user-initiated use of a feature at `date`.
+    public mutating func record(_ featureID: String, at date: Date) {
+        var stat = byFeature[featureID] ?? UsageStat()
+        stat.count += 1
+        stat.lastUsed = date
+        byFeature[featureID] = stat
+    }
+
+    /// Re-rank `ids` (a curated, ordered list) by real usage: most-used first,
+    /// most-recent use breaks count ties, and the original curated order is the
+    /// stable fallback for unused or otherwise-tied features. The comparator is
+    /// a total order (curated index is the final tiebreak), so the result is
+    /// deterministic regardless of `sorted`'s stability guarantees.
+    public func rank(_ ids: [String]) -> [String] {
+        ids.enumerated()
+            .sorted { lhs, rhs in
+                let a = byFeature[lhs.element]
+                let b = byFeature[rhs.element]
+                let countA = a?.count ?? 0
+                let countB = b?.count ?? 0
+                if countA != countB { return countA > countB }
+                if countA > 0, let lastA = a?.lastUsed, let lastB = b?.lastUsed, lastA != lastB {
+                    return lastA > lastB
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -237,4 +237,50 @@ import Testing
         #expect(layout.effectiveEnabledIDs.contains("custom-commands"))
         #expect(!layout.effectiveEnabledIDs.contains("fake-battery"))
     }
+
+    @Test func everyRoleMapsValidFeatureIDsAndCoversTheCatalog() {
+        for role in UserRole.allCases {
+            for id in FeatureRegistry.featuresByRole[role] ?? [] {
+                #expect(FeatureRegistry.byID[id] != nil, "role \(role.rawValue): unknown feature \(id)")
+                #expect(
+                    !(FeatureRegistry.byID[id]?.isAbsorbedByHub ?? false),
+                    "role \(role.rawValue): \(id) is a hub member; reference its hub instead"
+                )
+            }
+        }
+        // Every non-system catalog feature must be reachable from some role, so
+        // curation never orphans a feature. System features are always on
+        // regardless of role, so they're exempt.
+        let covered = Set(UserRole.allCases.flatMap { FeatureRegistry.featuresByRole[$0] ?? [] })
+        let mustCover = Set(FeatureRegistry.catalogFeatureIDs)
+            .subtracting(FeatureRegistry.systemFeatureIDs)
+        #expect(mustCover.isSubset(of: covered), "uncovered catalog features: \(mustCover.subtracting(covered))")
+    }
+
+    @Test func seedRoleCuratesEnabledSetAndOrder() {
+        var layout = LayoutState()
+        layout.seedRole(.qaTester)
+        let curated = FeatureRegistry.featureIDs(for: .qaTester)
+        #expect(layout.selectedRole == UserRole.qaTester.rawValue)
+        #expect(layout.roleChosen == true)
+        #expect(layout.enabledIds == curated)
+        #expect(layout.sidebarOrder == curated)
+        #expect(layout.effectiveEnabledIDs.isSuperset(of: Set(curated)))
+        #expect(layout.effectiveEnabledIDs.contains("custom-commands"))  // system stays on
+        #expect(!layout.effectiveEnabledIDs.contains("wifi"))            // curated out for QA
+        // The legacy migrations must not re-expand a curated role back to all-on.
+        #expect(layout.adoptAllEnabled() == false)
+        #expect(layout.adoptNewDefaults() == false)
+        #expect(layout.enabledIds == curated)
+    }
+
+    @Test func seedEverythingLeavesEverythingOn() {
+        var layout = LayoutState()
+        layout.seedRole(.qaTester)
+        layout.seedEverything()
+        #expect(layout.roleChosen == true)
+        #expect(layout.selectedRole == nil)
+        #expect(layout.enabledIds == nil)
+        #expect(Set(FeatureRegistry.catalogFeatureIDs).isSubset(of: layout.effectiveEnabledIDs))
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct UsageStatsTests {
+    private func date(_ seconds: Double) -> Date { Date(timeIntervalSince1970: seconds) }
+
+    @Test func recordIncrementsCountAndStampsLastUsed() {
+        var stats = UsageStats()
+        stats.record("logcat", at: date(100))
+        stats.record("logcat", at: date(200))
+        #expect(stats.count(for: "logcat") == 2)
+        #expect(stats.byFeature["logcat"]?.lastUsed == date(200))
+        #expect(stats.count(for: "screenshot") == 0)
+    }
+
+    @Test func rankPutsMostUsedFirstThenRecencyThenCuratedOrder() {
+        var stats = UsageStats()
+        // screenshot used most; logcat and apps tie on count, apps more recent.
+        for t in [10.0, 20, 30] { stats.record("screenshot", at: date(t)) }
+        stats.record("logcat", at: date(40))
+        stats.record("apps", at: date(50))
+        let curated = ["send-text", "logcat", "apps", "screenshot", "device-info"]
+        #expect(stats.rank(curated) == ["screenshot", "apps", "logcat", "send-text", "device-info"])
+    }
+
+    @Test func rankPreservesCuratedOrderWhenUnused() {
+        let stats = UsageStats()
+        let curated = ["a", "b", "c", "d"]
+        #expect(stats.rank(curated) == curated)
+    }
+}

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -96,6 +96,8 @@ struct FeatureDetailView: View {
                 VideoEditorView()
             case "crash-catcher":
                 CrashView()
+            case "bug-report":
+                BugReportView()
             case "wireless-adb":
                 WirelessAdbView()
             case "custom-commands":

--- a/App/Sources/FeatureDetail/HubKit.swift
+++ b/App/Sources/FeatureDetail/HubKit.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// Building blocks for hub / multi-section screens (Connection, Wireless ADB,
+/// Private DNS, and future hubs). They replace the macOS grouped `Form` — whose
+/// inset bars, wide leading gutter, and right-aligned value rows read as busy
+/// and ambiguous — with a uniform, scannable card layout.
+
+/// A titled content card: a header (title + optional one-line subtitle) above
+/// its controls, on a single lifted surface. The consistent container for every
+/// section, so the whole screen reads as one rhythm instead of mismatched bars.
+struct HubSection<Content: View>: View {
+    private let title: String
+    private let subtitle: String?
+    @ViewBuilder private let content: () -> Content
+
+    init(_ title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.headline).foregroundStyle(.textMain)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.bgSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(.borderSubtle, lineWidth: 1))
+    }
+}
+
+/// A labeled text input: a quiet caption above a brand-focus field, so a field
+/// always reads as "type here" rather than a static value row.
+struct HubField: View {
+    private let label: String
+    private let prompt: String?
+    @Binding private var text: String
+
+    init(_ label: String, prompt: String? = nil, text: Binding<String>) {
+        self.label = label
+        self.prompt = prompt
+        self._text = text
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(label).font(.caption).foregroundStyle(.textMuted)
+            TextField("", text: $text, prompt: prompt.map(Text.init))
+                .brandField()
+                .labelsHidden()
+        }
+    }
+}
+
+/// The standard scrollable, centered column that holds a screen's `HubSection`s
+/// — a readable max width so content never sprawls across the pane or strands
+/// in a side gutter.
+struct HubColumn<Content: View>: View {
+    @ViewBuilder private let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                content()
+            }
+            .frame(maxWidth: 600, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// A read-only label / value row for data inside a `HubSection` (e.g. device
+/// properties) — label at the leading edge, selectable value trailing.
+struct HubRow: View {
+    private let label: String
+    private let value: String
+
+    init(_ label: String, _ value: String) {
+        self.label = label
+        self.value = value
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label).foregroundStyle(.textMain)
+            Spacer(minLength: 16)
+            Text(value)
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/BugReportView.swift
+++ b/App/Sources/FeatureDetail/Views/BugReportView.swift
@@ -1,0 +1,83 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// Bug Report — assemble a shareable zip (screenshot + recent logcat + device
+/// info, plus the app version when a bundle is selected) and reveal it in
+/// Finder, ready to attach to a ticket.
+struct BugReportView: View {
+    @Environment(AppState.self) private var state
+
+    private var bundle: AppBundle? { state.selectedBundle }
+    private var lastReport: (result: FeatureResult, at: Date)? { state.lastResults["bug-report"] }
+
+    var body: some View {
+        HubColumn {
+            HubSection("What's included", subtitle: "A single zip you can drop straight into a bug ticket.") {
+                VStack(spacing: 0) {
+                    contentRow("camera", "Screenshot", "The current screen")
+                    Divider()
+                    contentRow("scroll", "Logcat", "The last 2,000 log lines")
+                    Divider()
+                    contentRow("info.circle", "Device info", "Model, Android version, ABI, serial")
+                    Divider()
+                    contentRow(
+                        "shippingbox", "App version",
+                        bundle.map { "Included for \($0.nickname)" } ?? "Select a bundle in the bar to include it"
+                    )
+                }
+            }
+
+            HubSection("Generate") {
+                Button { generate() } label: {
+                    Label("Generate bug report", systemImage: "doc.zipper")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
+
+                if state.isRunningFeature {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.small)
+                        Text("Collecting screenshot, logs, and device info…").foregroundStyle(.textMuted)
+                    }
+                } else if state.targetSerials.isEmpty {
+                    Text("Connect a device first.").font(.footnote).foregroundStyle(.textMuted)
+                }
+
+                if let last = lastReport, last.result.ok, let path = last.result.revealPath {
+                    Divider()
+                    HStack(spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill").foregroundStyle(.brandAccent)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Bug report saved").foregroundStyle(.textMain)
+                            Text((path as NSString).lastPathComponent)
+                                .font(.footnote).foregroundStyle(.textMuted)
+                        }
+                        Spacer()
+                        Button("Reveal in Finder") {
+                            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func contentRow(_ icon: String, _ title: String, _ detail: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon).foregroundStyle(.textMuted).frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title).foregroundStyle(.textMain)
+                Text(detail).font(.footnote).foregroundStyle(.textMuted)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 7)
+    }
+
+    private func generate() {
+        guard let feature = FeatureRegistry.byID["bug-report"] else { return }
+        Task { await state.run(feature: feature, params: [:]) }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -1,9 +1,8 @@
 import ADBKit
 import SwiftUI
 
-/// Saved deep links for the selected bundle, as a `Form` section so it composes
-/// into both the standalone screen and the React Native hub (and scrolls with
-/// the rest of the form).
+/// Saved deep links for the selected bundle, as a reusable card so it composes
+/// into both the standalone screen and the React Native hub.
 struct DeepLinksSection: View {
     @Environment(AppState.self) private var state
     @State private var links: [DeepLink] = []
@@ -13,7 +12,7 @@ struct DeepLinksSection: View {
     @State private var draftURL = ""
 
     var body: some View {
-        Section("Deep links") {
+        HubSection("Deep links", subtitle: "Saved per app — launch a URL on the device in one click.") {
             if state.selectedBundle == nil {
                 Text("Select a bundle in the bar above — deep links are saved per app.")
                     .foregroundStyle(.textMuted)
@@ -21,36 +20,12 @@ struct DeepLinksSection: View {
                 if links.isEmpty {
                     Text("No deep links yet. Add one like myapp://orders/123 to launch it in a click.")
                         .foregroundStyle(.textMuted)
-                }
-                ForEach(links) { link in
-                    HStack {
-                        Image(systemName: "link").foregroundStyle(.textMuted)
-                        VStack(alignment: .leading) {
-                            if !link.label.isEmpty { Text(link.label) }
-                            Text(link.url)
-                                .font(.footnote)
-                                .foregroundStyle(.textMuted)
-                                .textSelection(.enabled)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(links) { link in
+                            if link.id != links.first?.id { Divider() }
+                            linkRow(link)
                         }
-                        Spacer()
-                        Button { launch(link) } label: {
-                            Image(systemName: "play.fill").foregroundStyle(.brandAccent)
-                        }
-                        .buttonStyle(.borderless)
-                        .help("Launch on device")
-                        Button {
-                            editingLink = link
-                            draftLabel = link.label
-                            draftURL = link.url
-                            showEditor = true
-                        } label: {
-                            Image(systemName: "pencil")
-                        }
-                        .buttonStyle(.borderless)
-                        Button { remove(link) } label: {
-                            Image(systemName: "trash").foregroundStyle(.red)
-                        }
-                        .buttonStyle(.borderless)
                     }
                 }
                 Button {
@@ -61,10 +36,44 @@ struct DeepLinksSection: View {
                 } label: {
                     Label("Add deep link", systemImage: "plus")
                 }
+                .buttonStyle(.bordered)
             }
         }
         .task(id: state.selectedBundleId) { await loadLinks() }
         .sheet(isPresented: $showEditor) { editor }
+    }
+
+    private func linkRow(_ link: DeepLink) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "link").foregroundStyle(.textMuted)
+            VStack(alignment: .leading, spacing: 1) {
+                if !link.label.isEmpty { Text(link.label).foregroundStyle(.textMain) }
+                Text(link.url)
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+                    .textSelection(.enabled)
+            }
+            Spacer()
+            Button { launch(link) } label: {
+                Image(systemName: "play.fill").foregroundStyle(.brandAccent)
+            }
+            .buttonStyle(.borderless)
+            .help("Launch on device")
+            Button {
+                editingLink = link
+                draftLabel = link.label
+                draftURL = link.url
+                showEditor = true
+            } label: {
+                Image(systemName: "pencil")
+            }
+            .buttonStyle(.borderless)
+            Button { remove(link) } label: {
+                Image(systemName: "trash").foregroundStyle(.red)
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, 7)
     }
 
     private var editor: some View {
@@ -143,14 +152,9 @@ struct DeepLinksSection: View {
     }
 }
 
-/// Standalone Deep Links screen — the section on its own in a grouped form.
+/// Standalone Deep Links screen — the section on its own in the hub column.
 struct DeepLinksView: View {
     var body: some View {
-        Form {
-            DeepLinksSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { DeepLinksSection() }
     }
 }

--- a/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
@@ -57,7 +57,7 @@ struct DeviceInfoView: View {
         VStack(spacing: 0) {
             TextField("Filter properties…", text: $search)
                 .brandField()
-                .padding(10)
+                .padding(12)
 
             Divider()
 
@@ -70,36 +70,35 @@ struct DeviceInfoView: View {
     }
 
     private func curated(_ props: [String: String]) -> some View {
-        Form {
+        HubColumn {
             if let overview {
-                Section("Memory") {
-                    LabeledContent("Total RAM", value: formatKb(overview.ramTotalKb))
-                    LabeledContent("Used RAM", value: formatKb(overview.ramUsedKb))
-                    LabeledContent("Available RAM", value: formatKb(overview.ramAvailableKb))
+                HubSection("Memory") {
+                    infoRows([
+                        ("Total RAM", formatKb(overview.ramTotalKb)),
+                        ("Used RAM", formatKb(overview.ramUsedKb)),
+                        ("Available RAM", formatKb(overview.ramAvailableKb)),
+                    ])
                 }
-                Section("Storage") {
-                    LabeledContent("Total", value: formatKb(overview.storageTotalKb))
-                    LabeledContent("Used", value: formatKb(overview.storageUsedKb))
-                    LabeledContent("Available", value: formatKb(overview.storageAvailableKb))
+                HubSection("Storage") {
+                    infoRows([
+                        ("Total", formatKb(overview.storageTotalKb)),
+                        ("Used", formatKb(overview.storageUsedKb)),
+                        ("Available", formatKb(overview.storageAvailableKb)),
+                    ])
                 }
-                Section("Battery") {
-                    LabeledContent("Level", value: overview.batteryLevel.map { "\($0)%" } ?? "—")
-                    LabeledContent("Health", value: overview.batteryHealth ?? "—")
-                    if let cycles = overview.batteryCycleCount {
-                        LabeledContent("Cycle Count", value: "\(cycles)")
-                    }
-                }
-                Section("Apps & CPU") {
-                    LabeledContent("CPU Architecture", value: overview.cpuAbi ?? "—")
-                    LabeledContent("Installed Apps", value: overview.userAppCount.map(String.init) ?? "—")
-                    LabeledContent("System Apps", value: overview.systemAppCount.map(String.init) ?? "—")
+                HubSection("Battery") { infoRows(batteryRows) }
+                HubSection("Apps & CPU") {
+                    infoRows([
+                        ("CPU Architecture", overview.cpuAbi ?? "—"),
+                        ("Installed Apps", overview.userAppCount.map(String.init) ?? "—"),
+                        ("System Apps", overview.systemAppCount.map(String.init) ?? "—"),
+                    ])
                 }
             } else {
-                Section("Overview") {
-                    HStack {
+                HubSection("Overview") {
+                    HStack(spacing: 8) {
                         ProgressView().controlSize(.small)
-                        Text("Reading memory, storage, and battery…")
-                            .foregroundStyle(.textMuted)
+                        Text("Reading memory, storage, and battery…").foregroundStyle(.textMuted)
                     }
                 }
             }
@@ -110,25 +109,37 @@ struct DeviceInfoView: View {
                     return (item.label, value)
                 }
                 if !rows.isEmpty {
-                    Section(group.section) {
-                        ForEach(rows, id: \.0) { row in
-                            LabeledContent(row.0) {
-                                Text(row.1)
-                                    .textSelection(.enabled)
-                                    .foregroundStyle(.textMuted)
-                            }
-                        }
-                    }
+                    HubSection(group.section) { infoRows(rows) }
                 }
             }
-            Section("All properties (\(props.count))") {
+
+            HubSection("All properties (\(props.count))") {
                 Text("Type in the filter box above to search every raw getprop value.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
+    }
+
+    private var batteryRows: [(String, String)] {
+        guard let overview else { return [] }
+        var rows: [(String, String)] = [
+            ("Level", overview.batteryLevel.map { "\($0)%" } ?? "—"),
+            ("Health", overview.batteryHealth ?? "—"),
+        ]
+        if let cycles = overview.batteryCycleCount {
+            rows.append(("Cycle Count", "\(cycles)"))
+        }
+        return rows
+    }
+
+    private func infoRows(_ pairs: [(String, String)]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(pairs.enumerated()), id: \.offset) { index, pair in
+                if index > 0 { Divider() }
+                HubRow(pair.0, pair.1).padding(.vertical, 7)
+            }
+        }
     }
 
     private func filtered(_ props: [String: String]) -> some View {
@@ -155,6 +166,7 @@ struct DeviceInfoView: View {
                             .textSelection(.enabled)
                     }
                 }
+                .scrollContentBackground(.hidden)
             }
         }
     }

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -2,12 +2,14 @@ import ADBKit
 import AppKit
 import SwiftUI
 
-/// The landing screen: what Droidective is, the keyboard shortcuts that drive
-/// it, how to customize features and theme, and an overview of every feature
-/// category. Doubles as the no-device onboarding when nothing is connected.
+/// The landing screen, now a role-aware launchpad: a grid of the user's curated
+/// tools (sorted by what they use most), an expandable "More features" section
+/// to add the rest, the keyboard shortcuts that drive the app, and the
+/// no-device onboarding when nothing is connected.
 struct HomeView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
+    @State private var showMore = false
 
     var body: some View {
         ScrollView {
@@ -16,9 +18,9 @@ struct HomeView: View {
                 if state.devices.isEmpty {
                     connectCard
                 }
+                launchpadSection
+                moreFeaturesSection
                 shortcutsSection
-                customizeSection
-                categoriesSection
                 tourFooter
             }
             .frame(maxWidth: 760, alignment: .leading)
@@ -42,7 +44,124 @@ struct HomeView: View {
                     .font(.title3)
                     .foregroundStyle(.textMuted)
             }
+            Spacer(minLength: 12)
+            roleBadge
         }
+    }
+
+    /// Current role as a pill that opens the picker — the "change this anytime"
+    /// affordance the first-run picker promises.
+    private var roleBadge: some View {
+        Button { state.presentRolePicker = true } label: {
+            HStack(spacing: 6) {
+                Image(systemName: state.selectedRole?.icon ?? "square.grid.2x2")
+                Text(state.selectedRole?.label ?? "All features")
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.textMuted)
+            }
+            .font(.callout)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Color.bgSurface, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.borderSubtle, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .help("Your role decides which tools start here — change it anytime")
+    }
+
+    // MARK: - Launchpad
+
+    private var launchpadSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle("Your tools")
+            Text("Your most-used features, front and center. Add more below or from the sidebar.")
+                .font(.callout)
+                .foregroundStyle(.textMuted)
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 210), spacing: 12)],
+                alignment: .leading,
+                spacing: 12
+            ) {
+                ForEach(state.launchpadFeatures) { feature in
+                    FeatureCard(feature: feature) { state.openFeature(feature) }
+                }
+            }
+        }
+    }
+
+    // MARK: - More features
+
+    /// Catalog features the user hasn't enabled yet — the "show me other
+    /// features so I can pick" path, addable in one click. System features are
+    /// always on, so they never appear here.
+    private var addableFeatures: [FeatureDef] {
+        let enabled = Set(state.enabledFeatures.map(\.id))
+        let catalog = Set(FeatureRegistry.catalogFeatureIDs)
+        return state.orderedCategories.flatMap { state.catalogFeatures(in: $0) }
+            .filter { catalog.contains($0.id) && !enabled.contains($0.id) && $0.kind != .system }
+    }
+
+    @ViewBuilder private var moreFeaturesSection: some View {
+        let addable = addableFeatures
+        if !addable.isEmpty {
+            DisclosureGroup(isExpanded: $showMore) {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 210), spacing: 12)],
+                    alignment: .leading,
+                    spacing: 12
+                ) {
+                    ForEach(addable) { feature in
+                        addCard(feature)
+                    }
+                }
+                .padding(.top, 10)
+                Button("Manage all features…") { state.selectedFeatureID = "catalog" }
+                    .buttonStyle(.link)
+                    .font(.callout)
+                    .padding(.top, 8)
+            } label: {
+                HStack(spacing: 8) {
+                    Text("More features")
+                        .font(.title2.bold())
+                    Text("\(addable.count)")
+                        .font(.callout.monospacedDigit())
+                        .foregroundStyle(.textMuted)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { withAnimation { showMore.toggle() } }
+            }
+            .tint(.textMuted)
+        }
+    }
+
+    private func addCard(_ feature: FeatureDef) -> some View {
+        Button { state.setFeatureEnabled(feature.id, enabled: true) } label: {
+            HStack(spacing: 10) {
+                Image(systemName: feature.icon)
+                    .frame(width: 22)
+                    .foregroundStyle(.textMuted)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(feature.title).foregroundStyle(.textMain)
+                    if let subtitle = feature.subtitle {
+                        Text(subtitle)
+                            .font(.footnote)
+                            .foregroundStyle(.textMuted)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 6)
+                Image(systemName: "plus.circle")
+                    .foregroundStyle(.brandAccent)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help("Add \(feature.title) to your tools")
     }
 
     // MARK: - Shortcuts
@@ -102,69 +221,6 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10))
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.borderSubtle, lineWidth: 1))
-    }
-
-    // MARK: - Customize
-
-    private var customizeSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionTitle("Make it yours")
-
-            infoRow(
-                icon: "pin",
-                title: "Enable, disable & pin features",
-                detail: "Right-click any feature in the sidebar to pin it to the top, or enable/disable it. The Feature Catalog manages them all at once."
-            ) {
-                Button("Open Feature Catalog") { state.selectedFeatureID = "catalog" }
-            }
-
-            infoRow(
-                icon: "paintbrush",
-                title: "Theme",
-                detail: "Match the system appearance, or force light or dark."
-            ) {
-                ThemePicker()
-            }
-        }
-    }
-
-    // MARK: - Categories
-
-    private var categoriesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionTitle("All \(FeatureRegistry.catalogFeatureIDs.count) features")
-            Text("Grouped into \(FeatureCategory.displayOrder.count) categories — browse and toggle every tool in the catalog.")
-                .font(.callout)
-                .foregroundStyle(.textMuted)
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 220), spacing: 12)],
-                alignment: .leading,
-                spacing: 12
-            ) {
-                ForEach(FeatureCategory.displayOrder, id: \.self) { category in
-                    categoryChip(category)
-                }
-            }
-        }
-    }
-
-    private func categoryChip(_ category: FeatureCategory) -> some View {
-        let count = FeatureRegistry.all.filter { $0.category == category && !$0.isAbsorbedByHub }.count
-        return HStack(spacing: 10) {
-            Image(systemName: category.icon)
-                .foregroundStyle(.textMuted)
-                .frame(width: 22)
-            Text(category.label)
-                .lineLimit(1)
-            Spacer(minLength: 6)
-            Text("\(count)")
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.textMuted)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 8))
-        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle, lineWidth: 1))
     }
 
     // MARK: - Connect card (no device)
@@ -228,48 +284,50 @@ struct HomeView: View {
         Text(text)
             .font(.title2.bold())
     }
-
-    private func infoRow(
-        icon: String,
-        title: String,
-        detail: String,
-        @ViewBuilder action: () -> some View
-    ) -> some View {
-        HStack(alignment: .center, spacing: 12) {
-            Image(systemName: icon)
-                .font(.title2)
-                .foregroundStyle(.textMuted)
-                .frame(width: 26)
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.headline)
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(.textMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 12)
-            action()
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10))
-        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.borderSubtle, lineWidth: 1))
-    }
 }
 
-/// The Light / Dark / Auto segmented control, reused on Home and Settings.
-struct ThemePicker: View {
-    @AppStorage("theme") private var theme = "auto"
+/// One tappable tool on the launchpad grid — icon, title, and subtitle, with the
+/// brand-green hover border used across the app. Opens or runs the feature.
+private struct FeatureCard: View {
+    let feature: FeatureDef
+    let action: () -> Void
+    @State private var hovering = false
 
     var body: some View {
-        Picker("", selection: $theme) {
-            Text("Auto").tag("auto")
-            Text("Light").tag("light")
-            Text("Dark").tag("dark")
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: feature.icon)
+                    .font(.title2)
+                    .foregroundStyle(hovering ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(feature.title)
+                        .font(.headline)
+                        .foregroundStyle(.textMain)
+                    if let subtitle = feature.subtitle {
+                        Text(subtitle)
+                            .font(.callout)
+                            .foregroundStyle(.textMuted)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+            .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(
+                        hovering ? Color.brandAccent : Color.borderSubtle,
+                        lineWidth: hovering ? 2 : 1
+                    )
+            }
         }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .frame(width: 200)
-        .onChange(of: theme) { applyStoredTheme() }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(.easeInOut(duration: 0.15), value: hovering)
+        .help(feature.subtitle ?? feature.title)
     }
 }

--- a/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkConnectionView.swift
@@ -1,35 +1,34 @@
 import ADBKit
 import SwiftUI
 
-/// Connection hub — copy the device IP, forward a port, drop a wireless
-/// connection, set Private DNS, and run the wireless ADB pairing flow on one
-/// scrollable screen. Copy IP also stays a one-click sidebar action; the other
-/// gathered features stay searchable and hotkey-able. Wi-Fi, Network Speed, and
-/// Emulators remain their own screens.
+/// Connection hub — copy the device IP, forward a port, set Private DNS, and run
+/// the wireless ADB pairing flow on one scrollable screen. Copy IP also stays a
+/// one-click sidebar action; the other gathered features stay searchable and
+/// hotkey-able. Wi-Fi, Network Speed, and Emulators remain their own screens.
 struct NetworkConnectionView: View {
     @Environment(AppState.self) private var state
     @State private var reversePort = "8081"
 
     var body: some View {
-        Form {
-            Section("Quick") {
-                Button {
-                    run("get-ip")
-                } label: {
+        HubColumn {
+            HubSection("Device IP") {
+                Button { run("get-ip") } label: {
                     Label("Copy device IP", systemImage: "globe")
                 }
+                .buttonStyle(.bordered)
                 .disabled(state.targetSerials.isEmpty)
             }
 
-            Section("Reverse port") {
-                HStack(spacing: 8) {
-                    TextField("Port", text: $reversePort, prompt: Text("8081"))
+            HubSection("Reverse port", subtitle: "Forward a device port to your Mac — e.g. Metro on 8081.") {
+                HStack(spacing: 10) {
+                    TextField("", text: $reversePort, prompt: Text("8081"))
                         .brandField()
                         .labelsHidden()
                         .frame(maxWidth: 140)
                     Button("Forward") {
                         run("reverse-port", ["port": .string(reversePort.trimmingCharacters(in: .whitespaces))])
                     }
+                    .buttonStyle(.borderedProminent)
                     .disabled(state.targetSerials.isEmpty || reversePort.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
@@ -37,8 +36,6 @@ struct NetworkConnectionView: View {
             PrivateDnsSection()
             WirelessAdbSection()
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
     }
 
     private func run(_ id: String, _ params: [String: FeatureValue] = [:]) {

--- a/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
+++ b/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
@@ -1,7 +1,7 @@
 import ADBKit
 import SwiftUI
 
-/// Private DNS (DNS-over-TLS) controls as a `Form` section, so it composes into
+/// Private DNS (DNS-over-TLS) controls as a reusable card, so it composes into
 /// both the standalone screen and the Connection hub.
 struct PrivateDnsSection: View {
     @Environment(AppState.self) private var state
@@ -13,22 +13,22 @@ struct PrivateDnsSection: View {
     private var serial: String { state.targetSerials.first ?? "" }
 
     var body: some View {
-        Section("Private DNS") {
+        HubSection("Private DNS", subtitle: "Set DNS-over-TLS mode for this device.") {
             Picker("Mode", selection: $mode) {
                 Text("Off").tag(DnsStatus.Mode.off)
                 Text("Automatic").tag(DnsStatus.Mode.automatic)
-                Text("Provider hostname").tag(DnsStatus.Mode.hostname)
+                Text("Hostname").tag(DnsStatus.Mode.hostname)
             }
-            .pickerStyle(.radioGroup)
+            .pickerStyle(.segmented)
+            .labelsHidden()
 
             if mode == .hostname {
-                TextField("dns.google", text: $hostname)
-                    .brandField()
-                    .frame(maxWidth: 280)
+                HubField("Provider hostname", prompt: "dns.google", text: $hostname)
             }
 
-            HStack {
+            HStack(spacing: 10) {
                 Button("Apply") { Task { await apply() } }
+                    .buttonStyle(.borderedProminent)
                     .disabled(busy || !loaded || state.targetSerials.isEmpty
                         || (mode == .hostname && hostname.trimmingCharacters(in: .whitespaces).isEmpty))
                 Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
@@ -77,14 +77,9 @@ struct PrivateDnsSection: View {
     }
 }
 
-/// Standalone Private DNS screen — the section on its own in a grouped form.
+/// Standalone Private DNS screen — the section on its own in the hub column.
 struct PrivateDnsView: View {
     var body: some View {
-        Form {
-            PrivateDnsSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { PrivateDnsSection() }
     }
 }

--- a/App/Sources/FeatureDetail/Views/ReactNativeView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactNativeView.swift
@@ -1,21 +1,24 @@
 import ADBKit
 import SwiftUI
 
-/// React Native hub — dev menu, JS reload, process death, dev-server host, and
-/// saved deep links on one scrollable screen. The individual actions stay
-/// available from search and global hotkeys; this just gathers them so the
-/// sidebar isn't five rows of RN tools.
+/// React Native hub — dev menu, JS reload, process death, Metro forwarding,
+/// dev-server host, saved deep links, and quick links to the logs/perf tools RN
+/// work leans on. The individual actions stay available from search and global
+/// hotkeys; this just gathers them so the sidebar isn't a wall of RN tools.
 struct ReactNativeView: View {
     @Environment(AppState.self) private var state
     @AppStorage("rnDevHost") private var devHost = ""
 
+    private let actionColumns = [GridItem(.adaptive(minimum: 150), spacing: 10)]
+
     var body: some View {
-        Form {
-            Section("Quick actions") {
-                HStack(spacing: 10) {
+        HubColumn {
+            HubSection("Quick actions", subtitle: "Drive the in-app dev menu and Metro over adb.") {
+                LazyVGrid(columns: actionColumns, spacing: 10) {
                     actionButton("reload-js", "Reload JS", "arrow.clockwise", prominent: true)
                     actionButton("open-dev-menu", "Dev Menu", "filemenu.and.selection")
                     actionButton("process-death", "Process Death", "xmark.octagon")
+                    metroButton
                 }
                 if state.targetSerials.isEmpty {
                     Text("Connect a device to use these.")
@@ -24,39 +27,78 @@ struct ReactNativeView: View {
                 }
             }
 
-            Section("Dev server host") {
-                HStack(spacing: 8) {
-                    TextField("Dev server host", text: $devHost, prompt: Text("192.168.1.10:8081"))
+            HubSection("Dev server host", subtitle: "Point the app at your Metro bundler and reverse-tunnel its port.") {
+                HStack(spacing: 10) {
+                    TextField("", text: $devHost, prompt: Text("192.168.1.10:8081"))
                         .brandField()
                         .labelsHidden()
-                        .frame(maxWidth: 240)
                     Button("Set") {
                         run("rn-dev-host", ["host": .string(devHost.trimmingCharacters(in: .whitespaces))])
                     }
+                    .buttonStyle(.borderedProminent)
                     .disabled(state.targetSerials.isEmpty || devHost.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
 
             DeepLinksSection()
+
+            HubSection("Related tools") {
+                VStack(spacing: 0) {
+                    relatedRow("logcat", "Logcat", "Live JS & native logs", "scroll")
+                    Divider()
+                    relatedRow("crash-catcher", "Crash Catcher", "Catches ReactNativeJS crashes", "exclamationmark.triangle")
+                    Divider()
+                    relatedRow("performance", "Performance Monitor", "Live CPU, RAM & FPS", "chart.line.uptrend.xyaxis")
+                }
+            }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
     }
 
     @ViewBuilder
     private func actionButton(_ id: String, _ title: String, _ icon: String, prominent: Bool = false) -> some View {
-        let content = Label(title, systemImage: icon)
+        let label = Label(title, systemImage: icon).frame(maxWidth: .infinity)
         if prominent {
-            Button { run(id) } label: { content }
+            Button { run(id) } label: { label }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
         } else {
-            Button { run(id) } label: { content }
+            Button { run(id) } label: { label }
                 .buttonStyle(.bordered)
                 .controlSize(.large)
                 .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
         }
+    }
+
+    /// Reverse-tunnel Metro's 8081 so a USB device reaches the local bundler —
+    /// the one adb step every RN-on-device session needs (reuses Reverse Port).
+    private var metroButton: some View {
+        Button { run("reverse-port", ["port": .string("8081")]) } label: {
+            Label("Forward Metro", systemImage: "arrow.left.arrow.right").frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+        .disabled(state.targetSerials.isEmpty || state.isRunningFeature)
+        .help("adb reverse tcp:8081 — reach your local Metro bundler from a USB device")
+    }
+
+    private func relatedRow(_ id: String, _ title: String, _ detail: String, _ icon: String) -> some View {
+        Button {
+            if let feature = FeatureRegistry.byID[id] { state.openFeature(feature) }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon).foregroundStyle(.textMuted).frame(width: 22)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title).foregroundStyle(.textMain)
+                    Text(detail).font(.footnote).foregroundStyle(.textMuted)
+                }
+                Spacer()
+                Image(systemName: "chevron.right").font(.caption).foregroundStyle(.textMuted)
+            }
+            .contentShape(Rectangle())
+            .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
     }
 
     private func run(_ id: String, _ params: [String: FeatureValue] = [:]) {

--- a/App/Sources/FeatureDetail/Views/RolePickerView.swift
+++ b/App/Sources/FeatureDetail/Views/RolePickerView.swift
@@ -1,0 +1,98 @@
+import ADBKit
+import SwiftUI
+
+/// First-launch full-window takeover: the user picks a role and gets a focused
+/// set of features instead of all of them — the answer to "this app is
+/// overwhelming". Skippable ("Show me everything") and changeable later from
+/// Settings. Selecting a role seeds the curated set via `AppState.chooseRole`.
+///
+/// Presented as a full-bleed overlay (not a sheet) so it genuinely takes over
+/// the window; macOS has no `fullScreenCover`.
+struct RolePickerView: View {
+    @Environment(AppState.self) private var state
+    @AppStorage("hasChosenRole") private var hasChosenRole = false
+
+    private let columns = [GridItem(.adaptive(minimum: 240), spacing: 16)]
+
+    var body: some View {
+        VStack(spacing: 28) {
+            header
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(UserRole.allCases) { role in
+                    RoleCard(role: role) { choose(role) }
+                }
+            }
+            .frame(maxWidth: 560)
+            Button("Show me everything") { choose(nil) }
+                .buttonStyle(.plain)
+                .foregroundStyle(.textMuted)
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.bgRoot)
+    }
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "square.grid.2x2.fill")
+                .font(.system(size: 42))
+                .foregroundStyle(.brandAccent)
+                .symbolRenderingMode(.hierarchical)
+            Text("What do you do?")
+                .font(.largeTitle.bold())
+                .foregroundStyle(.textMain)
+            Text("Pick a role and we'll start you with the tools you'll use most. "
+                + "Everything else is one click away — and you can change this anytime.")
+                .font(.body)
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 480)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func choose(_ role: UserRole?) {
+        hasChosenRole = true
+        state.chooseRole(role)
+    }
+}
+
+/// One selectable role tile — icon, name, and a one-line description, with the
+/// brand-green hover border used elsewhere in the app.
+private struct RoleCard: View {
+    let role: UserRole
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 10) {
+                Image(systemName: role.icon)
+                    .font(.system(size: 26))
+                    .foregroundStyle(.brandAccent)
+                    .symbolRenderingMode(.hierarchical)
+                Text(role.label)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.textMain)
+                Text(role.blurb)
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+            .padding(18)
+            .background(.bgSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(
+                        hovering ? Color.brandAccent : Color.borderSubtle,
+                        lineWidth: hovering ? 2 : 1
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(.easeInOut(duration: 0.15), value: hovering)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/SimulateView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulateView.swift
@@ -18,25 +18,25 @@ struct SimulateView: View {
     @State private var proxy = ""
 
     var body: some View {
-        Form {
+        HubColumn {
             if !state.activeOverrides.isEmpty {
-                Section {
-                    Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
-                }
+                Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
+                    .buttonStyle(.bordered)
             }
 
-            Section("Battery") {
-                VStack(alignment: .leading) {
-                    Text("Level: \(Int(batteryLevel))%")
+            HubSection("Battery") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Level: \(Int(batteryLevel))%").foregroundStyle(.textMain)
                     Slider(value: $batteryLevel, in: 0...100, step: 1)
                 }
                 SwitchRow("Simulate unplugged", isOn: $batteryUnplugged)
                 Button("Apply") {
                     run("fake-battery", ["level": .number(batteryLevel), "unplugged": .bool(batteryUnplugged)])
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Appearance & Motion") {
+            HubSection("Appearance & motion") {
                 if let darkMode = FeatureRegistry.byID["dark-mode"] {
                     HStack {
                         Text("Dark mode")
@@ -55,55 +55,58 @@ struct SimulateView: View {
                 }
             }
 
-            Section("Layout") {
-                VStack(alignment: .leading) {
-                    Text("Font scale: \(fontScale, specifier: "%.2f")")
+            HubSection("Layout") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Font scale: \(fontScale, specifier: "%.2f")").foregroundStyle(.textMain)
                     Slider(value: $fontScale, in: 0.85...1.3, step: 0.05)
                 }
-                TextField("Density (dpi, blank = keep)", text: $density)
-                    .brandField()
-                    .frame(maxWidth: 200)
+                HubField("Display density", prompt: "dpi — blank to keep", text: $density)
                 Button("Apply") {
                     var params: [String: FeatureValue] = ["fontScale": .number(fontScale)]
                     let raw = density.trimmingCharacters(in: .whitespaces)
                     if !raw.isEmpty, let value = Double(raw) { params["density"] = .number(value) }
                     run("layout-overrides", params)
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Locale") {
-                Picker("Language", selection: $locale) {
-                    ForEach(localeOptions, id: \.value) { option in
-                        Text(option.label).tag(option.value)
+            HubSection("Locale") {
+                HStack {
+                    Text("Language")
+                    Spacer(minLength: 12)
+                    Picker("", selection: $locale) {
+                        ForEach(localeOptions, id: \.value) { option in
+                            Text(option.label).tag(option.value)
+                        }
                     }
+                    .labelsHidden()
+                    .fixedSize()
                 }
                 Button("Apply") { run("locale", ["locale": .string(locale)]) }
+                    .buttonStyle(.borderedProminent)
             }
 
-            Section("Network") {
+            HubSection("Network") {
                 SwitchRow("Wi-Fi", isOn: $wifi)
                 SwitchRow("Mobile data", isOn: $data)
                 SwitchRow("Airplane mode", isOn: $airplane)
                 Button("Apply") {
                     run("network-toggles", ["wifi": .bool(wifi), "data": .bool(data), "airplane": .bool(airplane)])
                 }
+                .buttonStyle(.borderedProminent)
             }
 
-            Section("Proxy") {
-                TextField("Proxy (host:port)", text: $proxy)
-                    .brandField()
-                    .frame(maxWidth: 200)
-                HStack {
+            HubSection("HTTP proxy", subtitle: "Route traffic through Charles, Proxyman, or mitmproxy.") {
+                HubField("Proxy", prompt: "10.0.0.5:8888", text: $proxy)
+                HStack(spacing: 10) {
                     Button("Set") { run("http-proxy", ["proxy": .string(proxy.trimmingCharacters(in: .whitespaces))]) }
+                        .buttonStyle(.borderedProminent)
                         .disabled(proxy.trimmingCharacters(in: .whitespaces).isEmpty)
-                    // Clear via the feature (empty proxy → engine resets it) so it
-                    // lands in the command log like Set, instead of a silent reset.
                     Button("Clear") { run("http-proxy", ["proxy": .string("")]) }
+                        .buttonStyle(.bordered)
                 }
             }
         }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
         .disabled(state.targetSerials.isEmpty)
         .overlay {
             if state.targetSerials.isEmpty {

--- a/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
+++ b/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
@@ -2,7 +2,7 @@ import ADBKit
 import SwiftUI
 
 /// Wireless ADB wizard (USB→tcpip bootstrap, Android 11+ pair, connect, and
-/// per-device disconnect) as `Form` sections, so it composes into both the
+/// per-device disconnect) as reusable cards, so it composes into both the
 /// standalone screen and the Connection hub.
 struct WirelessAdbSection: View {
     @Environment(AppState.self) private var state
@@ -16,62 +16,55 @@ struct WirelessAdbSection: View {
     private var wirelessDevices: [Device] { state.devices.filter(\.isWireless) }
 
     var body: some View {
-        Section("Wireless ADB — over USB") {
+        HubSection("Wireless ADB", subtitle: "Switch a USB-connected device to debugging over Wi-Fi.") {
             if usbDevices.isEmpty {
-                Text("Connect a device over USB to bootstrap wireless ADB.")
+                Text("Connect a device over USB to start.")
                     .foregroundStyle(.textMuted)
             } else {
                 ForEach(usbDevices) { device in
                     HStack {
                         Text(device.label)
                         Spacer()
-                        Button("Enable Wi-Fi & Connect") {
-                            enableTcpip(device.serial)
-                        }
-                        .disabled(busy)
+                        Button("Enable Wi-Fi & Connect") { enableTcpip(device.serial) }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(busy)
                     }
                 }
             }
         }
 
-        Section("Pair (Android 11+)") {
-            TextField("Host / IP", text: $host, prompt: Text("192.168.1.42"))
-                .brandField()
-            TextField("Pairing port", text: $pairingPort, prompt: Text("37123"))
-                .brandField()
-            TextField("Pairing code", text: $pairingCode, prompt: Text("123456"))
-                .brandField()
-            Button("Pair") {
-                pair()
+        HubSection("Pair a device", subtitle: "Android 11+ — pair with a code, then connect.") {
+            HubField("Host / IP", prompt: "192.168.1.42", text: $host)
+            HStack(spacing: 12) {
+                HubField("Pairing port", prompt: "37123", text: $pairingPort)
+                HubField("Pairing code", prompt: "123456", text: $pairingCode)
             }
-            .disabled(busy || host.isEmpty || pairingPort.isEmpty || pairingCode.isEmpty)
+            Button("Pair") { pair() }
+                .buttonStyle(.bordered)
+                .disabled(busy || host.isEmpty || pairingPort.isEmpty || pairingCode.isEmpty)
 
-            TextField("Connection port", text: $connectionPort, prompt: Text("5555"))
-                .brandField()
-            Button("Connect") {
-                connect()
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(busy || host.isEmpty || connectionPort.isEmpty)
+            Divider().padding(.vertical, 2)
 
-            Text("The pairing port (from \"Pair device with pairing code\") differs from the connection port on the Wireless Debugging screen.")
+            HubField("Connection port", prompt: "5555", text: $connectionPort)
+            Button("Connect") { connect() }
+                .buttonStyle(.borderedProminent)
+                .disabled(busy || host.isEmpty || connectionPort.isEmpty)
+
+            Text("The pairing port (from \"Pair device with pairing code\") differs from the connection port shown on the device's Wireless debugging screen.")
                 .font(.footnote)
                 .foregroundStyle(.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
         }
 
-        Section("Connected over Wi-Fi") {
-            if wirelessDevices.isEmpty {
-                Text("No wireless devices.")
-                    .foregroundStyle(.textMuted)
-            } else {
+        if !wirelessDevices.isEmpty {
+            HubSection("Connected over Wi-Fi") {
                 ForEach(wirelessDevices) { device in
                     HStack {
                         Text(device.label)
                         Spacer()
-                        Button("Disconnect") {
-                            disconnect(device.serial)
-                        }
-                        .disabled(busy)
+                        Button("Disconnect") { disconnect(device.serial) }
+                            .buttonStyle(.bordered)
+                            .disabled(busy)
                     }
                 }
             }
@@ -116,14 +109,9 @@ struct WirelessAdbSection: View {
     }
 }
 
-/// Standalone Wireless ADB screen — the sections on their own in a grouped form.
+/// Standalone Wireless ADB screen — the cards on their own in the hub column.
 struct WirelessAdbView: View {
     var body: some View {
-        Form {
-            WirelessAdbSection()
-        }
-        .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .centeredColumn()
+        HubColumn { WirelessAdbSection() }
     }
 }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -7,11 +7,16 @@ struct RootView: View {
     @Environment(\.openWindow) private var openWindow
     @AppStorage("sidebarWidth") private var sidebarWidth = 280.0
     @AppStorage("hasSeenTour") private var hasSeenTour = false
+    @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
     @AppStorage("launchCount") private var launchCount = 0
     @AppStorage("starPromptShown") private var starPromptShown = false
     @State private var presentConsent = false
     @State private var presentStar = false
+    /// True only while the *first-run* role picker is up, so its dismissal
+    /// chains into the welcome tour. Changing role later (pill / Settings)
+    /// leaves this false, so the tour never reappears.
+    @State private var pickerIsFirstRun = false
     @Environment(\.colorScheme) private var colorScheme
 
     /// Launches to allow before the first-run privacy disclosure appears.
@@ -33,6 +38,22 @@ struct RootView: View {
     var body: some View {
         @Bindable var state = state
         zoomedContent
+            .background(WindowAccessor { window in
+                // Fill the screen's usable area on launch — a regular maximized
+                // window, not a native full-screen Space.
+                if let screen = window.screen ?? NSScreen.main {
+                    window.setFrame(screen.visibleFrame, display: true)
+                }
+            })
+            .overlay {
+                // Full-window takeover (macOS has no fullScreenCover), shown
+                // before the tour for brand-new users and from "Change role".
+                if state.presentRolePicker {
+                    RolePickerView()
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: 0.2), value: state.presentRolePicker)
             .sheet(isPresented: $state.presentTour) {
                 TourView()
             }
@@ -56,12 +77,24 @@ struct RootView: View {
                 applyStoredTheme()
                 updateDockIcon()
                 HotkeyManager.install(state: state)
-                if !hasSeenTour {
+                if !hasChosenRole && !hasSeenTour {
+                    // Brand-new user: pick a role first, then run the tour.
+                    pickerIsFirstRun = true
+                    state.presentRolePicker = true
+                } else if !hasSeenTour {
                     state.presentTour = true
                 } else if shouldPromptConsent {
                     presentConsent = true
                 } else if shouldPromptStar {
                     presentStar = true
+                }
+            }
+            .onChange(of: state.presentRolePicker) { _, showing in
+                // Only the first-run picker chains into the tour; changing role
+                // later (pill / Settings) must not reopen it.
+                if !showing && pickerIsFirstRun {
+                    pickerIsFirstRun = false
+                    if !hasSeenTour { state.presentTour = true }
                 }
             }
             .onChange(of: state.presentTour) { _, showing in
@@ -147,6 +180,33 @@ struct RootView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)
     }
+}
+
+/// Reads the hosting `NSWindow` once it attaches, so the main window can be
+/// sized to fill the screen on launch. `viewDidMoveToWindow` runs on the main
+/// actor with the window in place — no async hop, so it stays Swift-6 clean.
+private final class WindowReaderView: NSView {
+    var onWindow: ((NSWindow) -> Void)?
+    private var resolved = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard !resolved, let window else { return }
+        resolved = true
+        onWindow?(window)
+    }
+}
+
+private struct WindowAccessor: NSViewRepresentable {
+    let onResolve: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> WindowReaderView {
+        let view = WindowReaderView()
+        view.onWindow = onResolve
+        return view
+    }
+
+    func updateNSView(_ nsView: WindowReaderView, context: Context) {}
 }
 
 /// A draggable divider that resizes an adjacent pane. `value` is the pane's

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -230,7 +230,6 @@ struct SidebarPaletteView: View {
         .background(.bgSurface)
         .background { shortcutButtons }
         .onChange(of: state.focusSearchToken) { searchFocused = true }
-        .onChange(of: state.selectedFeatureID) { state.persistLastFeature() }
         .onAppear {
             // Track ⌘ so the row hints can appear/disappear as it's held.
             flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
@@ -500,11 +499,7 @@ struct FeatureRowView: View {
     /// a screen, which just runs (feedback is the toast + clipboard) and leaves
     /// the current detail pane untouched.
     private func activate() {
-        if feature.firesWithoutScreen {
-            Task { await state.run(feature: feature, params: [:]) }
-        } else {
-            state.selectedFeatureID = feature.id
-        }
+        state.openFeature(feature)
     }
 
     /// Trailing edge of a row: a hover-revealed pin button, then a live switch

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -43,7 +43,6 @@ struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("theme") private var theme = "auto"
     @AppStorage("groupSidebar") private var groupSidebar = true
-    @AppStorage("restoreLastFeature") private var restoreLastFeature = true
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
     @AppStorage(ScreenCaptureService.captureFolderDefaultsKey) private var captureFolderPath = ""
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
@@ -92,6 +91,10 @@ struct GeneralSettingsView: View {
         )
     }
 
+    private var roleBinding: Binding<UserRole?> {
+        Binding(get: { state.selectedRole }, set: { state.chooseRole($0) })
+    }
+
     var body: some View {
         Form {
             Section("Appearance") {
@@ -116,8 +119,23 @@ struct GeneralSettingsView: View {
                     .foregroundStyle(.textMuted)
             }
 
+            Section("Role") {
+                Picker("Role", selection: roleBinding) {
+                    Text("All features").tag(Optional<UserRole>.none)
+                    ForEach(UserRole.allCases) { role in
+                        Text(role.label).tag(Optional(role))
+                    }
+                }
+                Text("Curates which features start visible — switching re-curates your set. Nothing is deleted; add any feature back from Home or the catalog.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+                Button("Open the role picker…") {
+                    state.activateMainWindow()
+                    state.presentRolePicker = true
+                }
+            }
+
             Section("Startup") {
-                Toggle("Reopen the last used feature", isOn: $restoreLastFeature)
                 Toggle("Open at login", isOn: openAtLogin)
             }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -60,6 +60,9 @@ final class AppState {
     var searchText = ""
     var selectedFeatureID: String?
     var layout = LayoutState()
+    /// Per-feature usage tally (persisted), used to re-rank the launchpad's
+    /// curated feature order by how the user actually works.
+    var usageStats = UsageStats()
     var toasts: [Toast] = []
     /// History of important notifications (errors, warnings, key wins), newest
     /// first. Routine success toasts are not kept.
@@ -76,6 +79,9 @@ final class AppState {
     var commandBarTab: CommandBarTab = .recent
     /// Drives the first-launch / replayable welcome tour sheet.
     var presentTour = false
+    /// Drives the first-launch role picker (a full-window takeover) and the
+    /// "Change role" flow. Picking a role seeds a curated feature set.
+    var presentRolePicker = false
     /// True while a performance/network recording is in flight — locks the
     /// device and bundle pickers so the captured series stays consistent.
     var recordingActive = false
@@ -215,6 +221,9 @@ final class AppState {
     var adbMissing: Bool { adbStatus?.installed == false }
 
     private var deviceStreamTask: Task<Void, Never>?
+    /// Set the moment the user picks a role this session, so `bootstrap`'s
+    /// async layout load can't overwrite the just-seeded curation.
+    private var roleChosenThisSession = false
 
     init(env: AppEnvironment) {
         self.env = env
@@ -228,16 +237,21 @@ final class AppState {
         selectedSerial = prefs.selectedSerial
         runOnAll = prefs.runOnAll
         selectedBundleId = prefs.selectedBundleId
-        let restoreLast = UserDefaults.standard.object(forKey: "restoreLastFeature") as? Bool ?? true
-        if restoreLast, let last = prefs.lastFeatureId, FeatureRegistry.byID[last] != nil {
-            selectedFeatureID = last
+        // The launchpad (Home) is the consistent entry point — land there on
+        // every launch rather than reopening the last-used feature.
+        selectedFeatureID = "home"
+        let loadedLayout = await env.stores.layout.load()
+        // A brand-new user can pick a role — which seeds `layout` — while these
+        // async store loads are still in flight; don't clobber that seed.
+        if !roleChosenThisSession {
+            layout = loadedLayout
+            var layoutChanged = layout.adoptNewDefaults()
+            layoutChanged = layout.adoptAllEnabled() || layoutChanged
+            if layoutChanged {
+                persistLayout()
+            }
         }
-        layout = await env.stores.layout.load()
-        var layoutChanged = layout.adoptNewDefaults()
-        layoutChanged = layout.adoptAllEnabled() || layoutChanged
-        if layoutChanged {
-            persistLayout()
-        }
+        usageStats = await env.stores.usage.load()
         bundles = await env.stores.bundles.load()
         await refreshToolStatus()
 
@@ -373,6 +387,15 @@ final class AppState {
     var enabledFeatures: [FeatureDef] {
         let enabled = layout.effectiveEnabledIDs
         return FeatureRegistry.all.filter { enabled.contains($0.id) && !$0.isAbsorbedByHub }
+    }
+
+    /// The launchpad grid: the role-curated enabled set in its curated order,
+    /// re-ranked by real usage (most-used first), with the curated order as the
+    /// stable fallback. Hub members stay excluded, exactly like the sidebar.
+    var launchpadFeatures: [FeatureDef] {
+        let curated = ordered(enabledFeatures)
+        let byID = Dictionary(uniqueKeysWithValues: curated.map { ($0.id, $0) })
+        return usageStats.rank(curated.map(\.id)).compactMap { byID[$0] }
     }
 
     var visibleFeatures: [FeatureDef] {
@@ -519,10 +542,31 @@ final class AppState {
 
     // MARK: - Feature running
 
+    /// Open or run a feature from a launch surface (launchpad or sidebar),
+    /// recording the engagement for adaptive ranking. Instant/toggle actions
+    /// that need no screen fire in place (recorded inside `run`); everything
+    /// else opens its detail pane.
+    func openFeature(_ feature: FeatureDef) {
+        if feature.firesWithoutScreen {
+            Task { await run(feature: feature, params: [:]) }
+        } else {
+            noteFeatureUse(feature.id)
+            selectedFeatureID = feature.id
+        }
+    }
+
+    /// Record one engagement with a feature, persisted for adaptive launchpad
+    /// ranking across launches.
+    func noteFeatureUse(_ featureID: String) {
+        usageStats.record(featureID, at: Date())
+        persistUsage()
+    }
+
     func run(feature: FeatureDef, params: [String: FeatureValue]) async {
         isRunningFeature = true
         defer { isRunningFeature = false }
         Telemetry.shared.track("feature_used", ["feature": feature.id])
+        noteFeatureUse(feature.id)
 
         // A screenshot from a quick path (sidebar ⏎, global hotkey, menu bar)
         // captures and saves straight to the capture folder; the Screenshot
@@ -642,6 +686,28 @@ final class AppState {
         notifications.removeAll { $0.id == id }
     }
 
+    // MARK: - Role
+
+    /// Apply the user's role choice (first-run or "Change role"): curate the
+    /// enabled set + sidebar order to that role, or keep everything on for
+    /// `nil` ("show me everything"). Persists and lands on the launchpad.
+    func chooseRole(_ role: UserRole?) {
+        if let role {
+            layout.seedRole(role)
+        } else {
+            layout.seedEverything()
+        }
+        roleChosenThisSession = true
+        persistLayout()
+        presentRolePicker = false
+        selectedFeatureID = "home"
+    }
+
+    /// The user's current role, nil when they chose "show me everything".
+    var selectedRole: UserRole? {
+        layout.selectedRole.flatMap(UserRole.init(rawValue:))
+    }
+
     // MARK: - Layout (catalog customization)
 
     func setFeatureEnabled(_ featureID: String, enabled: Bool) {
@@ -729,6 +795,13 @@ final class AppState {
         let snapshot = layout
         Task {
             try? await env.stores.layout.save(snapshot)
+        }
+    }
+
+    private func persistUsage() {
+        let snapshot = usageStats
+        Task {
+            try? await env.stores.usage.save(snapshot)
         }
     }
 
@@ -898,13 +971,6 @@ final class AppState {
                 let result = await env.engine.adbKeyboard.install(serial: serial)
                 showToast(Toast(message: result.message, ok: result.ok))
             }
-        }
-    }
-
-    func persistLastFeature() {
-        let id = selectedFeatureID
-        Task {
-            try? await env.stores.prefs.update { $0.lastFeatureId = id }
         }
     }
 


### PR DESCRIPTION
## What this adds

Users reported the app's 28 always-on features were overwhelming. This makes the feature set role-driven and gives every detail screen one consistent look.

### Role-based onboarding + launchpad
- First launch shows a full-window role picker: Android Developer, React Native Developer, QA / Tester, Support / Triage, or "show me everything". The chosen role curates a focused feature set; everything else stays one tap away under "More features" and in the catalog.
- Home is a role-aware launchpad grid, ordered by a curated seed that re-ranks by real per-feature usage (persisted in `UsageStats`). The app opens to Home every launch.
- Role is changeable any time from Home and Settings. Existing installs are never re-curated — the picker auto-shows only for new installs, before the tour.
- The window fills the screen on launch.

### Card-based screen revamp (HubKit)
- New `HubKit` primitives — `HubSection` (titled card), `HubField` (labeled input), `HubRow` (label/value), `HubColumn` (centered, max-width column) — replace the macOS grouped-`Form` look (floating bars, a wide left gutter, and value rows that read as static inputs).
- Applied to Connection, Wireless ADB, Private DNS, Simulate, Device Info, React Native, and Deep Links.

### Bug Report screen
- Bug Report is now a screen instead of a fire-and-forget action: it lists what the zip includes and reveals the result in Finder. Reuses the existing `BugReportService` and runner.

### React Native
- Forward Metro (`adb reverse tcp:8081`) one-tap action, plus a Related tools card linking Logcat, Crash Catcher, and Performance Monitor. Mirror Screen is now in every role.

## Data model
- Role curation drives the existing enablement (`LayoutState.enabledIds`); `seedRole`/`seedEverything` also mark the one-time all-on migration done so it can't re-expand a curated set.

## Verification
- `swift test`: 266 ADBKit tests pass (role coverage, seeding incl. existing-user safety, usage ranking).
- Builds clean with zero warnings.
- Verified live across all four roles and each revamped screen.

## Base
This branch sits on the pending v2.4.2 commits (version bump, telemetry consent, GitHub-star prompt, appcast) not yet on `main` — the onboarding flow builds on that first-run gating — so the PR brings those in as its base.
