### PR TITLE
Bound Crash Catcher output so a large crash log can't freeze the UI

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
+++ b/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
@@ -20,6 +20,11 @@ public enum CrashFormat: String, Sendable, CaseIterable {
 public struct CrashExtractor: Sendable {
     public static let crashPattern = "FATAL EXCEPTION|AndroidRuntime|ReactNativeJS|FATAL SIGNAL"
 
+    /// Cap the logcat dump we pull. The crash/main buffers can hold very large
+    /// lines (RN apps log big payloads), and the default 10 MB ceiling is far
+    /// more than the UI can render; 512 KB is plenty to find the latest crash.
+    static let maxLogcatBytes = 512 * 1024
+
     let client: AdbClient
 
     public init(client: AdbClient) {
@@ -41,6 +46,20 @@ public struct CrashExtractor: Sendable {
         return lines[start..<end].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Keep the rendered crash small. A fatal log line can be huge (RN payload
+    /// logging) and the crash buffer isn't otherwise trimmed, so the latest
+    /// crash can balloon into a multi-megabyte string that freezes the UI when
+    /// shown as a selectable Text. Keep the most recent lines (crashes are
+    /// chronological, newest last) under a character ceiling.
+    static func boundedBlock(_ block: String, maxLines: Int = 200, maxChars: Int = 64 * 1024) -> String {
+        var lines = block.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > maxLines {
+            lines = Array(lines.suffix(maxLines))
+        }
+        let result = lines.joined(separator: "\n")
+        return result.count > maxChars ? String(result.suffix(maxChars)) : result
+    }
+
     public static func format(_ block: String, as format: CrashFormat) -> String {
         switch format {
         case .slack: return "```\n\(block)\n```"
@@ -51,14 +70,19 @@ public struct CrashExtractor: Sendable {
 
     /// Last crash from the device, formatted — nil when none found.
     public func lastCrash(serial: String, format: CrashFormat) async throws(AdbError) -> String? {
-        let crashBuffer = try await client.run(on: serial, ["logcat", "-d", "-b", "crash", "-t", "300"])
+        let crashBuffer = try await client.run(
+            on: serial, ["logcat", "-d", "-b", "crash", "-t", "300"], maxOutputBytes: Self.maxLogcatBytes
+        )
         var block = crashBuffer.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if block.isEmpty {
-            let mainBuffer = try await client.run(on: serial, ["logcat", "-d", "-b", "main", "-t", "1000"])
+            let mainBuffer = try await client.run(
+                on: serial, ["logcat", "-d", "-b", "main", "-t", "1000"], maxOutputBytes: Self.maxLogcatBytes
+            )
             block = Self.extractLastCrash(mainBuffer.stdout)
         }
 
+        block = Self.boundedBlock(block)
         guard !block.isEmpty else { return nil }
         return Self.format(block, as: format)
     }

--- a/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
@@ -64,4 +64,34 @@ import Testing
 
         #expect(try await extractor.lastCrash(serial: "S1", format: .plain) == nil)
     }
+
+    @Test func boundedBlockKeepsShortInputUnchanged() {
+        let s = "line1\nline2\nline3"
+        #expect(CrashExtractor.boundedBlock(s) == s)
+    }
+
+    @Test func boundedBlockKeepsMostRecentLines() {
+        let many = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        let bounded = CrashExtractor.boundedBlock(many, maxLines: 50, maxChars: 1_000_000)
+        let lines = bounded.split(separator: "\n")
+        #expect(lines.count == 50)
+        #expect(lines.last == "line 1000")
+        #expect(lines.first == "line 951")
+    }
+
+    @Test func boundedBlockCapsAHugeSingleLine() {
+        let huge = String(repeating: "x", count: 200_000)
+        #expect(CrashExtractor.boundedBlock(huge, maxChars: 64 * 1024).count <= 64 * 1024)
+    }
+
+    @Test func lastCrashBoundsAHugeCrashBuffer() async throws {
+        let runner = MockProcessRunner()
+        let huge = (1...5000).map { "E AndroidRuntime: FATAL EXCEPTION line \($0)" }.joined(separator: "\n")
+        runner.script(argsPrefix: ["-s", "S1", "logcat", "-d", "-b", "crash"], stdout: huge)
+        let extractor = CrashExtractor(client: await makeTestClient(runner: runner))
+
+        let crash = try await extractor.lastCrash(serial: "S1", format: .plain)
+        #expect((crash?.split(separator: "\n").count ?? 0) <= 200)
+        #expect(crash?.contains("line 5000") == true)
+    }
 }


### PR DESCRIPTION
Crash Catcher renders the fetched crash as a selectable monospaced `Text` on the main thread. The crash-buffer path set `block` to the *entire* logcat dump (only the main-buffer fallback ran the line-bounded `extractLastCrash`), and the dump itself was capped at the default 10 MB. A fatal log with very large lines — common when a React Native app logs big payloads — became a multi-megabyte string, and laying that out as selectable text froze the UI.

- Cap the logcat dump at 512 KB at the source (`maxOutputBytes`).
- Bound the rendered block to the most recent 200 lines / 64 K characters (`boundedBlock`), applied to both buffer paths.

The recon hypothesis that `extractLastCrash`'s `String.split` blocked the MainActor was incorrect: `CrashExtractor` is a nonisolated `struct`, so its async methods run on the global executor (SE-0338). The freeze was the size of the text being rendered, not the parse.

Tests: `swift test` — 301 pass, including 4 new cases covering `boundedBlock` and a huge crash buffer bounded end-to-end.

**Note:** this addresses the most plausible cause (unbounded crash text on the main thread). If a freeze is still reproducible, I'd confirm the exact stack via Sentry (Droidective's own hang reports) — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)