### PR TITLE
Add role and feature SEO landing pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
           mkdir -p _site
           cp -R site/. _site/
           # Reuse the app's PostHog key (a public client-side token) so the site
-          # shares one project; the page no-ops analytics if the secret is unset.
+          # shares one project; analytics no-ops if the secret is unset. Every
+          # page loads the shared analytics.js, so the key is injected once here.
           if [ -n "${POSTHOG_KEY:-}" ]; then
-            sed -i "s|__POSTHOG_KEY__|${POSTHOG_KEY}|g" _site/index.html
+            sed -i "s|__POSTHOG_KEY__|${POSTHOG_KEY}|g" _site/analytics.js
           fi
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:

--- a/site/analytics.js
+++ b/site/analytics.js
@@ -1,0 +1,15 @@
+// PostHog product analytics. The __POSTHOG_KEY__ placeholder is replaced at
+// deploy time from the POSTHOG_KEY secret; analytics no-ops if it is unset
+// (local checkouts, forks), so this file is safe to open without a build.
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+var PH_KEY = "__POSTHOG_KEY__";
+if (PH_KEY.indexOf("phc_") === 0) {
+  posthog.init(PH_KEY, {
+    api_host: "https://us.i.posthog.com",
+    capture_pageview: true,
+    capture_pageleave: true,
+    autocapture: true,
+    respect_dnt: true,
+    person_profiles: "identified_only"
+  });
+}

