### PR TITLE
Add a preset command library to custom commands

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/CommandPreset.swift
+++ b/ADBKit/Sources/ADBKit/Services/CommandPreset.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A ready-made adb command the user can add to their custom commands. Every
+/// template is argv-safe (no shell pipes or redirection) so it runs through
+/// `CustomCommandService` unchanged.
+public struct CommandPreset: Identifiable, Sendable, Equatable {
+    public var id: String { name }
+    public let name: String
+    public let command: String
+    public let needsBundle: Bool
+    public let detail: String
+
+    public init(name: String, command: String, needsBundle: Bool = false, detail: String) {
+        self.name = name
+        self.command = command
+        self.needsBundle = needsBundle
+        self.detail = detail
+    }
+}
+
+public extension CommandPreset {
+    /// A small curated library of common adb commands to seed custom commands.
+    static let library: [CommandPreset] = [
+        CommandPreset(name: "Force-stop app", command: "shell am force-stop {bundleId}",
+                      needsBundle: true, detail: "Kill the selected app."),
+        CommandPreset(name: "Clear app data", command: "shell pm clear {bundleId}",
+                      needsBundle: true, detail: "Wipe the selected app's data and cache."),
+        CommandPreset(name: "Launch app", command: "shell monkey -p {bundleId} -c android.intent.category.LAUNCHER 1",
+                      needsBundle: true, detail: "Cold-launch the selected app."),
+        CommandPreset(name: "List installed apps", command: "shell pm list packages -3",
+                      detail: "List user-installed package names."),
+        CommandPreset(name: "Open a URL", command: "shell am start -a android.intent.action.VIEW -d https://example.com",
+                      detail: "Open a URL — edit the address first."),
+        CommandPreset(name: "Press Back", command: "shell input keyevent KEYCODE_BACK",
+                      detail: "Send the Back button."),
+        CommandPreset(name: "Press Home", command: "shell input keyevent KEYCODE_HOME",
+                      detail: "Send the Home button."),
+        CommandPreset(name: "Type text", command: "shell input text hello",
+                      detail: "Type into the focused field — edit the text first."),
+        CommandPreset(name: "Disable animations", command: "shell settings put global window_animation_scale 0",
+                      detail: "Turn the window animation scale off."),
+        CommandPreset(name: "Enable animations", command: "shell settings put global window_animation_scale 1",
+                      detail: "Restore the window animation scale."),
+        CommandPreset(name: "Show touches", command: "shell settings put system show_touches 1",
+                      detail: "Show on-screen touch feedback."),
+        CommandPreset(name: "Battery status", command: "shell dumpsys battery",
+                      detail: "Dump the device battery state."),
+        CommandPreset(name: "Clear logcat", command: "logcat -c",
+                      detail: "Clear the device log buffer."),
+        CommandPreset(name: "Reboot device", command: "reboot",
+                      detail: "Reboot the device."),
+    ]
+}

--- a/ADBKit/Tests/ADBKitTests/CommandPresetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CommandPresetTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct CommandPresetTests {
+    @Test func libraryIsNonEmptyWithUniqueNames() {
+        #expect(!CommandPreset.library.isEmpty)
+        let names = Set(CommandPreset.library.map(\.name))
+        #expect(names.count == CommandPreset.library.count)
+    }
+
+    @Test func everyPresetIsValidArgv() throws {
+        for preset in CommandPreset.library {
+            let args = try CustomCommandService.buildArgs(
+                template: preset.command, bundleId: "com.example.app", serial: "SER123"
+            )
+            #expect(!args.isEmpty, "preset \(preset.name) produced no args")
+        }
+    }
+
+    @Test func bundlePresetsUseTheBundlePlaceholder() {
+        for preset in CommandPreset.library where preset.needsBundle {
+            #expect(preset.command.contains("{bundleId}"), "\(preset.name) needs a bundle but has no {bundleId}")
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -7,6 +7,7 @@ struct CustomCommandsView: View {
     @State private var commands: [CustomCommand] = []
     @State private var editing: CustomCommand?
     @State private var showEditor = false
+    @State private var showPresets = false
     @State private var draftName = ""
     @State private var draftCommand = ""
     @State private var draftNeedsBundle = false
@@ -21,6 +22,10 @@ struct CustomCommandsView: View {
                         .foregroundStyle(.textMuted)
                 }
                 Spacer()
+                Button { showPresets = true } label: {
+                    Label("Presets", systemImage: "square.grid.2x2")
+                }
+                .controlSize(.small)
                 Button {
                     editing = nil
                     draftName = ""
@@ -86,6 +91,7 @@ struct CustomCommandsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task { commands = await state.env.stores.customCommands.load() }
         .sheet(isPresented: $showEditor) { editor }
+        .sheet(isPresented: $showPresets) { presetLibrary }
     }
 
     private var editor: some View {
@@ -152,5 +158,68 @@ struct CustomCommandsView: View {
                 state.showToast(Toast(message: result.message, ok: result.ok))
             }
         }
+    }
+
+    // MARK: - Presets
+
+    private var presetLibrary: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Preset Commands").font(.headline)
+                Spacer()
+                Button("Done") { showPresets = false }
+            }
+            Text("Common adb commands. Add one to your list, then run or edit it.")
+                .font(.footnote)
+                .foregroundStyle(.textMuted)
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(CommandPreset.library) { preset in
+                        presetRow(preset)
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(width: 520, height: 460)
+    }
+
+    private func presetRow(_ preset: CommandPreset) -> some View {
+        let added = commands.contains { $0.name == preset.name }
+        return HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(preset.name)
+                Text("adb \(preset.command)")
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(.textMuted)
+                Text(preset.detail)
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            }
+            Spacer(minLength: 8)
+            if added {
+                Label("Added", systemImage: "checkmark")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            } else {
+                Button("Add") { add(preset) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+        }
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func add(_ preset: CommandPreset) {
+        guard !commands.contains(where: { $0.name == preset.name }) else { return }
+        commands.append(CustomCommand(
+            name: preset.name,
+            command: preset.command,
+            needsBundle: preset.needsBundle,
+            createdAt: Date().timeIntervalSince1970 * 1000
+        ))
+        persist()
     }
 }


### PR DESCRIPTION
Custom commands could only be created from a blank editor (#3 asked for suggestions). This adds a curated library and a way to add them.

- `CommandPreset.library` (ADBKit): 14 argv-safe presets — force-stop, clear data, launch, list packages, open URL, Back/Home keyevents, type text, toggle animations, show touches, battery, clear logcat, reboot.
- A "Presets" button + sheet in `CustomCommandsView`: each preset shows its command + a one-line description and an Add button that drops it into your custom commands (already-added ones show "Added"). From there you run or edit it like any custom command.

Tests: `swift test` — `CommandPreset` cases assert unique names, that every template is valid argv (via `CustomCommandService.buildArgs`), and that bundle presets use `{bundleId}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)