### PR TITLE
Move site to droidective.com and add a privacy page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,16 @@ jobs:
         with:
           persist-credentials: false
       - name: Assemble site
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
         run: |
           mkdir -p _site
           cp -R site/. _site/
+          # Reuse the app's PostHog key (a public client-side token) so the site
+          # shares one project; the page no-ops analytics if the secret is unset.
+          if [ -n "${POSTHOG_KEY:-}" ]; then
+            sed -i "s|__POSTHOG_KEY__|${POSTHOG_KEY}|g" _site/index.html
+          fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: _site

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Droidective ships as a Developer ID-signed, notarized DMG via GitHub Releases
 and a Homebrew cask, and updates itself with
 [Sparkle](https://sparkle-project.org). The marketing site and the Sparkle
 appcast are both served from GitHub Pages at
-`https://droidective.github.io/Droidective/`.
+`https://droidective.com/`.
 
 ## One-time setup
 
@@ -134,7 +134,7 @@ On-page SEO is already in `site/index.html` (title, meta description, Open
 Graph, Twitter card, JSON-LD `SoftwareApplication`, `sitemap.xml`, `robots.txt`).
 Ranking for competitive terms still needs links and time:
 
-- Set the repo's **About → Website** to `https://droidective.github.io/Droidective/`.
+- Set the repo's **About → Website** to `https://droidective.com/`.
 - Add the URL to the README and link it from anywhere you can.
 - Verify the site in **Google Search Console** (URL-prefix property; use the
   meta-tag method — add the `google-site-verification` tag to `index.html`), then
@@ -247,8 +247,8 @@ Copy this into the release PR and tick each item.
 - [ ] GitHub release page shows the right version, the notes, and a downloadable DMG.
 - [ ] Fresh download launches cleanly: mount the DMG, drag to `/Applications`, open — no Gatekeeper warning. `spctl -a -vvv -t install Droidective-vX.Y.Z.dmg` reports *accepted, source=Notarized Developer ID*.
 - [ ] `brew install --cask rohindh-r/tap/droidective` installs the new version.
-- [ ] `https://droidective.github.io/Droidective/` shows the new screenshots and copy.
-- [ ] `https://droidective.github.io/Droidective/appcast.xml` lists the new version with a valid `sparkle:edSignature` and the release notes inline in `<description>`.
+- [ ] `https://droidective.com/` shows the new screenshots and copy.
+- [ ] `https://droidective.com/appcast.xml` lists the new version with a valid `sparkle:edSignature` and the release notes inline in `<description>`.
 - [ ] A prior install (v2.1.0+) offers the update via Sparkle, shows the release notes in the update window (not the GitHub web page), and applies it in place.
 - [ ] Repo **About → Website** still points at the Pages URL.
 

--- a/project.yml
+++ b/project.yml
@@ -63,7 +63,7 @@ targets:
         NSHumanReadableCopyright: ""
         SentryDSN: $(SENTRY_DSN)
         PostHogKey: $(POSTHOG_KEY)
-        SUFeedURL: https://droidective.github.io/Droidective/appcast.xml
+        SUFeedURL: https://droidective.com/appcast.xml
         SUPublicEDKey: "ma0kTe35r55/PKmemQOEBX7n6SuZPZjOBo973SdJqJ8="
         SUEnableAutomaticChecks: true
         UTImportedTypeDeclarations:

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -67,7 +67,7 @@ cat >"$APPCAST" <<XML
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Droidective</title>
-    <link>https://droidective.github.io/Droidective/appcast.xml</link>
+    <link>https://droidective.com/appcast.xml</link>
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -26,7 +26,7 @@ cask "droidective" do
   url "${URL}"
   name "Droidective"
   desc "Native macOS app for Android and React Native debugging over adb"
-  homepage "https://droidective.github.io/Droidective/"
+  homepage "https://droidective.com/"
 
   # Sparkle updates the app in place, so Homebrew should not fight it.
   auto_updates true

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+droidective.com

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>Droidective</title>
-    <link>https://droidective.github.io/Droidective/appcast.xml</link>
+    <link>https://droidective.com/appcast.xml</link>
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>

--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,7 @@
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#0d0f0e" />
-  <link rel="canonical" href="https://droidective.github.io/Droidective/" />
+  <link rel="canonical" href="https://droidective.com/" />
 
   <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
   <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
@@ -21,14 +21,14 @@
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
   <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 48 tools, one keystroke away." />
-  <meta property="og:url" content="https://droidective.github.io/Droidective/" />
-  <meta property="og:image" content="https://droidective.github.io/Droidective/assets/screenshot-home.png" />
+  <meta property="og:url" content="https://droidective.com/" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
   <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 48 tools, one keystroke away. Free & open source." />
-  <meta name="twitter:image" content="https://droidective.github.io/Droidective/assets/screenshot-home.png" />
+  <meta name="twitter:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -42,10 +42,10 @@
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS 14.0 or later",
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 48 tools in all.",
-    "url": "https://droidective.github.io/Droidective/",
+    "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
     "softwareVersion": "2.6.0",
-    "screenshot": "https://droidective.github.io/Droidective/assets/screenshot-home.png",
+    "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "author": { "@type": "Person", "name": "Rohindh R", "url": "https://github.com/Rohindh-R" }

--- a/site/index.html
+++ b/site/index.html
@@ -52,6 +52,22 @@
   }
   </script>
 