--- a/site/for-android-developers.html
+++ b/site/for-android-developers.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Android Debugging Tool for Developers on macOS — Droidective</title>
+  <meta name="description" content="Droidective is a free, open-source Android debugging tool for developers on macOS: live logcat, performance graphs, file explorer, app control, and a ⌘K command palette over adb — no terminal." />
+  <meta name="keywords" content="android debugging tool, android developer tool mac, adb gui, logcat viewer mac, android dev tool macos" />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/for-android-developers.html" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="Android Debugging Tool for Developers on macOS — Droidective" />
+  <meta property="og:description" content="Live logcat, performance graphs, file explorer, app control, and a ⌘K palette over adb — no terminal." />
+  <meta property="og:url" content="https://droidective.com/for-android-developers.html" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-logcat.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <script src="/analytics.js"></script>
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --green-bright: #b6f24a; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 960px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: inherit; text-decoration: none; }
+    header { border-bottom: 1px solid var(--line); padding: 18px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); z-index: 10; }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .nav a { color: var(--muted); font-size: 14px; margin-left: 22px; }
+    .nav a:hover { color: var(--text); }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: 11px; font-weight: 700; font-size: 15px; }
+    .btn-primary { background: var(--green); color: var(--ink-900); }
+    .btn-primary:hover { background: var(--green-bright); }
+    .btn-ghost { border: 1px solid var(--line-2); color: var(--text); }
+    .crumb { color: var(--faint); font-family: var(--mono); font-size: 12.5px; margin: 36px 0 0; }
+    .crumb a:hover { color: var(--muted); }
+    .kicker { display: inline-block; font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--green); margin: 14px 0 6px; }
+    h1 { font-size: clamp(32px, 5.5vw, 52px); line-height: 1.05; letter-spacing: -0.03em; margin: 0 0 16px; }
+    h1 .hl { color: var(--green); }
+    .lede { font-size: clamp(17px, 1.6vw, 20px); color: var(--muted); max-width: 60ch; margin: 0 0 30px; }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 14px; }
+    .note { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+    .shot { width: 100%; border: 1px solid var(--line-2); border-radius: var(--radius); margin: 40px 0; display: block; }
+    h2 { font-size: clamp(22px, 3vw, 30px); letter-spacing: -0.02em; margin: 56px 0 22px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; }
+    .card h3 { margin: 0 0 8px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); font-size: 15px; }
+    .card code { font-family: var(--mono); font-size: 0.88em; color: var(--green-bright); }
+    .closer { text-align: center; background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 44px 24px; margin: 64px 0; }
+    .closer h2 { margin: 0 0 18px; }
+    .related { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin-top: 10px; }
+    .related a { color: var(--green); font-size: 14px; }
+    .related a:hover { text-decoration: underline; }
+    footer { border-top: 1px solid var(--line); padding: 28px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/for-qa-and-testers.html">For QA</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="crumb"><a href="/">Droidective</a> / For Android developers</p>
+    <span class="kicker">For Android developers</span>
+    <h1>Your <span class="hl">adb</span> workflow, without the terminal</h1>
+    <p class="lede">Droidective is an all-in-one Android debugging tool for macOS. Tail logcat, watch performance, browse device files, and drive apps — every adb command behind a searchable ⌘K palette, so you stop memorising flags and start shipping.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" data-dl="android-dev" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective">View on GitHub</a>
+    </div>
+    <p class="note">Free &amp; open source · Apple Developer ID-signed &amp; notarized · macOS 14+</p>
+
+    <img class="shot" src="assets/screenshot-logcat.webp" alt="Live logcat with filters in Droidective on macOS" loading="lazy" />
+
+    <h2>The daily debugging loop, in one window</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Live logcat</h3>
+        <p>Stream device logs with instant search, level filters, and per-app scoping — find the stack trace without grepping a terminal.</p>
+      </div>
+      <div class="card">
+        <h3>Performance graphs</h3>
+        <p>Live FPS, per-core CPU, RAM, and per-process usage while your build runs — catch jank and leaks at a glance.</p>
+      </div>
+      <div class="card">
+        <h3>File explorer</h3>
+        <p>Browse, push, and pull files with real progress; full-filesystem access and read-write remount unlock on rooted devices.</p>
+      </div>
+      <div class="card">
+        <h3>App control</h3>
+        <p>Force-stop, clear cache/data, grant or revoke permissions, inspect meminfo and the sandbox, and fire deep links per app.</p>
+      </div>
+      <div class="card">
+        <h3>Custom commands &amp; ⌘K</h3>
+        <p>Save your own adb one-liners and run anything from a Raycast-style command palette — recent commands are one keystroke away.</p>
+      </div>
+      <div class="card">
+        <h3>Device info &amp; props</h3>
+        <p>Read <code>getprop</code>, build/ABI, RAM, storage, battery, and root status in a single overview — no <code>adb shell</code> spelunking.</p>
+      </div>
+    </div>
+
+    <div class="closer">
+      <h2>Spend less time fighting adb</h2>
+      <a class="btn btn-primary" data-dl="android-dev" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <div class="related">
+        <a href="/react-native-debugger.html">React Native debugger →</a>
+        <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
+        <a href="/">All 48 tools →</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a> · <a href="/privacy.html">Privacy</a></div>
+  </footer>
+</body>
+</html>

--- a/site/for-qa-and-testers.html
+++ b/site/for-qa-and-testers.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Android Testing &amp; QA Tool for macOS — Droidective</title>
+  <meta name="description" content="Droidective is a free, open-source Android testing tool for QA and testers on macOS: screen recording, annotated screenshots, one-click bug reports, device and emulator control, and condition simulation — no terminal." />
+  <meta name="keywords" content="android testing tool, qa android mac, android bug report tool, screen recorder android mac, android emulator manager mac" />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/for-qa-and-testers.html" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="Android Testing & QA Tool for macOS — Droidective" />
+  <meta property="og:description" content="Screen recording, annotated screenshots, one-click bug reports, device & emulator control, and condition simulation — no terminal." />
+  <meta property="og:url" content="https://droidective.com/for-qa-and-testers.html" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-catalog.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <script src="/analytics.js"></script>
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --green-bright: #b6f24a; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 960px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: inherit; text-decoration: none; }
+    header { border-bottom: 1px solid var(--line); padding: 18px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); z-index: 10; }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .nav a { color: var(--muted); font-size: 14px; margin-left: 22px; }
+    .nav a:hover { color: var(--text); }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: 11px; font-weight: 700; font-size: 15px; }
+    .btn-primary { background: var(--green); color: var(--ink-900); }
+    .btn-primary:hover { background: var(--green-bright); }
+    .btn-ghost { border: 1px solid var(--line-2); color: var(--text); }
+    .crumb { color: var(--faint); font-family: var(--mono); font-size: 12.5px; margin: 36px 0 0; }
+    .crumb a:hover { color: var(--muted); }
+    .kicker { display: inline-block; font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--green); margin: 14px 0 6px; }
+    h1 { font-size: clamp(32px, 5.5vw, 52px); line-height: 1.05; letter-spacing: -0.03em; margin: 0 0 16px; }
+    h1 .hl { color: var(--green); }
+    .lede { font-size: clamp(17px, 1.6vw, 20px); color: var(--muted); max-width: 60ch; margin: 0 0 30px; }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 14px; }
+    .note { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+    .shot { width: 100%; border: 1px solid var(--line-2); border-radius: var(--radius); margin: 40px 0; display: block; }
+    h2 { font-size: clamp(22px, 3vw, 30px); letter-spacing: -0.02em; margin: 56px 0 22px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; }
+    .card h3 { margin: 0 0 8px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); font-size: 15px; }
+    .card code { font-family: var(--mono); font-size: 0.88em; color: var(--green-bright); }
+    .closer { text-align: center; background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 44px 24px; margin: 64px 0; }
+    .closer h2 { margin: 0 0 18px; }
+    .related { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin-top: 10px; }
+    .related a { color: var(--green); font-size: 14px; }
+    .related a:hover { text-decoration: underline; }
+    footer { border-top: 1px solid var(--line); padding: 28px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/for-support-teams.html">For support</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="crumb"><a href="/">Droidective</a> / For QA &amp; testers</p>
+    <span class="kicker">For QA &amp; testers</span>
+    <h1>Reproduce, capture, and <span class="hl">report bugs</span> in minutes</h1>
+    <p class="lede">Droidective is an Android testing tool built for QA on macOS. Record the repro, mark up a screenshot, pull a full bug report, and spin up the right emulator — all from one app, no command line and no Android Studio.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" data-dl="qa" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective">View on GitHub</a>
+    </div>
+    <p class="note">Free &amp; open source · Apple Developer ID-signed &amp; notarized · macOS 14+</p>
+
+    <img class="shot" src="assets/screenshot-catalog.webp" alt="Droidective's tool catalog for Android QA on macOS" loading="lazy" />
+
+    <h2>From repro to ticket, without the friction</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Screen recording</h3>
+        <p>Record the exact steps to reproduce a bug straight from the device — bundled scrcpy and ffmpeg, no setup — then attach the clip to the ticket.</p>
+      </div>
+      <div class="card">
+        <h3>Annotated screenshots</h3>
+        <p>Capture and mark up with arrows, shapes, text, and redaction — blur out PII before the screenshot leaves your Mac.</p>
+      </div>
+      <div class="card">
+        <h3>One-click bug report</h3>
+        <p>Pull a full Android bug report and device state in a click, so developers get the logs and context they need the first time.</p>
+      </div>
+      <div class="card">
+        <h3>Device &amp; emulator control</h3>
+        <p>Launch and manage AVDs, switch between physical devices, and connect wirelessly — test the matrix without juggling terminals.</p>
+      </div>
+      <div class="card">
+        <h3>Simulate conditions</h3>
+        <p>Flip dark mode, change locale, throttle the network, and adjust battery state to reproduce edge cases on demand.</p>
+      </div>
+      <div class="card">
+        <h3>Logcat &amp; crashes</h3>
+        <p>Watch logcat live and catch crashes with filters, so an intermittent failure is captured the moment it happens.</p>
+      </div>
+    </div>
+
+    <div class="closer">
+      <h2>Better bug reports, far less back-and-forth</h2>
+      <a class="btn btn-primary" data-dl="qa" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <div class="related">
+        <a href="/for-android-developers.html">For Android developers →</a>
+        <a href="/for-support-teams.html">For support teams →</a>
+        <a href="/">All 48 tools →</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a> · <a href="/privacy.html">Privacy</a></div>
+  </footer>
+</body>
+</html>

--- a/site/for-support-teams.html
+++ b/site/for-support-teams.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Android Support &amp; Diagnostics Tool for macOS — Droidective</title>
+  <meta name="description" content="Droidective is a free, open-source Android support and diagnostics tool for macOS: screen mirroring, one-click bug reports and log pulls, device health, and file retrieval — no terminal, so any support engineer can use it." />
+  <meta name="keywords" content="android support tool, android diagnostics mac, pull android logs mac, android screen mirroring support, adb gui support" />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/for-support-teams.html" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="Android Support & Diagnostics Tool for macOS — Droidective" />
+  <meta property="og:description" content="Screen mirroring, one-click bug reports and log pulls, device health, and file retrieval — no terminal." />
+  <meta property="og:url" content="https://droidective.com/for-support-teams.html" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <script src="/analytics.js"></script>
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --green-bright: #b6f24a; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 960px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: inherit; text-decoration: none; }
+    header { border-bottom: 1px solid var(--line); padding: 18px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); z-index: 10; }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .nav a { color: var(--muted); font-size: 14px; margin-left: 22px; }
+    .nav a:hover { color: var(--text); }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: 11px; font-weight: 700; font-size: 15px; }
+    .btn-primary { background: var(--green); color: var(--ink-900); }
+    .btn-primary:hover { background: var(--green-bright); }
+    .btn-ghost { border: 1px solid var(--line-2); color: var(--text); }
+    .crumb { color: var(--faint); font-family: var(--mono); font-size: 12.5px; margin: 36px 0 0; }
+    .crumb a:hover { color: var(--muted); }
+    .kicker { display: inline-block; font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--green); margin: 14px 0 6px; }
+    h1 { font-size: clamp(32px, 5.5vw, 52px); line-height: 1.05; letter-spacing: -0.03em; margin: 0 0 16px; }
+    h1 .hl { color: var(--green); }
+    .lede { font-size: clamp(17px, 1.6vw, 20px); color: var(--muted); max-width: 60ch; margin: 0 0 30px; }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 14px; }
+    .note { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+    .shot { width: 100%; border: 1px solid var(--line-2); border-radius: var(--radius); margin: 40px 0; display: block; }
+    h2 { font-size: clamp(22px, 3vw, 30px); letter-spacing: -0.02em; margin: 56px 0 22px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; }
+    .card h3 { margin: 0 0 8px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); font-size: 15px; }
+    .card code { font-family: var(--mono); font-size: 0.88em; color: var(--green-bright); }
+    .closer { text-align: center; background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 44px 24px; margin: 64px 0; }
+    .closer h2 { margin: 0 0 18px; }
+    .related { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin-top: 10px; }
+    .related a { color: var(--green); font-size: 14px; }
+    .related a:hover { text-decoration: underline; }
+    footer { border-top: 1px solid var(--line); padding: 28px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/for-android-developers.html">For developers</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="crumb"><a href="/">Droidective</a> / For support teams</p>
+    <span class="kicker">For support &amp; field engineers</span>
+    <h1>See the device, pull the <span class="hl">diagnostics</span>, close the ticket</h1>
+    <p class="lede">Droidective gives support teams a no-terminal way to diagnose Android devices on a Mac. Mirror the screen to see exactly what the user sees, pull a bug report and logs in one click, and check device health — no adb knowledge required.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" data-dl="support" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective">View on GitHub</a>
+    </div>
+    <p class="note">Free &amp; open source · Apple Developer ID-signed &amp; notarized · macOS 14+</p>
+
+    <img class="shot" src="assets/screenshot-home.png" alt="Droidective device overview and diagnostics on macOS" loading="lazy" />
+
+    <h2>Diagnose without the command line</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Screen mirroring</h3>
+        <p>Mirror the connected device live to reproduce what the user is reporting — over USB or Wi-Fi, scrcpy bundled in.</p>
+      </div>
+      <div class="card">
+        <h3>One-click bug report</h3>
+        <p>Capture a full Android bug report and device state in a click to attach to the case — no copy-pasting from a shell.</p>
+      </div>
+      <div class="card">
+        <h3>Device health</h3>
+        <p>Battery, storage, RAM, CPU, build, and root status in one overview, so you can triage hardware vs. software fast.</p>
+      </div>
+      <div class="card">
+        <h3>Pull the problem file</h3>
+        <p>Grab a log, database, or config off the device with the file explorer — real progress, no sync-protocol guesswork.</p>
+      </div>
+      <div class="card">
+        <h3>Logcat with filters</h3>
+        <p>Tail and filter logs to confirm an error reproduces, then export it straight into the ticket.</p>
+      </div>
+      <div class="card">
+        <h3>No terminal required</h3>
+        <p>Everything is a click. Anyone on the team can run it — no adb commands, no SDK setup, just the app.</p>
+      </div>
+    </div>
+
+    <div class="closer">
+      <h2>Faster triage, happier users</h2>
+      <a class="btn btn-primary" data-dl="support" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <div class="related">
+        <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
+        <a href="/for-android-developers.html">For Android developers →</a>
+        <a href="/">All 48 tools →</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a> · <a href="/privacy.html">Privacy</a></div>
+  </footer>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -52,21 +52,23 @@
   }
   </script>
 
