### PR TITLE
Fix network-counter-reset spike + Reactotron snapshot hang; cover device-stream logic

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/NetworkSpeed.swift
+++ b/ADBKit/Sources/ADBKit/Services/NetworkSpeed.swift
@@ -59,18 +59,20 @@ public actor NetworkSpeedService {
         var totalUp = 0.0
         for interface in current {
             let priorBytes = prior.interfaces[interface.name]
-            // &- guards a counter reset; a brand-new interface (no prior) reads 0.
-            let down = Double(interface.rxBytes &- (priorBytes?.rx ?? interface.rxBytes)) / elapsed
-            let up = Double(interface.txBytes &- (priorBytes?.tx ?? interface.txBytes)) / elapsed
-            let clampedDown = max(0, down)
-            let clampedUp = max(0, up)
-            totalDown += clampedDown
-            totalUp += clampedUp
-            if priorBytes != nil || clampedDown > 0 || clampedUp > 0 {
+            // A brand-new interface (no prior) and a counter that went backwards
+            // (a reboot/reset) both read 0. Subtracting only when the counter
+            // advanced avoids the wrapping `&-` turning a reset into a huge spike.
+            let priorRx = priorBytes?.rx ?? interface.rxBytes
+            let priorTx = priorBytes?.tx ?? interface.txBytes
+            let down = interface.rxBytes > priorRx ? Double(interface.rxBytes - priorRx) / elapsed : 0
+            let up = interface.txBytes > priorTx ? Double(interface.txBytes - priorTx) / elapsed : 0
+            totalDown += down
+            totalUp += up
+            if priorBytes != nil || down > 0 || up > 0 {
                 speeds.append(InterfaceSpeed(
                     name: interface.name,
-                    downloadBytesPerSec: clampedDown,
-                    uploadBytesPerSec: clampedUp,
+                    downloadBytesPerSec: down,
+                    uploadBytesPerSec: up,
                     rxBytes: interface.rxBytes,
                     txBytes: interface.txBytes
                 ))

--- a/ADBKit/Tests/ADBKitTests/DeviceMonitorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceMonitorTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct DeviceMonitorTests {
+    private func makeMonitor(_ runner: MockProcessRunner) async -> DeviceMonitor {
+        DeviceMonitor(client: await makeTestClient(runner: runner))
+    }
+
+    @Test func listCachesWithinTTLAndForceRefetches() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\nABC123 device\n")
+        let monitor = await makeMonitor(runner)
+
+        let first = await monitor.list()
+        #expect(first.count == 1)
+        #expect(first.first?.serial == "ABC123")
+
+        // Output changes, but a cached list() (within the 2s TTL) must not re-fetch.
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\n")
+        #expect(await monitor.list().count == 1)
+        #expect(await monitor.list(force: true).isEmpty)
+    }
+
+    @Test func updatesYieldsInitialThenChangeOnInvalidate() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\nABC123 device\n")
+        let monitor = await makeMonitor(runner)
+
+        // A long interval so the poll loop fires once on subscription and then
+        // effectively never again — invalidate() drives the subsequent poll.
+        var iterator = await monitor.updates(interval: .seconds(3600)).makeAsyncIterator()
+        let first = await iterator.next()
+        #expect(first?.count == 1)
+        #expect(first?.first?.serial == "ABC123")
+
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\nABC123 device\nXYZ789 device\n")
+        await monitor.invalidate()
+        let second = await iterator.next()
+        #expect(second?.count == 2)
+    }
+
+    @Test func identicalPollDoesNotYieldButAChangeDoes() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\nABC123 device\n")
+        let monitor = await makeMonitor(runner)
+        var iterator = await monitor.updates(interval: .seconds(3600)).makeAsyncIterator()
+        #expect(await iterator.next()?.count == 1)
+
+        // Same list → no yield from invalidate; then a real change → a yield.
+        await monitor.invalidate()
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\n")
+        await monitor.invalidate()
+        #expect(await iterator.next()?.isEmpty == true)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/NetworkSpeedServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/NetworkSpeedServiceTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct NetworkSpeedServiceTests {
+    private func makeService(_ runner: MockProcessRunner) async -> NetworkSpeedService {
+        NetworkSpeedService(client: await makeTestClient(runner: runner))
+    }
+
+    private static func procNetDev(rx: UInt64, tx: UInt64) -> String {
+        """
+        Inter-|   Receive                                                |  Transmit
+         face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+          wlan0: \(rx) 900 0 0 0 0 0 0 \(tx) 800 0 0 0 0 0 0
+        """
+    }
+
+    private func script(_ runner: MockProcessRunner, rx: UInt64, tx: UInt64) {
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "cat", "/proc/net/dev"],
+            stdout: Self.procNetDev(rx: rx, tx: tx))
+    }
+
+    @Test func firstPollReturnsNilWithNoBaseline() async {
+        let runner = MockProcessRunner()
+        script(runner, rx: 1000, tx: 500)
+        #expect(await makeService(runner).poll(serial: "S1") == nil)
+    }
+
+    @Test func secondPollReportsCumulativeTotals() async {
+        let runner = MockProcessRunner()
+        script(runner, rx: 1000, tx: 500)
+        let service = await makeService(runner)
+        _ = await service.poll(serial: "S1")  // primes the baseline
+        script(runner, rx: 5000, tx: 2000)
+        let sample = await service.poll(serial: "S1")
+        #expect(sample?.totalRxBytes == 5000)
+        #expect(sample?.totalTxBytes == 2000)
+        #expect((sample?.downloadBytesPerSec ?? -1) >= 0)
+    }
+
+    @Test func counterResetClampsToZeroNotASpike() async {
+        let runner = MockProcessRunner()
+        script(runner, rx: 1_000_000, tx: 500_000)
+        let service = await makeService(runner)
+        _ = await service.poll(serial: "S1")
+        // Counters went backwards (a reboot) — throughput must read 0, not the
+        // huge spike a wrapping subtraction would produce.
+        script(runner, rx: 50, tx: 20)
+        let sample = await service.poll(serial: "S1")
+        #expect(sample?.downloadBytesPerSec == 0)
+        #expect(sample?.uploadBytesPerSec == 0)
+        #expect(sample?.interfaces.first?.downloadBytesPerSec == 0)
+    }
+
+    @Test func resetClearsBaselineSoNextPollIsNilAgain() async {
+        let runner = MockProcessRunner()
+        script(runner, rx: 1000, tx: 500)
+        let service = await makeService(runner)
+        _ = await service.poll(serial: "S1")
+        await service.reset()
+        #expect(await service.poll(serial: "S1") == nil)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -201,7 +201,19 @@ final class ReactotronSession {
 
     func takeSnapshot() {
         pendingSnapshot = true
-        Task { await sendToTarget(type: "state.backup.request", payload: .object([:])) }
+        Task {
+            await sendToTarget(type: "state.backup.request", payload: .object([:]))
+            // Mirror loadStateTree: if no store plugin replies, clear the pending
+            // flag and report it — otherwise it stays pending forever and the next
+            // unrelated backup response is silently captured as the snapshot.
+            try? await Task.sleep(for: .seconds(4))
+            guard pendingSnapshot else { return }
+            pendingSnapshot = false
+            app?.showToast(Toast(
+                message: "No snapshot received — wire reactotron-redux or reactotron-mst into your store to snapshot it.",
+                ok: false
+            ))
+        }
     }
 
     fileprivate func restore(_ snapshot: Snapshot) {


### PR DESCRIPTION
The medium audit batch — two real bugs plus tests for previously-untested shared logic.

## Bugs
- **NetworkSpeed counter reset**: `poll()` diffed `/proc/net/dev` counters with a wrapping `&-`, so a counter that went backwards (a device reboot) wrapped to a ~UInt64.max delta and reported a huge spurious throughput spike (`max(0,)` never helped — the wrapped value is positive). Now subtracts only when the counter advanced.
- **Reactotron snapshot hang**: `takeSnapshot` set `pendingSnapshot` and waited forever; with no store plugin wired it never cleared, and the next unrelated `state.backup.response` was silently captured as the snapshot. Now mirrors `loadStateTree`'s timeout + failure toast.

## Tests (previously-untested shared logic)
- `NetworkSpeedService.poll`: first-poll-nil, cumulative totals, reset-clamps-to-0, reset() clears baseline.
- `DeviceMonitor`: list() caching + force-refetch, updates() initial yield + change-on-invalidate, change-detection (identical poll doesn't yield).

344 ADBKit tests green under `-warnings-as-errors`; app builds warning-free. Follow-up to #67/#68/#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)