### PR TITLE
Fix Reactotron copy-as-cURL turning GET requests into POST

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Builds a copy-pasteable `curl` command that reproduces a Reactotron-captured
+/// API request. Lives in ADBKit (not the view) so it stays pure, `Sendable`,
+/// and unit-testable without the UI.
+public enum ReactotronCurl {
+    /// Render `method`/`url`/`request` as a multi-line `curl` invocation.
+    ///
+    /// - Parameters:
+    ///   - method: the HTTP verb as captured (any case).
+    ///   - url: the request URL.
+    ///   - request: the Reactotron `request` payload, read for `headers` and `data`.
+    public static func command(method: String, url: String, request: JSONValue?) -> String {
+        let verb = method.uppercased()
+        let body = requestBody(request)
+        var parts: [String] = ["curl"]
+        // `curl` switches to POST the moment a body is present, so the verb must
+        // be stated explicitly whenever it isn't a plain body-less GET —
+        // otherwise copying a GET that carries a body silently produces a POST.
+        if verb != "GET" || body != nil {
+            parts.append("-X \(verb)")
+        }
+        parts.append(shellQuote(url))
+        if let headers = request?["headers"]?.objectValue {
+            for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
+                let rendered = value.stringValue ?? rawJSON(value)
+                parts.append("-H \(shellQuote("\(key): \(rendered)"))")
+            }
+        }
+        if let body {
+            parts.append("--data \(shellQuote(body))")
+        }
+        return parts.joined(separator: " \\\n  ")
+    }
+
+    /// The body to send, or `nil` when the request carries nothing meaningful —
+    /// JSON null, an empty string, or an empty `{}` / `[]`. Keeps a body-less GET
+    /// body-less (and therefore a GET, not a POST inferred by `curl`).
+    private static func requestBody(_ request: JSONValue?) -> String? {
+        guard let data = request?["data"], !data.isNull else { return nil }
+        let rendered = data.stringValue ?? rawJSON(data)
+        switch rendered {
+        case "", "{}", "[]", "null": return nil
+        default: return rendered
+        }
+    }
+
+    /// Raw (non-marker-repaired) JSON, since a curl body must stay valid JSON —
+    /// unlike `JSONValue.jsonString`, which rewrites Reactotron's `~~~ … ~~~`
+    /// display markers.
+    private static func rawJSON(_ value: JSONValue) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let text = String(data: data, encoding: .utf8) else { return "" }
+        return text
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct ReactotronCurlTests {
+    @Test func getWithoutBodyHasNoMethodOrData() {
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/items", request: nil)
+        #expect(curl.contains("curl"))
+        #expect(curl.contains("'https://x.test/items'"))
+        #expect(!curl.contains("-X"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func getWithEmptyObjectDataStaysBodylessGet() {
+        // Reactotron often records `data: {}` for a GET — it must not gain a body
+        // (and therefore must not flip to POST).
+        let request = JSONValue.object(["data": .object([:])])
+        let curl = ReactotronCurl.command(method: "get", url: "https://x.test", request: request)
+        #expect(!curl.contains("--data"))
+        #expect(!curl.contains("-X"))
+    }
+
+    @Test func getWithRealBodyKeepsGetMethod() {
+        // The reported bug: a GET with a body must stay GET, not silently POST.
+        let request = JSONValue.object(["data": .string("q=1")])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(curl.contains("-X GET"))
+        #expect(curl.contains("--data 'q=1'"))
+    }
+
+    @Test func postWithBodySetsMethodAndData() {
+        let request = JSONValue.object(["data": .string(#"{"a":1}"#)])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains("-X POST"))
+        #expect(curl.contains(#"--data '{"a":1}'"#))
+    }
+
+    @Test func putWithoutBodyStillSetsMethod() {
+        let curl = ReactotronCurl.command(method: "PUT", url: "https://x.test", request: nil)
+        #expect(curl.contains("-X PUT"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func headersAreRenderedSortedAndQuoted() throws {
+        let request = JSONValue.object([
+            "headers": .object([
+                "Authorization": .string("Bearer t"),
+                "Accept": .string("application/json"),
+            ]),
+        ])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(curl.contains("-H 'Accept: application/json'"))
+        #expect(curl.contains("-H 'Authorization: Bearer t'"))
+        let accept = try #require(curl.range(of: "Accept"))
+        let auth = try #require(curl.range(of: "Authorization"))
+        #expect(accept.lowerBound < auth.lowerBound)
+    }
+
+    @Test func singleQuotesInValuesAreEscaped() {
+        let request = JSONValue.object(["data": .string("it's")])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains(#"--data 'it'\''s'"#))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1134,7 +1134,7 @@ private struct RtRow: View {
             HStack {
                 Spacer()
                 CopyButton(label: "Copy as cURL", icon: "terminal") {
-                    curlCommand(method: method, url: url, request: request)
+                    ReactotronCurl.command(method: method, url: url, request: request)
                 }
             }
             Picker("", selection: $apiTab) {
@@ -1218,36 +1218,6 @@ private struct RtRow: View {
               let data = text.data(using: .utf8),
               let parsed = try? JSONDecoder().decode(JSONValue.self, from: data) else { return nil }
         return parsed
-    }
-
-    /// Reproduce the request as a copy-pasteable curl command.
-    private func curlCommand(method: String, url: String, request: JSONValue?) -> String {
-        var parts: [String] = ["curl"]
-        let verb = method.uppercased()
-        if verb != "GET" { parts.append("-X \(verb)") }
-        parts.append(shellQuote(url))
-        if let headers = request?["headers"]?.objectValue {
-            for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
-                let rendered = value.stringValue ?? rawJSON(value)
-                parts.append("-H \(shellQuote("\(key): \(rendered)"))")
-            }
-        }
-        if let data = request?["data"], !data.isNull {
-            let body = data.stringValue ?? rawJSON(data)
-            if !body.isEmpty { parts.append("--data \(shellQuote(body))") }
-        }
-        return parts.joined(separator: " \\\n  ")
-    }
-
-    /// Raw (non-marker-repaired) JSON — for curl bodies that must stay valid.
-    private func rawJSON(_ value: JSONValue) -> String {
-        guard let data = try? JSONEncoder().encode(value),
-              let text = String(data: data, encoding: .utf8) else { return "" }
-        return text
-    }
-
-    private func shellQuote(_ string: String) -> String {
-        "'" + string.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     private func formatMs(_ ms: Double) -> String {


### PR DESCRIPTION
The Reactotron "Copy as cURL" action appended `--data` for any non-null
request body but only set `-X` for non-GET verbs. Because curl infers
POST as soon as `--data` is present, copying a GET request produced a POST.

The curl builder now lives in ADBKit as a pure `ReactotronCurl` type:
- States the method explicitly (`-X <verb>`) whenever a body is attached, so a GET with a body stays a GET.
- Treats null and empty `{}` / `[]` / `""` data as no body, so a plain GET stays body-less.
- Reuses ADBKit's `shellQuote`; the duplicated view helpers are removed.

Tests: `swift test` — 297 pass, including 7 new `ReactotronCurl` cases covering GET/POST/PUT with and without bodies, header sorting, and quote escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)