-  <!-- PostHog product analytics — key injected at deploy from the POSTHOG_KEY secret -->
-  <script>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    var PH_KEY = "__POSTHOG_KEY__";
-    if (PH_KEY.indexOf("phc_") === 0) {
-      posthog.init(PH_KEY, {
-        api_host: "https://us.i.posthog.com",
-        capture_pageview: true,
-        capture_pageleave: true,
-        autocapture: true,
-        respect_dnt: true,
-        person_profiles: "identified_only"
-      });
-    }
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      { "@type": "Question", "name": "Is it really free?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Droidective is MIT-licensed and fully open source — no account, no paywall, no pro tier. Star it, fork it, ship it." } },
+      { "@type": "Question", "name": "Is it signed and safe to open?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Release builds are signed with an Apple Developer ID and notarized by Apple, so they open with a normal double-click — no Gatekeeper workaround needed. Everything is open source, and you can build from source if you prefer." } },
+      { "@type": "Question", "name": "Do I need a rooted device?", "acceptedAnswer": { "@type": "Answer", "text": "No. Everything works on a normal device. A few extras — full-filesystem browsing, saved Wi-Fi passwords, SELinux mode and read-write remount — unlock automatically when root is available." } },
+      { "@type": "Question", "name": "What do I need installed?", "acceptedAnswer": { "@type": "Answer", "text": "Just Android adb. Droidective finds it via ANDROID_HOME, the default SDK path, or Homebrew, and offers a one-click install if it is missing. scrcpy and ffmpeg ship inside the app, so mirroring, recording, and video export work out of the box — only the Android emulator is optional, for AVD management." } },
+      { "@type": "Question", "name": "Does it send my data anywhere?", "acceptedAnswer": { "@type": "Answer", "text": "Anonymous crash reports and usage analytics are on by default (opt-out) — both disclosed on first launch and controlled in Settings → Privacy. Device serials, file paths, and command contents are never sent." } },
+      { "@type": "Question", "name": "Does it work with React Native?", "acceptedAnswer": { "@type": "Answer", "text": "Yes — there is a dedicated React Native hub: open the dev menu, reload the JS bundle, reverse the Metro port, save deep links per app, and set the dev-server host." } },
+      { "@type": "Question", "name": "Apple Silicon or Intel?", "acceptedAnswer": { "@type": "Answer", "text": "Both. Droidective runs on any Mac with macOS 14 Sonoma or later." } }
+    ]
+  }
   </script>
