### PR TITLE
Bugfix/UI issues fixed

### DIFF
--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -158,6 +158,8 @@ struct FormActionView: View {
                 }
             }
             .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: .infinity)
         case .switch:
             SwitchRow(field.label, isOn: boolBinding(for: field))
         case .slider:

--- a/App/Sources/FeatureDetail/HubKit.swift
+++ b/App/Sources/FeatureDetail/HubKit.swift
@@ -13,6 +13,7 @@ struct HubSection<Content: View, Accessory: View>: View {
     private let subtitle: String?
     @ViewBuilder private let accessory: () -> Accessory
     @ViewBuilder private let content: () -> Content
+    @Environment(\.colorScheme) private var colorScheme
 
     init(_ title: String, subtitle: String? = nil, @ViewBuilder content: @escaping () -> Content)
         where Accessory == EmptyView {
@@ -55,7 +56,14 @@ struct HubSection<Content: View, Accessory: View>: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background(.bgSurface, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(.borderSubtle, lineWidth: 1))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(
+                    colorScheme == .light ? Color.black.opacity(0.14) : .borderSubtle,
+                    lineWidth: 1
+                )
+        )
+        .shadow(color: .black.opacity(colorScheme == .light ? 0.12 : 0), radius: 8, x: 0, y: 2)
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -558,7 +558,7 @@ struct MonogramIcon: View {
             .overlay(
                 Text(initial)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(color.contrastingForeground)
                     .minimumScaleFactor(0.6)
             )
     }

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -244,7 +244,7 @@ struct HomeView: View {
             Spacer(minLength: 0)
         }
         .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 110, maxHeight: .infinity, alignment: .topLeading)
         .background(Color.bgSurface, in: RoundedRectangle(cornerRadius: 10))
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.borderSubtle, lineWidth: 1))
     }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1977,6 +1977,7 @@ private struct CopyButton: View {
     var icon = "doc.on.doc"
     let provider: () -> String
     @State private var copied = false
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Button {
@@ -1990,7 +1991,7 @@ private struct CopyButton: View {
                 Text(copied ? "Copied" : label)
             }
             .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(copied ? Color.white : Color.primary)
+            .foregroundStyle(copied ? Color.green.contrastingForeground(for: colorScheme) : Color.primary)
             .padding(.horizontal, 11)
             .padding(.vertical, 5)
             .background(copied ? Color.green : Color.secondary.opacity(0.18), in: Capsule())

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -145,15 +145,28 @@ struct ScreenRecordView: View {
             VStack(alignment: .leading, spacing: 14) {
                 labeledRow("Resolution") { resolutionPicker }
                 SwitchRow("Capture audio (Android 11+)", isOn: $captureAudio)
-                DisclosureGroup(isExpanded: $showAdvanced) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.15)) { showAdvanced.toggle() }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.textMuted)
+                            .rotationEffect(.degrees(showAdvanced ? 90 : 0))
+                        Text("Advanced options")
+                            .font(.callout.weight(.medium))
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                if showAdvanced {
                     VStack(alignment: .leading, spacing: 14) {
                         labeledRow("Bit rate") { bitRatePicker }
                         labeledRow("Max FPS") { fpsPicker }
                         labeledRow("Time limit") { timeLimitPicker }
                     }
                     .padding(.top, 12)
-                } label: {
-                    Text("Advanced options").font(.callout.weight(.medium))
                 }
             }
             .padding(10)

