### PR TITLE
screen record live preview added

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
@@ -52,6 +52,15 @@ public actor ScreenRecorder {
     /// Recording started but currently paused between segments.
     public var isPaused: Bool { session == nil && !segments.isEmpty }
 
+    /// The latest decoded frame of the segment being captured, for a live preview
+    /// of what's being recorded. `nil` between segments (paused) or before the
+    /// first frame decodes. This is free: the session already decodes every frame
+    /// for snapshots (`MirrorSession` does so unconditionally), so it reads the
+    /// latest without a second device connection or draining the record stream.
+    public func previewFrame() async -> MirrorSession.Snapshot? {
+        await session?.snapshot()
+    }
+
     public func start(serial: String, options: ScreenRecordOptions = ScreenRecordOptions()) async throws {
         guard !isRecording else { throw RecordingError.alreadyRecording }
         self.serial = serial

--- a/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
@@ -6,9 +6,22 @@ import Testing
 /// The live-mirror "record" scenario: a display session and a separate recording
 /// session run at the same time (two scrcpy connections), as the mirror now does.
 /// Run with `MIRROR_LIVE_TEST=1 swift test --filter MirrorPlusRecordLiveTests`.
-@Suite struct MirrorPlusRecordLiveTests {
+// Serialized: each test opens its own scrcpy session(s); running them in
+// parallel puts several concurrent connections on one device and the emulator
+// starves, failing to bring up video.
+@Suite(.serialized) struct MirrorPlusRecordLiveTests {
     private static var liveEnabled: Bool {
         ProcessInfo.processInfo.environment["MIRROR_LIVE_TEST"] == "1"
+    }
+
+    /// An installed scrcpy (Homebrew), else the app's bundled server passed via
+    /// `SCRCPY_SERVER_JAR` (+ optional `SCRCPY_VERSION`), so these live tests run
+    /// in the self-contained repo without `brew install scrcpy`.
+    private static func resolveServer(locator: ToolLocator) async -> ScrcpyServerInfo? {
+        if let info = await ScrcpyServerLocator.resolve(locator: locator) { return info }
+        let env = ProcessInfo.processInfo.environment
+        guard let jar = env["SCRCPY_SERVER_JAR"] else { return nil }
+        return ScrcpyServerInfo(jarPath: jar, version: env["SCRCPY_VERSION"] ?? "4.0")
     }
 
     @Test(.enabled(if: liveEnabled))
@@ -16,8 +29,8 @@ import Testing
         let serial = ProcessInfo.processInfo.environment["MIRROR_SERIAL"] ?? "emulator-5554"
         let locator = ToolLocator()
         let adb = AdbClient(locator: locator)
-        guard let server = await ScrcpyServerLocator.resolve(locator: locator) else {
-            Issue.record("scrcpy not installed"); return
+        guard let server = await Self.resolveServer(locator: locator) else {
+            Issue.record("scrcpy not installed and no SCRCPY_SERVER_JAR set"); return
         }
 
         // Display session (like the live mirror): video + audio + control.
@@ -54,5 +67,31 @@ import Testing
         #expect(displayAlive)
         #expect(duration > 0)
         #expect(hasVideo)
+    }
+
+    /// The recording session decodes every frame for snapshots, so a live preview
+    /// frame is available straight from the recorder — no second connection.
+    @Test(.enabled(if: liveEnabled))
+    func previewFrameIsAvailableWhileRecording() async throws {
+        let serial = ProcessInfo.processInfo.environment["MIRROR_SERIAL"] ?? "emulator-5554"
+        let locator = ToolLocator()
+        let adb = AdbClient(locator: locator)
+        guard let server = await Self.resolveServer(locator: locator) else {
+            Issue.record("scrcpy not installed and no SCRCPY_SERVER_JAR set"); return
+        }
+
+        let recorder = ScreenRecorder(client: adb, server: server)
+        try await recorder.start(serial: serial, options: ScreenRecordOptions(maxSize: 800))
+
+        var frame: MirrorSession.Snapshot?
+        for _ in 0 ..< 60 {
+            if let f = await recorder.previewFrame() { frame = f; break }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        let url = try await recorder.stop()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(frame != nil)
+        #expect((frame?.width ?? 0) > 0)
     }
 }

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorImage.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorImage.swift
@@ -6,9 +6,12 @@ import Foundation
 /// Converts a decoded frame's pixel buffer into shareable image formats for the
 /// in-mirror screenshot.
 enum MirrorImage {
-    static func cgImage(from imageBuffer: CVImageBuffer) -> CGImage? {
+    /// Pass a shared `context` when converting repeatedly (e.g. a live preview
+    /// poll) — a fresh `CIContext` per call is costly. Defaults to a one-shot
+    /// context for single conversions like the screenshot.
+    static func cgImage(from imageBuffer: CVImageBuffer, context: CIContext = CIContext()) -> CGImage? {
         let ciImage = CIImage(cvImageBuffer: imageBuffer)
-        return CIContext().createCGImage(ciImage, from: ciImage.extent)
+        return context.createCGImage(ciImage, from: ciImage.extent)
     }
 
     static func pngData(from imageBuffer: CVImageBuffer) -> Data? {
@@ -16,8 +19,8 @@ enum MirrorImage {
         return NSBitmapImageRep(cgImage: cgImage).representation(using: .png, properties: [:])
     }
 
-    static func nsImage(from imageBuffer: CVImageBuffer) -> NSImage? {
-        guard let cgImage = cgImage(from: imageBuffer) else { return nil }
+    static func nsImage(from imageBuffer: CVImageBuffer, context: CIContext = CIContext()) -> NSImage? {
+        guard let cgImage = cgImage(from: imageBuffer, context: context) else { return nil }
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
     }
 }

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import CoreImage
 import Foundation
 import SwiftUI
 
@@ -23,6 +24,12 @@ struct ScreenRecordView: View {
     @State private var limitTask: Task<Void, Never>?
     /// Identifies this view's leave guard so a stale clear can't wipe another's.
     @State private var exitGuardID = UUID()
+    /// Live preview of the frames being captured, polled from the recorder's
+    /// session while recording so the user sees what's going into the file.
+    @State private var previewImage: NSImage?
+    @State private var previewTask: Task<Void, Never>?
+    /// Reused across the preview poll — a fresh `CIContext` per frame is costly.
+    @State private var previewContext = CIContext()
 
     @AppStorage("recMaxSize") private var maxSize = 0
     @AppStorage("recBitRate") private var bitRateMbps = 0
@@ -57,6 +64,7 @@ struct ScreenRecordView: View {
         }
         .onDisappear {
             limitTask?.cancel()
+            stopPreviewPolling()
             state.setRecording(false, owner: "screen-record")
             state.clearExitGuard(exitGuardID)
             if isRecording, let recorder { Task { await recorder.abort() } }
@@ -67,7 +75,9 @@ struct ScreenRecordView: View {
     private var recordControls: some View {
         VStack(spacing: 28) {
             hero
-            optionsCard
+            // Options are irrelevant (and locked) once recording starts; hiding
+            // them frees the column for the live preview.
+            if !isRecording { optionsCard }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(28)
@@ -77,14 +87,17 @@ struct ScreenRecordView: View {
 
     private var hero: some View {
         VStack(spacing: 16) {
-            ZStack {
-                Circle()
-                    .fill(isRecording ? Color.red.opacity(0.15) : Color.brandAccent.opacity(0.12))
-                    .frame(width: 96, height: 96)
-                Image(systemName: "video.fill")
-                    .font(.system(size: 38))
-                    .foregroundStyle(isRecording ? .red : .brandAccent)
-                    .symbolEffect(.pulse, isActive: isRecording)
+            if isRecording {
+                recordingPreview
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(Color.brandAccent.opacity(0.12))
+                        .frame(width: 96, height: 96)
+                    Image(systemName: "video.fill")
+                        .font(.system(size: 38))
+                        .foregroundStyle(.brandAccent)
+                }
             }
 
             VStack(spacing: 4) {
@@ -104,6 +117,44 @@ struct ScreenRecordView: View {
             hints
         }
         .frame(maxWidth: 420)
+    }
+
+    /// Live mirror of the frames being captured. The recorder's session already
+    /// decodes every frame for snapshots, so this just renders the latest at a
+    /// preview-friendly rate — it freezes on the last frame (dimmed) while paused.
+    private var recordingPreview: some View {
+        previewContent
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.borderSubtle))
+            .overlay(alignment: .topLeading) { recBadge }
+            .animation(.easeInOut(duration: 0.2), value: isPaused)
+    }
+
+    @ViewBuilder private var previewContent: some View {
+        if let previewImage {
+            Image(nsImage: previewImage)
+                .resizable()
+                .interpolation(.medium)
+                .aspectRatio(contentMode: .fit)
+                .frame(maxHeight: 320)
+                .opacity(isPaused ? 0.55 : 1)
+        } else {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(0.85))
+                .frame(width: 200, height: 300)
+                .overlay { ProgressView().controlSize(.large).tint(.white) }
+        }
+    }
+
+    private var recBadge: some View {
+        Label(isPaused ? "PAUSED" : "REC", systemImage: isPaused ? "pause.fill" : "record.circle.fill")
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isPaused ? Color.secondary : Color.red, in: Capsule())
+            .symbolEffect(.pulse, isActive: !isPaused)
+            .padding(8)
     }
 
     @ViewBuilder private var recordControlButtons: some View {
@@ -245,6 +296,7 @@ struct ScreenRecordView: View {
             isRecording = true
             isPaused = false
             startedAt = Date()
+            startPreviewPolling()
             // Lock the device/bundle pickers for the duration, as the
             // performance/network recorders do. A recording targets one device;
             // switching it mid-capture would strand this recorder (the view stays
@@ -281,6 +333,31 @@ struct ScreenRecordView: View {
         isBusy = false
     }
 
+    /// Poll the recorder's latest decoded frame and show it as the preview. Kept
+    /// running across pause (it returns nil then, so the last frame stays, dimmed)
+    /// and cancelled on stop/leave. ~11 fps is plenty to see what's being captured
+    /// without loading the main thread.
+    private func startPreviewPolling() {
+        previewTask?.cancel()
+        guard let recorder else { return }
+        let context = previewContext
+        previewTask = Task { @MainActor in
+            while !Task.isCancelled {
+                if let snap = await recorder.previewFrame(),
+                   let image = MirrorImage.nsImage(from: snap.imageBuffer, context: context) {
+                    previewImage = image
+                }
+                try? await Task.sleep(for: .milliseconds(90))
+            }
+        }
+    }
+
+    private func stopPreviewPolling() {
+        previewTask?.cancel()
+        previewTask = nil
+        previewImage = nil
+    }
+
     /// The server has no time-limit knob, so the UI stops the recording after the
     /// chosen duration (0 = unlimited). Paused time still counts toward the limit.
     private func scheduleTimeLimit(_ seconds: Int) {
@@ -310,6 +387,7 @@ struct ScreenRecordView: View {
         isStopping = false
         startedAt = nil
         self.recorder = nil
+        stopPreviewPolling()
         state.setRecording(false, owner: "screen-record")
         state.clearExitGuard(exitGuardID)
     }
@@ -328,6 +406,7 @@ struct ScreenRecordView: View {
         isRecording = false
         isPaused = false
         startedAt = nil
+        stopPreviewPolling()
         do {
             let temp = try await recorder.stop()
             let dir = try ScreenCaptureService.ensureCaptureDir()

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -16,7 +16,12 @@ struct ScreenRecordView: View {
     @State private var isStarting = false
     @State private var isStopping = false
     @State private var isBusy = false
+    /// Reference date for the elapsed timer, shifted forward on each resume so
+    /// the displayed time counts only *active* recording (paused time excluded).
     @State private var startedAt: Date?
+    /// When the current pause began; drives the frozen timer and the time-limit
+    /// reschedule. `nil` while actively recording.
+    @State private var pausedAt: Date?
     @State private var recordedURL: URL?
     /// A finished recording awaiting the Discard/Save/Edit choice.
     @State private var decisionURL: URL?
@@ -102,9 +107,17 @@ struct ScreenRecordView: View {
 
             VStack(spacing: 4) {
                 if isRecording, let startedAt {
-                    Text(startedAt, style: .timer)
-                        .font(.system(size: 30, weight: .semibold, design: .monospaced))
-                        .monospacedDigit()
+                    Group {
+                        // Frozen while paused so a paused recording no longer
+                        // looks like it's still running; live otherwise.
+                        if isPaused {
+                            Text(Self.durationLabel(activeElapsed()))
+                        } else {
+                            Text(startedAt, style: .timer)
+                        }
+                    }
+                    .font(.system(size: 30, weight: .semibold, design: .monospaced))
+                    .monospacedDigit()
                     Text(isPaused ? "Paused" : "Recording…")
                         .font(.subheadline)
                         .foregroundStyle(isPaused ? Color.secondary : Color.red)
@@ -161,14 +174,22 @@ struct ScreenRecordView: View {
         if isRecording {
             HStack(spacing: 12) {
                 Button {
-                    Task { isPaused ? await resume() : await pause() }
+                    // Claim the busy gate synchronously, before spawning the
+                    // task, so a second tap can't start a competing toggle that
+                    // reads the just-flipped `isPaused` and fires the opposite
+                    // action.
+                    guard !isBusy else { return }
+                    isBusy = true
+                    Task { await togglePauseResume() }
                 } label: {
                     Label(isPaused ? "Resume" : "Pause",
                           systemImage: isPaused ? "play.fill" : "pause.fill")
                         .frame(width: 104)
                 }
                 .controlSize(.large)
-                .disabled(isBusy)
+                // Also disabled while stopping: a stop (manual or the auto
+                // time-limit) is terminal, so there's nothing left to pause.
+                .disabled(isBusy || isStopping)
 
                 Button { Task { await stop() } } label: {
                     Label("Stop", systemImage: "stop.fill").frame(width: 104)
@@ -295,6 +316,7 @@ struct ScreenRecordView: View {
             self.recorder = recorder
             isRecording = true
             isPaused = false
+            pausedAt = nil
             startedAt = Date()
             startPreviewPolling()
             // Lock the device/bundle pickers for the duration, as the
@@ -306,31 +328,76 @@ struct ScreenRecordView: View {
                 id: exitGuardID, featureID: tabFeatureID, style: .recording,
                 title: "Recording in progress",
                 message: "Leaving will stop the screen recording. Save it first, or discard it."))
-            scheduleTimeLimit(options.timeLimitSeconds)
+            scheduleTimeLimit(remaining: TimeInterval(options.timeLimitSeconds))
         } catch {
             state.showToast(Toast(message: error.localizedDescription, ok: false))
         }
         isStarting = false
     }
 
-    private func pause() async {
-        guard let recorder, !isBusy, !isPaused else { return }
-        isBusy = true
-        await recorder.pause()
-        isPaused = true
-        isBusy = false
+    /// Pause/resume as a single guarded operation. The button sets `isBusy`
+    /// synchronously before spawning this, so exactly one toggle runs at a time;
+    /// `defer` guarantees the gate is released even if `resume()` throws or the
+    /// task is cancelled mid-await, so the controls can never wedge disabled.
+    private func togglePauseResume() async {
+        defer { isBusy = false }
+        guard let recorder else { return }
+        if isPaused {
+            do {
+                try await recorder.resume()
+                // Stop is intentionally left tappable during a resume (its stream
+                // bring-up can take a while, and a dead Stop button is the very
+                // bug this screen is fixing). So a Stop can land mid-resume:
+                //   • already finished  → the session we just re-established is
+                //     orphaned; tear it down so the device stream doesn't leak.
+                //   • still in flight    → it will finalize this session itself,
+                //     so leave the teardown (and state) to it.
+                if !isRecording {
+                    await recorder.abort()
+                    return
+                }
+                guard !isStopping else { return }
+                // Shift the timer's reference forward by the paused gap so the
+                // displayed elapsed keeps counting only active recording time.
+                if let pausedAt, let startedAt {
+                    self.startedAt = startedAt.addingTimeInterval(Date().timeIntervalSince(pausedAt))
+                }
+                pausedAt = nil
+                isPaused = false
+                if timeLimit > 0 {
+                    scheduleTimeLimit(remaining: TimeInterval(timeLimit) - activeElapsed())
+                }
+            } catch {
+                // Re-establishing the stream failed; stay paused so the user can
+                // retry (isBusy is released by the defer above).
+                state.showToast(Toast(message: error.localizedDescription, ok: false))
+            }
+        } else {
+            limitTask?.cancel()  // freeze the time limit before tearing down
+            await recorder.pause()
+            // A concurrent Stop may have finished (or be finishing) the recording
+            // during the await; if so it owns the teardown — don't write stale
+            // paused state over it.
+            guard isRecording, !isStopping else { return }
+            pausedAt = Date()
+            isPaused = true
+        }
     }
 
-    private func resume() async {
-        guard let recorder, !isBusy, isPaused else { return }
-        isBusy = true
-        do {
-            try await recorder.resume()
-            isPaused = false
-        } catch {
-            state.showToast(Toast(message: error.localizedDescription, ok: false))
-        }
-        isBusy = false
+    /// Seconds of active (non-paused) recording elapsed so far.
+    private func activeElapsed(_ now: Date = Date()) -> TimeInterval {
+        guard let startedAt else { return 0 }
+        return max(0, (pausedAt ?? now).timeIntervalSince(startedAt))
+    }
+
+    /// Format a duration as `m:ss` (or `h:mm:ss`), matching the live `.timer`
+    /// style so the frozen paused readout doesn't visually jump.
+    private static func durationLabel(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let h = total / 3600, m = (total % 3600) / 60, s = total % 60
+        return h > 0
+            ? String(format: "%d:%02d:%02d", h, m, s)
+            : String(format: "%d:%02d", m, s)
     }
 
     /// Poll the recorder's latest decoded frame and show it as the preview. Kept
@@ -359,13 +426,16 @@ struct ScreenRecordView: View {
     }
 
     /// The server has no time-limit knob, so the UI stops the recording after the
-    /// chosen duration (0 = unlimited). Paused time still counts toward the limit.
-    private func scheduleTimeLimit(_ seconds: Int) {
+    /// chosen duration of *active* recording (0 = unlimited). Paused time is
+    /// excluded: the task is cancelled on pause and rescheduled for the remaining
+    /// time on resume, matching the frozen on-screen timer.
+    private func scheduleTimeLimit(remaining: TimeInterval) {
         limitTask?.cancel()
-        guard seconds > 0 else { return }
+        guard timeLimit > 0 else { return }
+        guard remaining > 0 else { Task { await stop() }; return }
         limitTask = Task {
-            try? await Task.sleep(for: .seconds(seconds))
-            if !Task.isCancelled, isRecording { await stop() }
+            try? await Task.sleep(for: .seconds(remaining))
+            if !Task.isCancelled, isRecording, !isPaused { await stop() }
         }
     }
 
@@ -384,6 +454,7 @@ struct ScreenRecordView: View {
         }
         isRecording = false
         isPaused = false
+        pausedAt = nil
         isStopping = false
         startedAt = nil
         self.recorder = nil
@@ -405,6 +476,7 @@ struct ScreenRecordView: View {
         self.recorder = nil
         isRecording = false
         isPaused = false
+        pausedAt = nil
         startedAt = nil
         stopPreviewPolling()
         do {


### PR DESCRIPTION
## What changed
A live preview of the device screen now appears in the Screen Record tab while
recording — a rounded, letterboxed view with a pulsing ● REC badge (turns gray
PAUSED and dims the frame when paused). It replaces the static video icon during
recording; the timer and Pause/Stop controls sit below it.

## Why
After starting a recording the tab showed only an elapsed-time counter — you
couldn't see what was actually being captured. This matters for QA/testers
running a standalone build, who otherwise can't tell what's in the recording.

## How it works
The recorder's `MirrorSession` already decodes every frame for the screenshot
path, so the preview reads the latest decoded frame (~11 fps) via a new
`ScreenRecorder.previewFrame()`. No second scrcpy connection, no draining the
record stream, zero added device-side cost — the preview can't degrade the
recording itself.

## Impact area
- ADBKit: `ScreenRecorder` gains a read-only `previewFrame()` accessor; the
  record pipeline is unchanged.
- App: `MirrorImage` gets a context-reusing overload (backward-compatible
  default); `ScreenRecordView` adds the preview UI + a poll task torn down on
  stop / leave / disappear.
- No persistence, feature-registry, or other shared-service changes.

## How verified
- `cd ADBKit && swift test` green (410); `make build` clean, zero warnings.
- Gated live tests on an Android emulator (bundled scrcpy):
  `previewFrameIsAvailableWhileRecording` and the record/display coexistence
  test both pass; recorded file stays valid (has video, duration > 0).
- Ran the app: preview appears ~1s after Record, updates live, freezes + dims on
  Pause, and Stop opens the editor as before.

## Risks / follow-ups
- Preview is polled at ~11 fps (not real-time); a smoother preview would mean
  draining the display stream (more code) — deferred.
- Frame→image conversion runs on the main actor at ~11 fps (light; the screen is
  otherwise idle).
- Also tidied the live-mirror tests: marked the suite `.serialized` (parallel
  runs opened multiple scrcpy sessions and starved the emulator) and added a
  bundled-server fallback so they run without `brew install scrcpy`.