+
+  <script src="/analytics.js"></script>
 
   <style>
     :root {
@@ -792,6 +794,11 @@ Pixel 8     device</pre>
           <a href="https://github.com/Droidective/Droidective/issues">Issues</a>
           <a href="https://github.com/Droidective/Droidective/blob/main/LICENSE">License</a>
           <a href="/privacy.html">Privacy</a>
+          <a href="/for-android-developers.html">For Android developers</a>
+          <a href="/for-qa-and-testers.html">For QA &amp; testers</a>
+          <a href="/for-support-teams.html">For support teams</a>
+          <a href="/react-native-debugger.html">React Native debugger</a>
+          <a href="/scrcpy-gui-mac.html">scrcpy GUI for Mac</a>
         </div>
       </div>
       <p class="disclaimer">

--- a/site/react-native-debugger.html
+++ b/site/react-native-debugger.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>React Native Debugger for macOS — Droidective</title>
+  <meta name="description" content="Droidective is a free, open-source React Native debugger for macOS: built-in Reactotron, the dev menu, JS reload, Metro port reverse, live logcat, and performance monitoring over adb — no terminal." />
+  <meta name="keywords" content="react native debugger, react native debugger mac, reactotron mac, debug react native macos, metro bundler, react native logcat" />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/react-native-debugger.html" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="React Native Debugger for macOS — Droidective" />
+  <meta property="og:description" content="Built-in Reactotron, dev menu, JS reload, Metro port reverse, logcat, and performance monitoring — one native macOS app, no terminal." />
+  <meta property="og:url" content="https://droidective.com/react-native-debugger.html" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-react.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <script src="/analytics.js"></script>
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --green-bright: #b6f24a; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 960px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: inherit; text-decoration: none; }
+    header { border-bottom: 1px solid var(--line); padding: 18px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); z-index: 10; }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .nav a { color: var(--muted); font-size: 14px; margin-left: 22px; }
+    .nav a:hover { color: var(--text); }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: 11px; font-weight: 700; font-size: 15px; }
+    .btn-primary { background: var(--green); color: var(--ink-900); }
+    .btn-primary:hover { background: var(--green-bright); }
+    .btn-ghost { border: 1px solid var(--line-2); color: var(--text); }
+    .crumb { color: var(--faint); font-family: var(--mono); font-size: 12.5px; margin: 36px 0 0; }
+    .crumb a:hover { color: var(--muted); }
+    h1 { font-size: clamp(32px, 5.5vw, 52px); line-height: 1.05; letter-spacing: -0.03em; margin: 14px 0 16px; }
+    h1 .hl { color: var(--green); }
+    .lede { font-size: clamp(17px, 1.6vw, 20px); color: var(--muted); max-width: 60ch; margin: 0 0 30px; }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 14px; }
+    .note { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+    .shot { width: 100%; border: 1px solid var(--line-2); border-radius: var(--radius); margin: 40px 0; display: block; }
+    h2 { font-size: clamp(22px, 3vw, 30px); letter-spacing: -0.02em; margin: 56px 0 22px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; }
+    .card h3 { margin: 0 0 8px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); font-size: 15px; }
+    .card code { font-family: var(--mono); font-size: 0.88em; color: var(--green-bright); }
+    .closer { text-align: center; background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 44px 24px; margin: 64px 0; }
+    .closer h2 { margin: 0 0 18px; }
+    .related { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin-top: 10px; }
+    .related a { color: var(--green); font-size: 14px; }
+    .related a:hover { text-decoration: underline; }
+    footer { border-top: 1px solid var(--line); padding: 28px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/scrcpy-gui-mac.html">scrcpy GUI</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="crumb"><a href="/">Droidective</a> / React Native debugger</p>
+    <h1>The <span class="hl">React Native debugger</span> for macOS</h1>
+    <p class="lede">Droidective puts React Native debugging in one native Mac app — a dedicated RN hub with built-in Reactotron, the dev menu, JS reload, Metro port forwarding, and live logcat, all over <code>adb</code>. No terminal, no extra installs.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" data-dl="rn" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective">View on GitHub</a>
+    </div>
+    <p class="note">Free &amp; open source · Apple Developer ID-signed &amp; notarized · macOS 14+</p>
+
+    <img class="shot" src="assets/screenshot-react.webp" alt="Droidective's React Native debugging hub on macOS" loading="lazy" />
+
+    <h2>Everything you reach for while debugging RN</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>Built-in Reactotron</h3>
+        <p>Inspect state, dispatched actions, API calls, and logs from a Reactotron client built into the app — nothing separate to launch or wire up.</p>
+      </div>
+      <div class="card">
+        <h3>The RN dev hub</h3>
+        <p>Open the dev menu, reload the JS bundle, reverse the Metro port (<code>8081</code>), set the dev-server host, and save deep links per app — one screen, one keystroke each.</p>
+      </div>
+      <div class="card">
+        <h3>Logcat, filtered for RN</h3>
+        <p>Tail device logs with live search and filters to catch red-box errors, native exceptions, and the noisy bridge output around them.</p>
+      </div>
+      <div class="card">
+        <h3>Performance you can see</h3>
+        <p>Live FPS, per-core CPU, RAM, and per-process stats while your app runs — spot jank and leaks without Android Studio open.</p>
+      </div>
+      <div class="card">
+        <h3>Mirror &amp; capture</h3>
+        <p>Screen-mirror the device on your Mac (scrcpy is bundled), record sessions, and grab annotated screenshots for bug reports.</p>
+      </div>
+      <div class="card">
+        <h3>Deep links in one click</h3>
+        <p>Save and fire universal/custom-scheme deep links per app to jump straight into the screen you're testing.</p>
+      </div>
+    </div>
+
+    <div class="closer">
+      <h2>Debug React Native without the terminal</h2>
+      <a class="btn btn-primary" data-dl="rn" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <div class="related">
+        <a href="/">All 48 tools →</a>
+        <a href="/scrcpy-gui-mac.html">scrcpy GUI for Mac →</a>
+        <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a> · <a href="/privacy.html">Privacy</a></div>
+  </footer>
+</body>
+</html>

--- a/site/scrcpy-gui-mac.html
+++ b/site/scrcpy-gui-mac.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>scrcpy GUI for Mac — Mirror &amp; Record Android | Droidective</title>
+  <meta name="description" content="Droidective is a free, open-source scrcpy GUI for Mac: mirror and record your Android screen with no terminal and no install — scrcpy and ffmpeg ship inside the app." />
+  <meta name="keywords" content="scrcpy gui mac, scrcpy mac app, scrcpy gui, android screen mirroring mac, record android screen mac, vysor alternative mac" />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/scrcpy-gui-mac.html" />
+  <link rel="icon" type="image/png" href="assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="scrcpy GUI for Mac — Mirror & Record Android | Droidective" />
+  <meta property="og:description" content="Mirror and record your Android screen on macOS with no terminal. scrcpy and ffmpeg are bundled — nothing to brew install." />
+  <meta property="og:url" content="https://droidective.com/scrcpy-gui-mac.html" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-device.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <script src="/analytics.js"></script>
+  <style>
+    :root {
+      --ink-900: #0a0c0b; --ink-850: #0d0f0e; --ink-800: #121514; --ink-700: #16191a;
+      --line: rgba(231, 234, 229, 0.08); --line-2: rgba(231, 234, 229, 0.14);
+      --green: #9be021; --green-bright: #b6f24a; --glow: rgba(155, 224, 33, 0.30);
+      --text: #e7eae5; --muted: #99a39a; --faint: #69716a;
+      --maxw: 960px; --radius: 16px;
+      --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: var(--sans); color: var(--text); background: var(--ink-850); line-height: 1.6; -webkit-font-smoothing: antialiased; }
+    .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+    a { color: inherit; text-decoration: none; }
+    header { border-bottom: 1px solid var(--line); padding: 18px 0; position: sticky; top: 0; background: rgba(13, 15, 14, 0.72); backdrop-filter: blur(10px); z-index: 10; }
+    header .wrap { display: flex; align-items: center; justify-content: space-between; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; font-weight: 700; }
+    .brand img { width: 26px; height: 26px; }
+    .nav a { color: var(--muted); font-size: 14px; margin-left: 22px; }
+    .nav a:hover { color: var(--text); }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; border-radius: 11px; font-weight: 700; font-size: 15px; }
+    .btn-primary { background: var(--green); color: var(--ink-900); }
+    .btn-primary:hover { background: var(--green-bright); }
+    .btn-ghost { border: 1px solid var(--line-2); color: var(--text); }
+    .crumb { color: var(--faint); font-family: var(--mono); font-size: 12.5px; margin: 36px 0 0; }
+    .crumb a:hover { color: var(--muted); }
+    h1 { font-size: clamp(32px, 5.5vw, 52px); line-height: 1.05; letter-spacing: -0.03em; margin: 14px 0 16px; }
+    h1 .hl { color: var(--green); }
+    .lede { font-size: clamp(17px, 1.6vw, 20px); color: var(--muted); max-width: 60ch; margin: 0 0 30px; }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 14px; }
+    .note { color: var(--faint); font-size: 13px; font-family: var(--mono); }
+    .shot { width: 100%; border: 1px solid var(--line-2); border-radius: var(--radius); margin: 40px 0; display: block; }
+    h2 { font-size: clamp(22px, 3vw, 30px); letter-spacing: -0.02em; margin: 56px 0 22px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; }
+    .card { background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 22px; }
+    .card h3 { margin: 0 0 8px; font-size: 17px; }
+    .card p { margin: 0; color: var(--muted); font-size: 15px; }
+    .card code { font-family: var(--mono); font-size: 0.88em; color: var(--green-bright); }
+    .closer { text-align: center; background: var(--ink-800); border: 1px solid var(--line); border-radius: var(--radius); padding: 44px 24px; margin: 64px 0; }
+    .closer h2 { margin: 0 0 18px; }
+    .related { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin-top: 10px; }
+    .related a { color: var(--green); font-size: 14px; }
+    .related a:hover { text-decoration: underline; }
+    footer { border-top: 1px solid var(--line); padding: 28px 0; color: var(--faint); font-size: 13px; }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <a class="brand" href="/"><img src="assets/icon.png" alt="" /> Droidective</a>
+      <nav class="nav">
+        <a href="/">Home</a>
+        <a href="/react-native-debugger.html">React Native</a>
+        <a href="https://github.com/Droidective/Droidective">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p class="crumb"><a href="/">Droidective</a> / scrcpy GUI for Mac</p>
+    <h1>A <span class="hl">scrcpy GUI for Mac</span> — mirror &amp; record, no terminal</h1>
+    <p class="lede">Droidective wraps scrcpy in a native macOS app. Mirror your Android screen, record it, and grab annotated screenshots — with scrcpy and ffmpeg bundled inside, so there's nothing to <code>brew install</code> and no command line to memorise.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" data-dl="scrcpy" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective">View on GitHub</a>
+    </div>
+    <p class="note">Free &amp; open source · Apple Developer ID-signed &amp; notarized · macOS 14+</p>
+
+    <img class="shot" src="assets/screenshot-device.webp" alt="Droidective mirroring an Android device on macOS via scrcpy" loading="lazy" />
+
+    <h2>scrcpy, without the command line</h2>
+    <div class="grid">
+      <div class="card">
+        <h3>One-keystroke mirroring</h3>
+        <p>Low-latency mirror of any connected device, started from a click or the ⌘K palette — no <code>scrcpy</code> flags to remember.</p>
+      </div>
+      <div class="card">
+        <h3>Record with no ffmpeg setup</h3>
+        <p>Capture the screen through a bundled scrcpy server and a static ffmpeg build, then trim and export the clip — all inside the app.</p>
+      </div>
+      <div class="card">
+        <h3>Annotated screenshots</h3>
+        <p>Grab a frame and mark it up — pen, highlighter, shapes, arrows, text, and redaction — before you save or copy.</p>
+      </div>
+      <div class="card">
+        <h3>Nothing to install</h3>
+        <p>scrcpy and ffmpeg ship inside Droidective. Only Android <code>adb</code> is needed, with a one-click install if it's missing.</p>
+      </div>
+      <div class="card">
+        <h3>Wireless or USB</h3>
+        <p>Mirror over USB or connect wirelessly — pair and reconnect to devices over Wi-Fi from the Connection hub.</p>
+      </div>
+      <div class="card">
+        <h3>47 more adb tools</h3>
+        <p>Logcat, file explorer, performance graphs, app management, emulators, and a searchable command palette — one app for everything.</p>
+      </div>
+    </div>
+
+    <div class="closer">
+      <h2>Mirror and record Android on your Mac</h2>
+      <a class="btn btn-primary" data-dl="scrcpy" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
+      <div class="related">
+        <a href="/">All 48 tools →</a>
+        <a href="/react-native-debugger.html">React Native debugger →</a>
+        <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="wrap">© 2026 Rohindh R · <a href="/">droidective.com</a> · <a href="/privacy.html">Privacy</a></div>
+  </footer>
+</body>
+</html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -7,6 +7,36 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://droidective.com/for-android-developers.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://droidective.com/for-qa-and-testers.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://droidective.com/for-support-teams.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://droidective.com/react-native-debugger.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://droidective.com/scrcpy-gui-mac.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://droidective.com/privacy.html</loc>
     <lastmod>2026-06-27</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
Adds keyword- and persona-targeted landing pages to capture long-tail search and let visitors self-select by role.

## Pages (each: own title/description/canonical/OG, internal links, sitemap entry)
**By role**
- `for-android-developers.html` — adb workflow: logcat, performance, files, app control, ⌘K palette
- `for-qa-and-testers.html` — repro, screen recording, annotated screenshots, one-click bug report, emulators
- `for-support-teams.html` — screen mirroring, diagnostics, log/bug-report pull, no terminal

**By feature**
- `react-native-debugger.html` — Reactotron, dev hub, Metro, logcat
- `scrcpy-gui-mac.html` — mirroring & recording, bundled scrcpy/ffmpeg

## Supporting changes
- `FAQPage` structured data on the homepage, built from the existing FAQ (eligible for rich results)
- Extract the PostHog snippet into a shared `analytics.js` loaded by every page, so the new pages are tracked too; CI injects the key into `analytics.js`
- All pages linked from the footer and listed in `sitemap.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)