### PR TITLE
Wire site Download buttons to latest release .dmg

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -43,10 +43,10 @@
     "operatingSystem": "macOS 14.0 or later",
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 45 tools in all.",
     "url": "https://droidective.github.io/Droidective/",
-    "downloadUrl": "https://github.com/Rohindh-R/Droidective/releases",
+    "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
     "softwareVersion": "2.2.1",
     "screenshot": "https://droidective.github.io/Droidective/assets/screenshot-home.png",
-    "license": "https://github.com/Rohindh-R/Droidective/blob/main/LICENSE",
+    "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Person", "name": "Rohindh R", "url": "https://github.com/Rohindh-R" }
   }
@@ -447,8 +447,8 @@
         <a href="#how">How it works</a>
         <a href="#changelog">Changelog</a>
         <a href="#faq">FAQ</a>
-        <a href="https://github.com/Rohindh-R/Droidective">GitHub</a>
-        <a class="btn btn-primary" href="https://github.com/Rohindh-R/Droidective/releases"><svg class="ic"><use href="#ic-dl"/></svg> Download</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+        <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download</a>
       </div>
     </div>
   </nav>
@@ -464,8 +464,8 @@
           performance live — <strong>45 tools</strong>, no terminal required.
         </p>
         <div class="cta-row">
-          <a class="btn btn-primary" href="https://github.com/Rohindh-R/Droidective/releases"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
-          <a class="btn btn-ghost" href="https://github.com/Rohindh-R/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
+          <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
+          <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
         </div>
         <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.2.1</span></p>
       </div>
@@ -671,7 +671,7 @@ Pixel 8     device</pre>
       </div>
     </div>
     <div class="changelog-cta">
-      <a class="btn btn-ghost" href="https://github.com/Rohindh-R/Droidective/releases">All releases on GitHub →</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective/releases">All releases on GitHub →</a>
     </div>
   </section>
 
@@ -725,8 +725,8 @@ Pixel 8     device</pre>
 <span class="c">$</span> make test    <span style="color:var(--faint)"># ADBKit unit tests — no device needed</span>
 <span class="c">$</span> make run     <span style="color:var(--faint)"># build &amp; launch</span></pre>
         <div class="cta-row" style="margin-top:20px">
-          <a class="btn btn-primary" href="https://github.com/Rohindh-R/Droidective"><svg class="ic"><use href="#ic-gh"/></svg> View on GitHub</a>
-          <a class="btn btn-ghost" href="https://github.com/Rohindh-R/Droidective/issues/new/choose">Open an issue</a>
+          <a class="btn btn-primary" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-gh"/></svg> View on GitHub</a>
+          <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective/issues/new/choose">Open an issue</a>
         </div>
       </div>
       <div class="panel reveal">
@@ -746,8 +746,8 @@ Pixel 8     device</pre>
       <h2>Debug Android without the terminal.</h2>
       <p>Free, open source, and one keystroke away.</p>
       <div class="cta-row">
-        <a class="btn btn-primary" href="https://github.com/Rohindh-R/Droidective/releases"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
-        <a class="btn btn-ghost" href="https://github.com/Rohindh-R/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
+        <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
+        <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
       </div>
     </div>
   </section>
@@ -757,11 +757,11 @@ Pixel 8     device</pre>
       <div class="foot-top">
         <a class="brand" href="#top"><img src="assets/icon.png" alt="" width="26" height="26" /> Droidective</a>
         <div class="foot-links">
-          <a href="https://github.com/Rohindh-R/Droidective">GitHub</a>
-          <a href="https://github.com/Rohindh-R/Droidective/releases">Releases</a>
+          <a href="https://github.com/Droidective/Droidective">GitHub</a>
+          <a href="https://github.com/Droidective/Droidective/releases">Releases</a>
           <a href="#changelog">Changelog</a>
-          <a href="https://github.com/Rohindh-R/Droidective/issues">Issues</a>
-          <a href="https://github.com/Rohindh-R/Droidective/blob/main/LICENSE">License</a>
+          <a href="https://github.com/Droidective/Droidective/issues">Issues</a>
+          <a href="https://github.com/Droidective/Droidective/blob/main/LICENSE">License</a>
         </div>
       </div>
       <p class="disclaimer">
@@ -776,6 +776,22 @@ Pixel 8     device</pre>
   <script>
     document.documentElement.classList.add("js");
     const motionOK = !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    /* Point the Download buttons straight at the latest release's .dmg.
+       Falls back to the /releases/latest page if the API call fails or JS is off. */
+    (function () {
+      const btns = document.querySelectorAll("[data-dl-latest]");
+      if (!btns.length) return;
+      fetch("https://api.github.com/repos/Droidective/Droidective/releases/latest", {
+        headers: { Accept: "application/vnd.github+json" },
+      })
+        .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+        .then((rel) => {
+          const dmg = (rel.assets || []).find((a) => a.name.toLowerCase().endsWith(".dmg"));
+          if (dmg) btns.forEach((b) => { b.href = dmg.browser_download_url; });
+        })
+        .catch(() => {});
+    })();
 
     /* Scroll reveal */
     if (motionOK && "IntersectionObserver" in window) {


### PR DESCRIPTION
## What

Clicking **Download** on the marketing site now downloads the latest release `.dmg` instead of landing on the releases listing page.

## Changes (`site/index.html`)

- Tag the three Download buttons (nav, hero, bottom CTA) with `data-dl-latest`. A small on-load script queries the GitHub API for the latest release, finds the `.dmg` asset, and rewrites each button's `href` to its direct download URL. GitHub serves the asset with `Content-Disposition: attachment`, so the click starts a file download.
- Fallback: if JS is disabled or the API call fails, the buttons stay on `…/releases/latest`, so they're never dead links.
- The asset filename is versioned (`Droidective-vX.Y.Z.dmg`), so a static link wasn't possible; this approach tracks every future release with no per-release edit.
- Point all repo links at the `Droidective/Droidective` org (the repo moved) and update the structured-data `downloadUrl` to `/releases/latest`.

## Verification

- No old-owner (`Rohindh-R/Droidective`) refs remain.
- Live API currently resolves to `https://github.com/Droidective/Droidective/releases/download/v2.6.0/Droidective-v2.6.0.dmg`.