### PR TITLE
Fix Welcome screen layout collapsing in a narrow detail pane

### DIFF
--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -36,6 +36,21 @@ struct ADTApp: App {
     @State private var appState: AppState
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
+    @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
+
+    /// The sidebar and notifications panel are fixed-width, so opening the
+    /// notifications panel on a narrow window would otherwise crush the detail
+    /// pane to uselessness (the welcome title wrapping one letter per line).
+    /// Grow the window's minimum width with whichever side panels are showing,
+    /// so the detail pane always keeps at least `detailMinWidth`.
+    private var minWindowWidth: CGFloat {
+        let detailMinWidth: CGFloat = 360
+        let notifications: CGFloat = appState.showNotifications ? 321 : 0
+        let sidebar: CGFloat = appState.sidebarVisible
+            ? CGFloat(min(max(sidebarWidth, 300), 460))
+            : 0
+        return max(760, sidebar + detailMinWidth + notifications)
+    }
 
     init() {
         // HotkeyManager.install is deferred to RootView.onAppear — Carbon
@@ -54,7 +69,7 @@ struct ADTApp: App {
         WindowGroup(id: "main") {
             RootView()
                 .environment(appState)
-                .frame(minWidth: 760, minHeight: 480)
+                .frame(minWidth: minWindowWidth, minHeight: 480)
                 // Force the brand accent on standard controls (prominent
                 // buttons, switches, sliders) so they stay green regardless of
                 // the Mac's system accent color, which otherwise overrides the

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -32,21 +32,45 @@ struct HomeView: View {
 
     // MARK: - Header
 
+    /// Responsive so a narrow detail pane (e.g. sidebar + notifications panel
+    /// open on a small window) never starves the title into per-character
+    /// wrapping. `ViewThatFits` keeps the role badge inline when there's room
+    /// and wraps it below the title when there isn't; the title scales rather
+    /// than breaking mid-word at the extreme. The subtitle always sits on its
+    /// own full-width line so it wraps cleanly and doesn't skew the fit.
     private var header: some View {
-        HStack(spacing: 16) {
-            Image(colorScheme == .dark ? "AppLogoDark" : "AppLogoLight")
-                .resizable()
-                .frame(width: 60, height: 60)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Welcome to Droidective")
-                    .font(.largeTitle.bold())
-                Text("An Android & React Native debugging command palette, driven over adb.")
-                    .font(.title3)
-                    .foregroundStyle(.textMuted)
+        VStack(alignment: .leading, spacing: 10) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 16) {
+                    logo
+                    Text("Welcome to Droidective")
+                        .font(.largeTitle.bold())
+                        .fixedSize()
+                    Spacer(minLength: 12)
+                    roleBadge
+                }
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .center, spacing: 12) {
+                        logo
+                        Text("Welcome to Droidective")
+                            .font(.largeTitle.bold())
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.6)
+                    }
+                    roleBadge
+                }
             }
-            Spacer(minLength: 12)
-            roleBadge
+            Text("An Android & React Native debugging command palette, driven over adb.")
+                .font(.title3)
+                .foregroundStyle(.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private var logo: some View {
+        Image(colorScheme == .dark ? "AppLogoDark" : "AppLogoLight")
+            .resizable()
+            .frame(width: 60, height: 60)
     }
 
     /// Current role as a pill that opens the picker — the "change this anytime"


### PR DESCRIPTION
The welcome screen's title collapsed into one syllable per line ("Wel / co / me …") when the detail pane was narrow — the header's fixed logo + role badge starved the flexible title.

- `HomeView` header is now responsive (`ViewThatFits`): the role badge sits inline when there's room and wraps below the title when there isn't; the subtitle moved to its own full-width line; the title scales rather than breaking mid-word at the extreme.
- The window's minimum width now grows with the sidebar / notifications panel so the detail pane always keeps ≥360pt — opening the notifications panel can no longer crush the welcome content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)