### PR TITLE
Cap scrcpy decoder payload sizes to prevent unbounded buffering

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyAudioStreamDecoder.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyAudioStreamDecoder.swift
@@ -32,6 +32,10 @@ public struct ScrcpyAudioStreamDecoder: Sendable {
     private var buffer: [UInt8] = []
     private var cursor = 0
 
+    /// Sanity ceiling for a packet's declared payload size; past this is a
+    /// corrupt/desynced length, so halt rather than buffer toward ~4 GB.
+    private static let maxPayloadSize = 64 * 1024 * 1024
+
     public init() {}
 
     private var available: Int { buffer.count - cursor }
@@ -51,6 +55,7 @@ public struct ScrcpyAudioStreamDecoder: Sendable {
                 guard available >= ScrcpyPacketHeader.byteCount else { break parse }
                 let ptsFlags = readU64BE()
                 let size = Int(readU32BE())
+                guard size <= Self.maxPayloadSize else { phase = .halted; break }
                 phase = .packetPayload(ScrcpyPacketHeader(ptsFlags: ptsFlags, payloadSize: size))
             case let .packetPayload(header):
                 guard available >= header.payloadSize else { break parse }

--- a/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyDeviceMessage.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyDeviceMessage.swift
@@ -19,6 +19,11 @@ public struct ScrcpyDeviceMessageDecoder: Sendable {
     private var buffer: [UInt8] = []
     private var cursor = 0
 
+    /// Sanity ceiling for a clipboard message's declared length (a UInt32 on the
+    /// wire); past this is a corrupt length, so drop the buffer rather than wait
+    /// for gigabytes that never arrive.
+    private static let maxClipboardBytes = 16 * 1024 * 1024
+
     public init() {}
 
     private var available: Int { buffer.count - cursor }
@@ -37,6 +42,10 @@ public struct ScrcpyDeviceMessageDecoder: Sendable {
             case .clipboard:
                 guard available >= 5 else { break parse }
                 let length = Int(readU32BE(at: cursor + 1))
+                guard length <= Self.maxClipboardBytes else {
+                    // Corrupt/oversized length — can't trust the frame; drop it.
+                    buffer.removeAll(); cursor = 0; break parse
+                }
                 guard available >= 5 + length else { break parse }
                 let text = String(decoding: buffer[(cursor + 5) ..< (cursor + 5 + length)], as: UTF8.self)
                 cursor += 5 + length

--- a/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyStreamDecoder.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyStreamDecoder.swift
@@ -68,6 +68,8 @@ public struct ScrcpyStreamDecoder: Sendable {
         case sessionMeta
         case packetHeader
         case packetPayload(ScrcpyPacketHeader)
+        /// Unrecoverable desync (an absurd packet size): swallow trailing bytes.
+        case halted
     }
 
     private let sendsDeviceName: Bool
@@ -75,6 +77,12 @@ public struct ScrcpyStreamDecoder: Sendable {
     private var buffer: [UInt8] = []
     private var cursor = 0
     private var pendingCodecRaw: UInt32 = 0
+
+    /// Sanity ceiling for a packet's declared payload size. A single encoded
+    /// frame is at most a few MB even at high resolution/bitrate; a larger value
+    /// is a corrupt/desynced length, so the decoder halts rather than buffer
+    /// toward the ~4 GB a UInt32 could claim.
+    private static let maxPayloadSize = 64 * 1024 * 1024
 
     /// - Parameters:
     ///   - tunnelForward: in forward mode the server writes one leading dummy
@@ -127,6 +135,9 @@ public struct ScrcpyStreamDecoder: Sendable {
                 guard available >= ScrcpyPacketHeader.byteCount else { break parse }
                 let ptsFlags = readU64BE()
                 let size = Int(readU32BE())
+                // A corrupt/desynced length would otherwise buffer toward a
+                // payload that never coheres; a binary stream can't resync, so halt.
+                guard size <= Self.maxPayloadSize else { phase = .halted; break }
                 phase = .packetPayload(ScrcpyPacketHeader(ptsFlags: ptsFlags, payloadSize: size))
             case let .packetPayload(header):
                 guard available >= header.payloadSize else { break parse }
@@ -134,6 +145,9 @@ public struct ScrcpyStreamDecoder: Sendable {
                 cursor += header.payloadSize
                 events.append(.packet(header, payload: payload))
                 phase = .packetHeader
+            case .halted:
+                cursor = buffer.count
+                break parse
             }
         }
         compact()

--- a/ADBKit/Tests/ADBKitTests/ScrcpyAudioStreamDecoderTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScrcpyAudioStreamDecoderTests.swift
@@ -72,4 +72,16 @@ import Testing
         }
         #expect(payload.count == 4)
     }
+
+    @Test func haltsOnOversizedPacketSize() {
+        // "raw" codec + a packet header whose size is an absurd 0xFFFFFFFF.
+        var bytes: [UInt8] = [0x00, 0x72, 0x61, 0x77]
+        bytes += [0, 0, 0, 0, 0, 0, 0, 0]    // ptsFlags
+        bytes += [0xFF, 0xFF, 0xFF, 0xFF]    // absurd size
+        bytes += [0x01, 0x02, 0x03]
+        var decoder = ScrcpyAudioStreamDecoder()
+        let events = decoder.consume(Data(bytes))
+        #expect(!events.contains { if case .packet = $0 { true } else { false } })
+        #expect(decoder.consume(Data([UInt8](repeating: 0xAB, count: 4096))).isEmpty)
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/ScrcpyDeviceMessageTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScrcpyDeviceMessageTests.swift
@@ -35,4 +35,12 @@ import Testing
         }
         #expect(messages == [.clipboard("abc")])
     }
+
+    @Test func dropsOnOversizedClipboardLength() {
+        var decoder = ScrcpyDeviceMessageDecoder()
+        // type 0 (clipboard), length 0xFFFFFFFF — dropped, not buffered toward 4 GB.
+        #expect(decoder.consume(Data([0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x68, 0x69])).isEmpty)
+        // The decoder recovered to a clean state and parses the next valid message.
+        #expect(decoder.consume(Data([0x00, 0, 0, 0, 1, 0x41])) == [.clipboard("A")])
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/ScrcpyStreamDecoderTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScrcpyStreamDecoderTests.swift
@@ -112,4 +112,22 @@ import Testing
         let events = decoder.consume(Data(bytes))
         #expect(events.first == .deviceName("sdk_gphone64_arm64"))
     }
+
+    @Test func haltsOnOversizedPacketSize() {
+        // dummy + empty 64-byte name + "h264" + session meta (800x500) + a packet
+        // header whose size field is an absurd 0xFFFFFFFF, then some payload bytes.
+        var bytes: [UInt8] = [0x00]
+        bytes += [UInt8](repeating: 0, count: 64)
+        bytes += [0x68, 0x32, 0x36, 0x34]                             // "h264"
+        bytes += [0x80, 0, 0, 0, 0, 0, 0x03, 0x20, 0, 0, 0x01, 0xF4]  // flags, w=800, h=500
+        bytes += [0, 0, 0, 0, 0, 0, 0, 0]                             // ptsFlags
+        bytes += [0xFF, 0xFF, 0xFF, 0xFF]                             // absurd size
+        bytes += [0x01, 0x02, 0x03, 0x04]
+        var decoder = ScrcpyStreamDecoder(tunnelForward: true)
+        let events = decoder.consume(Data(bytes))
+        // The header parses, but the absurd size must not yield a packet…
+        #expect(!events.contains { if case .packet = $0 { true } else { false } })
+        // …and the decoder is halted: further bytes yield nothing (not buffered).
+        #expect(decoder.consume(Data([UInt8](repeating: 0xAB, count: 4096))).isEmpty)
+    }
 }


### PR DESCRIPTION
The screen-mirror wire decoders (video, audio, device-message) read a length word (a UInt32) and buffered bytes until that many arrived. A corrupt or desynced length could claim up to ~4 GB, accumulating memory toward a payload that never coheres — a silent OOM instead of a recoverable failure.

Adds a sanity ceiling per decoder:
- Video/audio decoders halt on an oversized packet size (a binary stream can't resync after a desync) and discard trailing bytes.
- The device-message decoder drops an oversized clipboard frame and recovers to a clean state.

Adds fixture tests feeding an oversized length to each decoder (337 ADBKit tests green under `-warnings-as-errors`). No protocol/behavior change for valid streams.

Follow-up to the audit batch (#67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)