### PR TITLE
Add v2.6.1 to the website changelog

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 48 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "2.6.0",
+    "softwareVersion": "2.6.1",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -486,7 +486,7 @@
           <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
           <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
         </div>
-        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.6.0</span></p>
+        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.6.1</span></p>
       </div>
 
       <div class="palette reveal" aria-hidden="true">
@@ -666,11 +666,15 @@ Pixel 8     device</pre>
     <div class="section-head center reveal">
       <span class="eyebrow">changelog</span>
       <h2>Shipped, and still moving.</h2>
-      <p>Ten releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
+      <p>Eleven releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
     </div>
     <div class="timeline reveal">
       <div class="rel latest">
-        <div class="rel-head"><span class="rel-ver">v2.6.0</span><span class="rel-tag">latest</span><span class="rel-date">Jun 2026</span></div>
+        <div class="rel-head"><span class="rel-ver">v2.6.1</span><span class="rel-tag">latest</span><span class="rel-date">Jun 2026</span></div>
+        <p><b>Custom command presets</b> — a library of common adb commands to add and run — plus a round of polish: Reactotron copy-as-cURL, per-pane export, and a search affordance; plain-English <b>install errors</b>; a dismissable toast; and <b>mirroring that survives device rotation</b>.</p>
+      </div>
+      <div class="rel">
+        <div class="rel-head"><span class="rel-ver">v2.6.0</span><span class="rel-date">Jun 2026</span></div>
         <p><b>Reactotron</b> built in — no desktop app, with a live timeline, store browser, custom commands, and a REPL — plus an <b>Install App</b> screen (drag in an APK), and <b>dark mode by default</b>.</p>
       </div>
       <div class="rel">


### PR DESCRIPTION
The `release` job updates `site/appcast.xml` (the Sparkle feed) on each tag, but the marketing page's changelog timeline is maintained by hand — so the site still listed **v2.6.0** as the latest release after v2.6.1 shipped.

## Changes (`site/index.html`)
- Add the **v2.6.1** entry to the changelog timeline and mark it `latest`; demote the v2.6.0 entry to a regular historical row.
- Bump the JSON-LD `softwareVersion` and the hero fineprint from `2.6.0` → `2.6.1`.
- Update the intro count from "Ten releases" → "Eleven".

Merging re-runs the `pages` job, which redeploys the site to GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)