### PR TITLE
Update install test to match the plain-English failure message

### DIFF
--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -223,7 +223,9 @@ import Testing
             stdout: "", stderr: "adb: failed to install app.apk: Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]",
             exitCode: 1, timedOut: false))
         #expect(!failure.ok)
-        #expect(failure.message.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE"))
+        // parse now returns a plain-English reason; the raw code stays in copyText.
+        #expect(failure.message == "Not enough storage on the device.")
+        #expect(failure.copyText?.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE") == true)
     }
 
     @Test func multiWordSearchMatchesNonContiguousTokens() {


### PR DESCRIPTION
PR #54 made `AppInstallService.parse` return a plain-English reason and keep the raw `INSTALL_FAILED_*` code in `copyText`, but `FeatureEngineTests.installParsesSuccessAndFailure` still asserted the raw code in `message` — so the full `swift test` suite went red on v2.6.1 (the filtered run used for #54 missed it).

Updates the assertion to the new behavior (friendly `message`, raw code in `copyText`). Full suite: 310 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)