### PR TITLE
Show the demo as an inline GIF in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ actions in a Raycast-style command palette — no terminal required.
 
 <p align="center">
   <a href="https://droidective.com/assets/demo.mp4">
-    <img src="site/assets/demo-poster.webp" width="760" alt="Droidective demo — click to watch">
+    <img src="docs/demo.gif" width="760" alt="Droidective demo">
   </a>
   <br>
-  <em>▶ <a href="https://droidective.com/assets/demo.mp4">Watch the demo</a> · <a href="https://droidective.com/">droidective.com</a></em>
+  <em>▶ <a href="https://droidective.com/assets/demo.mp4">Full-resolution video</a> · <a href="https://droidective.com/">droidective.com</a></em>
 </p>
 
 Built in Swift 6 + SwiftUI, with all logic in a platform-agnostic Swift package

--- a/scripts/make-demo-gif.sh
+++ b/scripts/make-demo-gif.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Regenerate docs/demo.gif from site/assets/demo.mp4 — the README's inline demo.
+# GitHub can't play an externally-hosted <video> inline (its CSP blocks it), so
+# the README embeds this GIF instead. Re-run after updating the demo video.
+# Needs ffmpeg (Homebrew, or set FFMPEG=App/Resources/ffmpeg to use the bundled one).
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+src="$root/site/assets/demo.mp4"
+out="$root/docs/demo.gif"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+palette="$work/palette.png"
+
+ffmpeg="${FFMPEG:-ffmpeg}"
+# 720px wide, 12 fps keeps a 30+ second UI demo a few MB rather than hundreds.
+# A two-pass palette (diff stats + Bayer dither) holds quality at 256 colours.
+filters="fps=12,scale=720:-1:flags=lanczos"
+
+"$ffmpeg" -y -i "$src" -vf "${filters},palettegen=stats_mode=diff" "$palette"
+"$ffmpeg" -y -i "$src" -i "$palette" \
+  -lavfi "${filters}[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" "$out"
+
+echo "Wrote $out ($(du -h "$out" | cut -f1))"


### PR DESCRIPTION
The README's static poster can't play inline on GitHub (its CSP blocks `<video>` from an external host). Embed the demo as an animated **GIF** instead, so it plays inline on the repo page.

- `docs/demo.gif` — the website's "Real device" demo converted to a 720×450, 12 fps GIF (**4.8 MB**, two-pass palette), kept in `docs/` so it isn't deployed with the website.
- README's hero now shows the GIF, still linked to the full-resolution `droidective.com/assets/demo.mp4`.
- `scripts/make-demo-gif.sh` regenerates it from `site/assets/demo.mp4` (shellcheck + shfmt clean).

Docs-only; no app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)