+  <!-- PostHog product analytics — key injected at deploy from the POSTHOG_KEY secret -->
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    var PH_KEY = "__POSTHOG_KEY__";
+    if (PH_KEY.indexOf("phc_") === 0) {
+      posthog.init(PH_KEY, {
+        api_host: "https://us.i.posthog.com",
+        capture_pageview: true,
+        capture_pageleave: true,
+        autocapture: true,
+        respect_dnt: true,
+        person_profiles: "identified_only"
+      });
+    }
+  </script>
+
   <style>
     :root {
       /* Graphite ramp — the "case" the app lives in */

--- a/site/index.html
+++ b/site/index.html
@@ -713,7 +713,7 @@ Pixel 8     device</pre>
       </details>
       <details class="qa">
         <summary>Does it send my data anywhere?<span class="plus"></span></summary>
-        <div class="a">Anonymous crash reports are on by default (opt-out) and usage analytics are opt-in — both disclosed on first launch and controlled in Settings → Privacy. Device serials, file paths, and command contents are never sent.</div>
+        <div class="a">Anonymous crash reports and usage analytics are on by default (opt-out) — both disclosed on first launch and controlled in Settings → Privacy. Device serials, file paths, and command contents are never sent. See the <a href="/privacy.html">privacy page</a> for details.</div>
       </details>
       <details class="qa">
         <summary>Does it work with React Native?<span class="plus"></span></summary>
@@ -775,6 +775,7 @@ Pixel 8     device</pre>
           <a href="#changelog">Changelog</a>
           <a href="https://github.com/Droidective/Droidective/issues">Issues</a>
           <a href="https://github.com/Droidective/Droidective/blob/main/LICENSE">License</a>
+          <a href="/privacy.html">Privacy</a>
         </div>
       </div>
       <p class="disclaimer">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy — Droidective</title>
+  <meta name="description" content="What Droidective collects, why, and how to turn it off. Anonymous crash reporting and usage analytics, on by default and opt-out in Settings → Privacy." />
+  <link rel="canonical" href="https://droidective.com/privacy.html" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 760px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.65; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: var(--green); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    header { border-bottom: 1px solid var(--line); padding: 20px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; color: var(--text); font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .back { color: var(--muted); font-size: 14px; }
+    main { padding: 56px 0 80px; }
+    h1 { font-size: clamp(30px, 5vw, 42px); margin: 0 0 6px; letter-spacing: -0.02em; }
+    .updated { color: var(--faint); font-family: var(--mono); font-size: 13px; margin: 0 0 40px; }
+    h2 { font-size: 21px; margin: 44px 0 12px; letter-spacing: -0.01em; }
+    p, li { color: #cdd3cd; }
+    .muted { color: var(--muted); }
+    ul { padding-left: 20px; }
+    li { margin: 6px 0; }
+    code { font-family: var(--mono); font-size: 0.9em; background: var(--ink-700); padding: 2px 6px; border-radius: 6px; color: var(--text); }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px 22px; margin: 18px 0; color: #cdd3cd; }
+    .tldr { border-left: 3px solid var(--green); }
+    table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 14.5px; }
+    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line); vertical-align: top; color: #cdd3cd; }
+    th { color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+    footer { border-top: 1px solid var(--line); padding: 30px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <a class="back" href="/">← Back to site</a>
+    </div>
+  </header>
+
+  <main>
+    <div class="wrap">
+      <h1>Privacy</h1>
+      <p class="updated">Last updated 27 June 2026</p>
+
+      <div class="card tldr">
+        <strong>In short:</strong> Droidective collects a small amount of <em>anonymous</em> diagnostics to fix crashes and see which features get used. No device serials, file paths, IP addresses, or command contents ever leave your machine. You can turn it all off in <code>Settings → Privacy</code>, and this website honours “Do Not Track”.
+      </div>
+
+      <h2>The app</h2>
+      <p>Droidective collects two kinds of anonymous data, both <strong>on by default</strong> and switchable off any time in <code>Settings → Privacy</code> (a first-run notice explains this):</p>
+      <table>
+        <tr><th>What</th><th>Tool</th><th>Why</th></tr>
+        <tr><td>Crash &amp; error reports</td><td>Sentry</td><td>Find and fix crashes</td></tr>
+        <tr><td>Feature-usage events</td><td>PostHog</td><td>See which tools are used so the app improves</td></tr>
+      </table>
+      <p><strong>“Anonymous” means it:</strong></p>
+      <ul>
+        <li>never creates a profile or identifies you — PostHog person profiles are disabled;</li>
+        <li>never sends device serial numbers, package or app IDs, file paths, IP addresses, or the contents of any command — only <em>which</em> tool or feature was used;</li>
+        <li>sends no personal information to Sentry (<code>sendDefaultPii</code> is off).</li>
+      </ul>
+
+      <h2>The website</h2>
+      <p>This site (<code>droidective.com</code>) uses <strong>PostHog</strong> to understand how visitors use the page — pages viewed and interactions, captured automatically — purely to improve the site. It is anonymous (no person profiles), and it respects your browser’s <strong>Do Not Track</strong> setting. PostHog may store a random, non-identifying ID in your browser to tell sessions apart; no personal information is collected, and nothing is sold or shared for advertising.</p>
+
+      <h2>Where the data goes</h2>
+      <p class="muted">Analytics are processed by <a href="https://posthog.com/privacy" rel="noopener">PostHog</a> and crash reports by <a href="https://sentry.io/privacy/" rel="noopener">Sentry</a>, used only for the purposes above.</p>
+
+      <h2>Turning it off</h2>
+      <ul>
+        <li><strong>App:</strong> <code>Settings → Privacy</code> — toggle off crash reporting and/or analytics.</li>
+        <li><strong>Website:</strong> enable “Do Not Track” in your browser, or use any content blocker.</li>
+      </ul>
+
+      <h2>Contact</h2>
+      <p>Questions about privacy? <a href="https://github.com/Droidective/Droidective/issues/new/choose" rel="noopener">Open an issue</a> on GitHub.</p>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a></div>
+  </footer>
+</body>
+</html>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://droidective.github.io/Droidective/sitemap.xml
+Sitemap: https://droidective.com/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://droidective.github.io/Droidective/</loc>
+    <loc>https://droidective.com/</loc>
     <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
## What this does

Moves the marketing site to the custom domain `droidective.com` (now live on GitHub Pages with a valid TLS cert), adds a privacy page, and wires up PostHog analytics.

### Custom domain
- Add `site/CNAME` so Pages serves the custom domain and a future workflow deploy can't drop it.
- Replace `droidective.github.io/Droidective/` with `droidective.com/` across site metadata (canonical, Open Graph, Twitter, JSON-LD), `sitemap.xml`, `robots.txt`, the Sparkle appcast `<link>`, `SUFeedURL` in `project.yml`, both release scripts, and `RELEASING.md`.
- GitHub release/repo URLs are unchanged — the DMG stays on GitHub Releases.
- Existing installs keep auto-updating: the old appcast 301-redirects to `droidective.com/appcast.xml`, so the `SUFeedURL` change only affects new builds.

### Privacy page
- Add `site/privacy.html` covering the app's anonymous Sentry (crash) and PostHog (usage) telemetry — both on by default, opt-out in Settings → Privacy — and the site's PostHog analytics. Linked from the footer and the privacy FAQ.
- Correct the FAQ, which described usage analytics as "opt-in": the app defaults analytics on (opt-out), matching crash reporting and `Telemetry.swift`'s own documentation.

### Site analytics (PostHog)
- Add the PostHog loader to `index.html` behind a `__POSTHOG_KEY__` placeholder.
- The `pages` workflow substitutes the key from the existing `POSTHOG_KEY` secret at deploy time, so the key never lands in git and the site shares the app's PostHog project (one site → download → app funnel).
- Autocapture + `capture_pageleave`, anonymous (`person_profiles: identified_only`), and respects Do Not Track — matching what the privacy page promises.
- Region is US (`us.i.posthog.com`), matching the app. Goes live on merge (the `pages` job runs on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
