### PR TITLE
v2.6.1 — bug-fix batch (Reactotron, crash catcher, install, notifications, mirroring, welcome, custom commands)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,22 @@ jobs:
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
             SENTRY_DSN="$SENTRY_DSN" POSTHOG_KEY="$POSTHOG_KEY" \
             CODE_SIGN_IDENTITY="$SIGN_IDENTITY" DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Manual ENABLE_HARDENED_RUNTIME=YES OTHER_CODE_SIGN_FLAGS="--timestamp"
+            CODE_SIGN_STYLE=Manual ENABLE_HARDENED_RUNTIME=YES OTHER_CODE_SIGN_FLAGS="--timestamp" \
+            DEBUG_INFORMATION_FORMAT=dwarf-with-dsym
           SIGN_IDENTITY="$SIGN_IDENTITY" ./scripts/package-dmg.sh "${GITHUB_REF_NAME}"
+      # Upload dSYMs so Sentry can symbolicate first-party frames in crash/app-hang
+      # reports. Without this, our own frames show as <unknown>. Skips cleanly if
+      # the SENTRY_AUTH_TOKEN secret is absent (e.g. forks).
+      - name: Upload dSYMs to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ro-is
+          SENTRY_PROJECT: droidective-mac
+          SENTRY_URL: https://de.sentry.io
+        run: |
+          [[ -n "${SENTRY_AUTH_TOKEN:-}" ]] || { echo "no SENTRY_AUTH_TOKEN secret — skipping dSYM upload"; exit 0; }
+          brew install getsentry/tools/sentry-cli
+          sentry-cli debug-files upload --wait DerivedData/Build/Products/Release
       - name: Notarize and staple
         env:
           AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}

