### PR TITLE
Confirm before navigating away from active recordings and unsaved edits

### DIFF
--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -14,20 +14,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         InstallInbox.shared.receive(apks)
     }
 
-    /// If the Reactotron server is still running (the user kept it alive), stop
-    /// it before quitting so we don't orphan the listener or the reverse tunnel.
-    /// Defers termination until the async teardown finishes (bounded in
-    /// `stopForQuit`).
+    /// Block quit when losable work is in flight (an active recording / unsaved
+    /// edit) to show the leave prompt; otherwise stop a kept-alive Reactotron
+    /// session so we don't orphan the listener or the reverse tunnel. Both defer
+    /// termination and reply once resolved.
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        guard let session = appState?.reactotronSession,
-              MainActor.assumeIsolated({ session.isRunning }) else {
-            return .terminateNow
+        guard let appState else { return .terminateNow }
+        return MainActor.assumeIsolated {
+            // The leave prompt's resolution (quit / cancel) drives termination.
+            if !appState.requestQuit() { return .terminateLater }
+            guard appState.reactotronSession.isRunning else { return .terminateNow }
+            Task { @MainActor in
+                await appState.reactotronSession.stopForQuit()
+                NSApp.reply(toApplicationShouldTerminate: true)
+            }
+            return .terminateLater
         }
-        Task { @MainActor in
-            await session.stopForQuit()
-            NSApp.reply(toApplicationShouldTerminate: true)
-        }
-        return .terminateLater
     }
 }
 
@@ -83,7 +85,7 @@ struct ADTApp: App {
             CommandGroup(replacing: .appInfo) {
                 Button("About Droidective") {
                     appState.activateMainWindow()
-                    appState.selectedFeatureID = "about"
+                    appState.requestFeature("about")
                 }
                 #if !APPSTORE
                 CheckForUpdatesCommand(updater: SparkleUpdater.shared)
@@ -106,7 +108,7 @@ struct ADTApp: App {
 
                 Button("Manage Features") {
                     appState.activateMainWindow()
-                    appState.selectedFeatureID = "catalog"
+                    appState.requestFeature("catalog")
                 }
                 .keyboardShortcut(".", modifiers: .command)
             }
@@ -171,7 +173,7 @@ struct MenuBarView: View {
         }
         Button("Mirror Screen") {
             state.activateMainWindow()
-            state.selectedFeatureID = "scrcpy"
+            state.requestFeature("scrcpy")
         }
         Divider()
 
@@ -181,7 +183,7 @@ struct MenuBarView: View {
                     Task { await state.run(feature: feature, params: [:]) }
                 } else {
                     state.activateMainWindow()
-                    state.selectedFeatureID = feature.id
+                    state.requestFeature(feature.id)
                 }
             }
         }

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -143,7 +143,7 @@ struct HomeView: View {
                     }
                 }
                 .padding(.top, 10)
-                Button("Manage all features…") { state.selectedFeatureID = "catalog" }
+                Button("Manage all features…") { state.requestFeature("catalog") }
                     .buttonStyle(.link)
                     .font(.callout)
                     .padding(.top, 8)
