### PR TITLE
Make the Reactotron timeline search obvious

### DIFF
--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -915,8 +915,7 @@ private struct TimelinePane: View {
             .labelsHidden()
             .frame(width: 110)
 
-            TextField("Search…", text: $search)
-                .brandField()
+            SearchField(prompt: "Search…", text: $search)
                 .frame(maxWidth: 200)
 
             Spacer()

--- a/App/Sources/SearchField.swift
+++ b/App/Sources/SearchField.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A text field that reads as search: a leading magnifying glass, a clear
+/// button once there's text, and the same brand-green focus ring as
+/// ``brandField()`` (which on its own carries no search affordance).
+struct SearchField: View {
+    let prompt: String
+    @Binding var text: String
+    @FocusState private var focused: Bool
+    @Environment(\.controlActiveState) private var controlActive
+
+    private var ringVisible: Bool { focused && controlActive != .inactive }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.textMuted)
+            TextField(prompt, text: $text)
+                .textFieldStyle(.plain)
+                .focused($focused)
+            if !text.isEmpty {
+                Button { text = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.textMuted)
+                .help("Clear search")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(
+                    ringVisible ? Color.brandAccent : Color.borderSubtle,
+                    lineWidth: ringVisible ? 2 : 1
+                )
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { focused = true }
+    }
+}


### PR DESCRIPTION
The Reactotron timeline search was a plain bordered `TextField` with no search affordance, while the state-tree and apps searches already show a magnifying glass — so it didn't read as a search box.

Adds a small `SearchField` component (leading magnifying glass, a clear button once there's text, and the same brand-green focus ring as `brandField()`) and uses it for the timeline search.

Builds clean; visual review folds into the v2.6.1 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)