--- a/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
@@ -18,19 +18,48 @@ public struct AppInstallService: Sendable {
 
     /// Map adb's install output to a result. adb prints "Success" on success and
     /// "Failure [INSTALL_FAILED_…]" (or a streamed error line) on failure, often
-    /// on a zero exit, so the text — not the exit code — is authoritative.
+    /// on a zero exit, so the text — not the exit code — is authoritative. The
+    /// `message` is a short, plain-English reason for the toast; the full adb
+    /// output is kept in `copyText` for the notifications panel.
     static func parse(_ result: AdbResult) -> FeatureResult {
-        let combined = result.stdout + "\n" + result.stderr
+        let combined = (result.stdout + "\n" + result.stderr)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         if combined.range(of: "Success", options: .caseInsensitive) != nil {
             return FeatureResult(ok: true, message: "Installed")
         }
-        if let range = combined.range(of: "INSTALL_FAILED_[A-Z_]+", options: .regularExpression) {
-            return FeatureResult(ok: false, message: "Install failed — \(combined[range])")
+        let reason: String
+        if let range = combined.range(of: "INSTALL_FAILED_[A-Z0-9_]+", options: .regularExpression) {
+            reason = friendlyReason(String(combined[range]))
+        } else if combined.contains("INSTALL_PARSE_FAILED") {
+            reason = "The APK couldn't be parsed (corrupt or not an APK)."
+        } else {
+            reason = lastMeaningfulLine(combined) ?? "Unknown error."
         }
-        let lastLine = combined
-            .components(separatedBy: .newlines)
+        return FeatureResult(ok: false, message: reason, copyText: combined.isEmpty ? nil : combined)
+    }
+
+    /// Plain-English reason for an adb `INSTALL_FAILED_*` code; the raw code is
+    /// surfaced as-is when unmapped (still searchable).
+    static func friendlyReason(_ code: String) -> String {
+        switch code {
+        case "INSTALL_FAILED_INSUFFICIENT_STORAGE": "Not enough storage on the device."
+        case "INSTALL_FAILED_ALREADY_EXISTS": "The app is already installed."
+        case "INSTALL_FAILED_VERSION_DOWNGRADE": "A newer version is already installed."
+        case "INSTALL_FAILED_UPDATE_INCOMPATIBLE", "INSTALL_FAILED_DUPLICATE_PERMISSION":
+            "It conflicts with an installed copy (signature or permission mismatch) — uninstall it first."
+        case "INSTALL_FAILED_NO_MATCHING_ABIS": "The APK has no native code for this device's CPU."
+        case "INSTALL_FAILED_OLDER_SDK": "The device's Android version is too old for this APK."
+        case "INSTALL_FAILED_TEST_ONLY": "The APK is test-only — build a release APK."
+        case "INSTALL_FAILED_INVALID_APK": "The APK is invalid or corrupt."
+        case "INSTALL_FAILED_USER_RESTRICTED": "The device blocked it — allow USB install / unknown sources."
+        case "INSTALL_FAILED_VERIFICATION_FAILURE": "Play Protect or verification blocked the install."
+        default: code
+        }
+    }
+
+    private static func lastMeaningfulLine(_ text: String) -> String? {
+        text.components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .last { !$0.isEmpty }
-        return FeatureResult(ok: false, message: lastLine ?? "Install failed")
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
@@ -24,7 +24,10 @@ public struct AppInstallService: Sendable {
     static func parse(_ result: AdbResult) -> FeatureResult {
         let combined = (result.stdout + "\n" + result.stderr)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if combined.range(of: "Success", options: .caseInsensitive) != nil {
+        // adb prints a bare `Success` line on a successful (streamed) install.
+        // Anchor to the start of a line so an error that merely mentions the word
+        // (e.g. "not successful") isn't misread as success and masked.
+        if combined.range(of: "(?m)^\\s*Success", options: .regularExpression) != nil {
             return FeatureResult(ok: true, message: "Installed")
         }
         let reason: String

--- a/ADBKit/Sources/ADBKit/Services/CommandPreset.swift
+++ b/ADBKit/Sources/ADBKit/Services/CommandPreset.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A ready-made adb command the user can add to their custom commands. Every
+/// template is argv-safe (no shell pipes or redirection) so it runs through
+/// `CustomCommandService` unchanged.
+public struct CommandPreset: Identifiable, Sendable, Equatable {
+    public var id: String { name }
+    public let name: String
+    public let command: String
+    public let needsBundle: Bool
+    public let detail: String
+
+    public init(name: String, command: String, needsBundle: Bool = false, detail: String) {
+        self.name = name
+        self.command = command
+        self.needsBundle = needsBundle
+        self.detail = detail
+    }
+}
+
+public extension CommandPreset {
+    /// A small curated library of common adb commands to seed custom commands.
+    static let library: [CommandPreset] = [
+        CommandPreset(name: "Force-stop app", command: "shell am force-stop {bundleId}",
+                      needsBundle: true, detail: "Kill the selected app."),
+        CommandPreset(name: "Clear app data", command: "shell pm clear {bundleId}",
+                      needsBundle: true, detail: "Wipe the selected app's data and cache."),
+        CommandPreset(name: "Launch app", command: "shell monkey -p {bundleId} -c android.intent.category.LAUNCHER 1",
+                      needsBundle: true, detail: "Cold-launch the selected app."),
+        CommandPreset(name: "List installed apps", command: "shell pm list packages -3",
+                      detail: "List user-installed package names."),
+        CommandPreset(name: "Open a URL", command: "shell am start -a android.intent.action.VIEW -d https://example.com",
+                      detail: "Open a URL — edit the address first."),
+        CommandPreset(name: "Press Back", command: "shell input keyevent KEYCODE_BACK",
+                      detail: "Send the Back button."),
+        CommandPreset(name: "Press Home", command: "shell input keyevent KEYCODE_HOME",
+                      detail: "Send the Home button."),
+        CommandPreset(name: "Type text", command: "shell input text hello",
+                      detail: "Type into the focused field — edit the text first."),
+        CommandPreset(name: "Disable animations", command: "shell settings put global window_animation_scale 0",
+                      detail: "Turn the window animation scale off."),
+        CommandPreset(name: "Enable animations", command: "shell settings put global window_animation_scale 1",
+                      detail: "Restore the window animation scale."),
+        CommandPreset(name: "Show touches", command: "shell settings put system show_touches 1",
+                      detail: "Show on-screen touch feedback."),
+        CommandPreset(name: "Battery status", command: "shell dumpsys battery",
+                      detail: "Dump the device battery state."),
+        CommandPreset(name: "Clear logcat", command: "logcat -c",
+                      detail: "Clear the device log buffer."),
+        CommandPreset(name: "Reboot device", command: "reboot",
+                      detail: "Reboot the device."),
+    ]
+}

--- a/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
+++ b/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
@@ -20,6 +20,11 @@ public enum CrashFormat: String, Sendable, CaseIterable {
 public struct CrashExtractor: Sendable {
     public static let crashPattern = "FATAL EXCEPTION|AndroidRuntime|ReactNativeJS|FATAL SIGNAL"
 
+    /// Cap the logcat dump we pull. The crash/main buffers can hold very large
+    /// lines (RN apps log big payloads), and the default 10 MB ceiling is far
+    /// more than the UI can render; 512 KB is plenty to find the latest crash.
+    static let maxLogcatBytes = 512 * 1024
+
     let client: AdbClient
 
     public init(client: AdbClient) {
@@ -41,6 +46,20 @@ public struct CrashExtractor: Sendable {
         return lines[start..<end].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Keep the rendered crash small. A fatal log line can be huge (RN payload
+    /// logging) and the crash buffer isn't otherwise trimmed, so the latest
+    /// crash can balloon into a multi-megabyte string that freezes the UI when
+    /// shown as a selectable Text. Keep the most recent lines (crashes are
+    /// chronological, newest last) under a character ceiling.
+    static func boundedBlock(_ block: String, maxLines: Int = 200, maxChars: Int = 64 * 1024) -> String {
+        var lines = block.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > maxLines {
+            lines = Array(lines.suffix(maxLines))
+        }
+        let result = lines.joined(separator: "\n")
+        return result.count > maxChars ? String(result.suffix(maxChars)) : result
+    }
+
     public static func format(_ block: String, as format: CrashFormat) -> String {
         switch format {
         case .slack: return "```\n\(block)\n```"
@@ -51,14 +70,19 @@ public struct CrashExtractor: Sendable {
 
     /// Last crash from the device, formatted — nil when none found.
     public func lastCrash(serial: String, format: CrashFormat) async throws(AdbError) -> String? {
-        let crashBuffer = try await client.run(on: serial, ["logcat", "-d", "-b", "crash", "-t", "300"])
+        let crashBuffer = try await client.run(
+            on: serial, ["logcat", "-d", "-b", "crash", "-t", "300"], maxOutputBytes: Self.maxLogcatBytes
+        )
         var block = crashBuffer.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if block.isEmpty {
-            let mainBuffer = try await client.run(on: serial, ["logcat", "-d", "-b", "main", "-t", "1000"])
+            let mainBuffer = try await client.run(
+                on: serial, ["logcat", "-d", "-b", "main", "-t", "1000"], maxOutputBytes: Self.maxLogcatBytes
+            )
             block = Self.extractLastCrash(mainBuffer.stdout)
         }
 
+        block = Self.boundedBlock(block)
         guard !block.isEmpty else { return nil }
         return Self.format(block, as: format)
     }

--- a/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
+++ b/ADBKit/Sources/ADBKit/Services/CrashExtractor.swift
@@ -46,18 +46,37 @@ public struct CrashExtractor: Sendable {
         return lines[start..<end].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Keep the rendered crash small. A fatal log line can be huge (RN payload
-    /// logging) and the crash buffer isn't otherwise trimmed, so the latest
-    /// crash can balloon into a multi-megabyte string that freezes the UI when
-    /// shown as a selectable Text. Keep the most recent lines (crashes are
-    /// chronological, newest last) under a character ceiling.
+    /// Keep the rendered crash small without dropping its diagnostic header. A
+    /// fatal log line can be huge (RN payload logging) and the crash buffer
+    /// isn't otherwise trimmed, so the latest crash can balloon into a
+    /// multi-megabyte string that freezes the UI when shown as a selectable
+    /// Text. Android traces lead with the most useful lines (FATAL EXCEPTION,
+    /// the exception type and message) and trail with framework frames, while
+    /// the crash buffer itself is chronological (newest last). Keep both ends —
+    /// the head so the exception is never silently lost, the tail so the newest
+    /// crash survives — and elide the middle, under a character ceiling.
     static func boundedBlock(_ block: String, maxLines: Int = 200, maxChars: Int = 64 * 1024) -> String {
-        var lines = block.split(separator: "\n", omittingEmptySubsequences: false)
+        let lines = block.split(separator: "\n", omittingEmptySubsequences: false)
+        var result = block
         if lines.count > maxLines {
-            lines = Array(lines.suffix(maxLines))
+            let (head, tail) = headTailSplit(count: lines.count, keep: maxLines)
+            let elided = lines.count - head - tail
+            result = (lines.prefix(head) + ["… \(elided) lines elided …"] + lines.suffix(tail))
+                .joined(separator: "\n")
         }
-        let result = lines.joined(separator: "\n")
-        return result.count > maxChars ? String(result.suffix(maxChars)) : result
+        guard result.count > maxChars else { return result }
+        let chars = Array(result)
+        let (head, tail) = headTailSplit(count: chars.count, keep: maxChars)
+        let elided = chars.count - head - tail
+        return String(chars.prefix(head)) + "\n… \(elided) characters elided …\n" + String(chars.suffix(tail))
+    }
+
+    /// Head/tail counts for keeping the first ~2/3 and last ~1/3 of `count`
+    /// items within `keep`, reserving one slot for the elision marker.
+    private static func headTailSplit(count: Int, keep: Int) -> (head: Int, tail: Int) {
+        let budget = max(keep - 1, 0)
+        let head = budget * 2 / 3
+        return (head, budget - head)
     }
 
     public static func format(_ block: String, as format: CrashFormat) -> String {

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorAudioPlayer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorAudioPlayer.swift
@@ -11,7 +11,8 @@ import Foundation
 /// each stream just plays as fast as it arrives.
 ///
 /// `AVAudioEngine` isn't `Sendable`, so this is boxed `@unchecked` and every
-/// call is funnelled through the owning `@MainActor` view model.
+/// call is funnelled through the view model's single audio task (built and
+/// driven off the main thread — its construction blocks on Core Audio XPC).
 public final class MirrorAudioPlayer: @unchecked Sendable {
     public static let sampleRate: Double = 48_000
     public static let channelCount: AVAudioChannelCount = 2

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
@@ -16,6 +16,8 @@ import Foundation
 public actor MirrorSession {
     public struct DisplaySample: @unchecked Sendable {
         public let sampleBuffer: CMSampleBuffer
+        public let width: Int
+        public let height: Int
     }
 
     public struct Snapshot: @unchecked Sendable {
@@ -210,6 +212,11 @@ public actor MirrorSession {
                    let format = H264Format.formatDescription(sps: sets.sps, pps: sets.pps) {
                     formatDescription = format
                     decoder.setFormat(format)
+                    // A config packet also arrives on rotation, carrying the new
+                    // SPS; scrcpy doesn't resend the stream header, so refresh the
+                    // dimensions from the format here to track orientation changes.
+                    let size = CMVideoFormatDescriptionGetDimensions(format)
+                    dimensions = (Int(size.width), Int(size.height))
                     // Arm a pending recording now so the key frame that follows
                     // this config packet is the recording's first sample.
                     if let url = pendingRecordURL, recorder == nil {
@@ -224,7 +231,10 @@ public actor MirrorSession {
             guard let sampleBuffer = H264Format.sampleBuffer(
                 avcc: avcc, formatDescription: formatDescription, pts: pts) else { return }
 
-            continuation.yield(DisplaySample(sampleBuffer: sampleBuffer))
+            continuation.yield(DisplaySample(
+                sampleBuffer: sampleBuffer,
+                width: dimensions?.width ?? 0,
+                height: dimensions?.height ?? 0))
             decoder.decode(sampleBuffer)
 
             if let recorder {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Builds a copy-pasteable `curl` command that reproduces a Reactotron-captured
+/// API request. Lives in ADBKit (not the view) so it stays pure, `Sendable`,
+/// and unit-testable without the UI.
+public enum ReactotronCurl {
+    /// Render `method`/`url`/`request` as a multi-line `curl` invocation.
+    ///
+    /// - Parameters:
+    ///   - method: the HTTP verb as captured (any case).
+    ///   - url: the request URL.
+    ///   - request: the Reactotron `request` payload, read for `headers` and `data`.
+    public static func command(method: String, url: String, request: JSONValue?) -> String {
+        let verb = method.uppercased()
+        let body = requestBody(request)
+        var parts: [String] = ["curl"]
+        // `curl` switches to POST the moment a body is present, so the verb must
+        // be stated explicitly whenever it isn't a plain body-less GET —
+        // otherwise copying a GET that carries a body silently produces a POST.
+        if verb != "GET" || body != nil {
+            parts.append("-X \(verb)")
+        }
+        parts.append(shellQuote(url))
+        if let headers = request?["headers"]?.objectValue {
+            for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
+                let rendered = value.stringValue ?? rawJSON(value)
+                parts.append("-H \(shellQuote("\(key): \(rendered)"))")
+            }
+        }
+        if let body {
+            parts.append("--data \(shellQuote(body))")
+        }
+        return parts.joined(separator: " \\\n  ")
+    }
+
+    /// The body to send, or `nil` when the request carries nothing meaningful —
+    /// JSON null, an empty string, or an empty `{}` / `[]`. Keeps a body-less GET
+    /// body-less (and therefore a GET, not a POST inferred by `curl`).
+    private static func requestBody(_ request: JSONValue?) -> String? {
+        guard let data = request?["data"], !data.isNull else { return nil }
+        let rendered = data.stringValue ?? rawJSON(data)
+        switch rendered {
+        case "", "{}", "[]", "null": return nil
+        default: return rendered
+        }
+    }
+
+    /// Raw (non-marker-repaired) JSON, since a curl body must stay valid JSON —
+    /// unlike `JSONValue.jsonString`, which rewrites Reactotron's `~~~ … ~~~`
+    /// display markers.
+    private static func rawJSON(_ value: JSONValue) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let text = String(data: data, encoding: .utf8) else { return "" }
+        return text
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct AppInstallServiceTests {
+    private func result(_ stdout: String, _ stderr: String = "") -> AdbResult {
+        AdbResult(stdout: stdout, stderr: stderr, exitCode: 0, timedOut: false)
+    }
+
+    @Test func successIsInstalled() {
+        let r = AppInstallService.parse(result("Success\n"))
+        #expect(r.ok)
+        #expect(r.message == "Installed")
+    }
+
+    @Test func knownFailureCodeBecomesPlainEnglish() {
+        let raw = "Performing Streamed Install\nFailure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
+        let r = AppInstallService.parse(result("", raw))
+        #expect(!r.ok)
+        #expect(r.message == "Not enough storage on the device.")
+        // The full adb output is kept for the notifications panel.
+        #expect(r.copyText?.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE") == true)
+    }
+
+    @Test func signatureMismatchIsExplained() {
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"))
+        #expect(r.message.contains("uninstall it first"))
+    }
+
+    @Test func unmappedCodeIsSurfacedRaw() {
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_FAILED_CONTAINER_ERROR]"))
+        #expect(r.message == "INSTALL_FAILED_CONTAINER_ERROR")
+        #expect(r.copyText?.contains("INSTALL_FAILED_CONTAINER_ERROR") == true)
+    }
+
+    @Test func unrecognizedErrorUsesLastLineAndKeepsFullOutput() {
+        let raw = "Performing Streamed Install\nadb: failed to install app.apk: weird device error"
+        let r = AppInstallService.parse(result("", raw))
+        #expect(!r.ok)
+        #expect(r.message == "adb: failed to install app.apk: weird device error")
+        #expect(r.copyText == raw)
+    }
+
+    @Test func friendlyReasonMapsCommonCodes() {
+        #expect(AppInstallService.friendlyReason("INSTALL_FAILED_ALREADY_EXISTS") == "The app is already installed.")
+        #expect(AppInstallService.friendlyReason("INSTALL_FAILED_NO_MATCHING_ABIS").contains("CPU"))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInstallServiceTests.swift
@@ -45,4 +45,26 @@ import Testing
         #expect(AppInstallService.friendlyReason("INSTALL_FAILED_ALREADY_EXISTS") == "The app is already installed.")
         #expect(AppInstallService.friendlyReason("INSTALL_FAILED_NO_MATCHING_ABIS").contains("CPU"))
     }
+
+    @Test func parseFailureCodeGetsItsOwnMessage() {
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]"))
+        #expect(!r.ok)
+        #expect(r.message.contains("couldn't be parsed"))
+        #expect(r.copyText?.contains("INSTALL_PARSE_FAILED_NO_CERTIFICATES") == true)
+    }
+
+    @Test func emptyOutputIsUnknownErrorWithNoCopyText() {
+        let r = AppInstallService.parse(result("", ""))
+        #expect(!r.ok)
+        #expect(r.message == "Unknown error.")
+        #expect(r.copyText == nil)
+    }
+
+    @Test func failureMentioningTheWordSuccessIsNotMisreadAsSuccess() {
+        // The word appears mid-line in a failure — it must not be read as the
+        // bare `Success` line adb prints on a real install.
+        let r = AppInstallService.parse(result("", "Failure [INSTALL_FAILED_INVALID_APK]: not successful"))
+        #expect(!r.ok)
+        #expect(r.message == "The APK is invalid or corrupt.")
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/CommandPresetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CommandPresetTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct CommandPresetTests {
+    @Test func libraryIsNonEmptyWithUniqueNames() {
+        #expect(!CommandPreset.library.isEmpty)
+        let names = Set(CommandPreset.library.map(\.name))
+        #expect(names.count == CommandPreset.library.count)
+    }
+
+    @Test func everyPresetIsValidArgv() throws {
+        for preset in CommandPreset.library {
+            let args = try CustomCommandService.buildArgs(
+                template: preset.command, bundleId: "com.example.app", serial: "SER123"
+            )
+            #expect(!args.isEmpty, "preset \(preset.name) produced no args")
+        }
+    }
+
+    @Test func bundlePresetsUseTheBundlePlaceholder() {
+        for preset in CommandPreset.library where preset.needsBundle {
+            #expect(preset.command.contains("{bundleId}"), "\(preset.name) needs a bundle but has no {bundleId}")
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
@@ -70,18 +70,39 @@ import Testing
         #expect(CrashExtractor.boundedBlock(s) == s)
     }
 
-    @Test func boundedBlockKeepsMostRecentLines() {
+    @Test func boundedBlockKeepsHeadAndMostRecentTail() {
         let many = (1...1000).map { "line \($0)" }.joined(separator: "\n")
         let bounded = CrashExtractor.boundedBlock(many, maxLines: 50, maxChars: 1_000_000)
         let lines = bounded.split(separator: "\n")
-        #expect(lines.count == 50)
+        #expect(lines.count <= 50)
+        // The head (the exception line in a real crash) is never dropped...
+        #expect(lines.first == "line 1")
+        // ...and the most recent lines survive too, with the middle elided.
         #expect(lines.last == "line 1000")
-        #expect(lines.first == "line 951")
+        #expect(bounded.contains("lines elided"))
     }
 
-    @Test func boundedBlockCapsAHugeSingleLine() {
-        let huge = String(repeating: "x", count: 200_000)
-        #expect(CrashExtractor.boundedBlock(huge, maxChars: 64 * 1024).count <= 64 * 1024)
+    @Test func boundedBlockExactlyAtLineLimitIsUntouched() {
+        let exact = (1...50).map { "line \($0)" }.joined(separator: "\n")
+        #expect(CrashExtractor.boundedBlock(exact, maxLines: 50, maxChars: 1_000_000) == exact)
+    }
+
+    @Test func boundedBlockPreservesTheCrashHeaderOfASingleHugeTrace() {
+        let trace = (["FATAL EXCEPTION: main", "java.lang.IllegalStateException: boom"]
+            + (1...500).map { "  at com.app.Frame\($0).run(Frame.java:\($0))" })
+            .joined(separator: "\n")
+        let bounded = CrashExtractor.boundedBlock(trace, maxLines: 200, maxChars: 1_000_000)
+        #expect(bounded.contains("FATAL EXCEPTION: main"))
+        #expect(bounded.contains("IllegalStateException: boom"))
+        #expect(bounded.split(separator: "\n").count <= 200)
+    }
+
+    @Test func boundedBlockCapsAHugeSingleLineAndKeepsBothEnds() {
+        let huge = "HEAD" + String(repeating: "x", count: 200_000) + "TAIL"
+        let bounded = CrashExtractor.boundedBlock(huge, maxChars: 64 * 1024)
+        #expect(bounded.count <= 64 * 1024 + 64)
+        #expect(bounded.hasPrefix("HEAD"))
+        #expect(bounded.hasSuffix("TAIL"))
     }
 
     @Test func lastCrashBoundsAHugeCrashBuffer() async throws {

--- a/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CrashExtractorTests.swift
@@ -64,4 +64,34 @@ import Testing
 
         #expect(try await extractor.lastCrash(serial: "S1", format: .plain) == nil)
     }
+
+    @Test func boundedBlockKeepsShortInputUnchanged() {
+        let s = "line1\nline2\nline3"
+        #expect(CrashExtractor.boundedBlock(s) == s)
+    }
+
+    @Test func boundedBlockKeepsMostRecentLines() {
+        let many = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        let bounded = CrashExtractor.boundedBlock(many, maxLines: 50, maxChars: 1_000_000)
+        let lines = bounded.split(separator: "\n")
+        #expect(lines.count == 50)
+        #expect(lines.last == "line 1000")
+        #expect(lines.first == "line 951")
+    }
+
+    @Test func boundedBlockCapsAHugeSingleLine() {
+        let huge = String(repeating: "x", count: 200_000)
+        #expect(CrashExtractor.boundedBlock(huge, maxChars: 64 * 1024).count <= 64 * 1024)
+    }
+
+    @Test func lastCrashBoundsAHugeCrashBuffer() async throws {
+        let runner = MockProcessRunner()
+        let huge = (1...5000).map { "E AndroidRuntime: FATAL EXCEPTION line \($0)" }.joined(separator: "\n")
+        runner.script(argsPrefix: ["-s", "S1", "logcat", "-d", "-b", "crash"], stdout: huge)
+        let extractor = CrashExtractor(client: await makeTestClient(runner: runner))
+
+        let crash = try await extractor.lastCrash(serial: "S1", format: .plain)
+        #expect((crash?.split(separator: "\n").count ?? 0) <= 200)
+        #expect(crash?.contains("line 5000") == true)
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -223,7 +223,9 @@ import Testing
             stdout: "", stderr: "adb: failed to install app.apk: Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]",
             exitCode: 1, timedOut: false))
         #expect(!failure.ok)
-        #expect(failure.message.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE"))
+        // parse now returns a plain-English reason; the raw code stays in copyText.
+        #expect(failure.message == "Not enough storage on the device.")
+        #expect(failure.copyText?.contains("INSTALL_FAILED_INSUFFICIENT_STORAGE") == true)
     }
 
     @Test func multiWordSearchMatchesNonContiguousTokens() {

--- a/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct ReactotronCurlTests {
+    @Test func getWithoutBodyHasNoMethodOrData() {
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/items", request: nil)
+        #expect(curl.contains("curl"))
+        #expect(curl.contains("'https://x.test/items'"))
+        #expect(!curl.contains("-X"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func getWithEmptyObjectDataStaysBodylessGet() {
+        // Reactotron often records `data: {}` for a GET — it must not gain a body
+        // (and therefore must not flip to POST).
+        let request = JSONValue.object(["data": .object([:])])
+        let curl = ReactotronCurl.command(method: "get", url: "https://x.test", request: request)
+        #expect(!curl.contains("--data"))
+        #expect(!curl.contains("-X"))
+    }
+
+    @Test func getWithRealBodyKeepsGetMethod() {
+        // The reported bug: a GET with a body must stay GET, not silently POST.
+        let request = JSONValue.object(["data": .string("q=1")])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(curl.contains("-X GET"))
+        #expect(curl.contains("--data 'q=1'"))
+    }
+
+    @Test func postWithBodySetsMethodAndData() {
+        let request = JSONValue.object(["data": .string(#"{"a":1}"#)])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains("-X POST"))
+        #expect(curl.contains(#"--data '{"a":1}'"#))
+    }
+
+    @Test func putWithoutBodyStillSetsMethod() {
+        let curl = ReactotronCurl.command(method: "PUT", url: "https://x.test", request: nil)
+        #expect(curl.contains("-X PUT"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func headersAreRenderedSortedAndQuoted() throws {
+        let request = JSONValue.object([
+            "headers": .object([
+                "Authorization": .string("Bearer t"),
+                "Accept": .string("application/json"),
+            ]),
+        ])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(curl.contains("-H 'Accept: application/json'"))
+        #expect(curl.contains("-H 'Authorization: Bearer t'"))
+        let accept = try #require(curl.range(of: "Accept"))
+        let auth = try #require(curl.range(of: "Authorization"))
+        #expect(accept.lowerBound < auth.lowerBound)
+    }
+
+    @Test func singleQuotesInValuesAreEscaped() {
+        let request = JSONValue.object(["data": .string("it's")])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains(#"--data 'it'\''s'"#))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
@@ -61,4 +61,41 @@ import Testing
         let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
         #expect(curl.contains(#"--data 'it'\''s'"#))
     }
+
+    @Test func objectBodyIsSerializedToJSON() {
+        // Reactotron usually records the body as a JSON object, not a pre-encoded
+        // string — the rawJSON path must serialize it and attach it.
+        let request = JSONValue.object(["data": .object(["a": .number(1)])])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains("-X POST"))
+        #expect(curl.contains(#"--data '{"a":1}'"#))
+    }
+
+    @Test func nonEmptyArrayBodyIsAttached() {
+        let request = JSONValue.object(["data": .array([.number(1), .number(2)])])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains(#"--data '[1,2]'"#))
+    }
+
+    @Test func emptyArrayDataStaysBodyless() {
+        let request = JSONValue.object(["data": .array([])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(!curl.contains("--data"))
+        #expect(!curl.contains("-X"))
+    }
+
+    @Test func nullAndEmptyStringDataStayBodyless() {
+        for data: JSONValue in [.null, .string("")] {
+            let request = JSONValue.object(["data": data])
+            let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+            #expect(!curl.contains("--data"))
+            #expect(!curl.contains("-X"))
+        }
+    }
+
+    @Test func nonStringHeaderValueIsSerialized() {
+        let request = JSONValue.object(["headers": .object(["X-Retry": .number(3)])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
+        #expect(curl.contains("-H 'X-Retry: 3'"))
+    }
 }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -36,6 +36,21 @@ struct ADTApp: App {
     @State private var appState: AppState
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
+    @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
+
+    /// The sidebar and notifications panel are fixed-width, so opening the
+    /// notifications panel on a narrow window would otherwise crush the detail
+    /// pane to uselessness (the welcome title wrapping one letter per line).
+    /// Grow the window's minimum width with whichever side panels are showing,
+    /// so the detail pane always keeps at least `detailMinWidth`.
+    private var minWindowWidth: CGFloat {
+        let detailMinWidth: CGFloat = 360
+        let notifications: CGFloat = appState.showNotifications ? 321 : 0
+        let sidebar: CGFloat = appState.sidebarVisible
+            ? CGFloat(min(max(sidebarWidth, 300), 460))
+            : 0
+        return max(760, sidebar + detailMinWidth + notifications)
+    }
 
     init() {
         // HotkeyManager.install is deferred to RootView.onAppear — Carbon
@@ -54,7 +69,7 @@ struct ADTApp: App {
         WindowGroup(id: "main") {
             RootView()
                 .environment(appState)
-                .frame(minWidth: 760, minHeight: 480)
+                .frame(minWidth: minWindowWidth, minHeight: 480)
                 // Force the brand accent on standard controls (prominent
                 // buttons, switches, sliders) so they stay green regardless of
                 // the Mac's system accent color, which otherwise overrides the

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -7,6 +7,7 @@ struct CustomCommandsView: View {
     @State private var commands: [CustomCommand] = []
     @State private var editing: CustomCommand?
     @State private var showEditor = false
+    @State private var showPresets = false
     @State private var draftName = ""
     @State private var draftCommand = ""
     @State private var draftNeedsBundle = false
@@ -21,6 +22,10 @@ struct CustomCommandsView: View {
                         .foregroundStyle(.textMuted)
                 }
                 Spacer()
+                Button { showPresets = true } label: {
+                    Label("Presets", systemImage: "square.grid.2x2")
+                }
+                .controlSize(.small)
                 Button {
                     editing = nil
                     draftName = ""
@@ -86,6 +91,7 @@ struct CustomCommandsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task { commands = await state.env.stores.customCommands.load() }
         .sheet(isPresented: $showEditor) { editor }
+        .sheet(isPresented: $showPresets) { presetLibrary }
     }
 
     private var editor: some View {
@@ -152,5 +158,68 @@ struct CustomCommandsView: View {
                 state.showToast(Toast(message: result.message, ok: result.ok))
             }
         }
+    }
+
+    // MARK: - Presets
+
+    private var presetLibrary: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Preset Commands").font(.headline)
+                Spacer()
+                Button("Done") { showPresets = false }
+            }
+            Text("Common adb commands. Add one to your list, then run or edit it.")
+                .font(.footnote)
+                .foregroundStyle(.textMuted)
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(CommandPreset.library) { preset in
+                        presetRow(preset)
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(width: 520, height: 460)
+    }
+
+    private func presetRow(_ preset: CommandPreset) -> some View {
+        let added = commands.contains { $0.name == preset.name }
+        return HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(preset.name)
+                Text("adb \(preset.command)")
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(.textMuted)
+                Text(preset.detail)
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            }
+            Spacer(minLength: 8)
+            if added {
+                Label("Added", systemImage: "checkmark")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            } else {
+                Button("Add") { add(preset) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+        }
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func add(_ preset: CommandPreset) {
+        guard !commands.contains(where: { $0.name == preset.name }) else { return }
+        commands.append(CustomCommand(
+            name: preset.name,
+            command: preset.command,
+            needsBundle: preset.needsBundle,
+            createdAt: Date().timeIntervalSince1970 * 1000
+        ))
+        persist()
     }
 }

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -11,6 +11,8 @@ struct HomeView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var showMore = false
 
+    private static let welcomeTitle = "Welcome to Droidective"
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 30) {
@@ -43,7 +45,7 @@ struct HomeView: View {
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .center, spacing: 16) {
                     logo
-                    Text("Welcome to Droidective")
+                    Text(Self.welcomeTitle)
                         .font(.largeTitle.bold())
                         .fixedSize()
                     Spacer(minLength: 12)
@@ -52,7 +54,7 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(alignment: .center, spacing: 12) {
                         logo
-                        Text("Welcome to Droidective")
+                        Text(Self.welcomeTitle)
                             .font(.largeTitle.bold())
                             .lineLimit(2)
                             .minimumScaleFactor(0.6)

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -32,21 +32,45 @@ struct HomeView: View {
 
     // MARK: - Header
 
+    /// Responsive so a narrow detail pane (e.g. sidebar + notifications panel
+    /// open on a small window) never starves the title into per-character
+    /// wrapping. `ViewThatFits` keeps the role badge inline when there's room
+    /// and wraps it below the title when there isn't; the title scales rather
+    /// than breaking mid-word at the extreme. The subtitle always sits on its
+    /// own full-width line so it wraps cleanly and doesn't skew the fit.
     private var header: some View {
-        HStack(spacing: 16) {
-            Image(colorScheme == .dark ? "AppLogoDark" : "AppLogoLight")
-                .resizable()
-                .frame(width: 60, height: 60)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Welcome to Droidective")
-                    .font(.largeTitle.bold())
-                Text("An Android & React Native debugging command palette, driven over adb.")
-                    .font(.title3)
-                    .foregroundStyle(.textMuted)
+        VStack(alignment: .leading, spacing: 10) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 16) {
+                    logo
+                    Text("Welcome to Droidective")
+                        .font(.largeTitle.bold())
+                        .fixedSize()
+                    Spacer(minLength: 12)
+                    roleBadge
+                }
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .center, spacing: 12) {
+                        logo
+                        Text("Welcome to Droidective")
+                            .font(.largeTitle.bold())
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.6)
+                    }
+                    roleBadge
+                }
             }
-            Spacer(minLength: 12)
-            roleBadge
+            Text("An Android & React Native debugging command palette, driven over adb.")
+                .font(.title3)
+                .foregroundStyle(.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private var logo: some View {
+        Image(colorScheme == .dark ? "AppLogoDark" : "AppLogoLight")
+            .resizable()
+            .frame(width: 60, height: 60)
     }
 
     /// Current role as a pill that opens the picker — the "change this anytime"

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
@@ -8,12 +8,19 @@ import SwiftUI
     let displayLayer = AVSampleBufferDisplayLayer()
 
     private var renderer: AVSampleBufferVideoRenderer { displayLayer.sampleBufferRenderer }
+    private var lastDimensions: (width: Int, height: Int)?
 
     init() {
         displayLayer.videoGravity = .resizeAspect
     }
 
-    func enqueue(_ sampleBuffer: CMSampleBuffer) {
+    func enqueue(_ sampleBuffer: CMSampleBuffer, width: Int, height: Int) {
+        // A resolution change (device rotation) needs a flush, or the renderer can
+        // stall on the old format instead of re-priming on the incoming key frame.
+        if let last = lastDimensions, last != (width, height) {
+            renderer.flush()
+        }
+        lastDimensions = (width, height)
         // A failed renderer won't recover until flushed; the next key frame re-primes it.
         if renderer.status == .failed { renderer.flush() }
         renderer.enqueue(sampleBuffer)
@@ -21,6 +28,7 @@ import SwiftUI
 
     func clear() {
         renderer.flush()
+        lastDimensions = nil
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -127,16 +127,19 @@ final class MirrorViewModel {
             do {
                 for try await sample in stream {
                     guard let self else { break }
-                    self.renderer.enqueue(sample.sampleBuffer)
+                    self.renderer.enqueue(sample.sampleBuffer, width: sample.width, height: sample.height)
+                    // Track the live frame size so taps map correctly and the aspect
+                    // rect stays right across rotation, not only at the first frame.
+                    if sample.width > 0, sample.height > 0 {
+                        let size = CGSize(width: sample.width, height: sample.height)
+                        if self.videoSize != size { self.videoSize = size }
+                    }
                     if self.status == .connecting {
                         self.status = .streaming
                         // The transport (incl. the control socket) is connected
                         // once frames flow — fetch the control sender now, not
                         // right after start() when it isn't wired yet.
                         self.sendControl = await self.session?.controlSender()
-                        if let dimensions = await self.session?.currentDimensions() {
-                            self.videoSize = CGSize(width: dimensions.width, height: dimensions.height)
-                        }
                     }
                 }
                 self?.status = .stopped

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -44,7 +44,9 @@ final class MirrorViewModel {
     private var displayTask: Task<Void, Never>?
     private var clipboardTask: Task<Void, Never>?
     private var audioTask: Task<Void, Never>?
-    private let audioPlayer = MirrorAudioPlayer()
+    /// Built off the main thread on the first audio packet — see `start()`. nil
+    /// until then so audio-less devices never touch Core Audio.
+    private var audioPlayer: MirrorAudioPlayer?
     /// The bundled scrcpy server, resolved at start — reused to spin up a
     /// recording session.
     private var server: ScrcpyServerInfo?
@@ -100,17 +102,24 @@ final class MirrorViewModel {
         }
 
         let audio = await session.audioPCM()
-        audioTask = Task { @MainActor [weak self] in
-            guard let self, let audio else { return }
-            var started = false
+        audioTask = Task { [weak self] in
+            guard let audio else { return }
+            // Build and start the AVAudioEngine graph OFF the main thread. Creating
+            // AVAudioPlayerNode / attaching nodes makes a synchronous XPC round-trip
+            // to the audio-component registrar that can block for seconds on first
+            // use, freezing the UI (Sentry DROIDECTIVE-MAC-5). Built lazily on the
+            // first packet, so audio-less devices (Android < 11) never reach here.
+            // MirrorAudioPlayer is @unchecked Sendable and only ever touched here.
+            let player = await Task.detached(priority: .userInitiated) { () -> MirrorAudioPlayer? in
+                let player = MirrorAudioPlayer()
+                do { try player.start() } catch { return nil }
+                return player
+            }.value
+            guard let player else { return }
+            await MainActor.run { [weak self] in self?.audioPlayer = player }
+            defer { player.stop() }
             for await pcm in audio {
-                // Start the engine lazily on the first packet — devices without
-                // audio (Android < 11) never get here, so we don't touch Core Audio.
-                if !started {
-                    do { try self.audioPlayer.start() } catch { return }
-                    started = true
-                }
-                self.audioPlayer.enqueue(pcmS16LE: pcm)
+                player.enqueue(pcmS16LE: pcm)
             }
         }
 
@@ -146,7 +155,8 @@ final class MirrorViewModel {
         clipboardTask = nil
         audioTask?.cancel()
         audioTask = nil
-        audioPlayer.stop()
+        audioPlayer?.stop()
+        audioPlayer = nil
         if let recorder = screenRecorder { await recorder.abort() }
         screenRecorder = nil
         await session?.stop()

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -244,15 +244,15 @@ final class ReactotronSession {
     func clearTimeline() { items.removeAll() }
     fileprivate func deleteSnapshot(_ snapshot: Snapshot) { snapshots.removeAll { $0.id == snapshot.id } }
 
-    func export() {
+    fileprivate func export(_ itemsToExport: [RtItem]) {
         guard let file = app?.askSaveLocation(
             suggestedName: "reactotron_\(ScreenCaptureService.stamp()).json"
         ) else { return }
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-            try encoder.encode(items.map(\.command)).write(to: file)
-            app?.showToast(Toast(message: "Exported \(items.count) events", ok: true, revealPath: file.path))
+            try encoder.encode(itemsToExport.map(\.command)).write(to: file)
+            app?.showToast(Toast(message: "Exported \(itemsToExport.count) events", ok: true, revealPath: file.path))
         } catch {
             app?.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
         }
@@ -465,14 +465,6 @@ struct ReactotronView: View {
             .help(split ? "Back to a single pane" : "Split into two panes")
 
             Button {
-                session.export()
-            } label: {
-                Image(systemName: "square.and.arrow.up")
-            }
-            .help("Export timeline to JSON")
-            .disabled(session.items.isEmpty)
-
-            Button {
                 session.clearTimeline()
             } label: {
                 Image(systemName: "trash")
@@ -503,7 +495,8 @@ struct ReactotronView: View {
             items: session.displayedItems,
             targetEmpty: state.targetSerials.isEmpty,
             connection: session.connection,
-            showOnboarding: showOnboarding
+            showOnboarding: showOnboarding,
+            onExport: { session.export($0) }
         )
     }
 
@@ -898,6 +891,7 @@ private struct TimelinePane: View {
     let targetEmpty: Bool
     let connection: RtConnection
     let showOnboarding: Bool
+    let onExport: ([RtItem]) -> Void
 
     @State private var search = ""
     @State private var filter: RtFilter = .all
@@ -932,6 +926,14 @@ private struct TimelinePane: View {
                     .font(.caption)
                     .foregroundStyle(.textMuted)
             }
+
+            Button {
+                onExport(visibleItems)
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .help("Export this pane's filtered timeline to JSON")
+            .disabled(visibleItems.isEmpty)
 
             Button {
                 newestFirst.toggle()

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -915,8 +915,7 @@ private struct TimelinePane: View {
             .labelsHidden()
             .frame(width: 110)
 
-            TextField("Search…", text: $search)
-                .brandField()
+            SearchField(prompt: "Search…", text: $search)
                 .frame(maxWidth: 200)
 
             Spacer()

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1134,7 +1134,7 @@ private struct RtRow: View {
             HStack {
                 Spacer()
                 CopyButton(label: "Copy as cURL", icon: "terminal") {
-                    curlCommand(method: method, url: url, request: request)
+                    ReactotronCurl.command(method: method, url: url, request: request)
                 }
             }
             Picker("", selection: $apiTab) {
@@ -1218,36 +1218,6 @@ private struct RtRow: View {
               let data = text.data(using: .utf8),
               let parsed = try? JSONDecoder().decode(JSONValue.self, from: data) else { return nil }
         return parsed
-    }
-
-    /// Reproduce the request as a copy-pasteable curl command.
-    private func curlCommand(method: String, url: String, request: JSONValue?) -> String {
-        var parts: [String] = ["curl"]
-        let verb = method.uppercased()
-        if verb != "GET" { parts.append("-X \(verb)") }
-        parts.append(shellQuote(url))
-        if let headers = request?["headers"]?.objectValue {
-            for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
-                let rendered = value.stringValue ?? rawJSON(value)
-                parts.append("-H \(shellQuote("\(key): \(rendered)"))")
-            }
-        }
-        if let data = request?["data"], !data.isNull {
-            let body = data.stringValue ?? rawJSON(data)
-            if !body.isEmpty { parts.append("--data \(shellQuote(body))") }
-        }
-        return parts.joined(separator: " \\\n  ")
-    }
-
-    /// Raw (non-marker-repaired) JSON — for curl bodies that must stay valid.
-    private func rawJSON(_ value: JSONValue) -> String {
-        guard let data = try? JSONEncoder().encode(value),
-              let text = String(data: data, encoding: .utf8) else { return "" }
-        return text
-    }
-
-    private func shellQuote(_ string: String) -> String {
-        "'" + string.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     private func formatMs(_ ms: Double) -> String {

--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -33,8 +33,8 @@ struct NotificationPanelView: View {
             Text("Notifications")
                 .font(.headline)
             Spacer()
-            if !state.notifications.isEmpty {
-                Button("Clear") { state.clearNotifications() }
+            if state.notifications.count > 1 {
+                Button("Clear all") { state.clearNotifications() }
                     .buttonStyle(.plain)
                     .font(.callout)
                     .foregroundStyle(.textMuted)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -17,18 +17,6 @@ struct RootView: View {
     /// chains into the welcome tour. Changing role later (pill / Settings)
     /// leaves this false, so the tour never reappears.
     @State private var pickerIsFirstRun = false
-    /// Leaving the Reactotron feature with a live connection bounces back here
-    /// and prompts whether to keep streaming in the background; the target is
-    /// stashed until the user decides, and the bypass flag lets the chosen
-    /// navigation through without re-prompting.
-    @State private var pendingLeaveFeature: String?
-    @State private var showReactotronLeavePrompt = false
-    @State private var bypassReactotronLeavePrompt = false
-    /// Same maintain/kill choice when the active device changes while you're on
-    /// the Reactotron feature with a live connection.
-    @State private var pendingDeviceSerial: String?
-    @State private var showReactotronDevicePrompt = false
-    @State private var bypassReactotronDevicePrompt = false
     @Environment(\.colorScheme) private var colorScheme
 
     /// Launches to allow before the first-run privacy disclosure appears.
@@ -117,116 +105,6 @@ struct RootView: View {
                 if !showing && shouldPromptConsent { presentConsent = true }
             }
             .onChange(of: colorScheme) { _, _ in updateDockIcon() }
-            .onChange(of: state.selectedFeatureID) { old, new in
-                handleFeatureChange(from: old, to: new)
-            }
-            .onChange(of: state.selectedSerial) { old, new in
-                handleDeviceChange(from: old, to: new)
-            }
-            .confirmationDialog(
-                "Keep Reactotron running?",
-                isPresented: $showReactotronLeavePrompt,
-                titleVisibility: .visible
-            ) {
-                Button("Keep Running") { resolveReactotronLeave(keepAlive: true) }
-                Button("Disconnect", role: .destructive) { resolveReactotronLeave(keepAlive: false) }
-                Button("Stay", role: .cancel) { pendingLeaveFeature = nil }
-            } message: {
-                Text("Keep the server on :9090 alive in the background, or disconnect.")
-            }
-            .background {
-                // Its own host view so the two confirmation dialogs don't drop
-                // each other (same reason as the consent/star sheets above).
-                Color.clear.confirmationDialog(
-                    "Keep Reactotron running?",
-                    isPresented: $showReactotronDevicePrompt,
-                    titleVisibility: .visible
-                ) {
-                    Button("Keep Running") { resolveReactotronDeviceChange(keepAlive: true) }
-                    Button("Disconnect", role: .destructive) { resolveReactotronDeviceChange(keepAlive: false) }
-                    Button("Cancel", role: .cancel) { pendingDeviceSerial = nil }
-                } message: {
-                    Text("Switching device — keep the connection, or disconnect.")
-                }
-            }
-    }
-
-    /// Intercept leaving the Reactotron feature: if a device is connected, bounce
-    /// back and ask whether to keep the session alive; if it's only listening
-    /// with nothing connected, quietly stop it to free the port.
-    private func handleFeatureChange(from old: String?, to new: String?) {
-        guard old == "reactotron", new != "reactotron" else { return }
-        if bypassReactotronLeavePrompt {
-            bypassReactotronLeavePrompt = false
-            return
-        }
-        // The device prompt takes priority: if it's up, keep the user on
-        // Reactotron and let them answer it first (the revert won't re-prompt —
-        // its `old == "reactotron"` guard filters it out).
-        if showReactotronDevicePrompt {
-            state.selectedFeatureID = "reactotron"
-            return
-        }
-        let session = state.reactotronSession
-        guard session.isRunning else { return }
-        guard session.hasLiveConnection else {
-            Task { await session.stop() }
-            return
-        }
-        pendingLeaveFeature = new
-        state.selectedFeatureID = "reactotron"
-        showReactotronLeavePrompt = true
-    }
-
-    private func resolveReactotronLeave(keepAlive: Bool) {
-        guard let target = pendingLeaveFeature else { return }
-        pendingLeaveFeature = nil
-        if !keepAlive {
-            Task { await state.reactotronSession.stop() }
-        }
-        bypassReactotronLeavePrompt = true
-        state.selectedFeatureID = target
-    }
-
-    /// Mirror of `handleFeatureChange` for the device picker: only while viewing
-    /// Reactotron with a connection — a background session ignores device
-    /// switches the user makes for other features. Bounce back to the old device
-    /// (setting the bypass first, since this selection is symmetric) until the
-    /// user decides.
-    ///
-    /// Only a *user* switch between two present devices prompts. An automatic
-    /// reassignment when the selected device is unplugged/offline (AppState moves
-    /// `selectedSerial` off the vanished serial) must not prompt — the connection
-    /// is already going away and there's no live device to bounce back to.
-    private func handleDeviceChange(from old: String?, to new: String?) {
-        guard state.selectedFeatureID == "reactotron" else { return }
-        if bypassReactotronDevicePrompt {
-            bypassReactotronDevicePrompt = false
-            return
-        }
-        guard let old, old != new,
-              state.devices.contains(where: { $0.serial == old }) else { return }
-        guard state.reactotronSession.hasLiveConnection else { return }
-        // Device prompt wins over a pending feature-leave prompt: dismiss it and
-        // keep the user on Reactotron to answer the device question instead.
-        if showReactotronLeavePrompt || pendingLeaveFeature != nil {
-            showReactotronLeavePrompt = false
-            pendingLeaveFeature = nil
-        }
-        pendingDeviceSerial = new
-        bypassReactotronDevicePrompt = true
-        state.selectedSerial = old
-        showReactotronDevicePrompt = true
-    }
-
-    private func resolveReactotronDeviceChange(keepAlive: Bool) {
-        let target = pendingDeviceSerial
-        pendingDeviceSerial = nil
-        if !keepAlive {
-            Task { await state.reactotronSession.stop() }
-        }
-        bypassReactotronDevicePrompt = true
-        state.selectedSerial = target
     }
 
     /// macOS has no native light/dark app icon, so swap the Dock icon at

--- a/App/Sources/Root/ToastOverlay.swift
+++ b/App/Sources/Root/ToastOverlay.swift
@@ -19,6 +19,7 @@ struct ToastOverlay: View {
 }
 
 private struct ToastView: View {
+    @Environment(AppState.self) private var state
     let toast: Toast
 
     var body: some View {
@@ -47,6 +48,15 @@ private struct ToastView: View {
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
             }
+
+            Button { state.dismissToast(toast.id) } label: {
+                Image(systemName: "xmark")
+                    .font(.caption)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.textMuted)
+            .help("Dismiss")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)

--- a/App/Sources/SearchField.swift
+++ b/App/Sources/SearchField.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A text field that reads as search: a leading magnifying glass, a clear
+/// button once there's text, and the same brand-green focus ring as
+/// ``brandField()`` (which on its own carries no search affordance).
+struct SearchField: View {
+    let prompt: String
+    @Binding var text: String
+    @FocusState private var focused: Bool
+    @Environment(\.controlActiveState) private var controlActive
+
+    private var ringVisible: Bool { focused && controlActive != .inactive }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.textMuted)
+            TextField(prompt, text: $text)
+                .textFieldStyle(.plain)
+                .focused($focused)
+            if !text.isEmpty {
+                Button { text = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.textMuted)
+                .help("Clear search")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(
+                    ringVisible ? Color.brandAccent : Color.borderSubtle,
+                    lineWidth: ringVisible ? 2 : 1
+                )
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { focused = true }
+    }
+}

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -679,18 +679,35 @@ final class AppState {
                 for url in urls {
                     let name = url.lastPathComponent
                     var ok = 0
+                    var failures: [(serial: String, result: FeatureResult)] = []
                     for serial in serials {
                         let result = (try? await env.engine.appInstall.install(apkPath: url.path, serial: serial))
                             ?? FeatureResult(ok: false, message: "adb not found")
-                        if result.ok { ok += 1 }
+                        if result.ok { ok += 1 } else { failures.append((serial, result)) }
                     }
-                    let message = serials.count == 1
-                        ? (ok == 1 ? "Installed \(name)" : "Couldn't install \(name)")
-                        : "Installed \(name) on \(ok)/\(serials.count) devices"
-                    showToast(Toast(message: message, ok: ok > 0))
+                    showToast(Self.installToast(name: name, ok: ok, total: serials.count, failures: failures))
                 }
             }
         }
+    }
+
+    /// A short install headline for the toast; on failure the full adb output is
+    /// kept in `copyText` so the notifications panel carries the detail without
+    /// dumping it into the transient toast.
+    private static func installToast(
+        name: String, ok: Int, total: Int, failures: [(serial: String, result: FeatureResult)]
+    ) -> Toast {
+        if failures.isEmpty {
+            let message = total == 1 ? "Installed \(name)" : "Installed \(name) on \(total) devices"
+            return Toast(message: message, ok: true)
+        }
+        let message = total == 1
+            ? "Couldn't install \(name) — \(failures[0].result.message)"
+            : "Installed \(name) on \(ok)/\(total) devices — \(failures.count) failed"
+        let detail = failures
+            .map { total == 1 ? ($0.result.copyText ?? $0.result.message) : "\($0.serial): \($0.result.copyText ?? $0.result.message)" }
+            .joined(separator: "\n\n")
+        return Toast(message: message, ok: false, copyText: detail.isEmpty ? nil : detail)
     }
 
     func showToast(_ toast: Toast) {

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -731,6 +731,10 @@ final class AppState {
         notifications.removeAll { $0.id == id }
     }
 
+    func dismissToast(_ id: UUID) {
+        toasts.removeAll { $0.id == id }
+    }
+
     // MARK: - Role
 
     /// Apply the user's role choice (first-run or "Change role"): curate the

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -705,7 +705,10 @@ final class AppState {
             ? "Couldn't install \(name) — \(failures[0].result.message)"
             : "Installed \(name) on \(ok)/\(total) devices — \(failures.count) failed"
         let detail = failures
-            .map { total == 1 ? ($0.result.copyText ?? $0.result.message) : "\($0.serial): \($0.result.copyText ?? $0.result.message)" }
+            .map { failure in
+                let body = failure.result.copyText ?? failure.result.message
+                return total == 1 ? body : "\(failure.serial): \(body)"
+            }
             .joined(separator: "\n\n")
         return Toast(message: message, ok: false, copyText: detail.isEmpty ? nil : detail)
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ When adding a feature: logic + a parser test go in ADBKit; the view goes in
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 186 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 320 tests, keep green
 make build         # xcodegen generate + xcodebuild Debug
 make run           # build + open the .app
 ```
@@ -168,8 +168,9 @@ feature for existing users via `knownIds`.
 ## Status
 
 Feature-complete across all planned milestones plus several UX rounds (latest:
-**v2.2.0** — theme/hub overhaul, screenshot annotation editor, all-features-on
-default, live memory graph); 186 tests green; builds clean with zero warnings.
+**v2.6.1** — bug-fix batch across Reactotron, crash catcher, app install,
+notifications, mirroring, and the welcome screen, plus a custom-command preset
+library); 320 tests green; builds clean with zero warnings.
 Verified live against a physical device and an Android emulator. Release builds
 are Developer ID-signed + notarized and bundle scrcpy/ffmpeg
 (see `RELEASING.md`). Open gaps: the Apps list/detail divider isn't

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,48 @@
+## Droidective v2.6.1
+
+A bug-fix release that polishes the v2.6.0 features — Reactotron, the crash
+catcher, app install, notifications, and mirroring — and adds a preset library
+to custom commands.
+
+### New features
+
+- **Custom command presets** — start from a curated library of common adb
+  commands (force-stop, clear data, launch, list packages, key events, toggle
+  animations, battery, clear logcat, reboot, and more) instead of a blank
+  editor; add one and run or edit it.
+
+### Improvements
+
+- **Reactotron** — copy-as-cURL no longer turns a GET request into a POST (the
+  method is stated explicitly when a body is attached, and empty bodies aren't
+  sent); export now writes only the items currently shown in a pane after its
+  search and category filters, with the export action moved into each pane; the
+  connection stays alive when you switch features, with no "Keep Reactotron
+  running?" prompt; and the timeline search reads as search, with a magnifying
+  glass and clear button matching the other searches.
+- **adb install failures** show a plain-English reason (e.g. "Not enough storage
+  on the device.") instead of a raw error code; the full adb output stays on the
+  Copy button in the toast and the notifications panel.
+- **Notifications** — the flowing toast now has a dismiss (×) button, and the
+  panel's bulk action reads "Clear all" and appears only when there's more than
+  one notification.
+- **Mirroring survives device rotation** — the view refreshes its dimensions and
+  re-primes the renderer on the new orientation, so taps stay accurate after a
+  rotate.
+- **Welcome screen** no longer collapses one letter per line in a narrow detail
+  pane; the header is responsive and the window's minimum width grows with the
+  side panels.
+
+### Bug fixes
+
+- **Crash Catcher** bounds the fetched crash (caps the logcat dump and keeps the
+  diagnostic head plus the most recent lines) so a large log can't freeze the UI
+  while rendering.
+- The **mirror audio engine** is built off the main thread, fixing an app hang
+  on first use.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.6.0
 
 ### New features

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.6.0"
+        MARKETING_VERSION: "2.6.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
Accumulated bug-fix branch for v2.6.1. Each fix landed as its own PR into `v2.6.1`; this merges the batch into `main`. 310 tests pass (~20 new); build clean.

## Reactotron
- Copy-as-cURL no longer turns a GET request into a POST — the method is stated explicitly when a body is attached, and empty `{}`/`[]` bodies aren't sent (#47)
- Export writes only the currently filtered timeline items; export moved into each pane (#48)
- The connection stays alive when you switch features; the "Keep Reactotron running?" prompt and its bounce-back logic are removed (#49)
- The timeline search reads as search now (magnifying glass + clear button), matching the state/apps searches (#53)

## Crash & install
- Crash Catcher bounds the fetched crash (cap the logcat dump, keep the most recent lines) so a large log can't freeze the UI while rendering (#51)
- adb install failures show a plain-English reason ("Not enough storage on the device."); the full adb output is kept on the Copy button in the toast and panel (#54, test follow-up #57)

## Notifications
- The flowing toast has a dismiss (×) button; the panel's bulk action is "Clear all" and only appears with more than one notification (per-row hover-dismiss already existed) (#52)

## Mirroring
- Mirroring survives device rotation: dimensions refresh from the new SPS, the renderer flushes on a resolution change, and `videoSize` tracks the new orientation for correct taps (#58)
- The mirror audio engine builds off the main thread (#45, predated this batch)

## Custom commands
- A preset library of common adb commands you can add and then run or edit (#55)

## Welcome screen
- The header is responsive (`ViewThatFits`) and the window minimum grows with the side panels, so the title no longer collapses one letter per line in a narrow pane (#56)

---

Note for release: this is the code merge only — version bump / signed-notarized build per `RELEASING.md` still to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)