@@ -259,7 +259,7 @@ struct HomeView: View {
             step(2, "In **Developer options**, turn on **USB debugging**.")
             step(3, "Plug in via USB and tap **Allow** on the debugging prompt — or connect over Wi-Fi.")
             HStack(spacing: 10) {
-                Button { state.selectedFeatureID = "wireless-adb" } label: {
+                Button { state.requestFeature("wireless-adb") } label: {
                     Label("Connect wirelessly", systemImage: "wifi")
                 }
                 Button { state.refreshDevices() } label: {

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -239,6 +239,16 @@ final class MirrorViewModel {
         if let url = try? await recorder.stop() { pendingRecording = url }
     }
 
+    /// Stop recording for a "Stop & save" leave and return the finished file
+    /// without raising the Discard/Save/Edit prompt — the caller saves it.
+    func finishRecordingForLeave() async -> URL? {
+        guard let recorder = screenRecorder else { return nil }
+        screenRecorder = nil
+        isRecording = false
+        isPaused = false
+        return try? await recorder.stop()
+    }
+
     func pauseRecording() async {
         guard let recorder = screenRecorder, !recordBusy, !isPaused else { return }
         recordBusy = true

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -29,6 +29,8 @@ struct NetworkView: View {
     @State private var sessionRx: UInt64 = 0
     @State private var sessionTx: UInt64 = 0
     @State private var sampler: Task<Void, Never>?
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
 
     private static let interval: Duration = .seconds(1)
     private static let chartWindow = 120
@@ -44,8 +46,24 @@ struct NetworkView: View {
                 setLive(false)
                 setLive(true)
             }
+            .onChange(of: recorded.isEmpty) { _, empty in
+                if empty {
+                    state.clearExitGuard(exitGuardID)
+                } else {
+                    state.setExitGuard(.init(
+                        id: exitGuardID, style: .recording,
+                        title: "Recording not exported",
+                        message: "This network recording hasn’t been exported. Save it first, or discard it."))
+                }
+            }
+            .onChange(of: state.pendingExit?.saving) { _, saving in
+                guard saving == true else { return }
+                stopRecording()
+                if recorded.isEmpty || export() { state.finishExitSave() } else { state.cancelExit() }
+            }
             .onDisappear {
                 setLive(false)
+                state.clearExitGuard(exitGuardID)
             }
     }
 
@@ -350,9 +368,10 @@ struct NetworkView: View {
 
     // MARK: - Export
 
-    private func export() {
+    @discardableResult
+    private func export() -> Bool {
         guard !recorded.isEmpty,
-              let folder = state.askSaveFolder(prompt: "Export network report") else { return }
+              let folder = state.askSaveFolder(prompt: "Export network report") else { return false }
         let stamp = ScreenCaptureService.stamp()
         do {
             try buildJSON().write(to: folder.appendingPathComponent("network_\(stamp).json"))
@@ -362,8 +381,10 @@ struct NetworkView: View {
                 ok: true,
                 revealPath: folder.path
             ))
+            return true
         } catch {
             state.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
+            return false
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -38,6 +38,8 @@ struct PerformanceView: View {
     @State private var selectedElapsed: Double?
     /// Stopping with captured samples prompts to export before discarding them.
     @State private var confirmingStop = false
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
 
     /// Poll cadence. dumpsys meminfo (per-process) is heavy, so it runs every
     /// other tick while the lighter CPU/RAM/FPS counters run every tick.
@@ -79,9 +81,25 @@ struct PerformanceView: View {
             samples = []
             processes = []
         }
+        .onChange(of: samples.isEmpty) { _, empty in
+            if empty {
+                state.clearExitGuard(exitGuardID)
+            } else {
+                state.setExitGuard(.init(
+                    id: exitGuardID, style: .recording,
+                    title: "Recording not exported",
+                    message: "This performance recording hasn’t been exported. Save it first, or discard it."))
+            }
+        }
+        .onChange(of: state.pendingExit?.saving) { _, saving in
+            guard saving == true else { return }
+            stop()
+            if samples.isEmpty || export() { state.finishExitSave() } else { state.cancelExit() }
+        }
         .onDisappear {
             sampler?.cancel()
             state.recordingActive = false
+            state.clearExitGuard(exitGuardID)
         }
     }
 
@@ -577,9 +595,10 @@ struct PerformanceView: View {
 
     // MARK: - Export
 
-    private func export() {
+    @discardableResult
+    private func export() -> Bool {
         guard !samples.isEmpty,
-              let folder = state.askSaveFolder(prompt: "Export performance report") else { return }
+              let folder = state.askSaveFolder(prompt: "Export performance report") else { return false }
         let stamp = ScreenCaptureService.stamp()
         do {
             try buildJSON().write(to: folder.appendingPathComponent("performance_\(stamp).json"))
@@ -589,8 +608,10 @@ struct PerformanceView: View {
                 ok: true,
                 revealPath: folder.path
             ))
+            return true
         } catch {
             state.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
+            return false
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 struct ScreenMirrorView: View {
     @Environment(AppState.self) private var state
     @State private var model: MirrorViewModel?
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
 
     var body: some View {
         ZStack {
@@ -43,11 +45,42 @@ struct ScreenMirrorView: View {
             state.showToast(Toast(message: message, ok: false))
             model?.recordingError = nil
         }
+        .onChange(of: model?.isRecording) { _, recording in
+            if recording == true {
+                state.setExitGuard(.init(
+                    id: exitGuardID, style: .recording,
+                    title: "Recording in progress",
+                    message: "Leaving will stop the screen recording. Save it first, or discard it."))
+            } else {
+                state.clearExitGuard(exitGuardID)
+            }
+        }
+        .onChange(of: state.pendingExit?.saving) { _, saving in
+            if saving == true, model?.isRecording == true { Task { await saveRecordingForLeave() } }
+        }
         .onDisappear {
+            state.clearExitGuard(exitGuardID)
             let leaving = model
             model = nil
             Task { await leaving?.stop() }
         }
+    }
+
+    /// "Stop & save" from the leave prompt: finalize the in-mirror recording into
+    /// the capture folder (skipping the Discard/Save/Edit sheet), then proceed.
+    private func saveRecordingForLeave() async {
+        guard let model else { state.finishExitSave(); return }
+        if let temp = await model.finishRecordingForLeave() {
+            do {
+                let dir = try ScreenCaptureService.ensureCaptureDir()
+                let dest = dir.appendingPathComponent("recording_\(ScreenCaptureService.stamp()).mp4")
+                try FileManager.default.moveItem(at: temp, to: dest)
+                state.showToast(Toast(message: "Recording saved", ok: true, revealPath: dest.path))
+            } catch {
+                state.showToast(Toast(message: "Couldn’t save recording: \(error.localizedDescription)", ok: false))
+            }
+        }
+        state.finishExitSave()
     }
 
     private func reconnect(to serial: String?) async {

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -20,6 +20,8 @@ struct ScreenRecordView: View {
     @State private var decisionURL: URL?
     @State private var showAdvanced = false
     @State private var limitTask: Task<Void, Never>?
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
 
     @AppStorage("recMaxSize") private var maxSize = 0
     @AppStorage("recBitRate") private var bitRateMbps = 0
@@ -47,8 +49,12 @@ struct ScreenRecordView: View {
             }
         }
         .recordingDecision(url: $decisionURL) { recordedURL = $0 }
+        .onChange(of: state.pendingExit?.saving) { _, saving in
+            if saving == true, isRecording { Task { await saveRecordingForLeave() } }
+        }
         .onDisappear {
             limitTask?.cancel()
+            state.clearExitGuard(exitGuardID)
             if isRecording, let recorder { Task { await recorder.abort() } }
             if let url = recordedURL { try? FileManager.default.removeItem(at: url) }
         }
@@ -222,6 +228,10 @@ struct ScreenRecordView: View {
             isRecording = true
             isPaused = false
             startedAt = Date()
+            state.setExitGuard(.init(
+                id: exitGuardID, style: .recording,
+                title: "Recording in progress",
+                message: "Leaving will stop the screen recording. Save it first, or discard it."))
             scheduleTimeLimit(options.timeLimitSeconds)
         } catch {
             state.showToast(Toast(message: error.localizedDescription, ok: false))
@@ -278,5 +288,28 @@ struct ScreenRecordView: View {
         isStopping = false
         startedAt = nil
         self.recorder = nil
+        state.clearExitGuard(exitGuardID)
+    }
+
+    /// "Stop & save" from the leave prompt: finalize the recording straight into
+    /// the capture folder (skipping the Discard/Save/Edit sheet), then let the
+    /// navigation proceed.
+    private func saveRecordingForLeave() async {
+        limitTask?.cancel()
+        guard let recorder else { state.finishExitSave(); return }
+        self.recorder = nil
+        isRecording = false
+        isPaused = false
+        startedAt = nil
+        do {
+            let temp = try await recorder.stop()
+            let dir = try ScreenCaptureService.ensureCaptureDir()
+            let dest = dir.appendingPathComponent("recording_\(ScreenCaptureService.stamp()).mp4")
+            try FileManager.default.moveItem(at: temp, to: dest)
+            state.showToast(Toast(message: "Recording saved", ok: true, revealPath: dest.path))
+        } catch {
+            state.showToast(Toast(message: "Couldn’t save recording: \(error.localizedDescription)", ok: false))
+        }
+        state.finishExitSave()
     }
 }

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -53,6 +53,10 @@ struct ScreenshotEditorView: View {
     @State private var fillOpacity: Double = 1
     /// The text annotation currently being re-edited (nil = placing new text).
     @State private var editingTextID: Annotation.ID?
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
+    /// Unsaved markup/edits exist — drives the leave prompt. Reset on save/copy.
+    @State private var dirty = false
 
     private static let palette: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .black, .white]
     private static let widths: [(String, CGFloat)] = [("Thin", 3), ("Medium", 6), ("Thick", 12)]
@@ -142,6 +146,17 @@ struct ScreenshotEditorView: View {
         // Delete / Backspace removes the selected annotation. Skipped while a text
         // label is being edited so the field's own deletion keeps working.
         .onDeleteCommand { if editingTextID == nil { deleteSelected() } }
+        .onChange(of: dirty) { _, isDirty in
+            if isDirty {
+                state.setExitGuard(.init(
+                    id: exitGuardID, style: .edits,
+                    title: "Unsaved screenshot",
+                    message: "Your annotations and edits haven’t been saved. Leaving discards them."))
+            } else {
+                state.clearExitGuard(exitGuardID)
+            }
+        }
+        .onDisappear { state.clearExitGuard(exitGuardID) }
     }
 
     /// Undo/redo are unavailable while a text label is being typed, so ⌘Z falls
@@ -787,6 +802,7 @@ struct ScreenshotEditorView: View {
             undoStack.removeFirst(undoStack.count - Self.maxUndo)
         }
         redoStack.removeAll()
+        dirty = true
     }
 
     private func undo() {
@@ -891,6 +907,7 @@ struct ScreenshotEditorView: View {
         guard let flat = flattened() else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.writeObjects([flat])
+        dirty = false
         state.showToast(Toast(message: "Screenshot copied", ok: true))
     }
 
@@ -903,6 +920,7 @@ struct ScreenshotEditorView: View {
         do {
             try data.write(to: dest)
             lastSavedURL = dest
+            dirty = false
             state.showToast(Toast(message: "Screenshot saved", ok: true, revealPath: dest.path))
         } catch {
             state.showToast(Toast(message: error.localizedDescription, ok: false))

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -98,6 +98,12 @@ struct VideoEditorPane: View {
     @State private var videoSize: CGSize?
     @State private var assetDuration: Double = 0
 
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    @State private var exitGuardID = UUID()
+    /// The edit state at the last successful export; edits matching it count as
+    /// saved, so the leave prompt doesn't fire after exporting.
+    @State private var lastExportedEdit: EditState?
+
     init(source: VideoSource, onClose: @escaping () -> Void) {
         self.source = source
         self.onClose = onClose
@@ -109,6 +115,10 @@ struct VideoEditorPane: View {
     /// View transforms apply only while not trimming/cropping, so those UIs stay
     /// upright and map to the unrotated frame.
     private var transformActive: Bool { !cropMode && !isTrimming }
+
+    /// Edits exist when the state differs from the default and from the state
+    /// last exported — these are lost on leave unless exported first.
+    private var hasUnsavedEdits: Bool { edit != EditState() && edit != lastExportedEdit }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -123,7 +133,20 @@ struct VideoEditorPane: View {
         }
         .task(id: source.url) { await loadAsset() }
         .onReceive(player.publisher(for: \.status)) { playerReady = ($0 == .readyToPlay) }
-        .onDisappear { player.pause() }
+        .onChange(of: hasUnsavedEdits) { _, dirty in
+            if dirty {
+                state.setExitGuard(.init(
+                    id: exitGuardID, style: .edits,
+                    title: "Unsaved video edits",
+                    message: "Your trim, rotate, crop, and other edits haven’t been exported. Leaving discards them."))
+            } else {
+                state.clearExitGuard(exitGuardID)
+            }
+        }
+        .onDisappear {
+            player.pause()
+            state.clearExitGuard(exitGuardID)
+        }
     }
 
     // MARK: player + crop overlay
@@ -491,6 +514,7 @@ struct VideoEditorPane: View {
         guard let chosen = state.askSaveLocation(suggestedName: suggested) else { return }
         let dest = chosen.deletingPathExtension().appendingPathExtension(edit.format.fileExtension)
         let options = exportOptions
+        let exported = edit
         let url = source.url
         isExporting = true
         player.pause()
@@ -501,6 +525,7 @@ struct VideoEditorPane: View {
                         locator: state.env.client.locator, bundledPath: BundledTools.ffmpegPath())
                         .export(source: url, options: options, to: dest)
                 }
+                lastExportedEdit = exported
                 state.showToast(Toast(message: "Video exported", ok: true, revealPath: saved.path))
             } catch {
                 state.showToast(Toast(message: error.localizedDescription, ok: false))

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -132,8 +132,7 @@ struct DeviceBarView: View {
             }
             ForEach(state.devices) { device in
                 Button {
-                    state.selectedSerial = device.serial
-                    state.persistSelection()
+                    state.requestDevice(device.serial)
                 } label: {
                     if device.serial == state.selectedSerial {
                         Label(state.deviceTitle(device), systemImage: "checkmark")

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -199,7 +199,7 @@ struct PaletteWindowView: View {
         let feature = visibleMatches[index]
         close()
         state.activateMainWindow()
-        state.selectedFeatureID = feature.id
+        state.requestFeature(feature.id)
     }
 
     private func togglePinHighlighted() {

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -37,7 +37,10 @@ struct RootView: View {
 
     var body: some View {
         @Bindable var state = state
-        zoomedContent
+        // Read pendingExit here so body re-renders when a navigation is deferred
+        // (the exitGuard alone is often unchanged), driving the leave dialog.
+        let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
+        return zoomedContent
             .background(WindowAccessor { window in
                 // Fill the screen's usable area on launch — a regular maximized
                 // window, not a native full-screen Space.
@@ -105,6 +108,34 @@ struct RootView: View {
                 if !showing && shouldPromptConsent { presentConsent = true }
             }
             .onChange(of: colorScheme) { _, _ in updateDockIcon() }
+            .confirmationDialog(
+                state.exitGuard?.title ?? "",
+                isPresented: Binding(
+                    get: { showExitDialog },
+                    set: { shown in
+                        if !shown, state.pendingExit?.saving == false { state.cancelExit() }
+                    }
+                ),
+                titleVisibility: .visible,
+                presenting: state.exitGuard
+            ) { info in
+                exitDialogButtons(for: info)
+            } message: { info in
+                Text(info.message)
+            }
+    }
+
+    @ViewBuilder
+    private func exitDialogButtons(for info: AppState.ExitGuard) -> some View {
+        switch info.style {
+        case .recording:
+            Button("Stop & Save") { state.beginExitSave() }
+            Button("Discard", role: .destructive) { state.discardAndExit() }
+            Button("Keep Recording", role: .cancel) { state.cancelExit() }
+        case .edits:
+            Button("Discard", role: .destructive) { state.discardAndExit() }
+            Button("Keep Editing", role: .cancel) { state.cancelExit() }
+        }
     }
 
     /// macOS has no native light/dark app icon, so swap the Dock icon at

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -261,7 +261,7 @@ struct SidebarPaletteView: View {
     private var bottomBar: some View {
         HStack(spacing: 16) {
             Button {
-                state.selectedFeatureID = "home"
+                state.requestFeature("home")
             } label: {
                 Image(systemName: "house")
                     .font(.title2)
@@ -273,7 +273,7 @@ struct SidebarPaletteView: View {
             .help("Home — overview & getting started")
 
             Button {
-                state.selectedFeatureID = "catalog"
+                state.requestFeature("catalog")
             } label: {
                 Label(
                     state.hiddenFeatureCount > 0 ? "+ \(state.hiddenFeatureCount) more features" : "Manage features",
@@ -288,7 +288,7 @@ struct SidebarPaletteView: View {
             Spacer()
 
             Button {
-                state.selectedFeatureID = "about"
+                state.requestFeature("about")
             } label: {
                 Image(systemName: "info.circle")
                     .font(.title2)
@@ -546,7 +546,7 @@ struct SidebarPaletteView: View {
     private func activate(_ index: Int) {
         let matches = orderedMatches
         guard matches.indices.contains(index) else { return }
-        state.selectedFeatureID = matches[index].id
+        state.requestFeature(matches[index].id)
         searchFocused = false
     }
 
@@ -558,7 +558,7 @@ struct SidebarPaletteView: View {
         if target.firesWithoutScreen {
             Task { await state.run(feature: target, params: [:]) }
         } else {
-            state.selectedFeatureID = target.id
+            state.requestFeature(target.id)
             searchFocused = false
         }
     }
@@ -568,7 +568,7 @@ struct SidebarPaletteView: View {
         guard !matches.isEmpty else { return }
         let currentIndex = matches.firstIndex { $0.id == state.selectedFeatureID }
         let next = ((currentIndex ?? -1) + offset + matches.count) % matches.count
-        state.selectedFeatureID = matches[next].id
+        state.requestFeature(matches[next].id)
     }
 }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -55,10 +55,15 @@ final class AppState {
     let env: AppEnvironment
 
     var devices: [Device] = []
-    var selectedSerial: String?
+    /// Switch via `requestDevice(_:)`, not direct assignment — that routes the
+    /// change through the leave guard so an active recording isn't lost.
+    private(set) var selectedSerial: String?
     var runOnAll = false
     var searchText = ""
-    var selectedFeatureID: String?
+    /// Switch via `requestFeature(_:)`, not direct assignment — that routes the
+    /// change through the leave guard so an active recording / unsaved edit isn't
+    /// silently discarded.
+    private(set) var selectedFeatureID: String?
     var layout = LayoutState()
     /// Per-feature usage tally (persisted), used to re-rank the launchpad's
     /// curated feature order by how the user actually works.
@@ -85,6 +90,14 @@ final class AppState {
     /// True while a performance/network recording is in flight — locks the
     /// device and bundle pickers so the captured series stays consistent.
     var recordingActive = false
+
+    /// Registered by a view holding work that navigating away would destroy —
+    /// an active screen recording or unsaved editor edits. While set,
+    /// feature/device switches and app-quit route through `pendingExit` instead
+    /// of proceeding. See `setExitGuard` / `requestFeature`.
+    private(set) var exitGuard: ExitGuard?
+    /// A navigation deferred until the user resolves the active `exitGuard`.
+    private(set) var pendingExit: PendingExit?
     /// The command bar's Terminal tab — a real PTY-backed shell, shared
     /// app-wide so it persists across features.
     let terminalSession = TerminalSession()
@@ -562,6 +575,110 @@ final class AppState {
         devices.filter(\.isReady).count
     }
 
+    // MARK: - Leave guard (protect in-flight recordings / unsaved edits)
+
+    /// Work that navigating away would destroy. `style` picks the confirmation's
+    /// copy and button set: a recording offers Stop & save, an edit doesn't.
+    struct ExitGuard: Equatable, Identifiable {
+        enum Style: Equatable { case recording, edits }
+        let id: UUID
+        var style: Style
+        var title: String
+        var message: String
+    }
+
+    /// A navigation held back until the user resolves the active `ExitGuard`.
+    struct PendingExit: Equatable {
+        enum Target: Equatable { case feature(String), device(String), quit }
+        var target: Target
+        /// Flips true when the user chooses "Stop & save": the active view runs
+        /// its own save, then calls `finishExitSave()`. The dialog hides while
+        /// the save is in flight.
+        var saving = false
+    }
+
+    /// Register (or replace) the active leave guard. A protected view calls this
+    /// when losable work begins, and `clearExitGuard` when it ends.
+    func setExitGuard(_ value: ExitGuard) { exitGuard = value }
+
+    /// Clear the guard only if it's still the one identified by `id`, so a
+    /// torn-down view can't wipe a guard a newer view just registered.
+    func clearExitGuard(_ id: UUID) {
+        if exitGuard?.id == id { exitGuard = nil }
+    }
+
+    /// Switch the selected feature, or hold the switch behind a confirmation
+    /// when a leave guard is active. Every feature switch (sidebar, palette,
+    /// menu, hotkeys) routes through here.
+    func requestFeature(_ id: String) {
+        guard id != selectedFeatureID else { return }
+        if exitGuard == nil {
+            selectedFeatureID = id
+        } else {
+            pendingExit = PendingExit(target: .feature(id))
+        }
+    }
+
+    /// Switch the active device, or hold it behind a confirmation when a guard
+    /// is active.
+    func requestDevice(_ serial: String) {
+        guard serial != selectedSerial else { return }
+        if exitGuard == nil {
+            selectedSerial = serial
+            persistSelection()
+        } else {
+            pendingExit = PendingExit(target: .device(serial))
+        }
+    }
+
+    /// Called from `applicationShouldTerminate`. Returns true to quit now; false
+    /// means losable work is in flight — the leave prompt is shown and the
+    /// resolution drives termination (see `quitNow` / `cancelExit`).
+    func requestQuit() -> Bool {
+        guard exitGuard != nil else { return true }
+        pendingExit = PendingExit(target: .quit)
+        return false
+    }
+
+    /// "Discard" / "Discard changes": drop the work and run the deferred
+    /// navigation. The leaving view's `.onDisappear` aborts recorders / frees
+    /// edits, so nothing extra is needed here.
+    func discardAndExit() { performPendingExit() }
+
+    /// "Keep recording" / "Keep editing": abandon the pending navigation.
+    func cancelExit() {
+        let wasQuit = pendingExit?.target == .quit
+        pendingExit = nil
+        if wasQuit { NSApp.reply(toApplicationShouldTerminate: false) }
+    }
+
+    /// "Stop & save": ask the active view to save (it observes `pendingExit`),
+    /// keeping the dialog hidden until it calls `finishExitSave()`.
+    func beginExitSave() { pendingExit?.saving = true }
+
+    /// Called by the active view once its save-on-leave finished, to proceed.
+    func finishExitSave() { performPendingExit() }
+
+    private func performPendingExit() {
+        guard let pending = pendingExit else { return }
+        exitGuard = nil
+        pendingExit = nil
+        switch pending.target {
+        case .feature(let id): selectedFeatureID = id
+        case .device(let serial): selectedSerial = serial; persistSelection()
+        case .quit: quitNow()
+        }
+    }
+
+    /// Finish a deferred quit: tear down a kept-alive Reactotron session (as the
+    /// normal quit path does), then let termination proceed.
+    private func quitNow() {
+        Task {
+            if reactotronSession.isRunning { await reactotronSession.stopForQuit() }
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+    }
+
     // MARK: - Feature running
 
     /// Open or run a feature from a launch surface (launchpad or sidebar),
@@ -573,7 +690,7 @@ final class AppState {
             Task { await run(feature: feature, params: [:]) }
         } else {
             noteFeatureUse(feature.id)
-            selectedFeatureID = feature.id
+            requestFeature(feature.id)
         }
     }
 

--- a/App/Sources/State/HotkeyManager.swift
+++ b/App/Sources/State/HotkeyManager.swift
@@ -49,7 +49,7 @@ enum HotkeyManager {
                     Task { await state.run(feature: feature, params: [:]) }
                 } else {
                     state.activateMainWindow()
-                    state.selectedFeatureID = feature.id
+                    state.requestFeature(feature.id)
                 }
             }
         }


### PR DESCRIPTION
## What

Switching feature, switching device, or quitting **while work is in flight** used to silently destroy it:

- an active **screen recording** / **in-mirror recording** was aborted and deleted (`.onDisappear` → `recorder.abort()`)
- **performance / network** recordings lost their captured samples
- **screenshot** markup and **video-editor** edits (trim/rotate/crop/…) vanished with their `@State`

Now each of those moments raises a confirmation. Background jobs that *survive* a leave (file pulls, installs, bug reports run as detached tasks) are deliberately **not** guarded, so this isn't a blanket nag.

## How

- A protected view registers an `AppState.ExitGuard` while it holds losable work and clears it when done (id-matched, so a torn-down view can't wipe a newer view's guard).
- All feature/device switches route through guarded `requestFeature` / `requestDevice`. `selectedFeatureID` / `selectedSerial` are now `private(set)`, so the compiler enforces that every call site (sidebar, ⌘K palette, hotkeys, menu bar, Home buttons, device bar) goes through them. App-quit routes through `requestQuit` (reuses the same in-app dialog via `terminateLater`).
- A guarded navigation is parked in `pendingExit`; the leave dialog shows instead of switching. **Navigation never moves off the current feature until the user resolves the prompt** — the old "let it change, revert in `.onChange`" pattern can't work here, because the revert lands a frame *after* the leaving view's `.onDisappear` has already aborted the recording.
- Context-aware buttons (per the chosen design): **recordings** → Stop & Save (finalize to the capture folder / export JSON+CSV) · Discard · Keep; **editors** → Discard · Keep. "Stop & save" is driven by observation (`pendingExit.saving`) so the active view runs its own save against live state — no stale captured closures.

## Surfaces guarded

| Surface | Guard fires when | Save action |
|---|---|---|
| Screen Record | recording active | stop → move temp to capture folder |
| Mirror (in-mirror record) | `model.isRecording` | stop → move temp to capture folder |
| Performance | samples captured | export JSON+CSV |
| Network | session recorded | export JSON+CSV |
| Screenshot editor | unsaved markup (reset on Save/Copy) | — (Discard/Keep) |
| Video editor | edits ≠ default & ≠ last export | — (Discard/Keep) |

## Test

- `make build` → **BUILD SUCCEEDED**, zero code warnings.
- `cd ADBKit && swift test` → **320 tests pass** (no ADBKit changes).
- Needs on-device visual verification (automation is blocked under this terminal): Stop & Save on a live recording, Discard on a dirty editor, Keep on each, and quit-while-recording.

## Known gap

Closing the main window (⌘W) while recording still aborts via the existing `.onDisappear` and isn't intercepted (only feature/device switch + quit are). Can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)