### PR TITLE
Audit fixes: shell-injection, process cancellation, parsing, and guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep the SHA-pinned GitHub Actions current via grouped weekly PRs.
+# (Swift package versions are declared in project.yml for XcodeGen, which
+# Dependabot's SPM ecosystem can't scan, so they're updated manually.)
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run ADBKit tests
-        run: cd ADBKit && swift test
+        run: cd ADBKit && swift test -Xswiftc -warnings-as-errors
 
   build:
     runs-on: macos-15

--- a/ADBKit/Package.swift
+++ b/ADBKit/Package.swift
@@ -8,7 +8,10 @@ let package = Package(
         .library(name: "ADBKit", targets: ["ADBKit"])
     ],
     targets: [
-        .target(name: "ADBKit"),
-        .testTarget(name: "ADBKitTests", dependencies: ["ADBKit"]),
+        // Pin the Swift 6 language mode (complete strict concurrency) explicitly
+        // rather than inheriting it from the tools version, so it can't silently
+        // relax if the tools-version line is ever lowered.
+        .target(name: "ADBKit", swiftSettings: [.swiftLanguageMode(.v6)]),
+        .testTarget(name: "ADBKitTests", dependencies: ["ADBKit"], swiftSettings: [.swiftLanguageMode(.v6)]),
     ]
 )

