### PR TITLE
Keep mirroring alive across device rotation

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
@@ -16,6 +16,8 @@ import Foundation
 public actor MirrorSession {
     public struct DisplaySample: @unchecked Sendable {
         public let sampleBuffer: CMSampleBuffer
+        public let width: Int
+        public let height: Int
     }
 
     public struct Snapshot: @unchecked Sendable {
@@ -210,6 +212,11 @@ public actor MirrorSession {
                    let format = H264Format.formatDescription(sps: sets.sps, pps: sets.pps) {
                     formatDescription = format
                     decoder.setFormat(format)
+                    // A config packet also arrives on rotation, carrying the new
+                    // SPS; scrcpy doesn't resend the stream header, so refresh the
+                    // dimensions from the format here to track orientation changes.
+                    let size = CMVideoFormatDescriptionGetDimensions(format)
+                    dimensions = (Int(size.width), Int(size.height))
                     // Arm a pending recording now so the key frame that follows
                     // this config packet is the recording's first sample.
                     if let url = pendingRecordURL, recorder == nil {
@@ -224,7 +231,10 @@ public actor MirrorSession {
             guard let sampleBuffer = H264Format.sampleBuffer(
                 avcc: avcc, formatDescription: formatDescription, pts: pts) else { return }
 
-            continuation.yield(DisplaySample(sampleBuffer: sampleBuffer))
+            continuation.yield(DisplaySample(
+                sampleBuffer: sampleBuffer,
+                width: dimensions?.width ?? 0,
+                height: dimensions?.height ?? 0))
             decoder.decode(sampleBuffer)
 
             if let recorder {

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
@@ -8,12 +8,19 @@ import SwiftUI
     let displayLayer = AVSampleBufferDisplayLayer()
 
     private var renderer: AVSampleBufferVideoRenderer { displayLayer.sampleBufferRenderer }
+    private var lastDimensions: (width: Int, height: Int)?
 
     init() {
         displayLayer.videoGravity = .resizeAspect
     }
 
-    func enqueue(_ sampleBuffer: CMSampleBuffer) {
+    func enqueue(_ sampleBuffer: CMSampleBuffer, width: Int, height: Int) {
+        // A resolution change (device rotation) needs a flush, or the renderer can
+        // stall on the old format instead of re-priming on the incoming key frame.
+        if let last = lastDimensions, last != (width, height) {
+            renderer.flush()
+        }
+        lastDimensions = (width, height)
         // A failed renderer won't recover until flushed; the next key frame re-primes it.
         if renderer.status == .failed { renderer.flush() }
         renderer.enqueue(sampleBuffer)
@@ -21,6 +28,7 @@ import SwiftUI
 
     func clear() {
         renderer.flush()
+        lastDimensions = nil
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -127,16 +127,19 @@ final class MirrorViewModel {
             do {
                 for try await sample in stream {
                     guard let self else { break }
-                    self.renderer.enqueue(sample.sampleBuffer)
+                    self.renderer.enqueue(sample.sampleBuffer, width: sample.width, height: sample.height)
+                    // Track the live frame size so taps map correctly and the aspect
+                    // rect stays right across rotation, not only at the first frame.
+                    if sample.width > 0, sample.height > 0 {
+                        let size = CGSize(width: sample.width, height: sample.height)
+                        if self.videoSize != size { self.videoSize = size }
+                    }
                     if self.status == .connecting {
                         self.status = .streaming
                         // The transport (incl. the control socket) is connected
                         // once frames flow — fetch the control sender now, not
                         // right after start() when it isn't wired yet.
                         self.sendControl = await self.session?.controlSender()
-                        if let dimensions = await self.session?.currentDimensions() {
-                            self.videoSize = CGSize(width: dimensions.width, height: dimensions.height)
-                        }
                     }
                 }
                 self?.status = .stopped


### PR DESCRIPTION
Mirroring stopped whenever the device/emulator rotated.

**Root cause:** on rotation scrcpy sends a new SPS (config packet) but **not** a new stream header, so `MirrorSession.dimensions` (read from the header) went stale, and the display renderer (`AVSampleBufferVideoRenderer`) stalled on the old format — it only flushed on `.failed`, which a resolution change doesn't reliably trigger.

**Fix:**
- Refresh `dimensions` from the new SPS on every config packet (`CMVideoFormatDescriptionGetDimensions`).
- Carry the live frame size on each `DisplaySample`.
- `MirrorRenderer` flushes when the resolution changes so it re-primes on the rotation key frame.
- `MirrorViewModel.videoSize` updates per-frame, so taps and the aspect rect track the new orientation (not just the first frame).

Builds clean; full `swift test` 310 pass.

⚠️ **Needs device verification:** rotation can't be exercised by unit tests — please confirm on the emulator (rotate a few times during mirroring; the image should keep updating and taps should still land) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)