### PR TITLE
Show APK details (name, version, SDK) before installing

### DIFF
--- a/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
+++ b/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
@@ -28,6 +28,10 @@ public enum AdbError: Error, LocalizedError, Sendable {
 /// cached until `clearCache()` (e.g. after a tool install).
 public actor ToolLocator {
     private var cache: [Tool: String?] = [:]
+    /// Separate cache for aapt2 — resolved from the SDK build-tools, not the
+    /// `Tool` enum, so it stays out of the Doctor's tool report. Outer optional
+    /// = resolved-yet, inner = found-or-not.
+    private var aapt2Cache: String??
     private let runner: any ProcessRunning
     private let environment: [String: String]
     private let fileManager = FileManager.default
@@ -59,6 +63,28 @@ public actor ToolLocator {
 
     public func clearCache() {
         cache.removeAll()
+        aapt2Cache = nil
+    }
+
+    /// Resolve the newest `aapt2` from the SDK build-tools (it ships there, not
+    /// via Homebrew), or nil when no build-tools are installed. Cached; cleared
+    /// by `clearCache`. Used to read a local APK's badging before install.
+    public func aapt2Path() async -> String? {
+        if let cached = aapt2Cache { return cached }
+        var resolved: String?
+        search: for root in sdkRoots {
+            let buildTools = "\(root)/build-tools"
+            guard let versions = try? fileManager.contentsOfDirectory(atPath: buildTools) else { continue }
+            for version in versions.sorted(by: { $0.localizedStandardCompare($1) == .orderedDescending }) {
+                let candidate = "\(buildTools)/\(version)/aapt2"
+                if fileManager.isExecutableFile(atPath: candidate) {
+                    resolved = candidate
+                    break search
+                }
+            }
+        }
+        aapt2Cache = .some(resolved)
+        return resolved
     }
 
     /// Pre-populate the cache with a known path (tests, or a user-pinned
@@ -73,14 +99,18 @@ public actor ToolLocator {
         return path
     }
 
-    private func candidatePaths(for tool: Tool) -> [String] {
+    /// SDK roots to probe, from the environment then the default install path.
+    private var sdkRoots: [String] {
         let home = fileManager.homeDirectoryForCurrentUser.path
-        let brewPrefixes = ["/opt/homebrew/bin", "/usr/local/bin"]
-        let sdkRoots = [
+        return [
             environment["ANDROID_HOME"],
             environment["ANDROID_SDK_ROOT"],
             "\(home)/Library/Android/sdk",
         ].compactMap(\.self)
+    }
+
+    private func candidatePaths(for tool: Tool) -> [String] {
+        let brewPrefixes = ["/opt/homebrew/bin", "/usr/local/bin"]
 
         switch tool {
         case .adb:

--- a/ADBKit/Sources/ADBKit/Services/ApkInspection.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApkInspection.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Identifying details parsed from a local APK, shown in the install prompt.
+/// `label`/`packageName`/… are nil when aapt2 isn't available — the file name
+/// and size are always present.
+public struct ApkInfo: Sendable, Equatable {
+    public var fileName: String
+    public var fileSizeBytes: Int
+    public var label: String?
+    public var packageName: String?
+    public var versionName: String?
+    public var versionCode: String?
+    public var minSdk: String?
+    public var targetSdk: String?
+
+    public init(
+        fileName: String,
+        fileSizeBytes: Int,
+        label: String? = nil,
+        packageName: String? = nil,
+        versionName: String? = nil,
+        versionCode: String? = nil,
+        minSdk: String? = nil,
+        targetSdk: String? = nil
+    ) {
+        self.fileName = fileName
+        self.fileSizeBytes = fileSizeBytes
+        self.label = label
+        self.packageName = packageName
+        self.versionName = versionName
+        self.versionCode = versionCode
+        self.minSdk = minSdk
+        self.targetSdk = targetSdk
+    }
+
+    /// True when aapt2 resolved at least the app label, package, or version —
+    /// i.e. there's more to show than the file name and size.
+    public var hasDetails: Bool {
+        label != nil || packageName != nil || versionName != nil
+    }
+}
+
+/// Parses `aapt2 dump badging` output. Pure and isolated so it's unit-tested
+/// without aapt2 installed.
+public enum ApkBadging {
+    public struct Fields: Sendable, Equatable {
+        public var label: String?
+        public var packageName: String?
+        public var versionName: String?
+        public var versionCode: String?
+        public var minSdk: String?
+        public var targetSdk: String?
+    }
+
+    /// Pull the identifying fields out of badging text. Each lives on its own
+    /// line, e.g. `package: name='com.x' versionCode='1' versionName='1.0'` and
+    /// `application-label:'My App'`.
+    public static func parse(_ output: String) -> Fields {
+        Fields(
+            label: capture(output, #"application-label:'([^']*)'"#)
+                ?? capture(output, #"application: label='([^']*)'"#),
+            packageName: capture(output, #"package: name='([^']*)'"#),
+            versionName: capture(output, #"versionName='([^']*)'"#),
+            versionCode: capture(output, #"versionCode='([^']*)'"#),
+            minSdk: capture(output, #"sdkVersion:'([^']*)'"#),
+            targetSdk: capture(output, #"targetSdkVersion:'([^']*)'"#)
+        )
+    }
+
+    /// First capture group of `pattern` in `text`, or nil (also nil for an empty
+    /// capture, e.g. `versionName=''`).
+    private static func capture(_ text: String, _ pattern: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let full = NSRange(text.startIndex..., in: text)
+        guard let match = regex.firstMatch(in: text, range: full), match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: text) else { return nil }
+        let value = String(text[range])
+        return value.isEmpty ? nil : value
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInstallService.swift
@@ -16,6 +16,30 @@ public struct AppInstallService: Sendable {
         return Self.parse(result)
     }
 
+    /// Read a local APK's identifying details for the install prompt. Uses the
+    /// SDK's aapt2 when available; without build-tools it returns just the file
+    /// name and size, so the prompt still shows something useful.
+    public func inspect(apkPath: String) async -> ApkInfo {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: apkPath)
+        let size = (attrs?[.size] as? Int) ?? 0
+        var info = ApkInfo(fileName: URL(fileURLWithPath: apkPath).lastPathComponent, fileSizeBytes: size)
+        guard let aapt2 = await client.locator.aapt2Path() else { return info }
+        let result = await SystemProcessRunner().run(
+            executable: aapt2,
+            arguments: ["dump", "badging", apkPath],
+            timeout: .seconds(20),
+            maxOutputBytes: 4 * 1024 * 1024)
+        guard result.exitCode == 0 else { return info }
+        let fields = ApkBadging.parse(result.stdoutText)
+        info.label = fields.label
+        info.packageName = fields.packageName
+        info.versionName = fields.versionName
+        info.versionCode = fields.versionCode
+        info.minSdk = fields.minSdk
+        info.targetSdk = fields.targetSdk
+        return info
+    }
+
     /// Map adb's install output to a result. adb prints "Success" on success and
     /// "Failure [INSTALL_FAILED_…]" (or a streamed error line) on failure, often
     /// on a zero exit, so the text — not the exit code — is authoritative. The

--- a/ADBKit/Tests/ADBKitTests/ApkBadgingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApkBadgingTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct ApkBadgingTests {
+    /// A representative slice of `aapt2 dump badging` output.
+    private let sample = """
+    package: name='com.example.myapp' versionCode='42' versionName='2.1.0' compileSdkVersion='34' compileSdkVersionCodename='14'
+    sdkVersion:'24'
+    targetSdkVersion:'34'
+    uses-permission: name='android.permission.INTERNET'
+    application-label:'My Example App'
+    application-label-en-US:'My Example App'
+    application-label-fr:'Mon App'
+    application: label='My Example App' icon='res/mipmap-anydpi-v26/ic_launcher.xml'
+    launchable-activity: name='com.example.myapp.MainActivity'  label='My Example App'
+    """
+
+    @Test func parsesAllIdentifyingFields() {
+        let fields = ApkBadging.parse(sample)
+        #expect(fields.packageName == "com.example.myapp")
+        #expect(fields.versionName == "2.1.0")
+        #expect(fields.versionCode == "42")
+        #expect(fields.label == "My Example App")
+        #expect(fields.minSdk == "24")
+        #expect(fields.targetSdk == "34")
+    }
+
+    @Test func packageNameIsNotConfusedWithPermissionOrActivityNames() {
+        // `name='…'` also appears on uses-permission / launchable-activity lines;
+        // only the `package:` line's name is the package id.
+        #expect(ApkBadging.parse(sample).packageName == "com.example.myapp")
+    }
+
+    @Test func minSdkIsNotShadowedByTargetSdk() {
+        // `targetSdkVersion` must not be misread as `sdkVersion` (case matters).
+        let fields = ApkBadging.parse(sample)
+        #expect(fields.minSdk == "24")
+        #expect(fields.targetSdk == "34")
+    }
+
+    @Test func fallsBackToApplicationLineLabel() {
+        let output = """
+        package: name='com.x' versionCode='1' versionName='1.0'
+        application: label='Fallback Label' icon='res/ic.png'
+        """
+        #expect(ApkBadging.parse(output).label == "Fallback Label")
+    }
+
+    @Test func emptyValuesAndGarbageYieldNil() {
+        let fields = ApkBadging.parse("package: name='' versionName='' \nnonsense line")
+        #expect(fields.packageName == nil)
+        #expect(fields.versionName == nil)
+        #expect(fields.label == nil)
+        #expect(fields.minSdk == nil)
+    }
+
+    @Test func apkInfoHasDetailsReflectsBadging() {
+        let bare = ApkInfo(fileName: "app.apk", fileSizeBytes: 1024)
+        #expect(!bare.hasDetails)
+        let rich = ApkInfo(fileName: "app.apk", fileSizeBytes: 1024, packageName: "com.x")
+        #expect(rich.hasDetails)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/InstallAppView.swift
+++ b/App/Sources/FeatureDetail/Views/InstallAppView.swift
@@ -14,6 +14,9 @@ struct InstallAppView: View {
     /// APK(s) opened from Finder (double-click / Open With), staged for an
     /// explicit Install rather than installing on arrival.
     @State private var staged: [URL] = []
+    /// aapt2-parsed details per staged APK (app name, version, SDK), shown in the
+    /// card. Populated asynchronously; falls back to file name + size.
+    @State private var apkInfos: [URL: ApkInfo] = [:]
 
     private var targets: [Device] {
         state.devices.filter { state.targetSerials.contains($0.serial) }
@@ -39,6 +42,7 @@ struct InstallAppView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { consumePending() }
         .onChange(of: state.pendingInstallAPKs) { _, _ in consumePending() }
+        .task(id: staged) { await inspectStaged() }
     }
 
     /// An APK opened from Finder, staged and awaiting an explicit Install (the
@@ -48,15 +52,11 @@ struct InstallAppView: View {
             Image(systemName: "arrow.down.app.fill")
                 .font(.system(size: 46))
                 .foregroundStyle(.brandAccent)
-            VStack(spacing: 4) {
+            VStack(spacing: 6) {
                 Text(staged.count == 1 ? "Ready to install" : "Ready to install \(staged.count) APKs")
                     .font(.title3.weight(.medium))
                 ForEach(staged, id: \.self) { url in
-                    Text(url.lastPathComponent)
-                        .font(.callout)
-                        .foregroundStyle(.textMuted)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    apkRow(url)
                 }
             }
             HStack(spacing: 10) {
@@ -80,6 +80,45 @@ struct InstallAppView: View {
         guard !state.pendingInstallAPKs.isEmpty else { return }
         staged = state.pendingInstallAPKs
         state.pendingInstallAPKs = []
+    }
+
+    /// Read each staged APK's badging so the card shows what it is. Falls back to
+    /// file name + size when aapt2 (from the SDK build-tools) isn't installed.
+    private func inspectStaged() async {
+        var resolved: [URL: ApkInfo] = [:]
+        for url in staged {
+            resolved[url] = await state.env.engine.appInstall.inspect(apkPath: url.path)
+        }
+        guard !Task.isCancelled else { return }
+        apkInfos = resolved
+    }
+
+    /// One staged APK: app name (or file name) with a package · version · SDK ·
+    /// size subtitle once aapt2 has resolved it.
+    @ViewBuilder private func apkRow(_ url: URL) -> some View {
+        let info = apkInfos[url]
+        VStack(spacing: 1) {
+            Text(info?.label ?? url.lastPathComponent)
+                .font(.callout.weight(.medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if let info {
+                Text(apkSubtitle(info))
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+    }
+
+    private func apkSubtitle(_ info: ApkInfo) -> String {
+        var parts: [String] = []
+        if let package = info.packageName { parts.append(package) }
+        if let version = info.versionName { parts.append("v\(version)") }
+        if let target = info.targetSdk { parts.append("SDK \(target)") }
+        parts.append(ByteCountFormatter.string(fromByteCount: Int64(info.fileSizeBytes), countStyle: .file))
+        return parts.joined(separator: " · ")
     }
 
     private var dropZone: some View {


### PR DESCRIPTION
Ports the genuinely-useful piece of the abandoned install-picker WIP onto the shipped install flow: a preview of what an APK is, before you install it.

- **ADBKit**: `ApkInspection` (an `ApkInfo` value + a pure `ApkBadging` parser for `aapt2 dump badging`, unit-tested), `ToolLocator.aapt2Path()` resolving the newest aapt2 from the SDK build-tools (cached separately so it stays out of the Doctor's tool report), and `AppInstallService.inspect(apkPath:)`.
- **UI**: when an APK is staged (opened from Finder), the "Ready to install" card shows the app name, package, version, target SDK, and size instead of just the file name.

Graceful fallback: with no SDK build-tools (no aapt2), it shows file name + size, exactly as before. Drag-and-drop / file-pick keep their immediate-install behavior (preview applies to the staged Finder-open card); extending it there is an easy follow-up.

The divergent floating "InstallPicker" panel from the WIP is intentionally dropped — the shipped #65 routing is the source of truth. ADBKit 350 + App 8 tests green; app builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)