--- a/ADBKit/Sources/ADBKit/Devices/DeviceDetails.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceDetails.swift
@@ -12,9 +12,9 @@ public struct DeviceDetails: Sendable, Equatable {
 
         let version = (await versionResult)?.stdout
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let battery = (await batteryResult)?.stdout
-            .firstMatch(of: /level:\s*(\d+)/)
-            .flatMap { Int($0.1) }
+        // Reuse DeviceOverview's parser so battery-level parsing lives in one
+        // place (and inherits its line-anchored, decoy-proof matching).
+        let battery = (await batteryResult).flatMap { DeviceOverview.parseBattery($0.stdout).level }
 
         return DeviceDetails(
             androidVersion: (version?.isEmpty == false) ? version : nil,

--- a/ADBKit/Sources/ADBKit/Devices/DeviceOverview.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceOverview.swift
@@ -36,17 +36,31 @@ public struct DeviceOverview: Sendable, Equatable {
     public static func parseDf(_ output: String) -> (total: Int?, used: Int?, available: Int?) {
         let lines = output.split(whereSeparator: \.isNewline)
         guard lines.count >= 2 else { return (nil, nil, nil) }
-        // Split on any whitespace (incl. a trailing CR on CRLF output) so the
-        // last numeric column parses cleanly.
-        let fields = lines[1].split(whereSeparator: \.isWhitespace)
-        guard fields.count >= 4 else { return (nil, nil, nil) }
-        return (Int(fields[1]), Int(fields[2]), Int(fields[3]))
+        // Gather tokens from every line after the header. On dynamic-partition
+        // devices (Pixel, most Android 11+) `df` wraps a long filesystem name
+        // onto its own line, pushing the numbers to the next physical line —
+        // joining the tokens keeps them reachable. Whitespace splitting also
+        // drops a trailing CR on CRLF output.
+        let tokens = lines.dropFirst().flatMap { $0.split(whereSeparator: \.isWhitespace) }
+        guard tokens.count >= 3 else { return (nil, nil, nil) }
+        // df -k columns are: Filesystem 1K-blocks Used Available Use% Mounted.
+        // The first run of three consecutive integers is (total, used,
+        // available); Use% carries a '%' so it never parses as an Int.
+        for i in 0...(tokens.count - 3) {
+            if let total = Int(tokens[i]), let used = Int(tokens[i + 1]), let available = Int(tokens[i + 2]) {
+                return (total, used, available)
+            }
+        }
+        return (nil, nil, nil)
     }
 
     /// `dumpsys battery` → (level, health label, cycle count).
     public static func parseBattery(_ output: String) -> (level: Int?, health: String?, cycles: Int?) {
-        let level = output.firstMatch(of: /level:\s*(\d+)/).flatMap { Int($0.1) }
-        let healthCode = output.firstMatch(of: /health:\s*(\d+)/).flatMap { Int($0.1) }
+        // Anchor to the start of a line (multiline) so a decoy such as
+        // "Max charging level: 80" on some ROMs can't be matched ahead of the
+        // canonical "  level: 55".
+        let level = output.firstMatch(of: /(?m)^\s*level:\s*(\d+)/).flatMap { Int($0.1) }
+        let healthCode = output.firstMatch(of: /(?m)^\s*health:\s*(\d+)/).flatMap { Int($0.1) }
         let health: String? = healthCode.map {
             switch $0 {
             case 2: return "Good"

--- a/ADBKit/Sources/ADBKit/Exec/SystemProcessRunner.swift
+++ b/ADBKit/Sources/ADBKit/Exec/SystemProcessRunner.swift
@@ -53,55 +53,72 @@ public struct SystemProcessRunner: ProcessRunning {
         stderr.attach(errPipe.fileHandleForReading)
 
         let timedOut = LockedBox(false)
+        let cancelled = LockedBox(false)
         let boxed = UncheckedSendable(process)
 
-        // Started before the exit await so it runs concurrently; Task.sleep
-        // parks no thread. `isRunning` is false both before launch and after
-        // exit, so terminate() is only ever sent to a live process — and the
-        // timedOut flag is only set when termination was actually forced
-        // (a process exiting cleanly right at the deadline isn't a timeout).
-        let watchdog = Task {
-            try await Task.sleep(for: timeout)
-            if boxed.value.isRunning {
-                timedOut.set(true)
-                boxed.value.terminate()
+        return await withTaskCancellationHandler {
+            // Started before the exit await so it runs concurrently; Task.sleep
+            // parks no thread. `isRunning` is false both before launch and after
+            // exit, so terminate() is only ever sent to a live process — and the
+            // timedOut flag is only set when termination was actually forced
+            // (a process exiting cleanly right at the deadline isn't a timeout).
+            let watchdog = Task {
+                try await Task.sleep(for: timeout)
+                if boxed.value.isRunning {
+                    timedOut.set(true)
+                    boxed.value.terminate()
+                }
+                try await Task.sleep(for: .seconds(2))
+                if boxed.value.isRunning {
+                    kill(boxed.value.processIdentifier, SIGKILL)
+                }
             }
-            try await Task.sleep(for: .seconds(2))
-            if boxed.value.isRunning {
-                kill(boxed.value.processIdentifier, SIGKILL)
+
+            let exitCode: Int32? = await withCheckedContinuation { continuation in
+                let resumed = LockedBox(false)
+                process.terminationHandler = { finished in
+                    guard !resumed.swap(true) else { return }
+                    let exited = finished.terminationReason == .exit
+                    continuation.resume(returning: exited ? finished.terminationStatus : nil)
+                }
+                do {
+                    try process.run()
+                    // Cancelled during launch: tear the child down now so it
+                    // doesn't keep running after the caller's Task is gone.
+                    if cancelled.get(), boxed.value.isRunning { boxed.value.terminate() }
+                } catch {
+                    guard !resumed.swap(true) else { return }
+                    stdout.cancel(outPipe.fileHandleForReading)
+                    stderr.cancel(errPipe.fileHandleForReading)
+                    stderr.injectFailure("failed to launch \(executable): \(error.localizedDescription)")
+                    continuation.resume(returning: nil)
+                }
+            }
+            watchdog.cancel()
+
+            // Bounded: a grandchild (e.g. a spawned daemon) can inherit the pipe
+            // and delay EOF past the parent's exit.
+            await stdout.waitUntilEOF(grace: .seconds(3))
+            await stderr.waitUntilEOF(grace: .seconds(3))
+
+            return ProcessOutput(
+                stdout: stdout.data,
+                stderr: stderr.data,
+                exitCode: timedOut.get() ? nil : exitCode,
+                timedOut: timedOut.get()
+            )
+        } onCancel: {
+            // Cancelling the calling Task (e.g. a SwiftUI .task torn down on
+            // navigation, or a .task(id:) re-keying) must kill the child so
+            // run() returns promptly and no orphaned adb process lingers until
+            // its timeout. SIGTERM first, then SIGKILL for anything ignoring it.
+            cancelled.set(true)
+            if boxed.value.isRunning { boxed.value.terminate() }
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                if boxed.value.isRunning { kill(boxed.value.processIdentifier, SIGKILL) }
             }
         }
-
-        let exitCode: Int32? = await withCheckedContinuation { continuation in
-            let resumed = LockedBox(false)
-            process.terminationHandler = { finished in
-                guard !resumed.swap(true) else { return }
-                let exited = finished.terminationReason == .exit
-                continuation.resume(returning: exited ? finished.terminationStatus : nil)
-            }
-            do {
-                try process.run()
-            } catch {
-                guard !resumed.swap(true) else { return }
-                stdout.cancel(outPipe.fileHandleForReading)
-                stderr.cancel(errPipe.fileHandleForReading)
-                stderr.injectFailure("failed to launch \(executable): \(error.localizedDescription)")
-                continuation.resume(returning: nil)
-            }
-        }
-        watchdog.cancel()
-
-        // Bounded: a grandchild (e.g. a spawned daemon) can inherit the pipe
-        // and delay EOF past the parent's exit.
-        await stdout.waitUntilEOF(grace: .seconds(3))
-        await stderr.waitUntilEOF(grace: .seconds(3))
-
-        return ProcessOutput(
-            stdout: stdout.data,
-            stderr: stderr.data,
-            exitCode: timedOut.get() ? nil : exitCode,
-            timedOut: timedOut.get()
-        )
     }
 }
 
@@ -121,7 +138,9 @@ final class PipeCollector: @unchecked Sendable {
     private weak var handle: FileHandle?
 
     func attach(_ handle: FileHandle) {
+        lock.lock()
         self.handle = handle
+        lock.unlock()
         handle.readabilityHandler = { [weak self] handle in
             let chunk = handle.availableData
             if chunk.isEmpty {
@@ -153,6 +172,12 @@ final class PipeCollector: @unchecked Sendable {
         return buffer
     }
 
+    private func currentHandle() -> FileHandle? {
+        lock.lock()
+        defer { lock.unlock() }
+        return handle
+    }
+
     func waitUntilEOF(grace: Duration) async {
         // On expiry, also tear down the read source — a grandchild holding
         // the pipe's write end would otherwise keep the FD and handler alive
@@ -160,7 +185,7 @@ final class PipeCollector: @unchecked Sendable {
         let deadline = Task { [weak self] in
             try await Task.sleep(for: grace)
             guard let self else { return }
-            if let handle = self.handle {
+            if let handle = self.currentHandle() {
                 self.cancel(handle)
             } else {
                 self.finish()

--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -196,8 +196,6 @@ public struct FieldDef: Sendable {
 
 public struct FeatureDef: Sendable, Identifiable {
     public let id: String
-    /// Spec feature number (registry order; 1–49, with gaps from removed features).
-    public let num: Int
     public let title: String
     public let subtitle: String?
     public let keywords: [String]
@@ -224,7 +222,6 @@ public struct FeatureDef: Sendable, Identifiable {
 
     public init(
         id: String,
-        num: Int,
         title: String,
         subtitle: String? = nil,
         keywords: [String] = [],
@@ -244,7 +241,6 @@ public struct FeatureDef: Sendable, Identifiable {
         confirmLabel: String? = nil
     ) {
         self.id = id
-        self.num = num
         self.title = title
         self.subtitle = subtitle
         self.keywords = keywords

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -23,7 +23,7 @@ public enum FeatureRegistry {
     public static let all: [FeatureDef] = [
         // ── Input & Clipboard ────────────────────────────────────────────
         FeatureDef(
-            id: "send-text", num: 1, title: "Send Text",
+            id: "send-text", title: "Send Text",
             subtitle: "Type text, URLs, or symbols on the device",
             keywords: ["type", "paste", "input", "keyboard", "url"],
             category: .input, icon: "keyboard", kind: .formAction,
@@ -32,7 +32,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "get-ip", num: 2, title: "Copy Device IP",
+            id: "get-ip", title: "Copy Device IP",
             subtitle: "Get the Wi-Fi IP address and copy it",
             keywords: ["ip", "address", "wifi", "network", "clipboard"],
             category: .connection, icon: "globe", kind: .instantAction
@@ -40,7 +40,7 @@ public enum FeatureRegistry {
 
         // ── Connection ───────────────────────────────────────────────────
         FeatureDef(
-            id: "connection", num: 49, title: "Connection",
+            id: "connection", title: "Connection",
             subtitle: "Copy IP, reverse port, disconnect, DNS & wireless setup",
             keywords: [
                 "connection", "network", "reverse port", "reverse", "port", "8081",
@@ -51,7 +51,7 @@ public enum FeatureRegistry {
             category: .connection, icon: "network", kind: .view, needsDevice: false
         ),
         FeatureDef(
-            id: "reverse-port", num: 3, title: "Reverse Port",
+            id: "reverse-port", title: "Reverse Port",
             subtitle: "Forward a device port to your machine (Metro 8081)",
             keywords: ["reverse", "port", "8081", "metro", "tcp", "forward"],
             category: .connection, icon: "arrow.left.arrow.right", kind: .formAction,
@@ -60,19 +60,19 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "wireless-adb", num: 4, title: "Wireless ADB",
+            id: "wireless-adb", title: "Wireless ADB",
             subtitle: "Connect over Wi-Fi (tcpip + Android 11 pairing)",
             keywords: ["wireless", "wifi", "tcpip", "pair", "connect", "untethered"],
             category: .connection, icon: "wifi", kind: .view, needsDevice: false
         ),
         FeatureDef(
-            id: "emulators", num: 40, title: "Emulators",
+            id: "emulators", title: "Emulators",
             subtitle: "List, launch, and stop Android emulators",
             keywords: ["emulator", "avd", "virtual", "simulator", "launch", "boot"],
             category: .connection, icon: "play.display", kind: .view, needsDevice: false
         ),
         FeatureDef(
-            id: "network-speed", num: 41, title: "Network Speed",
+            id: "network-speed", title: "Network Speed",
             subtitle: "Live download & upload throughput with recording",
             keywords: [
                 "network", "speed", "bandwidth", "throughput", "upload", "download",
@@ -81,7 +81,7 @@ public enum FeatureRegistry {
             category: .connection, icon: "speedometer", kind: .view
         ),
         FeatureDef(
-            id: "wifi", num: 43, title: "Wi-Fi",
+            id: "wifi", title: "Wi-Fi",
             subtitle: "Connection details, toggle, saved networks & passwords",
             keywords: [
                 "wifi", "wi-fi", "wlan", "ssid", "password", "saved", "network",
@@ -90,7 +90,7 @@ public enum FeatureRegistry {
             category: .connection, icon: "wifi", kind: .view
         ),
         FeatureDef(
-            id: "private-dns", num: 45, title: "Private DNS",
+            id: "private-dns", title: "Private DNS",
             subtitle: "Off, automatic, or a DNS-over-TLS provider",
             keywords: ["dns", "private dns", "dot", "dns-over-tls", "hostname", "resolver", "doh", "edit dns"],
             category: .connection, icon: "lock.shield", kind: .view
@@ -98,7 +98,7 @@ public enum FeatureRegistry {
 
         // ── React Native ─────────────────────────────────────────────────
         FeatureDef(
-            id: "react-native", num: 47, title: "React Native",
+            id: "react-native", title: "React Native",
             subtitle: "Dev menu, reload, deep links, dev server, process death",
             keywords: [
                 "react native", "rn", "metro", "expo", "dev menu", "reload",
@@ -109,31 +109,31 @@ public enum FeatureRegistry {
             category: .reactNative, icon: "atom", kind: .view, needsDevice: false
         ),
         FeatureDef(
-            id: "open-dev-menu", num: 7, title: "Open Dev Menu",
+            id: "open-dev-menu", title: "Open Dev Menu",
             subtitle: "Open the React Native developer menu",
             keywords: ["dev", "menu", "82", "react native", "shake"],
             category: .reactNative, icon: "filemenu.and.selection", kind: .instantAction
         ),
         FeatureDef(
-            id: "reload-js", num: 8, title: "Reload JS",
+            id: "reload-js", title: "Reload JS",
             subtitle: "Reload the JS bundle (double-tap R)",
             keywords: ["reload", "refresh", "js", "bundle", "rr"],
             category: .reactNative, icon: "arrow.clockwise", kind: .instantAction
         ),
         FeatureDef(
-            id: "deep-link", num: 10, title: "Deep Links",
+            id: "deep-link", title: "Deep Links",
             subtitle: "Launch and save deep links per app",
             keywords: ["deep link", "url", "intent", "scheme", "universal"],
             category: .reactNative, icon: "link", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "process-death", num: 11, title: "Simulate Process Death",
+            id: "process-death", title: "Simulate Process Death",
             subtitle: "Background then kill the app to test restoration",
             keywords: ["process death", "kill", "restore", "state", "background"],
             category: .reactNative, icon: "xmark.octagon", kind: .instantAction, needsBundle: true
         ),
         FeatureDef(
-            id: "rn-dev-host", num: 12, title: "Set Dev Server Host",
+            id: "rn-dev-host", title: "Set Dev Server Host",
             subtitle: "Point the app at a different Metro host",
             keywords: ["dev host", "bundle host", "metro", "ip", "debug server"],
             category: .reactNative, icon: "network", kind: .formAction,
@@ -142,7 +142,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "reactotron", num: 51, title: "Reactotron",
+            id: "reactotron", title: "Reactotron",
             subtitle: "Live React Native inspector — logs, network, state, custom display",
             keywords: [
                 "reactotron", "inspector", "timeline", "redux", "mst", "state",
@@ -154,32 +154,32 @@ public enum FeatureRegistry {
 
         // ── Screen & Capture ─────────────────────────────────────────────
         FeatureDef(
-            id: "scrcpy", num: 13, title: "Mirror Screen",
+            id: "scrcpy", title: "Mirror Screen",
             subtitle: "Mirror and control the device with scrcpy",
             keywords: ["scrcpy", "mirror", "screen", "cast", "control", "record", "bitrate", "fps"],
             category: .screen, icon: "display", kind: .view, needsScrcpy: true
         ),
         FeatureDef(
-            id: "screenshot", num: 14, title: "Screenshot",
+            id: "screenshot", title: "Screenshot",
             subtitle: "Capture the screen and save it to your Mac",
             keywords: ["screenshot", "capture", "screencap", "png", "image"],
             category: .screen, icon: "camera", kind: .instantAction
         ),
         FeatureDef(
-            id: "screen-record", num: 15, title: "Screen Record",
+            id: "screen-record", title: "Screen Record",
             subtitle: "Record via scrcpy — no time limit, with audio",
             keywords: ["record", "video", "screen", "scrcpy", "audio", "screenrecord", "capture"],
             category: .screen, icon: "video", kind: .view, needsScrcpy: true
         ),
         FeatureDef(
-            id: "video-editor", num: 50, title: "Video Editor",
+            id: "video-editor", title: "Video Editor",
             subtitle: "Trim, rotate, crop, convert & compress video",
             keywords: ["video", "edit", "editor", "trim", "rotate", "crop", "convert",
                        "compress", "gif", "mp4", "mov", "speed"],
             category: .screen, icon: "film", kind: .view, needsDevice: false, needsFfmpeg: true
         ),
         FeatureDef(
-            id: "demo-mode", num: 16, title: "Demo Mode",
+            id: "demo-mode", title: "Demo Mode",
             subtitle: "Clean status bar for store screenshots",
             keywords: ["demo", "status bar", "clean", "screenshot", "store"],
             category: .screen, icon: "wand.and.stars", kind: .toggleAction,
@@ -189,25 +189,25 @@ public enum FeatureRegistry {
 
         // ── Device Info & State Simulation ───────────────────────────────
         FeatureDef(
-            id: "file-explorer", num: 38, title: "File Explorer",
+            id: "file-explorer", title: "File Explorer",
             subtitle: "Browse device storage — copy, move, delete, pull",
             keywords: ["files", "storage", "sdcard", "browse", "folder", "explorer", "copy", "paste"],
             category: .deviceState, icon: "externaldrive", kind: .view
         ),
         FeatureDef(
-            id: "device-info", num: 17, title: "Device Info",
+            id: "device-info", title: "Device Info",
             subtitle: "Browse and search every device property",
             keywords: ["info", "getprop", "android version", "model", "serial", "ram"],
             category: .deviceState, icon: "info.circle", kind: .view
         ),
         FeatureDef(
-            id: "root-status", num: 42, title: "Root Status",
+            id: "root-status", title: "Root Status",
             subtitle: "Check whether the device is rooted, and how",
             keywords: ["root", "rooted", "su", "magisk", "superuser", "selinux", "test-keys", "jailbreak"],
             category: .logs, icon: "checkmark.shield", kind: .view
         ),
         FeatureDef(
-            id: "system-restrictions", num: 46, title: "System Restrictions",
+            id: "system-restrictions", title: "System Restrictions",
             subtitle: "Dev toggles — verifier, hidden APIs, SELinux (root)",
             keywords: [
                 "restriction", "bypass", "verifier", "package verifier", "hidden api",
@@ -216,7 +216,7 @@ public enum FeatureRegistry {
             category: .deviceState, icon: "lock.open", kind: .view
         ),
         FeatureDef(
-            id: "simulate", num: 48, title: "Simulate",
+            id: "simulate", title: "Simulate",
             subtitle: "Fake battery, appearance, locale, network & proxy",
             keywords: [
                 "simulate", "device state", "override", "battery", "fake", "unplugged",
@@ -229,7 +229,7 @@ public enum FeatureRegistry {
             category: .deviceState, icon: "slider.horizontal.3", kind: .view, needsDevice: false
         ),
         FeatureDef(
-            id: "fake-battery", num: 18, title: "Fake Battery",
+            id: "fake-battery", title: "Fake Battery",
             subtitle: "Set a fake battery level and unplugged state",
             keywords: ["battery", "fake", "level", "unplugged", "charge"],
             category: .deviceState, icon: "battery.25percent", kind: .formAction,
@@ -243,7 +243,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "dark-mode", num: 19, title: "Dark Mode",
+            id: "dark-mode", title: "Dark Mode",
             subtitle: "Toggle system dark mode",
             keywords: ["dark", "light", "theme", "night", "ui mode"],
             category: .deviceState, icon: "moon", kind: .toggleAction,
@@ -251,7 +251,7 @@ public enum FeatureRegistry {
             toggleOnLabel: "Dark", toggleOffLabel: "Light"
         ),
         FeatureDef(
-            id: "layout-overrides", num: 20, title: "Font & Density",
+            id: "layout-overrides", title: "Font & Density",
             subtitle: "Override font scale and display density",
             keywords: ["font scale", "density", "dpi", "responsive", "layout", "text size"],
             category: .deviceState, icon: "ruler", kind: .formAction,
@@ -268,7 +268,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "animation-scale", num: 21, title: "Animation Scale",
+            id: "animation-scale", title: "Animation Scale",
             subtitle: "Set animation scales to 0× or 1×",
             keywords: ["animation", "scale", "0x", "speed", "transition", "animator"],
             category: .deviceState, icon: "speedometer", kind: .toggleAction,
@@ -276,7 +276,7 @@ public enum FeatureRegistry {
             toggleOnLabel: "Animations off (0×)", toggleOffLabel: "Animations on (1×)"
         ),
         FeatureDef(
-            id: "locale", num: 22, title: "Change Locale",
+            id: "locale", title: "Change Locale",
             subtitle: "Switch device language for i18n testing",
             keywords: ["locale", "language", "i18n", "rtl", "translation"],
             category: .deviceState, icon: "character.bubble", kind: .formAction,
@@ -289,7 +289,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "network-toggles", num: 23, title: "Network Toggles",
+            id: "network-toggles", title: "Network Toggles",
             subtitle: "Toggle Wi-Fi, mobile data, and airplane mode",
             keywords: ["wifi", "data", "airplane", "network", "radio", "offline"],
             category: .deviceState, icon: "antenna.radiowaves.left.and.right", kind: .formAction,
@@ -300,7 +300,7 @@ public enum FeatureRegistry {
             ]
         ),
         FeatureDef(
-            id: "http-proxy", num: 24, title: "HTTP Proxy",
+            id: "http-proxy", title: "HTTP Proxy",
             subtitle: "Set or clear the global proxy (Charles, Proxyman)",
             keywords: ["proxy", "charles", "proxyman", "mitmproxy", "http", "debug"],
             category: .deviceState, icon: "point.3.connected.trianglepath.dotted", kind: .formAction,
@@ -315,7 +315,7 @@ public enum FeatureRegistry {
 
         // ── App Management ───────────────────────────────────────────────
         FeatureDef(
-            id: "apps", num: 39, title: "Apps",
+            id: "apps", title: "Apps",
             subtitle: "All installed & system apps — manage, permissions, info",
             keywords: [
                 "apps", "applications", "packages", "installed", "system", "explore",
@@ -326,7 +326,7 @@ public enum FeatureRegistry {
             category: .appManagement, icon: "square.grid.3x3", kind: .view
         ),
         FeatureDef(
-            id: "install-app", num: 50, title: "Install App",
+            id: "install-app", title: "Install App",
             subtitle: "Install an APK — drag and drop or pick a file",
             keywords: [
                 "install", "apk", "sideload", "side load", "drag", "drop",
@@ -335,49 +335,49 @@ public enum FeatureRegistry {
             category: .appManagement, icon: "arrow.down.app", kind: .view
         ),
         FeatureDef(
-            id: "app-management", num: 25, title: "Manage App",
+            id: "app-management", title: "Manage App",
             subtitle: "Open, stop, clear, or uninstall an app",
             keywords: ["open", "close", "force stop", "clear data", "uninstall", "cache"],
             category: .appManagement, icon: "macwindow", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "permissions", num: 26, title: "Permissions",
+            id: "permissions", title: "Permissions",
             subtitle: "Grant or revoke runtime permissions",
             keywords: ["permission", "grant", "revoke", "runtime", "checklist"],
             category: .appManagement, icon: "checkmark.shield", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "app-info", num: 27, title: "App Info",
+            id: "app-info", title: "App Info",
             subtitle: "Version, target SDK, size — and pull the APK",
             keywords: ["version", "version code", "sdk", "apk", "install date", "size"],
             category: .appManagement, icon: "shippingbox", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "current-activity", num: 28, title: "Copy Current Activity",
+            id: "current-activity", title: "Copy Current Activity",
             subtitle: "Show the foreground Activity right now",
             keywords: ["activity", "foreground", "screen", "resumed", "dumpsys", "copy"],
             category: .appManagement, icon: "square.stack.3d.up", kind: .instantAction
         ),
         FeatureDef(
-            id: "foreground-package", num: 37, title: "Copy Foreground Bundle ID",
+            id: "foreground-package", title: "Copy Foreground Bundle ID",
             subtitle: "Get the package id of the app on screen now",
             keywords: ["package", "bundle id", "foreground", "current app", "which app"],
             category: .appManagement, icon: "scope", kind: .instantAction
         ),
         FeatureDef(
-            id: "meminfo", num: 29, title: "Memory Usage",
+            id: "meminfo", title: "Memory Usage",
             subtitle: "Live memory usage for an app",
             keywords: ["memory", "meminfo", "ram", "pss", "heap"],
             category: .appManagement, icon: "memorychip", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "sandbox-browser", num: 30, title: "Sandbox Browser",
+            id: "sandbox-browser", title: "Sandbox Browser",
             subtitle: "Browse and pull app files (debug builds)",
             keywords: ["sandbox", "files", "run-as", "sqlite", "shared prefs", "mmkv"],
             category: .appManagement, icon: "folder", kind: .view, needsBundle: true
         ),
         FeatureDef(
-            id: "monkey", num: 31, title: "Monkey Test",
+            id: "monkey", title: "Monkey Test",
             subtitle: "Fire random events to hunt for crashes",
             keywords: ["monkey", "stress", "random", "fuzz", "crash"],
             category: .appManagement, icon: "die.face.5", kind: .formAction, needsBundle: true,
@@ -391,25 +391,25 @@ public enum FeatureRegistry {
 
         // ── Logs & Diagnostics ───────────────────────────────────────────
         FeatureDef(
-            id: "logcat", num: 32, title: "Logcat",
+            id: "logcat", title: "Logcat",
             subtitle: "Live log stream with search and filters",
             keywords: ["logcat", "logs", "stream", "filter", "tag", "level"],
             category: .logs, icon: "scroll", kind: .view
         ),
         FeatureDef(
-            id: "crash-catcher", num: 33, title: "Crash Catcher",
+            id: "crash-catcher", title: "Crash Catcher",
             subtitle: "Filtered crashes + copy-last-crash for Slack/Jira",
             keywords: ["crash", "fatal", "exception", "androidruntime", "reactnativejs"],
             category: .logs, icon: "exclamationmark.triangle", kind: .view
         ),
         FeatureDef(
-            id: "bug-report", num: 34, title: "Bug Report",
+            id: "bug-report", title: "Bug Report",
             subtitle: "Zip screenshot + logs + device info + version",
             keywords: ["bug report", "zip", "bundle", "diagnostics", "export"],
             category: .logs, icon: "doc.zipper", kind: .view
         ),
         FeatureDef(
-            id: "performance", num: 35, title: "Performance Monitor",
+            id: "performance", title: "Performance Monitor",
             subtitle: "Live CPU, RAM & FPS with recording and export",
             keywords: [
                 "performance", "perf", "cpu", "core", "ram", "memory", "fps",
@@ -421,7 +421,7 @@ public enum FeatureRegistry {
 
         // ── Tool UX (system) ─────────────────────────────────────────────
         FeatureDef(
-            id: "custom-commands", num: 36, title: "Custom Commands",
+            id: "custom-commands", title: "Custom Commands",
             subtitle: "Define your own adb actions with {bundleId}",
             keywords: ["custom", "command", "palette", "adb", "macro", "shortcut"],
             category: .toolUX, icon: "terminal", kind: .system, needsDevice: false

--- a/ADBKit/Sources/ADBKit/Services/EmulatorService.swift
+++ b/ADBKit/Sources/ADBKit/Services/EmulatorService.swift
@@ -106,4 +106,26 @@ public struct EmulatorService: Sendable {
             ? FeatureResult(ok: true, message: "Stopping emulator…")
             : FeatureResult(ok: false, message: friendlyAdbError(result, fallback: "Couldn't stop the emulator"))
     }
+
+    /// pid of the process listening on the emulator's console port (the number
+    /// in "emulator-5554"). That port is held by exactly that qemu process, so
+    /// `lsof` maps the serial to the right pid even with several emulators up.
+    /// Runs through the non-blocking runner so it can't park a cooperative
+    /// thread (the reason this lives here, not in the view).
+    public func consolePID(serial: String) async -> pid_t? {
+        guard let port = serial.split(separator: "-").last.flatMap({ Int($0) }) else { return nil }
+        let output = await runner.run(
+            executable: "/usr/sbin/lsof",
+            arguments: ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"],
+            timeout: .seconds(5), maxOutputBytes: 64 * 1024
+        )
+        return Self.parseLsofPID(output.stdoutText)
+    }
+
+    /// First pid from `lsof -t` output (one pid per line; tolerates CRLF).
+    static func parseLsofPID(_ output: String) -> pid_t? {
+        output.split(whereSeparator: \.isNewline)
+            .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+            .first
+    }
 }

--- a/ADBKit/Sources/ADBKit/Services/FileExplorerService.swift
+++ b/ADBKit/Sources/ADBKit/Services/FileExplorerService.swift
@@ -159,9 +159,14 @@ public struct FileExplorerService: Sendable {
     }
 
     private func verdict(_ result: AdbResult, success: String, fallback: String) -> FeatureResult {
-        if result.succeeded && result.stderr.isEmpty {
-            return FeatureResult(ok: true, message: success)
+        guard result.succeeded else {
+            return FeatureResult(ok: false, message: friendlyAdbError(result, fallback: fallback))
         }
-        return FeatureResult(ok: false, message: friendlyAdbError(result, fallback: fallback))
+        // Some toybox utilities print a warning to stderr (e.g. `cp -r` skipping
+        // an unreadable sub-entry, or an `su` banner) while still exiting 0 and
+        // doing the work. Trust the exit code and surface any warning text rather
+        // than misreporting a completed operation as failed.
+        let warning = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return FeatureResult(ok: true, message: warning.isEmpty ? success : "\(success) (with warnings)")
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/OverridesService.swift
+++ b/ADBKit/Sources/ADBKit/Services/OverridesService.swift
@@ -47,7 +47,7 @@ public struct OverridesService: Sendable {
     // MARK: - Apply
 
     public func applyProxy(serial: String, proxy: String) async throws(AdbError) -> String {
-        _ = try await client.run(on: serial, ["shell", "settings", "put", "global", "http_proxy", proxy])
+        _ = try await client.run(on: serial, ["shell", "settings", "put", "global", "http_proxy", shellQuote(proxy)])
         await record(serial: serial, kind: .proxy, value: proxy)
         return proxy
     }
@@ -98,7 +98,7 @@ public struct OverridesService: Sendable {
     /// the broadcast path many ROMs honor; record so the user can reset.
     public func applyLocale(serial: String, locale: String) async throws(AdbError) -> String {
         _ = try await client.run(on: serial, [
-            "shell", "am", "broadcast", "-a", "android.intent.action.LOCALE_CHANGED", "--es", "locale", locale,
+            "shell", "am", "broadcast", "-a", "android.intent.action.LOCALE_CHANGED", "--es", "locale", shellQuote(locale),
         ])
         await record(serial: serial, kind: .locale, value: locale)
         return locale

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -66,6 +66,11 @@ public actor ReactotronServer {
         }
 
         let parameters = NWParameters.tcp
+        // Bind to loopback only. The device reaches the server through
+        // `adb reverse tcp:9090` (forwarded over loopback), so this is
+        // transparent — and it keeps the debug server off the LAN, where it
+        // would otherwise accept unauthenticated connections from anyone.
+        parameters.requiredInterfaceType = .loopback
         let webSocket = NWProtocolWebSocket.Options()
         webSocket.autoReplyPing = true
         parameters.defaultProtocolStack.applicationProtocols.insert(webSocket, at: 0)

--- a/ADBKit/Sources/ADBKit/Services/TextInputService.swift
+++ b/ADBKit/Sources/ADBKit/Services/TextInputService.swift
@@ -39,9 +39,11 @@ public struct TextInputService: Sendable {
             return FeatureResult(ok: false, message: "Nothing to send")
         }
 
-        // `input text` has no escape for a literal % (%s means space), so
-        // %-containing text goes through the ADBKeyboard path like Unicode.
-        let needsIME = text.contains { !$0.isASCII } || text.contains("%")
+        // `input text` has no escape for a literal % (%s means space), and a
+        // newline/tab in the argument would act as a device-shell command
+        // separator. So %, control whitespace, and non-ASCII all go through the
+        // base64 ADBKeyboard path, which can't be shell-injected.
+        let needsIME = text.contains { !$0.isASCII || $0.isNewline || $0 == "\t" } || text.contains("%")
         if !needsIME {
             let result = try await client.run(
                 on: serial, ["shell", "input", "text", Self.escapeForInput(text)]
@@ -55,7 +57,7 @@ public struct TextInputService: Sendable {
         guard imeList.stdout.contains(Self.adbKeyboardIME) else {
             return FeatureResult(
                 ok: false,
-                message: "This text needs the ADBKeyboard app on the device (Unicode and % can't go through `input text`).",
+                message: "This text needs the ADBKeyboard app on the device (Unicode, %, and line breaks can't go through `input text`).",
                 needsAdbKeyboard: true
             )
         }

--- a/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
@@ -129,6 +129,13 @@ import Testing
     @Test func parsesAvdListWithCrlf() {
         #expect(EmulatorService.parseAvdList("Pixel_7\r\nMedium_Tablet\r\n") == ["Pixel_7", "Medium_Tablet"])
     }
+
+    @Test func parsesLsofPidTakingFirstLine() {
+        #expect(EmulatorService.parseLsofPID("12345\n") == 12345)
+        #expect(EmulatorService.parseLsofPID("12345\r\n67890\r\n") == 12345)
+        #expect(EmulatorService.parseLsofPID("") == nil)
+        #expect(EmulatorService.parseLsofPID("not-a-pid") == nil)
+    }
 }
 
 @Suite struct AppsExplorerParsingTests {

--- a/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceOverviewTests.swift
@@ -33,6 +33,20 @@ import Testing
         #expect(available == 34_057_940)
     }
 
+    @Test func parsesDfWithWrappedLongFilesystemName() {
+        // Dynamic-partition devices (Pixel, most Android 11+) wrap a long device
+        // path onto its own line, pushing the numbers to the next physical line.
+        let output = """
+        Filesystem               1K-blocks      Used Available Use% Mounted on
+        /dev/block/mapper/userdata
+                                  56371708  22152504  34057940  40% /data
+        """
+        let (total, used, available) = DeviceOverview.parseDf(output)
+        #expect(total == 56_371_708)
+        #expect(used == 22_152_504)
+        #expect(available == 34_057_940)
+    }
+
     @Test func parsesBatteryWithHealthAndCycles() {
         let output = """
         Current Battery Service state:
@@ -51,6 +65,20 @@ import Testing
         #expect(level == 80)
         #expect(health == "Overheat")
         #expect(cycles == nil)
+    }
+
+    @Test func parsesBatteryIgnoresDecoyLevelLine() {
+        // Some ROMs print "Max charging level:" before the real "level:"; the
+        // line-anchored match must take the canonical value, not the decoy.
+        let output = """
+        Current Battery Service state:
+          Max charging level: 80
+          level: 55
+          health: 2
+        """
+        let (level, health, _) = DeviceOverview.parseBattery(output)
+        #expect(level == 55)
+        #expect(health == "Good")
     }
 
     @Test func countsPackages() {

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -142,6 +142,35 @@ import Testing
         #expect(!result.ok)
         #expect(result.message.contains("isn't implemented yet"))
     }
+
+    @Test func implementedIDsAreAllRealFeatures() {
+        // A typo'd or stale id in implementedIDs would silently mark a
+        // non-existent feature as runnable.
+        let registryIDs = Set(FeatureRegistry.byID.keys)
+        for id in FeatureEngine.implementedIDs {
+            #expect(registryIDs.contains(id), "implementedIDs lists \"\(id)\", which is not in the registry")
+        }
+    }
+
+    @Test func everyImplementedActionResolvesToARunner() async {
+        // The #1 scaling hazard: an action feature added to implementedIDs but
+        // missing its dispatch case silently falls through to the "coming soon"
+        // placeholder, with no other signal. (View features are intentionally in
+        // implementedIDs without a dispatch case — the App layer serves them —
+        // so this guard is scoped to action kinds.)
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: [], stdout: "")
+        let engine = await makeEngine(runner)
+        let actionKinds: Set<FeatureKind> = [.instantAction, .formAction, .toggleAction]
+        for feature in FeatureRegistry.all
+        where actionKinds.contains(feature.kind) && FeatureEngine.implementedIDs.contains(feature.id) {
+            let result = await engine.run(featureID: feature.id, serial: "S1", params: [:])
+            #expect(
+                !result.message.contains("isn't implemented yet"),
+                "\(feature.id) is action-kind and in implementedIDs but has no dispatch case"
+            )
+        }
+    }
 }
 
 @Suite struct FeatureRegistryTests {

--- a/ADBKit/Tests/ADBKitTests/FileExplorerServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FileExplorerServiceTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct FileExplorerServiceTests {
+    private func makeService(_ runner: MockProcessRunner) async -> FileExplorerService {
+        FileExplorerService(client: await makeTestClient(runner: runner))
+    }
+
+    @Test func cleanSuccessReportsPlainMessage() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "mkdir"], stdout: "", stderr: "", exitCode: 0)
+        let result = try await makeService(runner).makeDirectory(serial: "S1", path: "/sdcard/New Folder")
+        #expect(result.ok)
+        #expect(result.message == "Folder created")
+    }
+
+    @Test func zeroExitWithStderrSucceedsWithWarning() async throws {
+        // A toybox warning printed on a zero exit (the op still happened) must
+        // not be misreported as a failure.
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "cp"],
+            stdout: "", stderr: "cp: can't open 'sub': Permission denied", exitCode: 0
+        )
+        let result = try await makeService(runner).copy(serial: "S1", from: "/a", toDir: "/b")
+        #expect(result.ok)
+        #expect(result.message.contains("with warnings"))
+    }
+
+    @Test func nonZeroExitReportsFailure() async throws {
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "rm"],
+            stdout: "", stderr: "rm: No such file or directory", exitCode: 1
+        )
+        let result = try await makeService(runner).delete(serial: "S1", path: "/missing")
+        #expect(!result.ok)
+    }
+
+    @Test func devicePathsAreShellQuoted() async throws {
+        // Paths with spaces/metacharacters must reach the device shell quoted.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "mkdir"], stdout: "", exitCode: 0)
+        _ = try await makeService(runner).makeDirectory(serial: "S1", path: "/sdcard/a b;c")
+        #expect(runner.invocations.contains {
+            $0.arguments == ["-s", "S1", "shell", "mkdir", "-p", "'/sdcard/a b;c'"]
+        })
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/OverridesServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/OverridesServiceTests.swift
@@ -125,4 +125,31 @@ import Testing
             $0.arguments == ["-s", "S1", "shell", "am", "broadcast", "-a", "com.android.systemui.demo", "-e", "command", "exit"]
         })
     }
+
+    @Test func proxyValueIsShellQuotedAgainstInjection() async throws {
+        // A proxy carrying shell metacharacters must reach the device as one
+        // quoted argument, not as `settings put … ; reboot`.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = await makeService(runner)
+        _ = try await service.applyProxy(serial: "S1", proxy: "10.0.0.5; reboot:8888")
+        #expect(runner.invocations.contains {
+            $0.arguments == [
+                "-s", "S1", "shell", "settings", "put", "global", "http_proxy", "'10.0.0.5; reboot:8888'",
+            ]
+        })
+    }
+
+    @Test func localeValueIsShellQuotedAgainstInjection() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = await makeService(runner)
+        _ = try await service.applyLocale(serial: "S1", locale: "fr-FR; rm -rf /")
+        #expect(runner.invocations.contains {
+            $0.arguments == [
+                "-s", "S1", "shell", "am", "broadcast", "-a", "android.intent.action.LOCALE_CHANGED",
+                "--es", "locale", "'fr-FR; rm -rf /'",
+            ]
+        })
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
@@ -113,9 +113,9 @@ import Testing
             arguments: VideoEditing.thumbnailArguments(input: url.path, output: out.path),
             timeout: .seconds(20), maxOutputBytes: 1_000_000)
         let size = (try? FileManager.default.attributesOfItem(atPath: out.path)[.size] as? Int) ?? 0
-        print("THUMB FFMPEG: exit=\(result.exitCode) size=\(size ?? 0)")
+        print("THUMB FFMPEG: exit=\(result.exitCode ?? -1) size=\(size)")
         #expect(result.exitCode == 0)
-        #expect((size ?? 0) > 0)
+        #expect(size > 0)
     }
 }
 

--- a/ADBKit/Tests/ADBKitTests/SystemProcessRunnerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SystemProcessRunnerTests.swift
@@ -77,4 +77,20 @@ import Testing
         canary.cancel()
         #expect(canaryTicks.get() > 5, "canary task starved — runner is blocking cooperative threads")
     }
+
+    @Test func cancellationKillsChildAndReturnsPromptly() async {
+        // A long-running child under a generous timeout: cancelling the calling
+        // Task must kill it and return now, not block until the 60s timeout.
+        let clock = ContinuousClock()
+        let started = clock.now
+        let task = Task {
+            await runner.run(executable: "/bin/sleep", arguments: ["30"], timeout: .seconds(60))
+        }
+        try? await Task.sleep(for: .milliseconds(200))
+        task.cancel()
+        let output = await task.value
+        #expect(clock.now - started < .seconds(10), "cancellation did not tear the child down promptly")
+        #expect(!output.timedOut, "a cancelled run is not a timeout")
+        #expect(output.exitCode == nil, "a killed child has no clean exit code")
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/TextInputServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TextInputServiceTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct TextInputServiceTests {
+    @Test func asciiTextUsesInputTextWithEscaping() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "input", "text"], stdout: "", exitCode: 0)
+        let service = TextInputService(client: await makeTestClient(runner: runner))
+        let result = try await service.send(serial: "S1", text: "hello world")
+        #expect(result.ok)
+        #expect(runner.invocations.contains {
+            $0.arguments == ["-s", "S1", "shell", "input", "text", "hello%sworld"]
+        })
+    }
+
+    @Test func newlineRoutesAwayFromRawInputText() async throws {
+        // A newline must never reach `input text`, where the device shell would
+        // treat it as a command separator. Such text routes through the base64
+        // IME path, which prompts for ADBKeyboard when it isn't installed.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "ime", "list"], stdout: "")
+        let service = TextInputService(client: await makeTestClient(runner: runner))
+        let result = try await service.send(serial: "S1", text: "ok\nrm -rf /")
+        #expect(!result.ok)
+        #expect(result.needsAdbKeyboard)
+        #expect(!runner.invocations.contains { $0.arguments.contains("input") })
+    }
+}

--- a/App/Sources/FeatureDetail/Views/EmulatorsView.swift
+++ b/App/Sources/FeatureDetail/Views/EmulatorsView.swift
@@ -160,34 +160,13 @@ struct EmulatorsView: View {
     /// emulators running. Falls back to any emulator if the lookup misses.
     private func focus(serial: String) {
         Task {
-            let pid = await Self.consolePortPID(serial: serial)
+            let pid = await state.env.engine.emulators.consolePID(serial: serial)
             if let pid, let app = NSRunningApplication(processIdentifier: pid) {
                 app.activate(options: .activateAllWindows)
             } else {
                 for app in emulatorApps() { app.activate(options: .activateAllWindows) }
             }
         }
-    }
-
-    /// pid of the process listening on the emulator's console port. Runs `lsof`
-    /// off the main actor so the tap handler never blocks.
-    nonisolated private static func consolePortPID(serial: String) async -> pid_t? {
-        guard let port = serial.split(separator: "-").last.flatMap({ Int($0) }) else { return nil }
-        return await Task.detached {
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-            task.arguments = ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = FileHandle.nullDevice
-            do { try task.run() } catch { return nil }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            task.waitUntilExit()
-            return String(data: data, encoding: .utf8)?
-                .split(whereSeparator: \.isNewline)
-                .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
-                .first
-        }.value
     }
 
     /// The emulator window appears a few seconds after launch — poll briefly and

--- a/App/Sources/FeatureDetail/Views/FileExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/FileExplorerView.swift
@@ -313,7 +313,7 @@ struct FileExplorerView: View {
             } label: {
                 Image(systemName: selection.contains(entry.id) ? "checkmark.square.fill" : "square")
                     .imageScale(.large)
-                    .foregroundStyle(selection.contains(entry.id) ? Color("BrandAccent") : Color("TextMuted"))
+                    .foregroundStyle(selection.contains(entry.id) ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -281,7 +281,9 @@ final class ReactotronSession {
             let parsed = ReactotronEvent(command: command)
             switch parsed {
             case .clear:
-                items.removeAll()
+                // Scope to the sending client so one app's clear doesn't wipe
+                // another connected app's timeline.
+                items.removeAll { $0.connectionId == connectionId }
                 return
             case let .customCommandRegister(id, name, title, description, args):
                 registerCommand(RegisteredCommand(id: id, command: name, title: title, description: description, args: args))
@@ -1493,12 +1495,15 @@ private struct JSONNode: Identifiable {
     var children: [JSONNode] {
         switch value {
         case let .object(dict):
-            return dict.sorted { $0.key < $1.key }.map {
-                JSONNode(path: path + "/" + $0.key, key: $0.key, value: $0.value, depth: depth + 1)
+            // Identity is positional (parent path + ordinal), never the key
+            // text, so a key containing "/" or "[0]" can't collide with another
+            // node and toggle the wrong branch.
+            return dict.sorted { $0.key < $1.key }.enumerated().map { offset, entry in
+                JSONNode(path: "\(path).\(offset)", key: entry.key, value: entry.value, depth: depth + 1)
             }
         case let .array(items):
             return items.enumerated().map {
-                JSONNode(path: path + "/\($0.offset)", key: "[\($0.offset)]", value: $0.element, depth: depth + 1)
+                JSONNode(path: "\(path).\($0.offset)", key: "[\($0.offset)]", value: $0.element, depth: depth + 1)
             }
         default:
             return []

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -19,16 +19,23 @@ struct RootView: View {
     @State private var pickerIsFirstRun = false
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Launches to allow before the first-run privacy disclosure appears.
-    /// Telemetry is anonymous and on by default in the meantime (opt-out in
-    /// Settings → Privacy); the modal then lets the user confirm or opt out.
+    /// Temporary toggle: flip to `true` to surface the privacy disclosure on the
+    /// first launch (after the welcome flow) instead of deferring it. Left
+    /// `false` for now to keep current behavior. Telemetry stays anonymous and
+    /// on by default either way (opt-out in Settings → Privacy). Remove this
+    /// (and the deferral below) when switching to ask-on-first-launch for good.
+    private let askConsentOnFirstLaunch = false
+
+    /// Launches to allow before the first-run privacy disclosure appears, when
+    /// `askConsentOnFirstLaunch` is false.
     private let consentPromptAfterLaunches = 5
 
     /// Launches before the one-time GitHub-star nudge (shown after consent).
     private let starPromptAfterLaunches = 10
 
     private var shouldPromptConsent: Bool {
-        !consentAsked && launchCount >= consentPromptAfterLaunches
+        guard !consentAsked else { return false }
+        return askConsentOnFirstLaunch || launchCount >= consentPromptAfterLaunches
     }
 
     private var shouldPromptStar: Bool {

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -280,9 +280,11 @@ final class AppState {
         await refreshToolStatus()
 
         deviceStreamTask = Task { [weak self, monitor = env.monitor] in
+            // This Task inherits AppState's @MainActor isolation, so the loop
+            // body already runs on the main actor — no extra hop needed.
             for await devices in await monitor.updates() {
                 guard let self else { break }
-                await MainActor.run { self.devicesChanged(devices) }
+                self.devicesChanged(devices)
             }
         }
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,51 @@ Two layers, strictly separated so a future cross-platform port only re-does UI:
 
 When adding a feature: logic + a parser test go in ADBKit; the view goes in
 `App/Sources/FeatureDetail/Views/`. Never put adb/Process logic in a SwiftUI view.
+Follow the **Adding a feature** checklist below — a feature's `id` is a contract
+spread across several files, and most omissions fail *silently* (a "Coming Soon"
+screen), not loudly.
+
+## Adding a feature — the checklist
+
+A feature's string `id` is the contract across several files. Do these in order.
+**[test]** steps fail `swift test` if skipped; **[silent]** steps have *no*
+automated guard, so the failure mode is a non-working feature you only catch by
+opening it — verify those by hand.
+
+1. **Define it** — add a `FeatureDef` to `FeatureRegistry.all` (unique `id`,
+   title, keywords, category, `kind`). **[test: `hasAll48Features` — bump the
+   count; `byID` traps on a duplicate id]**
+2. **How-it-works note** — add to `FeatureNotes`. **[test: `everyFeatureHasAHowToNote`]**
+3. **Command reference** — add to `FeatureCommands` (each entry leads with the
+   tool name). **[test: `everyFeatureHasACommandReference`, `commandReferenceLeadsWithTheTool`]**
+4. **If it's an action** (`.instantAction`/`.formAction`/`.toggleAction`):
+   - add the runner `case` to `FeatureEngine.dispatch`,
+   - add the `id` to `FeatureEngine.implementedIDs`,
+   - add an arg-vector test in `FeatureEngineTests` asserting the exact adb
+     arguments (and the quoted form of any user value). **[test:
+     `everyImplementedActionResolvesToARunner` catches a missing dispatch case;
+     `implementedIDsAreAllRealFeatures` catches a typo'd id; your arg-vector test
+     catches wrong/omitted-quote arguments]**
+5. **If it's a view** (`.view`/`.system`):
+   - build the SwiftUI view in `App/Sources/FeatureDetail/Views/`,
+   - add the `id` → view `case` in `FeatureDetailView.detailByKind`,
+   - add the `id` to `implementedIDs`,
+   - if it runs adb directly, wrap each user action in
+     `CommandLog.userInitiated(feature: <id>)`. **[test: `implementedIDsAreAllRealFeatures`
+     for the id] · [silent: a missing `detailByKind` case renders "Coming Soon";
+     missing `userInitiated` leaves the Recent tab empty]**
+6. **If it joins a hub** — add it to `FeatureRegistry.absorbedByHub` and fold its
+   keywords into the hub's `keywords`. **[test: `hubsStaySearchableByTheirMembersPrimaryKeyword`]**
+7. **Logic lives in ADBKit.** adb/Process/parsing go in an ADBKit service with a
+   pure, static, tested parser — never `Process`/`adb` in a SwiftUI view.
+   **[silent — but a review red flag]**
+8. **Verify** — `cd ADBKit && swift test` green, then `make build` with zero
+   warnings (warnings are errors).
 
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 320 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 334 tests, keep green
 make build         # xcodegen generate + xcodebuild Debug
 make run           # build + open the .app
 ```
@@ -48,7 +88,7 @@ spawn adb/scrcpy/emulator/brew).
 - `Devices/`: `DeviceMonitor` (actor, 2s poll, `AsyncStream<[Device]>`),
   `DeviceListParser`, `DeviceProps` (getprop), `DeviceOverview` (RAM/storage/
   battery/CPU/app counts), `DeviceDetails` (picker enrichment).
-- `Features/`: `FeatureRegistry` (45 features, declarative; `absorbedByHub`
+- `Features/`: `FeatureRegistry` (48 `FeatureDef`s, declarative; `absorbedByHub`
   maps a hub screen to the features it gathers, flattened to
   `absorbedFeatureIDs`; `catalogFeatureIDs` is the registry minus those),
   `FeatureModel`,
@@ -115,10 +155,18 @@ feature for existing users via `knownIds`.
   16-concurrent-process canary test guarding this — don't regress it.
 - **`"\r\n"` is ONE Swift Character.** Splitting adb/emu console output on
   `"\n"` silently fails on CRLF. Use `.components(separatedBy: .newlines)`.
-- **Device-side shell quoting:** anything going through `adb shell` is joined
-  with spaces and run by the device's `sh`. Quote URLs/paths with
-  `shellQuote()` (deep links, sandbox, file explorer). `adb push`/`pull` use
-  the sync protocol — no shell, no quoting.
+- **Device-side shell quoting is the security boundary.** Anything going through
+  `adb shell` is joined with spaces and run by the device's `sh`, so EVERY
+  user-controlled value (path, URL, SSID, hostname, proxy, locale, free text)
+  must be wrapped with `shellQuote()` — never rely on caller-side validation to
+  reject metacharacters (an engine `host:port` check is UX, not security).
+  `adb push`/`pull`/`exec-out` use the sync protocol — no shell, no quoting.
+  There's no linter for this; a missing `shellQuote` is command injection, so
+  add an arg-vector test asserting the quoted form (see `OverridesServiceTests`).
+- **Cancellation kills the child.** `SystemProcessRunner.run` wraps its body in
+  `withTaskCancellationHandler`, so cancelling the calling `.task` (navigation, a
+  `.task(id:)` re-key) terminates the adb child instead of orphaning it until its
+  timeout. Keep long-running adb work in a cancellable `Task` so this fires.
 - **Pull progress** is the destination file's on-disk size polled against the
   known source size (real %). Screenshots/recordings/dir pulls stay
   indeterminate (no reliable total). The progress strip lives in RootView's
@@ -159,19 +207,87 @@ feature for existing users via `knownIds`.
 - UI automation for verification: prefer AX element refs over coordinate
   clicks; the user works on the Mac alongside you (see memory).
 
-## Git / contributing
+## Standards
 
-- Work on a feature branch; open a PR to `main`. Keep `swift test` green and the
-  build warning-free before pushing.
-- Commits are imperative-mood, one logical change each.
+The bar: every change ships with tests, leaves the build warning-free, and keeps
+the ADBKit/App boundary intact. The architecture exists to make bugs *fail at
+compile or test time* — lean on it instead of manual vigilance.
+
+### Development
+
+- **Logic in ADBKit, UI in App.** A new capability is an ADBKit service (a small
+  `Sendable` struct/actor over `AdbClient`) plus a pure parser; the view only
+  renders and calls it. If a view reaches for `Process`/`adb`/parsing, stop —
+  move it down. The boundary is what keeps logic testable without a device.
+- **Parsers are pure and static.** `static func parseX(_:) -> …` with no I/O, so
+  it's tested directly. Split adb output on `.newlines`, never `"\n"` (CRLF).
+- **Quote every device-shell value with `shellQuote()`** (see Conventions). It's
+  the security boundary, not caller validation.
+- **Long-running work goes in a cancellable `Task`**; `.task(id:)` keys include
+  device readiness; guard `!Task.isCancelled` before writing `@State`.
+- **No new dependency without a reason.** Each is attack surface + maintenance.
+- **Replace, don't deprecate.** Delete dead code in the same change; no shims or
+  unused fields (a test like `everyImplementedActionResolvesToARunner` is cheaper
+  than a stale parallel list).
+- **Keep files focused.** `AppState` and the largest views are already big — put
+  a new feature's glue in its own type/extension, not the nearest god-object.
+
+### Testing
+
+- **Test behavior, not implementation** — assert observable output and the exact
+  adb argument vector (via `MockProcessRunner`), never private state. A
+  behavior-preserving refactor must not break tests.
+- **Cover edges and errors, not just the happy path** — empty input, CRLF,
+  malformed/partial output, non-zero exit, the failure branch. Mock only the
+  boundary (`ProcessRunning`, the filesystem via temp dirs), never logic.
+- **Every new parser/runner gets a test in the same change.** For anything taking
+  user input that hits `adb shell`, assert the `shellQuote`d form appears in
+  `runner.invocations`.
+- **Registry invariants are tests, not review folklore** — when you add a
+  cross-feature rule, add a loop over `FeatureRegistry.all` that enforces it (the
+  `everyFeature*` / `*ResolvesToARunner` tests are the pattern to copy).
+- Device-dependent checks are `@Test(.enabled(if:))` gated on `MIRROR_LIVE_TEST=1`
+  so they skip cleanly in CI.
+
+### Review (in order: architecture → correctness → tests → quality)
+
+- **Architecture:** does ADBKit stay UI-free? Any `Process`/`adb` in a view? Is
+  the new logic in a testable service?
+- **Correctness:** every device-shell value `shellQuote`d? output split on
+  `.newlines`? `.task(id:)` readiness + `!Task.isCancelled` guard present?
+  failure paths handled (not optimistic success)?
+- **Tests:** parser + arg-vector tests present and meaningful (would they fail if
+  the code broke)? edges covered?
+- **Quality:** dead code removed, file not bloated, names clear, zero warnings.
+- Adversarially verify a finding before acting on it — read the cited code; many
+  plausible findings misread it (a refactor that "removes dead code" can delete a
+  live path). Sync to `origin` first.
+
+### Bug-prevention gates (already wired — keep them green)
+
+- `swift test -Xswiftc -warnings-as-errors` (CI) and
+  `SWIFT_TREAT_WARNINGS_AS_ERRORS` on the App target — warnings are build errors.
+- Swift 6 complete strict concurrency (pinned in `Package.swift` and project.yml)
+  — data races fail the build.
+- The 16-process starvation canary, the feature-dispatch consistency tests, and
+  the registry-invariant tests guard the highest-risk seams. Don't regress them.
+
+### Git / contributing
+
+- Work on a feature branch; open a PR to `main`. `swift test` green and the build
+  warning-free before pushing.
+- Commits are imperative-mood, one logical change each. PR descriptions state
+  what the diff does in plain, factual language — no "critical/comprehensive".
+- Never commit secrets (gitleaks runs pre-commit); telemetry keys are build-time
+  injected, never committed.
 
 ## Status
 
 Feature-complete across all planned milestones plus several UX rounds (latest:
 **v2.6.1** — bug-fix batch across Reactotron, crash catcher, app install,
 notifications, mirroring, and the welcome screen, plus a custom-command preset
-library); 320 tests green; builds clean with zero warnings.
-Verified live against a physical device and an Android emulator. Release builds
+library; v2.6.2 in progress); 334 tests green; builds clean with zero warnings
+(now enforced as errors in CI). Verified live against a physical device and an Android emulator. Release builds
 are Developer ID-signed + notarized and bundle scrcpy/ffmpeg
 (see `RELEASING.md`). Open gaps: the Apps list/detail divider isn't
 drag-resizable.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -29,4 +29,9 @@ separate ffmpeg install.
   https://ffmpeg.org/download.html and https://git.ffmpeg.org/ffmpeg.git
 
 Because this ffmpeg build is GPLv3, distributing the app bundle with it included
-carries GPLv3 obligations for the combined distribution.
+carries GPLv3 obligations. Droidective invokes ffmpeg only as a separate
+executable (via `Process`) and never links against it or its libraries, so the
+app and ffmpeg are aggregated rather than a combined/derivative work — the app's
+own MIT license is unaffected. The obligation is to make ffmpeg's corresponding
+source and license available to recipients, which the upstream links above
+satisfy; the unmodified binary is redistributed under GPLv3.

--- a/project.yml
+++ b/project.yml
@@ -90,6 +90,9 @@ targets:
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
+        # Enforce the zero-warnings policy for first-party App code. Scoped to
+        # this target's sources — SPM dependencies build with their own settings.
+        SWIFT_TREAT_WARNINGS_AS_ERRORS: YES
         CODE_SIGN_IDENTITY: "-"
         CODE_SIGN_STYLE: Manual
         ENABLE_HARDENED_RUNTIME: NO


### PR DESCRIPTION
A batch of correctness, security, and guardrail fixes from a full code audit, branched off v2.6.2 (includes #64 and #65). Each change has tests where testable; 334 ADBKit tests green; app builds warning-free.

## Security / correctness
- Quote the proxy and locale values passed to `adb shell` (`OverridesService`) — they reached the device shell unquoted, so a value like `10.0.0.5; reboot:8888` passed the host:port check and ran `; reboot` on the device. `shellQuote` at the service layer is now the boundary.
- `SystemProcessRunner` kills the child process when the calling Task is cancelled (was orphaning long-running adb processes until their timeout on navigation / `.task(id:)` re-key). Adds a cancellation test; also closes a small unsynchronised-field gap in `PipeCollector`.
- Bind the Reactotron WebSocket server to loopback only (was listening on all interfaces with no auth).
- Route control-character text (newline/tab) through the base64 IME path so it can't act as a device-shell separator (defense-in-depth).

## Bugs
- `parseDf`: handle dynamic-partition devices that wrap the long filesystem name onto its own line (storage was blank on Pixel/Android 11+).
- `parseBattery`: anchor `level`/`health` to a line start so a decoy "Max charging level:" line isn't matched first; `DeviceDetails` now reuses the parser.
- File Explorer: treat a zero exit with stderr as success-with-warning instead of a false "failed" toast.
- Reactotron JSON tree: identity is now positional (parent path + ordinal), not key text, so a key containing `/` no longer collides and toggles the wrong branch; a device-sent `clear` is scoped to its own connection.

## Architecture / quality
- Move the emulator console-PID `lsof` lookup out of `EmulatorsView` (raw `Process` + `waitUntilExit` in a view) into `EmulatorService`, run through the non-blocking runner, with a pure `parseLsofPID` + test.
- Remove the dead `FeatureDef.num` field (read nowhere; two entries collided on 50).
- Tidy two App-layer nits (typed shape styles; a redundant MainActor hop).

## Guardrails
- Tests asserting the feature-dispatch contract: `implementedIDs` are all real features, and every action-kind implemented id resolves to a runner (catches the silent "Coming Soon" failure when a feature is half-wired).
- Enforce the zero-warnings policy in CI (`-warnings-as-errors` for ADBKit; `SWIFT_TREAT_WARNINGS_AS_ERRORS` on the App target); fixed two latent warnings.
- Pin the Swift 6 language mode in `Package.swift`; Dependabot for GitHub Actions; documented the ffmpeg GPL aggregation basis.
- A removable `askConsentOnFirstLaunch` toggle (default off — current behavior unchanged).

## Docs
- CLAUDE.md: an ordered "Adding a feature" checklist (marking which edit sites a test guards vs. which fail silently) and Development / Testing / Review / Bug-prevention standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)