### PR TITLE
Make adb install notifications meaningful (reason in toast, full detail in panel)

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
@@ -18,19 +18,48 @@ public struct AppInstallService: Sendable {
 
     /// Map adb's install output to a result. adb prints "Success" on success and
     /// "Failure [INSTALL_FAILED_…]" (or a streamed error line) on failure, often
-    /// on a zero exit, so the text — not the exit code — is authoritative.
+    /// on a zero exit, so the text — not the exit code — is authoritative. The
+    /// `message` is a short, plain-English reason for the toast; the full adb
+    /// output is kept in `copyText` for the notifications panel.
     static func parse(_ result: AdbResult) -> FeatureResult {
-        let combined = result.stdout + "\n" + result.stderr
+        let combined = (result.stdout + "\n" + result.stderr)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         if combined.range(of: "Success", options: .caseInsensitive) != nil {
             return FeatureResult(ok: true, message: "Installed")
         }
-        if let range = combined.range(of: "INSTALL_FAILED_[A-Z_]+", options: .regularExpression) {
-            return FeatureResult(ok: false, message: "Install failed — \(combined[range])")
+        let reason: String
+        if let range = combined.range(of: "INSTALL_FAILED_[A-Z0-9_]+", options: .regularExpression) {
+            reason = friendlyReason(String(combined[range]))
+        } else if combined.contains("INSTALL_PARSE_FAILED") {
+            reason = "The APK couldn't be parsed (corrupt or not an APK)."
+        } else {
+            reason = lastMeaningfulLine(combined) ?? "Unknown error."
         }
-        let lastLine = combined
-            .components(separatedBy: .newlines)
+        return FeatureResult(ok: false, message: reason, copyText: combined.isEmpty ? nil : combined)
+    }
+
+    /// Plain-English reason for an adb `INSTALL_FAILED_*` code; the raw code is
+    /// surfaced as-is when unmapped (still searchable).
+    static func friendlyReason(_ code: String) -> String {
+        switch code {
+        case "INSTALL_FAILED_INSUFFICIENT_STORAGE": "Not enough storage on the device."
+        case "INSTALL_FAILED_ALREADY_EXISTS": "The app is already installed."
+        case "INSTALL_FAILED_VERSION_DOWNGRADE": "A newer version is already installed."
+        case "INSTALL_FAILED_UPDATE_INCOMPATIBLE", "INSTALL_FAILED_DUPLICATE_PERMISSION":
+            "It conflicts with an installed copy (signature or permission mismatch) — uninstall it first."
+        case "INSTALL_FAILED_NO_MATCHING_ABIS": "The APK has no native code for this device's CPU."
+        case "INSTALL_FAILED_OLDER_SDK": "The device's Android version is too old for this APK."
+        case "INSTALL_FAILED_TEST_ONLY": "The APK is test-only — build a release APK."
+        case "INSTALL_FAILED_INVALID_APK": "The APK is invalid or corrupt."
+        case "INSTALL_FAILED_USER_RESTRICTED": "The device blocked it — allow USB install / unknown sources."
+        case "INSTALL_FAILED_VERIFICATION_FAILURE": "Play Protect or verification blocked the install."
+        default: code
+        }
+    }
+
+    private static func lastMeaningfulLine(_ text: String) -> String? {
+        text.components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .last { !$0.isEmpty }
-        return FeatureResult(ok: false, message: lastLine ?? "Install failed")
     }
 }

--- a/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct AppInstallServiceTests {
+    private func result(_ stdout: String, _ stderr: String = "") -> AdbResult {
+        AdbResult(stdout: stdout, stderr: stderr, exitCode: 0, timedOut: false)
+    }
+
+    @Test func successIsInstalled() {
+        let r = AppInstallService.parse(result("Success\n"))
+        #expect(r.ok)
+        #expect(r.message == "Installed")
+    }
+
+    @Test func knownFailureCodeBecomesPlainEnglish() {
+        let raw = "Performing Streamed Install\nFailure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
+        let r = AppInstallService.parse(result("", raw))
+        #expect(!r.ok)
+        #expect(r.message == "Not enough storage on the device.")
+        // The full adb output is kept for the notifications panel.
+        #expect(r.copyText?.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE") == true)
+    }
+
+    @Test func signatureMismatchIsExplained() {
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"))
+        #expect(r.message.contains("uninstall it first"))
+    }
+
+    @Test func unmappedCodeIsSurfacedRaw() {
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_FAILED_CONTAINER_ERROR]"))
+        #expect(r.message == "INSTALL_FAILED_CONTAINER_ERROR")
+        #expect(r.copyText?.contains("INSTALL_FAILED_CONTAINER_ERROR") == true)
+    }
+
+    @Test func unrecognizedErrorUsesLastLineAndKeepsFullOutput() {
+        let raw = "Performing Streamed Install\nadb: failed to install app.apk: weird device error"
+        let r = AppInstallService.parse(result("", raw))
+        #expect(!r.ok)
+        #expect(r.message == "adb: failed to install app.apk: weird device error")
+        #expect(r.copyText == raw)
+    }
+
+    @Test func friendlyReasonMapsCommonCodes() {
+        #expect(AppInstallService.friendlyReason("INSTALL_FAILED_ALREADY_EXISTS") == "The app is already installed.")
+        #expect(AppInstallService.friendlyReason("INSTALL_FAILED_NO_MATCHING_ABIS").contains("CPU"))
+    }
+}

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -679,18 +679,35 @@ final class AppState {
                 for url in urls {
                     let name = url.lastPathComponent
                     var ok = 0
+                    var failures: [(serial: String, result: FeatureResult)] = []
                     for serial in serials {
                         let result = (try? await env.engine.appInstall.install(apkPath: url.path, serial: serial))
                             ?? FeatureResult(ok: false, message: "adb not found")
-                        if result.ok { ok += 1 }
+                        if result.ok { ok += 1 } else { failures.append((serial, result)) }
                     }
-                    let message = serials.count == 1
-                        ? (ok == 1 ? "Installed \(name)" : "Couldn't install \(name)")
-                        : "Installed \(name) on \(ok)/\(serials.count) devices"
-                    showToast(Toast(message: message, ok: ok > 0))
+                    showToast(Self.installToast(name: name, ok: ok, total: serials.count, failures: failures))
                 }
             }
         }
