### PR TITLE
Resolve latest .dmg from same-origin appcast instead of api.github.com

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -777,22 +777,29 @@ Pixel 8     device</pre>
     document.documentElement.classList.add("js");
     const motionOK = !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    /* Point the Download buttons straight at the latest release's .dmg.
-       Rewrites the href as soon as the API responds, and also intercepts a
-       click that lands before the request finishes so the first click still
-       gets the .dmg. Falls back to the /releases/latest page (the static href)
-       if the API call fails or JS is off. */
+    /* Point the Download buttons straight at the latest release's .dmg, read
+       from the same-origin appcast.xml the release pipeline publishes (no
+       api.github.com — that's rate-limited and often blocked by extensions).
+       Rewrites the href as soon as it resolves and intercepts an early click
+       so the first click still gets the .dmg. Falls back to the
+       /releases/latest page (the static href) if the fetch fails or JS is off. */
     (function () {
       const btns = document.querySelectorAll("[data-dl-latest]");
       if (!btns.length) return;
       let dmgUrl = null;
-      const pending = fetch("https://api.github.com/repos/Droidective/Droidective/releases/latest", {
-        headers: { Accept: "application/vnd.github+json" },
-      })
-        .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
-        .then((rel) => {
-          const dmg = (rel.assets || []).find((a) => a.name.toLowerCase().endsWith(".dmg"));
-          if (dmg) { dmgUrl = dmg.browser_download_url; btns.forEach((b) => { b.href = dmgUrl; }); }
+      const pending = fetch("appcast.xml", { headers: { Accept: "application/xml" } })
+        .then((r) => (r.ok ? r.text() : Promise.reject(r.status)))
+        .then((xml) => {
+          const doc = new DOMParser().parseFromString(xml, "application/xml");
+          const enc = Array.from(doc.querySelectorAll("item"))
+            .map((it) => {
+              const e = it.querySelector("enclosure");
+              const vEl = it.getElementsByTagName("sparkle:version")[0];
+              return { url: e && e.getAttribute("url"), v: vEl ? parseInt(vEl.textContent, 10) || 0 : 0 };
+            })
+            .filter((x) => x.url && x.url.toLowerCase().endsWith(".dmg"))
+            .sort((a, b) => b.v - a.v)[0];
+          if (enc) { dmgUrl = enc.url; btns.forEach((b) => { b.href = dmgUrl; }); }
           return dmgUrl;
         })
         .catch(() => null);


### PR DESCRIPTION
## Problem

The Download button kept landing on the releases page instead of downloading the `.dmg`. The button resolves the latest release at runtime, but it was calling `api.github.com`, which is:
- rate-limited to 60 requests/hour per IP (easy to hit while testing), and
- frequently blocked by privacy/ad-block extensions and corporate proxies.

On any of those failures the button falls back to the `/releases/latest` page — the behavior being reported.

## Fix (`site/index.html`)

Read the latest `.dmg` URL from the **same-origin `appcast.xml`** that the release pipeline already publishes to the site (`update-appcast.sh` → committed to `main` each release). Same origin means no CORS, no rate limit, and no third-party blocking. Pick the `<enclosure>` from the highest `sparkle:version` `<item>`.

Behavior is otherwise unchanged: the href is rewritten as soon as the fetch resolves, an early click waits on the in-flight request, and it falls back to `/releases/latest` if the fetch fails or JS is off.

## Verification

- Live appcast at `https://droidective.github.io/Droidective/appcast.xml` contains the `v2.6.0` DMG enclosure (`sparkle:version` 104).
- No `api.github.com` dependency remains in the site.