### PR TITLE
v2.6.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## Droidective v2.5.1
+## Droidective v2.6.0
 
 ### New features
 

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.5.1"
+        MARKETING_VERSION: "2.6.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
Cuts **v2.6.0**, shipping the work merged to main since v2.5.0 (no 2.5.1 was tagged): Install App (APK installer + Finder association + device picker), dark mode by default with a Light Beta tag, and Emulators added to the Android/React Native roles with auto-adoption for existing users. Just bumps `MARKETING_VERSION` to 2.6.0 and retitles the release notes. CI on main is green.