### PR TITLE
Add an App test target and cover the launch-prompt decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Debug -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO
+      - name: Run App tests
+        run: xcodebuild -project Droidective.xcodeproj -scheme AppTests -configuration Debug -derivedDataPath DerivedData test CODE_SIGNING_ALLOWED=NO
 
   # Publish the marketing site (and the committed Sparkle appcast) to GitHub
   # Pages on every push to main. The appcast in site/ is the single source of

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -82,43 +82,8 @@ struct RootView: View {
                     StarPromptView(onStar: { state.openRepository() })
                 }
             }
-            .onAppear {
-                state.openMainWindow = { openWindow(id: "main") }
-                state.openPalette = { PaletteController.shared.show(appState: state) }
-                (NSApp.delegate as? AppDelegate)?.appState = state
-                InstallInbox.shared.onReceive = { urls in state.openAPKs(urls) }
-                migrateDefaultsIfNeeded()
-                applyStoredTheme()
-                updateDockIcon()
-                HotkeyManager.install(state: state)
-                switch LaunchPrompt.next(
-                    hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
-                    consentAsked: consentAsked, starPromptShown: starPromptShown,
-                    launchCount: launchCount, askConsentOnFirstLaunch: askConsentOnFirstLaunch,
-                    consentAfterLaunches: consentPromptAfterLaunches, starAfterLaunches: starPromptAfterLaunches
-                ) {
-                case .rolePicker:
-                    // Brand-new user: pick a role first, then run the tour.
-                    pickerIsFirstRun = true
-                    state.presentRolePicker = true
-                case .tour:
-                    state.presentTour = true
-                case .consent:
-                    presentConsent = true
-                case .star:
-                    presentStar = true
-                case nil:
-                    break
-                }
-            }
-            .onChange(of: state.presentRolePicker) { _, showing in
-                // Only the first-run picker chains into the tour; changing role
-                // later (pill / Settings) must not reopen it.
-                if !showing && pickerIsFirstRun {
-                    pickerIsFirstRun = false
-                    if !hasSeenTour { state.presentTour = true }
-                }
-            }
+            .onAppear { performLaunchSetup() }
+            .onChange(of: state.presentRolePicker) { _, showing in rolePickerVisibilityChanged(showing) }
             .onChange(of: state.presentTour) { _, showing in
                 if !showing && shouldPromptConsent { presentConsent = true }
             }
@@ -138,6 +103,48 @@ struct RootView: View {
             } message: { info in
                 Text(info.message)
             }