+    }
+
+    /// A short install headline for the toast; on failure the full adb output is
+    /// kept in `copyText` so the notifications panel carries the detail without
+    /// dumping it into the transient toast.
+    private static func installToast(
+        name: String, ok: Int, total: Int, failures: [(serial: String, result: FeatureResult)]
+    ) -> Toast {
+        if failures.isEmpty {
+            let message = total == 1 ? "Installed \(name)" : "Installed \(name) on \(total) devices"
+            return Toast(message: message, ok: true)
+        }
+        let message = total == 1
+            ? "Couldn't install \(name) — \(failures[0].result.message)"
+            : "Installed \(name) on \(ok)/\(total) devices — \(failures.count) failed"
+        let detail = failures
+            .map { total == 1 ? ($0.result.copyText ?? $0.result.message) : "\($0.serial): \($0.result.copyText ?? $0.result.message)" }
+            .joined(separator: "\n\n")
+        return Toast(message: message, ok: false, copyText: detail.isEmpty ? nil : detail)
     }
 
     func showToast(_ toast: Toast) {


### PR DESCRIPTION
adb install failures were unhelpful: `parse` returned either a raw `INSTALL_FAILED_*` code or a truncated last line, and `installAPKs` threw that away and showed only "Couldn't install <name>" — no reason, and long errors were truncated in the toast.

- `AppInstallService.parse` maps common `INSTALL_FAILED_*` codes to plain English (insufficient storage, signature/permission mismatch, no matching ABIs, too-old SDK, test-only, …; unmapped codes surfaced raw) and keeps the full adb output in `copyText`.
- `installAPKs` puts the reason in the toast headline ("Couldn't install X — Not enough storage on the device.") and carries the full output in `copyText`, so the notifications panel's Copy gives the complete error without dumping it into the transient toast.

Tests: `swift test` — 6 new `AppInstallService` cases.

**Note:** the panel shows the reason + a Copy button for the full output; if you'd prefer the full detail visually expanded inline, I can add that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)