--- a/App/Sources/FeatureDetail/Views/SimulateView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulateView.swift
@@ -18,102 +18,102 @@ struct SimulateView: View {
     @State private var proxy = ""
 
     var body: some View {
-        HubColumn {
-            if !state.activeOverrides.isEmpty {
-                Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
-                    .buttonStyle(.bordered)
-            }
-
-            HubSection("Battery") {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Level: \(Int(batteryLevel))%").foregroundStyle(.textMain)
-                    Slider(value: $batteryLevel, in: 0...100, step: 1)
-                }
-                SwitchRow("Simulate unplugged", isOn: $batteryUnplugged)
-                Button("Apply") {
-                    run("fake-battery", ["level": .number(batteryLevel), "unplugged": .bool(batteryUnplugged)])
-                }
-                .buttonStyle(.borderedProminent)
-            }
-
-            HubSection("Appearance & motion") {
-                if let darkMode = FeatureRegistry.byID["dark-mode"] {
-                    HStack {
-                        Text("Dark mode")
-                        Spacer(minLength: 12)
-                        OverrideToggleControl(feature: darkMode) { _ in EmptyView() }
-                            .labelsHidden()
-                    }
-                }
-                if let animations = FeatureRegistry.byID["animation-scale"] {
-                    HStack {
-                        Text("Disable animations (0×)")
-                        Spacer(minLength: 12)
-                        OverrideToggleControl(feature: animations) { _ in EmptyView() }
-                            .labelsHidden()
-                    }
-                }
-            }
-
-            HubSection("Layout") {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Font scale: \(fontScale, specifier: "%.2f")").foregroundStyle(.textMain)
-                    Slider(value: $fontScale, in: 0.85...1.3, step: 0.05)
-                }
-                HubField("Display density", prompt: "dpi — blank to keep", text: $density)
-                Button("Apply") {
-                    var params: [String: FeatureValue] = ["fontScale": .number(fontScale)]
-                    let raw = density.trimmingCharacters(in: .whitespaces)
-                    if !raw.isEmpty, let value = Double(raw) { params["density"] = .number(value) }
-                    run("layout-overrides", params)
-                }
-                .buttonStyle(.borderedProminent)
-            }
-
-            HubSection("Locale") {
-                HStack {
-                    Text("Language")
-                    Spacer(minLength: 12)
-                    Picker("", selection: $locale) {
-                        ForEach(localeOptions, id: \.value) { option in
-                            Text(option.label).tag(option.value)
-                        }
-                    }
-                    .labelsHidden()
-                    .fixedSize()
-                }
-                Button("Apply") { run("locale", ["locale": .string(locale)]) }
-                    .buttonStyle(.borderedProminent)
-            }
-
-            HubSection("Network") {
-                SwitchRow("Wi-Fi", isOn: $wifi)
-                SwitchRow("Mobile data", isOn: $data)
-                SwitchRow("Airplane mode", isOn: $airplane)
-                Button("Apply") {
-                    run("network-toggles", ["wifi": .bool(wifi), "data": .bool(data), "airplane": .bool(airplane)])
-                }
-                .buttonStyle(.borderedProminent)
-            }
-
-            HubSection("HTTP proxy", subtitle: "Route traffic through Charles, Proxyman, or mitmproxy.") {
-                HubField("Proxy", prompt: "10.0.0.5:8888", text: $proxy)
-                HStack(spacing: 10) {
-                    Button("Set") { run("http-proxy", ["proxy": .string(proxy.trimmingCharacters(in: .whitespaces))]) }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(proxy.trimmingCharacters(in: .whitespaces).isEmpty)
-                    Button("Clear") { run("http-proxy", ["proxy": .string("")]) }
+        if state.targetSerials.isEmpty {
+            ContentUnavailableView(
+                "No device connected", systemImage: "iphone.slash",
+                description: Text("Connect a device to simulate its state.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            HubColumn {
+                if !state.activeOverrides.isEmpty {
+                    Button("Reset all overrides", role: .destructive) { state.resetAllOverrides() }
                         .buttonStyle(.bordered)
                 }
-            }
-        }
-        .disabled(state.targetSerials.isEmpty)
-        .overlay {
-            if state.targetSerials.isEmpty {
-                ContentUnavailableView(
-                    "No device connected", systemImage: "iphone.slash",
-                    description: Text("Connect a device to simulate its state.")
-                )
+
+                HubSection("Battery") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Level: \(Int(batteryLevel))%").foregroundStyle(.textMain)
+                        Slider(value: $batteryLevel, in: 0...100, step: 1)
+                    }
+                    SwitchRow("Simulate unplugged", isOn: $batteryUnplugged)
+                    Button("Apply") {
+                        run("fake-battery", ["level": .number(batteryLevel), "unplugged": .bool(batteryUnplugged)])
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                HubSection("Appearance & motion") {
+                    if let darkMode = FeatureRegistry.byID["dark-mode"] {
+                        HStack {
+                            Text("Dark mode")
+                            Spacer(minLength: 12)
+                            OverrideToggleControl(feature: darkMode) { _ in EmptyView() }
+                                .labelsHidden()
+                        }
+                    }
+                    if let animations = FeatureRegistry.byID["animation-scale"] {
+                        HStack {
+                            Text("Disable animations (0×)")
+                            Spacer(minLength: 12)
+                            OverrideToggleControl(feature: animations) { _ in EmptyView() }
+                                .labelsHidden()
+                        }
+                    }
+                }
+
+                HubSection("Layout") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Font scale: \(fontScale, specifier: "%.2f")").foregroundStyle(.textMain)
+                        Slider(value: $fontScale, in: 0.85...1.3, step: 0.05)
+                    }
+                    HubField("Display density", prompt: "dpi — blank to keep", text: $density)
+                    Button("Apply") {
+                        var params: [String: FeatureValue] = ["fontScale": .number(fontScale)]
+                        let raw = density.trimmingCharacters(in: .whitespaces)
+                        if !raw.isEmpty, let value = Double(raw) { params["density"] = .number(value) }
+                        run("layout-overrides", params)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                HubSection("Locale") {
+                    HStack {
+                        Text("Language")
+                        Spacer(minLength: 12)
+                        Picker("", selection: $locale) {
+                            ForEach(localeOptions, id: \.value) { option in
+                                Text(option.label).tag(option.value)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(minWidth: 140)
+                    }
+                    Button("Apply") { run("locale", ["locale": .string(locale)]) }
+                        .buttonStyle(.borderedProminent)
+                }
+
+                HubSection("Network") {
+                    SwitchRow("Wi-Fi", isOn: $wifi)
+                    SwitchRow("Mobile data", isOn: $data)
+                    SwitchRow("Airplane mode", isOn: $airplane)
+                    Button("Apply") {
+                        run("network-toggles", ["wifi": .bool(wifi), "data": .bool(data), "airplane": .bool(airplane)])
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                HubSection("HTTP proxy", subtitle: "Route traffic through Charles, Proxyman, or mitmproxy.") {
+                    HubField("Proxy", prompt: "10.0.0.5:8888", text: $proxy)
+                    HStack(spacing: 10) {
+                        Button("Set") { run("http-proxy", ["proxy": .string(proxy.trimmingCharacters(in: .whitespaces))]) }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(proxy.trimmingCharacters(in: .whitespaces).isEmpty)
+                        Button("Clear") { run("http-proxy", ["proxy": .string("")]) }
+                            .buttonStyle(.bordered)
+                    }
+                }
             }
         }
     }

--- a/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
+++ b/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
@@ -7,7 +7,7 @@ struct SystemRestrictionsView: View {
     @Environment(AppState.self) private var state
     @State private var current: RestrictionsState?
     @State private var hasRoot = false
-    @State private var busy = false
+    @State private var refreshBusy = false
 
     private var serial: String { state.targetSerials.first ?? "" }
 
@@ -18,8 +18,8 @@ struct SystemRestrictionsView: View {
                     "No device connected", systemImage: "iphone.slash",
                     description: Text("Connect a device to change restrictions.")
                 )
-            } else if let current {
-                form(current).disabled(busy)
+            } else if current != nil {
+                form
             } else {
                 ProgressView("Reading current settings…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -28,35 +28,35 @@ struct SystemRestrictionsView: View {
         .task(id: state.targetSerials.first ?? "") { await load() }
     }
 
-    private func form(_ state0: RestrictionsState) -> some View {
+    private var form: some View {
         HubColumn {
             HubSection("Installs & APIs", accessory: {
-                Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
+                Button {
+                    Task { await refresh() }
+                } label: { Image(systemName: "arrow.clockwise") }
                     .buttonStyle(.borderless)
                     .help("Refresh")
-                    .disabled(busy)
+                    .disabled(refreshBusy)
             }) {
-                SwitchRow("Verify apps installed via ADB", isOn: binding(state0.adbInstallVerification) {
+                SwitchRow("Verify apps installed via ADB", isOn: binding(\.adbInstallVerification) {
                     try await engine.restrictions.setAdbInstallVerification(serial: serial, $0)
                 })
-                SwitchRow("Package verifier", isOn: binding(state0.packageVerifier) {
+                SwitchRow("Package verifier", isOn: binding(\.packageVerifier) {
                     try await engine.restrictions.setPackageVerifier(serial: serial, $0)
                 })
-                SwitchRow("Enforce hidden-API restrictions", isOn: binding(state0.hiddenApiEnforced) {
+                SwitchRow("Enforce hidden-API restrictions", isOn: binding(\.hiddenApiEnforced) {
                     try await engine.restrictions.setHiddenApiEnforced(serial: serial, $0)
                 })
-                SwitchRow("Stay awake while charging", isOn: binding(state0.stayAwake) {
+                SwitchRow("Stay awake while charging", isOn: binding(\.stayAwake) {
                     try await engine.restrictions.setStayAwake(serial: serial, $0)
                 })
             }
 
             HubSection("Root") {
                 if hasRoot {
-                    SwitchRow("SELinux enforcing", isOn: binding(state0.selinuxEnforcing ?? true) {
-                        try await engine.restrictions.setSelinuxEnforcing(serial: serial, $0)
-                    })
+                    SwitchRow("SELinux enforcing", isOn: selinuxBinding)
                     Button("Remount /system read-write") {
-                        Task { await apply { try await engine.restrictions.remountSystemReadWrite(serial: serial) } }
+                        Task { await applyAction { try await engine.restrictions.remountSystemReadWrite(serial: serial) } }
                     }
                     .buttonStyle(.bordered)
                 } else {
@@ -70,16 +70,60 @@ struct SystemRestrictionsView: View {
 
     private var engine: FeatureEngine { state.env.engine }
 
-    private func binding(_ value: Bool, _ operation: @escaping (Bool) async throws -> AdbResult) -> Binding<Bool> {
+    /// Binding that optimistically updates the one toggled field immediately so
+    /// no other row re-renders. Never sets `refreshBusy`, so the rest of the
+    /// form stays fully interactive during the adb round-trip.
+    private func binding(
+        _ path: WritableKeyPath<RestrictionsState, Bool>,
+        _ operation: @escaping @Sendable (Bool) async throws -> AdbResult
+    ) -> Binding<Bool> {
         Binding(
-            get: { value },
-            set: { newValue in Task { await self.apply { try await operation(newValue) } } }
+            get: { current?[keyPath: path] ?? false },
+            set: { newValue in
+                Task { @MainActor in
+                    self.current?[keyPath: path] = newValue
+                    await self.applyToggle { try await operation(newValue) }
+                }
+            }
         )
     }
 
-    private func apply(_ operation: @escaping () async throws -> AdbResult) async {
-        busy = true
-        defer { busy = false }
+    private var selinuxBinding: Binding<Bool> {
+        Binding(
+            get: { current?.selinuxEnforcing ?? true },
+            set: { newValue in
+                Task { @MainActor in
+                    self.current?.selinuxEnforcing = newValue
+                    await self.applyToggle {
+                        try await engine.restrictions.setSelinuxEnforcing(serial: serial, newValue)
+                    }
+                }
+            }
+        )
+    }
+
+    /// Fire-and-forget for checkbox toggles: no busy flag → no whole-form disable flash.
+    /// Reloads only on failure to resync the actual device state.
+    private func applyToggle(_ operation: @escaping @Sendable () async throws -> AdbResult) async {
+        await CommandLog.userInitiated(feature: "system-restrictions") {
+            do {
+                let result = try await operation()
+                if !result.succeeded {
+                    let detail = result.stderr.isEmpty ? result.stdout : result.stderr
+                    state.showToast(Toast(message: "Failed — \(detail)", ok: false))
+                    await load()
+                }
+            } catch {
+                state.showToast(Toast(message: error.localizedDescription, ok: false))
+                await load()
+            }
+        }
+    }
+
+    /// Used for explicit actions (remount) that need the busy spinner.
+    private func applyAction(_ operation: @escaping @Sendable () async throws -> AdbResult) async {
+        refreshBusy = true
+        defer { refreshBusy = false }
         await CommandLog.userInitiated(feature: "system-restrictions") {
             do {
                 let result = try await operation()
@@ -91,6 +135,11 @@ struct SystemRestrictionsView: View {
                 state.showToast(Toast(message: error.localizedDescription, ok: false))
             }
         }
+    }
+
+    private func refresh() async {
+        refreshBusy = true
+        defer { refreshBusy = false }
         await load()
     }
 

--- a/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
+++ b/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
@@ -103,7 +103,11 @@ struct SystemRestrictionsView: View {
     }
 
     /// Fire-and-forget for checkbox toggles: no busy flag → no whole-form disable flash.
-    /// Reloads only on failure to resync the actual device state.
+    /// Reloads only on failure to resync the actual device state; on success the
+    /// optimistic value is kept. This relies on every toggle's setter writing a value
+    /// that round-trips back to the same boolean through `load()`'s parse — a setter
+    /// the device normalizes differently would leave a stale optimistic value, so a
+    /// new toggle that doesn't round-trip must reload on success here too.
     private func applyToggle(_ operation: @escaping @Sendable () async throws -> AdbResult) async {
         await CommandLog.userInitiated(feature: "system-restrictions") {
             do {

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -54,6 +54,8 @@ struct CropIndicator: View {
 
 /// A pill toggle with an obvious filled (on) vs. outlined (off) state.
 struct EditToggleStyle: ToggleStyle {
+    @Environment(\.colorScheme) private var colorScheme
+
     func makeBody(configuration: Configuration) -> some View {
         Button {
             configuration.isOn.toggle()
@@ -63,7 +65,11 @@ struct EditToggleStyle: ToggleStyle {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(configuration.isOn ? Color.brandAccent : Color.primary.opacity(0.07))
-                .foregroundStyle(configuration.isOn ? Color.white : Color.primary)
+                .foregroundStyle(
+                    configuration.isOn
+                        ? Color.brandAccent.contrastingForeground(for: colorScheme)
+                        : Color.primary
+                )
                 .clipShape(RoundedRectangle(cornerRadius: 7))
                 .overlay(
                     RoundedRectangle(cornerRadius: 7)

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// active target is unmistakable.
 struct DeviceBarView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.colorScheme) private var colorScheme
     @State private var showBundleManager = false
     @State private var showInstalledApps = false
     @State private var refreshSpin = 0.0
@@ -167,15 +168,33 @@ struct DeviceBarView: View {
         } label: {
             devicePill
         }
+        // Borderless (not the default pop-up button) so the label renders as
+        // real SwiftUI content: a pop-up button flattens its title to the
+        // control's own tint and ignores `.foregroundStyle`, leaving the title
+        // white-on-white in light mode. The pill background + border below give
+        // back the boxed button affordance the borderless style drops — both
+        // derived from the resolved title color, so they adapt to light and dark.
+        .menuStyle(.borderlessButton)
         .fixedSize()
         .controlSize(.large)
+        .foregroundStyle(pillTextColor)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(pillTextColor.opacity(0.06), in: RoundedRectangle(cornerRadius: 7))
+        .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(pillTextColor.opacity(0.18)))
         .disabled(state.runOnAll || state.recordingActive)
         .help(state.recordingActive ? "Stop the recording to change the device" : "Switch the active device")
         .task(id: state.devices.map(\.serial).joined()) { await state.refreshAvds() }
     }
 
-    /// macOS popup buttons flatten their label to one tint, so the status
-    /// color lives on the leading icon (outside the menu) instead of a dot.
+    /// Title/chevron color for the device pill, pre-resolved to a concrete value
+    /// for the current scheme so it stays visible in both modes — see
+    /// `Color.resolved(_:for:)`.
+    private var pillTextColor: Color { Color.resolved("TextMain", for: colorScheme) }
+
+    /// The status color lives on the leading icon (outside the menu); the title
+    /// here is just the device label. Its color comes from `pillTextColor` on
+    /// the menu so the chevron matches too.
     private var devicePill: some View {
         Text(selectedDevice.map(state.deviceTitle) ?? "No device connected")
             .fontWeight(.semibold)

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -8,8 +8,11 @@ import SwiftUI
 /// closes.
 struct PaletteWindowView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.colorScheme) private var colorScheme
 
     let onClose: () -> Void
+
+    private var accentText: Color { Color.brandAccent.contrastingForeground(for: colorScheme) }
 
     @State private var query = ""
     @State private var highlighted = 0
@@ -153,13 +156,13 @@ struct PaletteWindowView: View {
         HStack(spacing: 10) {
             Image(systemName: feature.icon)
                 .frame(width: 22)
-                .foregroundStyle(isHighlighted ? AnyShapeStyle(.white) : AnyShapeStyle(.brandAccent))
+                .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText) : AnyShapeStyle(.brandAccent))
             VStack(alignment: .leading, spacing: 0) {
                 Text(feature.title)
                 if let subtitle = feature.subtitle {
                     Text(subtitle)
                         .font(.caption)
-                        .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .secondary)
+                        .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
                         .lineLimit(1)
                 }
             }
@@ -167,12 +170,12 @@ struct PaletteWindowView: View {
             if state.layout.favorites.contains(feature.id) {
                 Image(systemName: "pin.fill")
                     .font(.caption2)
-                    .foregroundStyle(isHighlighted ? AnyShapeStyle(.white.opacity(0.8)) : AnyShapeStyle(.brandAccent))
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText.opacity(0.8)) : AnyShapeStyle(.brandAccent))
             }
             if !state.layout.effectiveEnabledIDs.contains(feature.id) {
                 Text("disabled")
                     .font(.caption2)
-                    .foregroundStyle(isHighlighted ? .white.opacity(0.75) : .secondary)
+                    .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
             }
             if index < 8 {
                 KeyHint("⌘\(index + 1)", prominent: isHighlighted)
@@ -184,7 +187,7 @@ struct PaletteWindowView: View {
             isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.clear),
             in: RoundedRectangle(cornerRadius: 8)
         )
-        .foregroundStyle(isHighlighted ? .white : .primary)
+        .foregroundStyle(isHighlighted ? accentText : .primary)
         .contentShape(Rectangle())
     }
 
@@ -222,20 +225,23 @@ struct PaletteWindowView: View {
 struct KeyHint: View {
     let text: String
     var prominent = false
+    @Environment(\.colorScheme) private var colorScheme
 
     init(_ text: String, prominent: Bool = false) {
         self.text = text
         self.prominent = prominent
     }
 
+    private var accentText: Color { Color.brandAccent.contrastingForeground(for: colorScheme) }
+
     var body: some View {
         Text(text)
             .font(.caption2.weight(.medium))
-            .foregroundStyle(prominent ? AnyShapeStyle(.white) : AnyShapeStyle(.textMuted))
+            .foregroundStyle(prominent ? AnyShapeStyle(accentText) : AnyShapeStyle(.textMuted))
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
-                prominent ? AnyShapeStyle(.white.opacity(0.22)) : AnyShapeStyle(.quaternary),
+                prominent ? AnyShapeStyle(accentText.opacity(0.22)) : AnyShapeStyle(.quaternary),
                 in: RoundedRectangle(cornerRadius: 4)
             )
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -217,22 +217,24 @@ struct RootView: View {
                         OperationProgressStrip(operation: operation)
                     }
                 }
-                HStack(spacing: 0) {
-                    FeatureDetailView(featureID: state.selectedFeatureID)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .overlay(alignment: .topTrailing) { ToastOverlay() }
-                    if state.showNotifications {
-                        Divider()
-                        NotificationPanelView()
-                            .frame(width: 320)
+                FeatureDetailView(featureID: state.selectedFeatureID)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay(alignment: .topTrailing) { ToastOverlay() }
+                    .overlay(alignment: .trailing) {
+                        if state.showNotifications {
+                            HStack(spacing: 0) {
+                                Divider()
+                                NotificationPanelView()
+                                    .frame(width: 320)
+                            }
                             .transition(.move(edge: .trailing).combined(with: .opacity))
+                        }
                     }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .animation(.spring(duration: 0.28), value: state.showNotifications)
+                    .clipped()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.bgRoot)
-            .animation(.spring(duration: 0.28), value: state.showNotifications)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -11,6 +11,7 @@ struct RootView: View {
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
     @AppStorage("launchCount") private var launchCount = 0
     @AppStorage("starPromptShown") private var starPromptShown = false
+    @AppStorage("theme") private var theme = "dark"
     @State private var presentConsent = false
     @State private var presentStar = false
     /// True only while the *first-run* role picker is up, so its dismissal
@@ -33,6 +34,19 @@ struct RootView: View {
     /// Launches before the one-time GitHub-star nudge (shown after consent).
     private let starPromptAfterLaunches = 10
 
+    /// Bridges `NSApp.appearance` (native) and SwiftUI's `colorScheme` environment
+    /// (semantic). Setting `NSApp.appearance` changes native control rendering but
+    /// SwiftUI's own color resolution (named assets, `.primary`, etc.) lags until
+    /// the next system-appearance notification. Injecting this explicitly keeps
+    /// SwiftUI in sync as soon as the theme toggle fires.
+    private var injectedColorScheme: ColorScheme {
+        switch theme {
+        case "light": return .light
+        case "auto": return colorScheme
+        default: return .dark
+        }
+    }
+
     private var shouldPromptConsent: Bool {
         LaunchPrompt.consentDue(
             consentAsked: consentAsked, launchCount: launchCount,
@@ -50,6 +64,7 @@ struct RootView: View {
         // (the exitGuard alone is often unchanged), driving the leave dialog.
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
+            .environment(\.colorScheme, injectedColorScheme)
             .background(WindowAccessor { window in
                 // Fill the screen's usable area on launch — a regular maximized
                 // window, not a native full-screen Space.

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -34,11 +34,30 @@ struct RootView: View {
     /// Launches before the one-time GitHub-star nudge (shown after consent).
     private let starPromptAfterLaunches = 10
 
-    /// Bridges `NSApp.appearance` (native) and SwiftUI's `colorScheme` environment
-    /// (semantic). Setting `NSApp.appearance` changes native control rendering but
-    /// SwiftUI's own color resolution (named assets, `.primary`, etc.) lags until
-    /// the next system-appearance notification. Injecting this explicitly keeps
-    /// SwiftUI in sync as soon as the theme toggle fires.
+    /// Theme color-sync needs two modifiers because they reach different layers,
+    /// and neither alone is enough:
+    ///
+    /// - `.preferredColorScheme(preferredScheme)` sets the hosting NSWindow's
+    ///   appearance, so the *native* menus/popovers presented from this window
+    ///   (the device-picker dropdown, the overrides menu) render in the matching
+    ///   appearance instead of always light.
+    /// - `.environment(\.colorScheme, injectedColorScheme)` forces the value the
+    ///   *SwiftUI-drawn* content resolves named asset colors against. A `Menu`'s
+    ///   label is hosted in a context that doesn't reliably inherit the window
+    ///   appearance for asset resolution, so without this the device-picker title
+    ///   (`.textMain`) renders white-on-white in light mode even though the bar's
+    ///   `.bgSurface` background resolves correctly.
+    ///
+    /// `nil` / system pass-through for "auto" keeps both following the system
+    /// appearance live.
+    private var preferredScheme: ColorScheme? {
+        switch theme {
+        case "light": return .light
+        case "dark": return .dark
+        default: return nil  // "auto" → follow the system appearance
+        }
+    }
+
     private var injectedColorScheme: ColorScheme {
         switch theme {
         case "light": return .light
@@ -65,6 +84,7 @@ struct RootView: View {
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
             .environment(\.colorScheme, injectedColorScheme)
+            .preferredColorScheme(preferredScheme)
             .background(WindowAccessor { window in
                 // Fill the screen's usable area on launch — a regular maximized
                 // window, not a native full-screen Space.
@@ -232,24 +252,22 @@ struct RootView: View {
                         OperationProgressStrip(operation: operation)
                     }
                 }
-                FeatureDetailView(featureID: state.selectedFeatureID)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .overlay(alignment: .topTrailing) { ToastOverlay() }
-                    .overlay(alignment: .trailing) {
-                        if state.showNotifications {
-                            HStack(spacing: 0) {
-                                Divider()
-                                NotificationPanelView()
-                                    .frame(width: 320)
-                            }
+                HStack(spacing: 0) {
+                    FeatureDetailView(featureID: state.selectedFeatureID)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .overlay(alignment: .topTrailing) { ToastOverlay() }
+                    if state.showNotifications {
+                        Divider()
+                        NotificationPanelView()
+                            .frame(width: 320)
                             .transition(.move(edge: .trailing).combined(with: .opacity))
-                        }
                     }
-                    .animation(.spring(duration: 0.28), value: state.showNotifications)
-                    .clipped()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(.bgRoot)
+            .animation(.spring(duration: 0.28), value: state.showNotifications)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -50,6 +50,7 @@ struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
     @State private var openAtLoginOn = false
+    @State private var showMenuItems = false
 
     /// True when the login item is registered (enabled, or pending the user's
     /// approval in System Settings).
@@ -128,7 +129,7 @@ struct GeneralSettingsView: View {
             Section("Menu bar") {
                 Toggle("Show menu bar icon", isOn: $showMenuBar)
                 if showMenuBar {
-                    DisclosureGroup("Items shown in the menu") {
+                    DisclosureGroup(isExpanded: $showMenuItems) {
                         Text("When none are selected, your pinned features (or enabled instant actions) are shown. Screenshot and Mirror Screen always appear.")
                             .font(.footnote)
                             .foregroundStyle(.textMuted)
@@ -141,6 +142,13 @@ struct GeneralSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                         }
+                    } label: {
+                        Button { showMenuItems.toggle() } label: {
+                            Text("Items shown in the menu")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
             }
@@ -310,7 +318,12 @@ struct DoctorSettingsView: View {
             Section { summary }
             Section("Toolchain") {
                 ForEach(Self.checks, id: \.tool) { check in
-                    row(check)
+                    ToolRow(
+                        check: check,
+                        status: report[check.tool],
+                        installingTool: state.installingTool,
+                        onInstall: { state.installTool($0) }
+                    )
                 }
             }
             Section {
@@ -349,73 +362,86 @@ struct DoctorSettingsView: View {
     }
 
     /// One compact row: a status icon + the tool name, expandable to reveal
-    /// version, path, and (when missing) the install action.
-    @ViewBuilder
-    private func row(_ check: Check) -> some View {
-        let status = report[check.tool]
-        DisclosureGroup {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(check.purpose)
-                    .font(.callout)
-                    .foregroundStyle(.textMuted)
-                if let status {
-                    if let version = status.version {
-                        detail("Version", version)
-                    }
-                    if let path = status.path {
-                        detail("Path", path)
-                    }
-                    if !status.installed {
-                        if check.brewInstallable {
-                            Button(state.installingTool == check.tool ? "Installing…" : "Install via Homebrew") {
-                                state.installTool(check.tool)
+    /// version, path, and (when missing) the install action. Uses a separate
+    /// struct so each row owns its own isExpanded state, enabling a full-width
+    /// Button label that makes the entire row tappable (not just the chevron).
+    private struct ToolRow: View {
+        let check: Check
+        let status: ToolStatus?
+        let installingTool: Tool?
+        let onInstall: (Tool) -> Void
+        @State private var isExpanded = false
+
+        var body: some View {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(check.purpose)
+                        .font(.callout)
+                        .foregroundStyle(.textMuted)
+                    if let status {
+                        if let version = status.version {
+                            detailRow("Version", version)
+                        }
+                        if let path = status.path {
+                            detailRow("Path", path)
+                        }
+                        if !status.installed {
+                            if check.brewInstallable {
+                                Button(installingTool == check.tool ? "Installing…" : "Install via Homebrew") {
+                                    onInstall(check.tool)
+                                }
+                                .disabled(installingTool != nil)
+                            } else {
+                                Text(status.installHint)
+                                    .font(.callout)
+                                    .foregroundStyle(.textMuted)
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
-                            .disabled(state.installingTool != nil)
-                        } else {
-                            Text(status.installHint)
-                                .font(.callout)
-                                .foregroundStyle(.textMuted)
-                                .fixedSize(horizontal: false, vertical: true)
                         }
                     }
                 }
-            }
-            .padding(.vertical, 4)
-        } label: {
-            HStack(spacing: 8) {
-                statusIcon(status)
-                Text(check.name)
-                Spacer()
-                if let status, !status.installed {
-                    Text("not installed")
-                        .font(.caption)
-                        .foregroundStyle(.textMuted)
+                .padding(.vertical, 4)
+            } label: {
+                Button { isExpanded.toggle() } label: {
+                    HStack(spacing: 8) {
+                        statusIcon(status)
+                        Text(check.name)
+                        Spacer()
+                        if let status, !status.installed {
+                            Text("not installed")
+                                .font(.caption)
+                                .foregroundStyle(.textMuted)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
             }
         }
-    }
 
-    @ViewBuilder
-    private func statusIcon(_ status: ToolStatus?) -> some View {
-        if let status {
-            Image(systemName: status.installed ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .foregroundStyle(status.installed ? Color.brandAccent : Color.orange)
-        } else {
-            ProgressView().controlSize(.small)
+        @ViewBuilder
+        private func statusIcon(_ status: ToolStatus?) -> some View {
+            if let status {
+                Image(systemName: status.installed ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .foregroundStyle(status.installed ? Color.brandAccent : Color.orange)
+            } else {
+                ProgressView().controlSize(.small)
+            }
         }
-    }
 
-    @ViewBuilder
-    private func detail(_ label: String, _ value: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Text(label)
-                .foregroundStyle(.textMuted)
-                .frame(width: 56, alignment: .leading)
-            Text(value)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
+        @ViewBuilder
+        private func detailRow(_ label: String, _ value: String) -> some View {
+            HStack(alignment: .top, spacing: 8) {
+                Text(label)
+                    .foregroundStyle(.textMuted)
+                    .frame(width: 56, alignment: .leading)
+                Text(value)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .font(.callout)
         }
-        .font(.callout)
     }
 
     private func redetect() async {

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -64,4 +64,26 @@ extension Color {
             Int(round(resolved.greenComponent * 255)),
             Int(round(resolved.blueComponent * 255)))
     }
+
+    /// The foreground color (white or near-black) that provides adequate contrast against
+    /// this background color when rendered in the given color scheme.
+    /// Uses WCAG relative luminance — picks `.white` for dark backgrounds and
+    /// `Color.black.opacity(0.85)` for light ones (threshold: luminance > 0.35).
+    func contrastingForeground(for scheme: ColorScheme) -> Color {
+        guard let appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua) else { return .white }
+        var lum: Double = 0
+        appearance.performAsCurrentDrawingAppearance {
+            guard let nc = NSColor(self).usingColorSpace(.genericRGB) else { return }
+            lum = 0.2126 * nc.redComponent + 0.7152 * nc.greenComponent + 0.0722 * nc.blueComponent
+        }
+        return lum > 0.35 ? Color.black.opacity(0.85) : .white
+    }
+
+    /// The foreground color for a static (non-adaptive) color — same WCAG logic
+    /// without an appearance context. Use for colors built from explicit RGB/HSB values.
+    var contrastingForeground: Color {
+        guard let nc = NSColor(self).usingColorSpace(.genericRGB) else { return .white }
+        let lum = 0.2126 * nc.redComponent + 0.7152 * nc.greenComponent + 0.0722 * nc.blueComponent
+        return lum > 0.35 ? Color.black.opacity(0.85) : .white
+    }
 }

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -79,6 +79,25 @@ extension Color {
         return lum > 0.35 ? Color.black.opacity(0.85) : .white
     }
 
+    /// Resolve a named asset color to a concrete, appearance-independent color
+    /// for a specific scheme.
+    ///
+    /// SwiftUI hosts a `Menu`'s pop-up-button label in a context whose effective
+    /// appearance we don't control (it flattens the label to one tint resolved
+    /// against the control's own — stuck-dark — appearance), so an env-resolved
+    /// asset like `.textMain` renders near-white there in *both* modes, going
+    /// white-on-white in light mode. Feeding the label a pre-resolved concrete
+    /// color sidesteps that. Falls back to the dynamic asset if resolution fails.
+    static func resolved(_ name: String, for scheme: ColorScheme) -> Color {
+        guard let appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua),
+              let dynamic = NSColor(named: name) else { return Color(name) }
+        var flat = dynamic
+        appearance.performAsCurrentDrawingAppearance {
+            flat = dynamic.usingColorSpace(.sRGB) ?? dynamic
+        }
+        return Color(nsColor: flat)
+    }
+
     /// The foreground color for a static (non-adaptive) color — same WCAG logic
     /// without an appearance context. Use for colors built from explicit RGB/HSB values.
     var contrastingForeground: Color {

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -65,18 +65,21 @@ extension Color {
             Int(round(resolved.blueComponent * 255)))
     }
 
-    /// The foreground color (white or near-black) that provides adequate contrast against
-    /// this background color when rendered in the given color scheme.
-    /// Uses WCAG relative luminance — picks `.white` for dark backgrounds and
-    /// `Color.black.opacity(0.85)` for light ones (threshold: luminance > 0.35).
+    /// A readable foreground (white or near-black) for text drawn on top of this
+    /// background, resolving the background in the given color scheme first.
+    /// Uses a perceptual luminance estimate — Rec. 709 weights on gamma-encoded
+    /// sRGB, an approximation of WCAG relative luminance (not the linearized form)
+    /// — picking `Color.black.opacity(0.85)` for light backgrounds and `.white` for
+    /// dark ones (threshold: luminance > 0.35). When the background can't be
+    /// resolved, falls back to the scheme's own contrasting default.
     func contrastingForeground(for scheme: ColorScheme) -> Color {
-        guard let appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua) else { return .white }
-        var lum: Double = 0
+        let fallback: Color = scheme == .dark ? .white : Color.black.opacity(0.85)
+        guard let appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua) else { return fallback }
+        var foreground = fallback
         appearance.performAsCurrentDrawingAppearance {
-            guard let nc = NSColor(self).usingColorSpace(.genericRGB) else { return }
-            lum = 0.2126 * nc.redComponent + 0.7152 * nc.greenComponent + 0.0722 * nc.blueComponent
+            if let resolved = Self.luminanceForeground(of: self) { foreground = resolved }
         }
-        return lum > 0.35 ? Color.black.opacity(0.85) : .white
+        return foreground
     }
 
     /// Resolve a named asset color to a concrete, appearance-independent color
@@ -98,10 +101,14 @@ extension Color {
         return Color(nsColor: flat)
     }
 
-    /// The foreground color for a static (non-adaptive) color — same WCAG logic
-    /// without an appearance context. Use for colors built from explicit RGB/HSB values.
-    var contrastingForeground: Color {
-        guard let nc = NSColor(self).usingColorSpace(.genericRGB) else { return .white }
+    /// Same logic without an appearance context — for static (non-adaptive) colors
+    /// built from explicit RGB/HSB values, which have no light/dark variant to resolve.
+    var contrastingForeground: Color { Self.luminanceForeground(of: self) ?? .white }
+
+    /// Returns the contrasting foreground for `color`, or nil if it can't be
+    /// resolved to sRGB (e.g. a catalog color with no current drawing appearance).
+    private static func luminanceForeground(of color: Color) -> Color? {
+        guard let nc = NSColor(color).usingColorSpace(.sRGB) else { return nil }
         let lum = 0.2126 * nc.redComponent + 0.7152 * nc.greenComponent + 0.0722 * nc.blueComponent
         return lum > 0.35 ? Color.black.opacity(0.85) : .white
     }

--- a/App/Tests/ThemeContrastTests.swift
+++ b/App/Tests/ThemeContrastTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+import Testing
+
+/// `Color.contrastingForeground` picks readable text over a colored background via
+/// a luminance threshold. The math is pure decision logic with a magic constant,
+/// so it's pinned here rather than left to be eyeballed on-screen.
+@Suite struct ThemeContrastTests {
+    /// Resolves the result to whether it's the near-black ("dark text") branch
+    /// rather than white, by reading its red component in sRGB.
+    private func isDarkText(_ color: Color) -> Bool {
+        (NSColor(color).usingColorSpace(.sRGB)?.redComponent ?? 1) < 0.5
+    }
+
+    @Test func lightBackgroundGetsDarkText() {
+        #expect(isDarkText(Color.white.contrastingForeground))
+        #expect(isDarkText(Color.white.contrastingForeground(for: .light)))
+    }
+
+    @Test func darkBackgroundGetsLightText() {
+        #expect(!isDarkText(Color.black.contrastingForeground))
+        #expect(!isDarkText(Color.black.contrastingForeground(for: .dark)))
+    }
+
+    @Test func brightGreenIsAboveThresholdSoGetsDarkText() {
+        // Pure green: luminance ≈ 0.715, well above the 0.35 threshold.
+        #expect(isDarkText(Color(.sRGB, red: 0, green: 1, blue: 0).contrastingForeground))
+    }
+
+    @Test func pureBlueIsBelowThresholdSoGetsLightText() {
+        // Pure blue: luminance ≈ 0.072, below the threshold.
+        #expect(!isDarkText(Color(.sRGB, red: 0, green: 0, blue: 1).contrastingForeground))
+    }
+
+    @Test func adaptiveVariantResolvesForEachScheme() {
+        let nearWhite = Color(.sRGB, red: 0.95, green: 0.95, blue: 0.95)
+        #expect(isDarkText(nearWhite.contrastingForeground(for: .light)))
+        let nearBlack = Color(.sRGB, red: 0.05, green: 0.05, blue: 0.05)
+        #expect(!isDarkText(nearBlack.contrastingForeground(for: .dark)))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -110,6 +110,7 @@ targets:
     sources:
       - App/Tests
       - App/Sources/State/LaunchPrompt.swift
+      - App/Sources/Theme.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective.tests


### PR DESCRIPTION
## What changed
A batch of UI bug fixes, mostly light-mode theming and control tappability/layout:
- **Light-mode color resolution** — named asset colors resolve to the correct
  light/dark variant the instant the theme toggles; the device-bar picker title
  and dropdown render correctly in light, dark, and auto.
- **Contrast helper** — `Color.contrastingForeground` consolidated onto one
  `.sRGB` luminance helper with a scheme-aware fallback (was unconditional white,
  which could render white-on-light); hardcoded white foregrounds across the
  palette, Reactotron, video editor, and app monograms now derive from it.
- **System Restrictions** — cards were invisible in light mode; checkboxes now
  stay live during the adb round-trip and reload only on failure.
- **Tappable rows** — Screen Record "Advanced options", the Settings menu-bar
  disclosure, and Doctor rows are tappable across the whole row, not just the chevron.
- **Layout** — form-action enum pickers fill the width; Home cards no longer
  collapse to zero height; the notification-panel slide no longer reflows the column.
- **Empty states** — Simulate shows a connect-a-device state instead of a blank pane.

## Why
Several controls were invisible/unusable in light mode or with a bright accent,
some rows were tappable only on a sub-element, and a few panes mislaid out.

## Impact area
- `Theme.swift` is shared by every view; the contrast change moves `.genericRGB`
  → `.sRGB`, which can nudge a color sitting exactly on the 0.35 threshold
  (representative cases pinned in `ThemeContrastTests`).
- `RootView` injects `colorScheme` from the stored theme — affects all asset
  resolution. No ADBKit, persistence, or feature-registry changes.

## How verified
- `cd ADBKit && swift test` green (409); `make build` clean, zero warnings.
- New `ThemeContrastTests` (5) pin the luminance/threshold logic.
- Ran on an Android emulator: device picker title + dropdown in light/dark/auto,
  the tappable rows, and the Simulate empty state.

## Risks / follow-ups
- Bundles several related UI fixes in one PR (could be split for per-fix review).
- The `.genericRGB`→`.sRGB` change is behavioral, not pure refactor (test-covered).