+    }
+
+    /// Runs once when the root view appears: wires AppState callbacks, applies
+    /// stored prefs/theme/hotkeys, and shows the first due launch prompt. Kept
+    /// out of `body` so the view-builder expression stays cheap to type-check.
+    private func performLaunchSetup() {
+        state.openMainWindow = { openWindow(id: "main") }
+        state.openPalette = { PaletteController.shared.show(appState: state) }
+        (NSApp.delegate as? AppDelegate)?.appState = state
+        InstallInbox.shared.onReceive = { urls in state.openAPKs(urls) }
+        migrateDefaultsIfNeeded()
+        applyStoredTheme()
+        updateDockIcon()
+        HotkeyManager.install(state: state)
+        switch LaunchPrompt.next(
+            hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
+            consentAsked: consentAsked, starPromptShown: starPromptShown,
+            launchCount: launchCount, askConsentOnFirstLaunch: askConsentOnFirstLaunch,
+            consentAfterLaunches: consentPromptAfterLaunches, starAfterLaunches: starPromptAfterLaunches
+        ) {
+        case .rolePicker:
+            // Brand-new user: pick a role first, then run the tour.
+            pickerIsFirstRun = true
+            state.presentRolePicker = true
+        case .tour:
+            state.presentTour = true
+        case .consent:
+            presentConsent = true
+        case .star:
+            presentStar = true
+        case nil:
+            break
+        }
+    }
+
+    /// Only the first-run role picker chains into the tour; changing role later
+    /// (pill / Settings) must not reopen it.
+    private func rolePickerVisibilityChanged(_ showing: Bool) {
+        if !showing && pickerIsFirstRun {
+            pickerIsFirstRun = false
+            if !hasSeenTour { state.presentTour = true }
+        }
     }
 
     @ViewBuilder

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -34,12 +34,14 @@ struct RootView: View {
     private let starPromptAfterLaunches = 10
 
     private var shouldPromptConsent: Bool {
-        guard !consentAsked else { return false }
-        return askConsentOnFirstLaunch || launchCount >= consentPromptAfterLaunches
+        LaunchPrompt.consentDue(
+            consentAsked: consentAsked, launchCount: launchCount,
+            askOnFirstLaunch: askConsentOnFirstLaunch, afterLaunches: consentPromptAfterLaunches)
     }
 
     private var shouldPromptStar: Bool {
-        !starPromptShown && launchCount >= starPromptAfterLaunches
+        LaunchPrompt.starDue(
+            starPromptShown: starPromptShown, launchCount: launchCount, afterLaunches: starPromptAfterLaunches)
     }
 
     var body: some View {
@@ -89,16 +91,24 @@ struct RootView: View {
                 applyStoredTheme()
                 updateDockIcon()
                 HotkeyManager.install(state: state)
-                if !hasChosenRole && !hasSeenTour {
+                switch LaunchPrompt.next(
+                    hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
+                    consentAsked: consentAsked, starPromptShown: starPromptShown,
+                    launchCount: launchCount, askConsentOnFirstLaunch: askConsentOnFirstLaunch,
+                    consentAfterLaunches: consentPromptAfterLaunches, starAfterLaunches: starPromptAfterLaunches
+                ) {
+                case .rolePicker:
                     // Brand-new user: pick a role first, then run the tour.
                     pickerIsFirstRun = true
                     state.presentRolePicker = true
-                } else if !hasSeenTour {
+                case .tour:
                     state.presentTour = true
-                } else if shouldPromptConsent {
+                case .consent:
                     presentConsent = true
-                } else if shouldPromptStar {
+                case .star:
                     presentStar = true
+                case nil:
+                    break
                 }
             }
             .onChange(of: state.presentRolePicker) { _, showing in

--- a/App/Sources/State/LaunchPrompt.swift
+++ b/App/Sources/State/LaunchPrompt.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Which first-run prompt (if any) to show on launch, in priority order.
+///
+/// Pure logic so the onboarding decision tree — five interacting persisted flags
+/// across role picker → tour → privacy consent → GitHub-star nudge — is
+/// unit-tested rather than only exercised by hand. `RootView` reads the flags and
+/// drives the UI; this just decides which prompt is due.
+enum LaunchPrompt: Equatable {
+    /// Brand-new user picks a role; its dismissal chains into the tour.
+    case rolePicker
+    case tour
+    case consent
+    case star
+
+    /// The highest-priority prompt due for the given persisted state, or nil.
+    static func next(
+        hasChosenRole: Bool,
+        hasSeenTour: Bool,
+        consentAsked: Bool,
+        starPromptShown: Bool,
+        launchCount: Int,
+        askConsentOnFirstLaunch: Bool,
+        consentAfterLaunches: Int,
+        starAfterLaunches: Int
+    ) -> LaunchPrompt? {
+        if !hasChosenRole && !hasSeenTour { return .rolePicker }
+        if !hasSeenTour { return .tour }
+        if consentDue(
+            consentAsked: consentAsked, launchCount: launchCount,
+            askOnFirstLaunch: askConsentOnFirstLaunch, afterLaunches: consentAfterLaunches
+        ) {
+            return .consent
+        }
+        if starDue(starPromptShown: starPromptShown, launchCount: launchCount, afterLaunches: starAfterLaunches) {
+            return .star
+        }
+        return nil
+    }
+
+    /// Whether the privacy disclosure is due (also consulted after the tour closes).
+    static func consentDue(consentAsked: Bool, launchCount: Int, askOnFirstLaunch: Bool, afterLaunches: Int) -> Bool {
+        guard !consentAsked else { return false }
+        return askOnFirstLaunch || launchCount >= afterLaunches
+    }
+
+    /// Whether the one-time GitHub-star nudge is due.
+    static func starDue(starPromptShown: Bool, launchCount: Int, afterLaunches: Int) -> Bool {
+        !starPromptShown && launchCount >= afterLaunches
+    }
+}

--- a/App/Tests/LaunchPromptTests.swift
+++ b/App/Tests/LaunchPromptTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+/// The launch-prompt decision tree (role → tour → consent → star) is the kind of
+/// multi-flag onboarding logic the audit flagged as bug-prone and untested.
+@Suite struct LaunchPromptTests {
+    /// Defaults represent a fully-onboarded user (nothing due); each test flips
+    /// only the inputs it cares about. Thresholds mirror RootView's.
+    private func next(
+        hasChosenRole: Bool = true, hasSeenTour: Bool = true,
+        consentAsked: Bool = true, starPromptShown: Bool = true,
+        launchCount: Int = 0, askConsentOnFirstLaunch: Bool = false,
+        consentAfterLaunches: Int = 5, starAfterLaunches: Int = 10
+    ) -> LaunchPrompt? {
+        LaunchPrompt.next(
+            hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
+            consentAsked: consentAsked, starPromptShown: starPromptShown,
+            launchCount: launchCount, askConsentOnFirstLaunch: askConsentOnFirstLaunch,
+            consentAfterLaunches: consentAfterLaunches, starAfterLaunches: starAfterLaunches)
+    }
+
+    @Test func brandNewUserGetsRolePicker() {
+        #expect(next(hasChosenRole: false, hasSeenTour: false) == .rolePicker)
+    }
+
+    @Test func roleChosenButTourUnseenGetsTour() {
+        #expect(next(hasChosenRole: true, hasSeenTour: false) == .tour)
+    }
+
+    @Test func tourTakesPriorityOverDueConsent() {
+        #expect(next(hasSeenTour: false, consentAsked: false, launchCount: 50) == .tour)
+    }
+
+    @Test func consentIsDeferredUntilThreshold() {
+        #expect(next(consentAsked: false, launchCount: 4) == nil)
+        #expect(next(consentAsked: false, launchCount: 5) == .consent)
+    }
+
+    @Test func firstLaunchToggleSurfacesConsentImmediately() {
+        #expect(next(consentAsked: false, launchCount: 0, askConsentOnFirstLaunch: true) == .consent)
+    }
+
+    @Test func consentTakesPriorityOverStar() {
+        #expect(next(consentAsked: false, starPromptShown: false, launchCount: 20) == .consent)
+    }
+
+    @Test func starNudgeShownOnlyAtItsThresholdAfterConsent() {
+        #expect(next(consentAsked: true, starPromptShown: false, launchCount: 9) == nil)
+        #expect(next(consentAsked: true, starPromptShown: false, launchCount: 10) == .star)
+    }
+
+    @Test func fullyOnboardedUserSeesNothing() {
+        #expect(next(launchCount: 100) == nil)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -100,3 +100,20 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         DEAD_CODE_STRIPPING: YES
+  AppTests:
+    type: bundle.unit-test
+    platform: macOS
+    # A logic-test bundle (no app host to launch): it compiles the pure
+    # App-layer sources under test directly, so decision logic like LaunchPrompt
+    # is tested fast and deterministically. Genuinely UI-coupled coordinators
+    # would need a hosted/XCUITest target instead.
+    sources:
+      - App/Tests
+      - App/Sources/State/LaunchPrompt.swift
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective.tests
+        GENERATE_INFOPLIST_FILE: YES
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: complete
+        SWIFT_TREAT_WARNINGS_AS_ERRORS: YES


### PR DESCRIPTION
Closes the "App layer has zero tests" gap from the audit.

- Extracts the first-run prompt decision (role picker → tour → privacy consent → GitHub-star nudge — five interacting persisted flags the audit flagged as bug-prone) into a pure `LaunchPrompt` type, and drives `RootView.onAppear` from it.
- Adds an `AppTests` logic-test bundle (no app host, so it runs fast and deterministically — the right pattern for App-layer logic; UI-coupled coordinators would need a hosted/XCUITest target). 8 cases cover the ordering and thresholds.
- Runs the App tests in CI.

No behavior change — the decision tree is identical, now expressed in one tested place. ADBKit 337 + App 8 tests green. Follow-up to #67/#68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)