### PR TITLE
Add toast dismiss; show notifications Clear all only when >1

### DIFF
--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -33,8 +33,8 @@ struct NotificationPanelView: View {
             Text("Notifications")
                 .font(.headline)
             Spacer()
-            if !state.notifications.isEmpty {
-                Button("Clear") { state.clearNotifications() }
+            if state.notifications.count > 1 {
+                Button("Clear all") { state.clearNotifications() }
                     .buttonStyle(.plain)
                     .font(.callout)
                     .foregroundStyle(.textMuted)

--- a/App/Sources/Root/ToastOverlay.swift
+++ b/App/Sources/Root/ToastOverlay.swift
@@ -19,6 +19,7 @@ struct ToastOverlay: View {
 }
 
 private struct ToastView: View {
+    @Environment(AppState.self) private var state
     let toast: Toast
 
     var body: some View {
@@ -47,6 +48,15 @@ private struct ToastView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
             }
+
+            Button { state.dismissToast(toast.id) } label: {
+                Image(systemName: "xmark")
+                    .font(.caption)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.textMuted)
+            .help("Dismiss")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -731,6 +731,10 @@ final class AppState {
         notifications.removeAll { $0.id == id }
     }
 
+    func dismissToast(_ id: UUID) {
+        toasts.removeAll { $0.id == id }
+    }
+
     // MARK: - Role
 
     /// Apply the user's role choice (first-run or "Change role"): curate the


### PR DESCRIPTION
Per #6:
- The transient ("flowing") toast had no dismiss control — added a close (×) button so it can be dismissed before the 5s auto-timeout.
- The notifications panel's bulk-clear button now reads "Clear all" and shows only when there is more than one notification; a single notification is removed with its existing hover ×.

Per-notification hover-dismiss in the panel already existed and is unchanged.

Builds clean; visual review folds into the v2.6.1 pass (Warp can't grant Screen Recording mid-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)