### PR TITLE
v2.5.1: Install App, dark default, light beta, emulators in dev roles

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureCommands.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureCommands.swift
@@ -83,6 +83,9 @@ extension FeatureRegistry {
             ),
             FeatureCommand("adb emu kill", note: "stop a running emulator"),
         ],
+        "install-app": [
+            FeatureCommand("adb install -r <path.apk>", note: "install or reinstall (keeps data)"),
+        ],
 
         // ── React Native ─────────────────────────────────────────────────
         "react-native": [

--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -35,6 +35,7 @@ public struct FeatureEngine: Sendable {
     public let locator: ToolLocator
     public let monitor: DeviceMonitor
     public let appControl: AppControlService
+    public let appInstall: AppInstallService
     public let inspection: AppInspectionService
     public let toolDetection: ToolDetectionService
     public let overrides: OverridesService
@@ -62,6 +63,7 @@ public struct FeatureEngine: Sendable {
         self.locator = locator
         self.monitor = monitor
         self.appControl = AppControlService(client: client)
+        self.appInstall = AppInstallService(client: client)
         self.inspection = AppInspectionService(client: client)
         self.toolDetection = ToolDetectionService(locator: locator)
         self.overrides = OverridesService(client: client, store: overridesStore)

--- a/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
@@ -52,6 +52,7 @@ extension FeatureRegistry {
         "custom-commands": "Your own adb one-liners with {bundleId} and {serial} placeholders. Tokenized safely — never run through a shell.",
         "file-explorer": "Browse the device's shared storage. Double-click a folder to open it, single-click to select, right-click for options. Copy/cut/paste, delete, create folders, and pull files to your Mac. On a rooted device, flip Root on to browse the whole filesystem from / via su (pulls stage through /data/local/tmp).",
         "apps": "Every installed app (user + system) with search. Select one for its info, live permission toggles, APK pull, and full management — open, force-stop, clear cache (Android 14+) or clear data, disable/enable, and uninstall-for-user/restore (`pm clear` / `pm disable-user` / `pm uninstall --user 0` / `cmd package install-existing`). The reversible per-user actions double as a debloater; removing core system apps can break the UI, so stick to ones you recognise.",
+        "install-app": "Install an APK onto the connected device(s) with `adb install -r` — reinstalling keeps the app's data. Drag an `.apk` onto the drop zone or pick one with the file button; with several devices selected it installs on each. Double-clicking an `.apk` in Finder opens Droidective and offers the same install.",
         "emulators": "Your Android Studio AVDs: launch normally, cold boot (skip the snapshot), or wipe data first; running ones show their adb serial and can be stopped. Needs the SDK emulator.",
     ]
 }

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -316,6 +316,15 @@ public enum FeatureRegistry {
             category: .appManagement, icon: "square.grid.3x3", kind: .view
         ),
         FeatureDef(
+            id: "install-app", num: 50, title: "Install App",
+            subtitle: "Install an APK — drag and drop or pick a file",
+            keywords: [
+                "install", "apk", "sideload", "side load", "drag", "drop",
+                "install app", "add app", "package",
+            ],
+            category: .appManagement, icon: "arrow.down.app", kind: .view
+        ),
+        FeatureDef(
             id: "app-management", num: 25, title: "Manage App",
             subtitle: "Open, stop, clear, or uninstall an app",
             keywords: ["open", "close", "force stop", "clear data", "uninstall", "cache"],
@@ -453,12 +462,12 @@ public enum FeatureRegistry {
     public static let featuresByRole: [UserRole: [String]] = [
         .androidDeveloper: [
             "logcat", "crash-catcher", "device-info", "current-activity", "foreground-package",
-            "file-explorer", "sandbox-browser", "apps", "emulators", "connection", "get-ip",
+            "file-explorer", "sandbox-browser", "apps", "install-app", "emulators", "connection", "get-ip",
             "meminfo", "monkey", "scrcpy", "screenshot", "send-text", "custom-commands",
         ],
         .reactNativeDeveloper: [
             "react-native", "logcat", "crash-catcher", "performance", "network-speed",
-            "apps", "emulators", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
+            "apps", "install-app", "emulators", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
         ],
         .qaTester: [
             "screenshot", "screen-record", "scrcpy", "video-editor", "bug-report",

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -453,12 +453,12 @@ public enum FeatureRegistry {
     public static let featuresByRole: [UserRole: [String]] = [
         .androidDeveloper: [
             "logcat", "crash-catcher", "device-info", "current-activity", "foreground-package",
-            "file-explorer", "sandbox-browser", "apps", "connection", "get-ip",
+            "file-explorer", "sandbox-browser", "apps", "emulators", "connection", "get-ip",
             "meminfo", "monkey", "scrcpy", "screenshot", "send-text", "custom-commands",
         ],
         .reactNativeDeveloper: [
             "react-native", "logcat", "crash-catcher", "performance", "network-speed",
-            "apps", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
+            "apps", "emulators", "connection", "device-info", "scrcpy", "screenshot", "send-text", "custom-commands",
         ],
         .qaTester: [
             "screenshot", "screen-record", "scrcpy", "video-editor", "bug-report",

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -96,6 +96,11 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// `didEnableAll`/`knownIds` so the legacy migrations can't re-expand a
     /// curated role back to all-on. Optional so older files decode.
     public var roleChosen: Bool?
+    /// The curated id list as it was when this layout last seeded its role — the
+    /// baseline `adoptNewRoleFeatures` diffs against, so a feature later added to
+    /// the user's role turns on for them without re-running the picker. Optional
+    /// so older files decode.
+    public var seededRoleIds: [String]?
 
     public init(
         enabledIds: [String]? = nil,
@@ -108,7 +113,8 @@ public struct LayoutState: Codable, Sendable, Equatable {
         menuBarItems: [String]? = nil,
         didEnableAll: Bool? = nil,
         selectedRole: String? = nil,
-        roleChosen: Bool? = nil
+        roleChosen: Bool? = nil,
+        seededRoleIds: [String]? = nil
     ) {
         self.enabledIds = enabledIds
         self.favorites = favorites
@@ -120,6 +126,7 @@ public struct LayoutState: Codable, Sendable, Equatable {
         self.menuBarItems = menuBarItems
         self.didEnableAll = didEnableAll
         self.selectedRole = selectedRole
+        self.seededRoleIds = seededRoleIds
         self.roleChosen = roleChosen
     }
 
@@ -180,6 +187,7 @@ public struct LayoutState: Codable, Sendable, Equatable {
         roleChosen = true
         enabledIds = ids
         sidebarOrder = ids
+        seededRoleIds = ids
         knownIds = FeatureRegistry.all.map(\.id)
         didEnableAll = true
     }
@@ -190,8 +198,29 @@ public struct LayoutState: Codable, Sendable, Equatable {
         selectedRole = nil
         roleChosen = true
         enabledIds = nil
+        seededRoleIds = nil
         knownIds = FeatureRegistry.all.map(\.id)
         didEnableAll = true
+    }
+
+    /// Enable features added to the user's role since it was last seeded, so a
+    /// role curation change reaches existing role users without re-running the
+    /// picker (the role analog of `adoptNewDefaults`). Returns true when
+    /// something changed (caller persists). No-op for "everything" users
+    /// (`enabledIds == nil`) and unknown roles.
+    public mutating func adoptNewRoleFeatures() -> Bool {
+        guard let roleRaw = selectedRole, let role = UserRole(rawValue: roleRaw),
+              var ids = enabledIds else { return false }
+        let roleIDs = FeatureRegistry.featureIDs(for: role)
+        let seeded = Set(seededRoleIds ?? [])
+        let additions = roleIDs.filter { !seeded.contains($0) && !ids.contains($0) }
+        let baselineChanged = seededRoleIds != roleIDs
+        guard !additions.isEmpty || baselineChanged else { return false }
+        ids.append(contentsOf: additions)
+        enabledIds = ids
+        if sidebarOrder != nil { sidebarOrder?.append(contentsOf: additions) }
+        seededRoleIds = roleIDs
+        return true
     }
 }
 

--- a/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Installs an APK onto a device with `adb install -r` (reinstall, keeping data
+/// when the app is already there). The path is a local file handed to adb over
+/// the sync protocol — no shell, so no quoting is needed. Install can take a
+/// while, so it uses a generous timeout.
+public struct AppInstallService: Sendable {
+    let client: AdbClient
+
+    public init(client: AdbClient) {
+        self.client = client
+    }
+
+    public func install(apkPath: String, serial: String) async throws(AdbError) -> FeatureResult {
+        let result = try await client.run(on: serial, ["install", "-r", apkPath], timeout: .seconds(180))
+        return Self.parse(result)
+    }
+
+    /// Map adb's install output to a result. adb prints "Success" on success and
+    /// "Failure [INSTALL_FAILED_…]" (or a streamed error line) on failure, often
+    /// on a zero exit, so the text — not the exit code — is authoritative.
+    static func parse(_ result: AdbResult) -> FeatureResult {
+        let combined = result.stdout + "\n" + result.stderr
+        if combined.range(of: "Success", options: .caseInsensitive) != nil {
+            return FeatureResult(ok: true, message: "Installed")
+        }
+        if let range = combined.range(of: "INSTALL_FAILED_[A-Z_]+", options: .regularExpression) {
+            return FeatureResult(ok: false, message: "Install failed — \(combined[range])")
+        }
+        let lastLine = combined
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .last { !$0.isEmpty }
+        return FeatureResult(ok: false, message: lastLine ?? "Install failed")
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -145,9 +145,9 @@ import Testing
 }
 
 @Suite struct FeatureRegistryTests {
-    @Test func hasAll46Features() {
-        #expect(FeatureRegistry.all.count == 46)
-        #expect(FeatureRegistry.byID.count == 46)
+    @Test func hasAll47Features() {
+        #expect(FeatureRegistry.all.count == 47)
+        #expect(FeatureRegistry.byID.count == 47)
     }
 
     @Test func everyCatalogFeatureIsEnabledByDefault() {
@@ -212,6 +212,18 @@ import Testing
         #expect(logcat.matches("logs"))
         #expect(logcat.matches("LOGCAT"))
         #expect(!logcat.matches("battery"))
+    }
+
+    @Test func installParsesSuccessAndFailure() {
+        let success = AppInstallService.parse(
+            AdbResult(stdout: "Performing Streamed Install\nSuccess\n", stderr: "", exitCode: 0, timedOut: false))
+        #expect(success.ok)
+
+        let failure = AppInstallService.parse(AdbResult(
+            stdout: "", stderr: "adb: failed to install app.apk: Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]",
+            exitCode: 1, timedOut: false))
+        #expect(!failure.ok)
+        #expect(failure.message.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE"))
     }
 
     @Test func multiWordSearchMatchesNonContiguousTokens() {

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -299,6 +299,25 @@ import Testing
         #expect(LayoutState().flatOrder == nil)
     }
 
+    @Test func adoptNewRoleFeaturesEnablesFeaturesAddedToTheRole() {
+        var layout = LayoutState()
+        layout.seedRole(.androidDeveloper)
+        // Simulate a layout seeded before "emulators" joined the Android role.
+        layout.enabledIds?.removeAll { $0 == "emulators" }
+        layout.seededRoleIds?.removeAll { $0 == "emulators" }
+        #expect(layout.enabledIds?.contains("emulators") == false)
+
+        #expect(layout.adoptNewRoleFeatures() == true)
+        #expect(layout.enabledIds?.contains("emulators") == true)
+        // Idempotent once the baseline catches up.
+        #expect(layout.adoptNewRoleFeatures() == false)
+
+        // "Everything" users aren't role-curated — no-op.
+        var everything = LayoutState()
+        everything.seedEverything()
+        #expect(everything.adoptNewRoleFeatures() == false)
+    }
+
     @Test func seedEverythingLeavesEverythingOn() {
         var layout = LayoutState()
         layout.seedRole(.qaTester)

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -1,9 +1,20 @@
 import ADBKit
 import SwiftUI
 
+/// Routes APKs opened from Finder (double-click / "Open With") into the install
+/// inbox, which surfaces the device picker once the UI is ready.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func application(_ application: NSApplication, open urls: [URL]) {
+        let apks = urls.filter { $0.pathExtension.lowercased() == "apk" }
+        guard !apks.isEmpty else { return }
+        InstallInbox.shared.receive(apks)
+    }
+}
+
 @main
 struct ADTApp: App {
     @State private var appState: AppState
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
 
     init() {

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -106,6 +106,8 @@ struct FeatureDetailView: View {
                 FileExplorerView()
             case "apps":
                 AppsExplorerView()
+            case "install-app":
+                InstallAppView()
             case "emulators":
                 EmulatorsView()
             case "performance":

--- a/App/Sources/FeatureDetail/Views/InstallAppView.swift
+++ b/App/Sources/FeatureDetail/Views/InstallAppView.swift
@@ -1,0 +1,111 @@
+import ADBKit
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Install an APK onto the selected device(s): drag an `.apk` onto the drop zone
+/// or pick one with the file button. Reinstalls with `adb install -r` (keeps
+/// data), and installs on every targeted device when run-on-all is on.
+struct InstallAppView: View {
+    @Environment(AppState.self) private var state
+    @State private var dropTargeted = false
+    @State private var installing = false
+    @State private var lastResult: String?
+
+    private var targets: [Device] {
+        state.devices.filter { state.targetSerials.contains($0.serial) }
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            dropZone
+            targetSummary
+            if let lastResult {
+                Text(lastResult)
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(24)
+        .frame(maxWidth: 600, maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var dropZone: some View {
+        VStack(spacing: 12) {
+            Image(systemName: installing ? "arrow.down.circle.dotted" : "arrow.down.app")
+                .font(.system(size: 46))
+                .foregroundStyle(.brandAccent)
+            Text(installing ? "Installing…" : "Drag an APK here")
+                .font(.title3.weight(.medium))
+            Button("Choose APK…") { pickAndInstall() }
+                .disabled(installing)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+        .background(.bgSurface, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(
+                    dropTargeted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.borderSubtle),
+                    style: StrokeStyle(lineWidth: dropTargeted ? 2 : 1, dash: [7])
+                )
+        }
+        .dropDestination(for: URL.self) { urls, _ in
+            guard let apk = urls.first(where: { $0.pathExtension.lowercased() == "apk" }) else { return false }
+            install(apk)
+            return true
+        } isTargeted: { dropTargeted = $0 }
+    }
+
+    @ViewBuilder private var targetSummary: some View {
+        if targets.isEmpty {
+            Label("Connect a device to install onto", systemImage: "iphone.slash")
+                .font(.callout)
+                .foregroundStyle(.textMuted)
+        } else {
+            Text("Installs on \(targets.map(\.label).joined(separator: ", "))")
+                .font(.callout)
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func pickAndInstall() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "apk") ?? .data]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        if panel.runModal() == .OK, let url = panel.url { install(url) }
+    }
+
+    private func install(_ url: URL) {
+        let serials = targets.map(\.serial)
+        guard !serials.isEmpty else {
+            state.showToast(Toast(message: "Connect a device first", ok: false))
+            return
+        }
+        installing = true
+        let name = url.lastPathComponent
+        Task {
+            await CommandLog.userInitiated(feature: "install-app") {
+                var ok = 0
+                for serial in serials {
+                    let result = (try? await state.env.engine.appInstall.install(apkPath: url.path, serial: serial))
+                        ?? FeatureResult(ok: false, message: "adb not found")
+                    if result.ok { ok += 1 }
+                    if serials.count == 1 {
+                        state.showToast(Toast(message: result.message, ok: result.ok))
+                    }
+                }
+                if serials.count > 1 {
+                    state.showToast(Toast(message: "Installed \(name) on \(ok)/\(serials.count) devices", ok: ok > 0))
+                }
+                lastResult = ok == serials.count
+                    ? "Installed \(name)"
+                    : "Installed \(name) on \(ok) of \(serials.count) devices"
+            }
+            installing = false
+        }
+    }
+}

--- a/App/Sources/Root/InstallPicker.swift
+++ b/App/Sources/Root/InstallPicker.swift
@@ -1,0 +1,142 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// Buffers APKs opened from Finder until the UI is ready to show the picker —
+/// a double-clicked APK can reach the app delegate before `RootView` appears on
+/// a cold launch.
+@MainActor
+final class InstallInbox {
+    static let shared = InstallInbox()
+    private var pending: [URL] = []
+    var onReceive: (([URL]) -> Void)? { didSet { drain() } }
+
+    func receive(_ urls: [URL]) {
+        pending.append(contentsOf: urls)
+        drain()
+    }
+
+    private func drain() {
+        guard let onReceive, !pending.isEmpty else { return }
+        let urls = pending
+        pending = []
+        onReceive(urls)
+    }
+}
+
+/// Borderless floating panel (same chrome as the ⌘K palette) that asks which
+/// connected device to install an opened APK onto.
+@MainActor
+final class InstallPickerController {
+    static let shared = InstallPickerController()
+    private var panel: KeyablePanel?
+
+    func present(apks: [URL], state: AppState) {
+        close()
+        let view = InstallPickerView(apks: apks, onClose: { [weak self] in self?.close() })
+            .environment(state)
+            .tint(.brandAccent)
+        let hosting = NSHostingController(rootView: view)
+        hosting.sizingOptions = [.preferredContentSize]
+
+        let panel = KeyablePanel(contentViewController: hosting)
+        panel.styleMask = [.borderless]
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isMovableByWindowBackground = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        if let screen = panel.screen ?? NSScreen.main {
+            let frame = panel.frame
+            panel.setFrameOrigin(NSPoint(
+                x: screen.visibleFrame.midX - frame.width / 2,
+                y: screen.visibleFrame.midY - frame.height / 2
+            ))
+        }
+        NSApp.activate()
+        panel.makeKeyAndOrderFront(nil)
+        self.panel = panel
+    }
+
+    func close() {
+        panel?.orderOut(nil)
+        panel?.close()
+        panel = nil
+    }
+}
+
+private struct InstallPickerView: View {
+    @Environment(AppState.self) private var state
+    let apks: [URL]
+    let onClose: () -> Void
+
+    private var ready: [Device] { state.devices.filter(\.isReady) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            if ready.isEmpty {
+                Text("No device connected. Connect one, then reopen the APK.")
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .padding(16)
+            } else {
+                ForEach(ready) { device in
+                    row(label: device.label, sub: device.serial, icon: "iphone") {
+                        state.installAPKs(apks, onSerials: [device.serial])
+                    }
+                }
+                if ready.count > 1 {
+                    Divider()
+                    row(label: "Install on all devices", sub: "\(ready.count) devices", icon: "square.stack.3d.up") {
+                        state.installAPKs(apks, onSerials: ready.map(\.serial))
+                    }
+                }
+            }
+        }
+        .frame(width: 420)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .onExitCommand { onClose() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.down.app")
+                .font(.title2)
+                .foregroundStyle(.brandAccent)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Install").font(.headline)
+                Text(apks.map(\.lastPathComponent).joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+    }
+
+    private func row(label: String, sub: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+            onClose()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon).frame(width: 22).foregroundStyle(.brandAccent)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(label)
+                    Text(sub).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -110,13 +110,13 @@ struct RootView: View {
         NSApp.applicationIconImage = NSImage(named: dark ? "AppLogoDark" : "AppLogoLight")
     }
 
-    /// One-time switch to the v2 defaults — Auto appearance and how-it-works
+    /// One-time switch to the v2 defaults — dark appearance and how-it-works
     /// notes hidden — for users who installed before they changed. Runs once;
     /// any later manual change in Settings sticks.
     private func migrateDefaultsIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: "didMigrateDefaultsV2") else { return }
-        defaults.set("auto", forKey: "theme")
+        defaults.set("dark", forKey: "theme")
         defaults.set(false, forKey: "showFeatureNotes")
         defaults.set(true, forKey: "didMigrateDefaultsV2")
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -73,6 +73,9 @@ struct RootView: View {
             .onAppear {
                 state.openMainWindow = { openWindow(id: "main") }
                 state.openPalette = { PaletteController.shared.show(appState: state) }
+                InstallInbox.shared.onReceive = { urls in
+                    InstallPickerController.shared.present(apks: urls, state: state)
+                }
                 migrateDefaultsIfNeeded()
                 applyStoredTheme()
                 updateDockIcon()

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -33,15 +33,15 @@ struct SettingsView: View {
 func applyStoredTheme() {
     switch UserDefaults.standard.string(forKey: "theme") {
     case "light": NSApp.appearance = NSAppearance(named: .aqua)
-    case "dark": NSApp.appearance = NSAppearance(named: .darkAqua)
-    // "auto" — and the default when unset, so new users follow the system.
-    default: NSApp.appearance = nil
+    case "auto": NSApp.appearance = nil
+    // "dark" — and the default when unset, so new users get dark.
+    default: NSApp.appearance = NSAppearance(named: .darkAqua)
     }
 }
 
 struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
-    @AppStorage("theme") private var theme = "auto"
+    @AppStorage("theme") private var theme = "dark"
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
     @AppStorage(ScreenCaptureService.captureFolderDefaultsKey) private var captureFolderPath = ""
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
@@ -98,12 +98,17 @@ struct GeneralSettingsView: View {
         Form {
             Section("Appearance") {
                 Picker("Theme", selection: $theme) {
-                    Text("Auto").tag("auto")
-                    Text("Light").tag("light")
                     Text("Dark").tag("dark")
+                    Text("Auto").tag("auto")
+                    Text("Light (Beta)").tag("light")
                 }
                 .pickerStyle(.segmented)
                 .onChange(of: theme) { applyStoredTheme() }
+                if theme == "light" {
+                    Text("Light mode is in beta — a few screens are still being tuned for it.")
+                        .font(.footnote)
+                        .foregroundStyle(.textMuted)
+                }
 
                 Toggle("Show how-it-works notes", isOn: $showFeatureNotes)
                 Text("The info text beneath each feature, above the command bar.")

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -247,6 +247,7 @@ final class AppState {
             layout = loadedLayout
             var layoutChanged = layout.adoptNewDefaults()
             layoutChanged = layout.adoptAllEnabled() || layoutChanged
+            layoutChanged = layout.adoptNewRoleFeatures() || layoutChanged
             if layoutChanged {
                 persistLayout()
             }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -664,6 +664,29 @@ final class AppState {
         ))
     }
 
+    /// Install one or more APKs on the given device serials, one toast per APK.
+    /// Shared by the Install App screen and the Finder-drop device picker.
+    func installAPKs(_ urls: [URL], onSerials serials: [String]) {
+        guard !urls.isEmpty, !serials.isEmpty else { return }
+        Task {
+            await CommandLog.userInitiated(feature: "install-app") {
+                for url in urls {
+                    let name = url.lastPathComponent
+                    var ok = 0
+                    for serial in serials {
+                        let result = (try? await env.engine.appInstall.install(apkPath: url.path, serial: serial))
+                            ?? FeatureResult(ok: false, message: "adb not found")
+                        if result.ok { ok += 1 }
+                    }
+                    let message = serials.count == 1
+                        ? (ok == 1 ? "Installed \(name)" : "Couldn't install \(name)")
+                        : "Installed \(name) on \(ok)/\(serials.count) devices"
+                    showToast(Toast(message: message, ok: ok > 0))
+                }
+            }
+        }
+    }
+
     func showToast(_ toast: Toast) {
         toasts.append(toast)
         if toast.important {

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+## Droidective v2.5.1
+
+### Improvements
+
+- **Dark by default** — new installs start in dark mode. Light mode is now marked
+  **Beta** in Settings → Appearance while a few screens are tuned for it; Auto and
+  your own choice still work as before.
+- **Emulators in the dev roles** — the Android and React Native roles now include
+  the Emulators feature, and existing users on those roles pick it up
+  automatically (no need to re-pick your role).
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.5.0
 
 A big UX release: pick your role on first launch and get a focused Home, a faster

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 ## Droidective v2.5.1
 
+### New features
+
+- **Install App** — install an APK onto your device(s) by dragging it onto the
+  new Install App screen or picking a file (reinstalls keep app data, and it
+  installs on every selected device). Double-clicking an `.apk` in Finder opens
+  Droidective and asks which device to install onto.
+
 ### Improvements
 
 - **Dark by default** — new installs start in dark mode. Light mode is now marked

--- a/project.yml
+++ b/project.yml
@@ -66,6 +66,20 @@ targets:
         SUFeedURL: https://droidective.github.io/Droidective/appcast.xml
         SUPublicEDKey: "ma0kTe35r55/PKmemQOEBX7n6SuZPZjOBo973SdJqJ8="
         SUEnableAutomaticChecks: true
+        UTImportedTypeDeclarations:
+          - UTTypeIdentifier: com.android.package-archive
+            UTTypeDescription: Android Package
+            UTTypeConformsTo:
+              - public.data
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - apk
+        CFBundleDocumentTypes:
+          - CFBundleTypeName: Android Package
+            CFBundleTypeRole: Viewer
+            LSHandlerRank: Owner
+            LSItemContentTypes:
+              - com.android.package-archive
     settings:
       base:
         PRODUCT_NAME: Droidective

--- a/project.yml
+++ b/project.yml
@@ -72,7 +72,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.5.0"
+        MARKETING_VERSION: "2.5.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
Ships **v2.5.1**.

## New features
- **Install App** — install an APK onto your device(s): drag it onto the new Install App screen or pick a file. Reinstalls with `adb install -r` (keeps data) and installs on every selected device (run-on-all aware). Double-clicking an `.apk` in Finder opens Droidective and pops a device picker to choose where to install.

## Improvements
- **Dark by default** — new installs start in dark mode; `applyStoredTheme` treats unset as dark, while explicit Auto/Light still work. Light mode is labeled **Beta** in Settings → Appearance.
- **Emulators in the dev roles** — added to the Android and React Native curated roles. `adoptNewRoleFeatures` (the role analog of `adoptNewDefaults`, keyed off a `seededRoleIds` baseline) enables features newly added to a user's role on launch, so existing role users pick them up without re-running the picker.

## Implementation notes
- `AppInstallService` (ADBKit) parses adb's install output; `install-app` registered as a view feature with its note, command reference, and role membership.
- `InstallAppView`, `InstallPicker` (borderless panel reusing the palette's `KeyablePanel`), an `AppDelegate` open handler routing through an inbox, and a shared `AppState.installAPKs`. `.apk` declared as a document type (`LSHandlerRank: Owner`).

## Tests
- ADBKit: 270 tests green (install-parse, role-adoption, feature-count → 47). App builds clean at `MARKETING_VERSION` 2.5.1.

## Note
`.apk` is also a zip, so another app could claim it; with `LSHandlerRank: Owner` Droidective should win, but a user may need "Open With → Droidective" once if something else grabbed it first.
