### PR TITLE
Add PR and code-review standards docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+PR guidelines: docs/PULL_REQUESTS.md
+Describe what the code does NOW — not discarded approaches. Plain, factual
+language. No AI attribution (no co-author trailer, no "Generated with…").
+-->
+
+## What changed
+
+<!-- One or two sentences. What does the code do now? -->
+
+## Why
+
+<!-- The problem or motivation. Closes #NN if applicable. -->
+
+## Impact area
+
+<!-- What else could this affect? Delete the lines that don't apply. -->
+
+- [ ] Shared `ADBKit` service used by other features
+- [ ] `FeatureRegistry` / `FeatureNotes` / hub membership
+- [ ] Persisted state schema (`Persistence/`, `~/Library/Application Support/Droidective/`)
+- [ ] Bundled tools / release / signing / appcast
+- [ ] None — isolated to one feature
+
+## How verified
+
+<!-- swift test + build, and what you exercised live. Screenshots/GIF for UI. -->
+
+- [ ] `make test` green
+- [ ] `make build` succeeds with **zero warnings**
+- [ ] Ran the app and verified live (device/emulator + Android version): …
+
+## Checklist
+
+- [ ] Logic lives in `ADBKit`, not in a SwiftUI view
+- [ ] New parsers / command construction are tested
+- [ ] New feature registered in `FeatureRegistry` **and** has a `FeatureNotes` entry
+- [ ] `prek run` passes (gitleaks secret scan)
+- [ ] No secrets, no commented-out code, no relative `..` imports, no AI attribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ empty-state layout). Please skim it before a non-trivial change.
 - Keep commits focused and in imperative mood (e.g. "Add foo", not "added foo").
 - Open the PR against `main` with a short description of what changed and why.
 
+For anything non-trivial, the detail lives in [`docs/`](docs/README.md):
+[opening a PR](docs/PULL_REQUESTS.md) and [reviewing one](docs/CODE_REVIEW.md)
+(architecture, code quality, testing, the known pitfalls, UI/UX, impact
+analysis, security).
+
 ## Reporting bugs
 
 Include your macOS version, the device/emulator and its Android version, the

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,72 @@
+# Code Review
+
+How to review a Droidective PR. The job is not to prove the code is perfect —
+it's to catch the things CI can't: wrong behavior, the architecture eroding,
+hidden blast radius, and UX that only shows up when you run the app.
+
+CI already proves `swift test` passes and the build is warning-free. Don't spend
+review time re-checking those; spend it on what a machine can't see.
+
+## Order of review
+
+Review in this order — a problem at an earlier level makes later levels moot.
+
+1. **Architecture** — is the change in the right layer, the right service, the
+   right shape? A correct feature in the wrong place still gets sent back.
+   → [review/ARCHITECTURE.md](review/ARCHITECTURE.md)
+2. **Correctness & pitfalls** — does it do what it claims, including the edges?
+   Does it step on one of the known traps (threading, CRLF, shell quoting,
+   `.task(id:)`)? → [review/CONCURRENCY_AND_PITFALLS.md](review/CONCURRENCY_AND_PITFALLS.md)
+3. **Impact area** — what else does this touch? Shared services, persisted
+   state, the registry, the release path.
+   → [review/IMPACT_ANALYSIS.md](review/IMPACT_ANALYSIS.md)
+4. **Tests** — do they test behavior and edges, not implementation? Would they
+   actually fail if the code broke? → [review/TESTING.md](review/TESTING.md)
+5. **Code quality** — style, complexity, naming, dead code.
+   → [review/CODE_QUALITY.md](review/CODE_QUALITY.md)
+6. **UI/UX** — for anything user-facing, run it. → [review/UI_UX.md](review/UI_UX.md)
+7. **Security** — secrets, on-device input, file operations.
+   → [review/SECURITY.md](review/SECURITY.md)
+8. **Performance** — only where it's load-bearing (polling loops, large pulls,
+   the per-process performance graphs). Don't ask for micro-optimization without
+   a measurement.
+
+## Before you start
+
+```sh
+git fetch origin          # review against the latest main, not a stale base
+```
+
+Pull the branch and, for anything user-facing or device-touching, **run it**
+(`make run`). The architecture exists so most logic is testable without a
+device, but rendering and real adb output are not in the test suite — a review
+that never ran the app can't sign off on UI or live behavior.
+
+## Writing review comments
+
+For each issue:
+
+- Anchor it: `file:line`, concrete.
+- State the failure, not just the smell: *what input produces what wrong
+  result*. "This crashes on CRLF logcat output" beats "consider newline
+  handling".
+- When the fix isn't obvious, give options with trade-offs and recommend one.
+- Separate **blocking** (correctness, architecture, security, missing tests for
+  new logic) from **non-blocking** (nits, preferences) — say which.
+
+## When to approve
+
+Approve when: it's in the right layer, it does what it says including the edges
+you can think of, the new logic is tested, it's warning-free, and — if it's
+user-facing — you ran it and it behaves. Nits alone don't block.
+
+## Self-review
+
+Author and reviewer can be the same person here (solo project). The discipline
+still applies: re-read your own diff against these lenses before you open the PR,
+and run the app. Reviewing your own change a few hours later catches more than
+re-reading it the moment you wrote it.
+
+There are repo skills for this: `/code-review` for a correctness+cleanup pass on
+the working diff, `/review` for a GitHub PR, `/security-review` for the security
+lens. Use them as a first pass, not a substitute for running the app.

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -1,0 +1,112 @@
+# Pull Requests
+
+How to take a change from idea to a merged PR. The goal is a PR that a reviewer
+can understand and verify quickly, against a green CI and a warning-free build.
+
+## 1. Scope a PR
+
+One PR = one logical change. If you can't describe it in a single sentence
+without "and", it's probably two PRs.
+
+- A feature, a bug fix, a refactor, and a docs change are four PRs, not one.
+- Refactors that touch many files should land *separately* from behavior
+  changes — mixing them hides the real diff from review.
+- If a change grows past what one sitting can review (~400 lines of real diff is
+  a soft signal, not a rule), split it or call out in the description why it
+  can't be split.
+
+## 2. Branch
+
+Never push to `main`. Branch from an up-to-date `main`:
+
+```sh
+git fetch origin
+git switch -c <type>/<short-slug> origin/main
+```
+
+`<type>` is one of `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `perf`.
+Example: `feat/rn-devtools`, `fix/logcat-crlf-split`.
+
+## 3. Build the change the project way
+
+The load-bearing rule is the architecture: **all logic in `ADBKit`, UI in
+`App`** (see [review/ARCHITECTURE.md](review/ARCHITECTURE.md)).
+
+A feature's string `id` is a contract spread across several files, and most
+omissions fail *silently* (a "Coming Soon" screen, an empty Recent tab), not at
+compile time. **`CLAUDE.md` → "Adding a feature — the checklist" is the
+authoritative step-by-step** — follow it in order rather than working from
+memory. In short: define the `FeatureDef` in `FeatureRegistry`, add a
+`FeatureNotes` how-it-works note and a `FeatureCommands` reference, then either
+wire the runner (`FeatureEngine.dispatch` + `implementedIDs` + an arg-vector
+test) for an action, or build the view (`App/Sources/FeatureDetail/Views/` +
+`FeatureDetailView.detailByKind` + `implementedIDs`) for a view feature. Several
+of those steps have enforcing tests; the silent ones you verify by opening the
+feature.
+
+## 4. Commits
+
+- Imperative mood, ≤72-char subject: "Add logcat CRLF guard", not "added" or
+  "fixes".
+- One logical change per commit. A commit should build and pass tests on its
+  own where practical.
+- Don't amend or force-push commits already pushed to a shared branch.
+- Don't commit secrets, generated artifacts (`*.xcodeproj` is gitignored and
+  regenerated), `DerivedData`, or `.env.*` files.
+
+## 5. Pre-flight checklist (run before you open the PR)
+
+This is exactly what the PR template asks you to confirm.
+
+- [ ] `make test` is green (`cd ADBKit && swift test`).
+- [ ] `make build` succeeds with **zero warnings** — see the
+      [zero-warning policy](review/CODE_QUALITY.md#zero-warnings).
+- [ ] New/changed parsers and command construction have tests
+      ([review/TESTING.md](review/TESTING.md)).
+- [ ] New feature follows the `CLAUDE.md` "Adding a feature" checklist
+      (`FeatureRegistry` + `FeatureNotes` + `FeatureCommands`, then runner or
+      view wiring).
+- [ ] `prek run` passes (the gitleaks secret scan in particular).
+- [ ] You ran the app and verified the change live if it touches UI or
+      device behavior — tests don't cover rendering or real adb output.
+- [ ] No secrets, no `claude`/AI-attribution in committed content, no
+      relative-`..` imports, no commented-out code.
+
+## 6. PR description standard
+
+A reviewer should understand the change without reading the diff first. Include:
+
+- **What changed** — describe what the code does *now*. Not the discarded
+  approaches, not the journey. Only what's in the diff.
+- **Why** — the problem or motivation. Link the issue if there is one
+  (`Closes #NN`).
+- **Impact area** — what else this could affect: shared services, persistence
+  schema, the feature registry, release/signing. See
+  [review/IMPACT_ANALYSIS.md](review/IMPACT_ANALYSIS.md).
+- **How verified** — `swift test`, build, and what you exercised live (device or
+  emulator, Android version, the feature screen). Screenshots/GIF for UI.
+- **Risks / follow-ups** — known gaps, anything deferred.
+
+Use plain, factual language. A bug fix is a bug fix — avoid "critical",
+"comprehensive", "robust", "elegant". No AI attribution anywhere (no co-author
+trailer, no "Generated with…", no "claude" in the body or commits).
+
+## 7. CI gates
+
+Opening a PR runs CI (`.github/workflows/ci.yml`):
+
+- **test** — `swift test` on macOS.
+- **build** — `xcodegen generate` + `xcodebuild` Debug with signing disabled.
+
+Both must be green to merge. CI does not run the app or exercise a device, so
+live verification is on you (item 6 above). The release pipeline (sign / notarize
+/ appcast / cask) runs only on `v*` tags, not on PRs — see `RELEASING.md`.
+
+## 8. Merging
+
+- Open against `main`. Address review comments with new commits (don't
+  force-push over a review in progress).
+- Keep the branch current with `main` if it drifts; resolve conflicts locally
+  and re-run `make test` + `make build`.
+- Squash or keep history per the change's shape — but the merged result should
+  read as clean, focused commits.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Droidective Engineering Docs
+
+Process and standards for contributing to Droidective. `CONTRIBUTING.md` (repo
+root) is the short on-ramp; these docs are the detail you reach for when opening
+or reviewing a non-trivial change.
+
+## Authoring a change
+
+- **[PULL_REQUESTS.md](PULL_REQUESTS.md)** — how to scope, branch, commit, and
+  open a PR. Pre-flight checklist, commit conventions, PR description standard.
+- The GitHub PR template (`.github/PULL_REQUEST_TEMPLATE.md`) auto-fills the PR
+  body with the checklist from that doc.
+
+## Reviewing a change
+
+- **[CODE_REVIEW.md](CODE_REVIEW.md)** — the review process and the order to
+  apply it. Start here; it links the topic standards below.
+
+### Topic standards (each is a review lens and an authoring guide)
+
+| Doc | What it covers |
+|-----|----------------|
+| [review/ARCHITECTURE.md](review/ARCHITECTURE.md) | The two-layer rule, actor boundaries, where logic vs. UI lives |
+| [review/CODE_QUALITY.md](review/CODE_QUALITY.md) | Swift style, complexity limits, naming, the zero-warning policy |
+| [review/TESTING.md](review/TESTING.md) | What must be tested, how, and the mocked-process discipline |
+| [review/CONCURRENCY_AND_PITFALLS.md](review/CONCURRENCY_AND_PITFALLS.md) | Process threading, CRLF, shell quoting, `.task(id:)` keys, the bug traps learned the hard way |
+| [review/UI_UX.md](review/UI_UX.md) | SwiftUI layout, empty states, hotkeys, the feature/hub/notes contract |
+| [review/IMPACT_ANALYSIS.md](review/IMPACT_ANALYSIS.md) | Reasoning about blast radius: persistence, registry, shared services, releases |
+| [review/SECURITY.md](review/SECURITY.md) | Secrets, on-device shell input, file operations, the public-repo rule |
+
+## A note on these docs
+
+They describe the project as it is, not an aspirational process. If a standard
+here no longer matches the code, the doc is the bug — fix it in the same PR that
+changes the behavior.

--- a/docs/review/ARCHITECTURE.md
+++ b/docs/review/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Architecture
+
+The one rule that everything else serves: **all logic lives in `ADBKit`; `App`
+is a thin SwiftUI shell.** The two layers are strictly separated so a future
+cross-platform port only re-does the UI. A change that violates this gets sent
+back even if it works.
+
+## The layer boundary
+
+**`ADBKit/`** — a SwiftPM package with *zero UI imports*. No `SwiftUI`, no
+`AppKit`. Feature icons are SF Symbol *name strings*, not `Image`s. Stateful
+services are actors; values crossing concurrency boundaries are `Sendable`
+value types; strict concurrency is complete. Testable with `cd ADBKit &&
+swift test` — no Xcode, no device.
+
+**`App/`** — the SwiftUI shell. `@Observable @MainActor AppState` consumes
+ADBKit. Views render; they don't compute. Built via XcodeGen + xcodebuild; the
+`.xcodeproj` is gitignored and regenerated.
+
+### Review checks
+
+- [ ] **No `adb`/`Process` in a view.** Any shelling out goes through an
+      `ADBKit` service. A view calling `AdbClient` directly is the most common
+      violation — it belongs in a service with a test.
+- [ ] **No `import SwiftUI`/`import AppKit` anywhere in `ADBKit/Sources`.** If a
+      type needs a color or an icon, it carries a *string* the App layer maps.
+- [ ] **No business logic in `AppState` or a view.** Parsing, command
+      construction, polling, state machines — all in `ADBKit`. `AppState`
+      orchestrates and exposes; it doesn't parse.
+- [ ] New logic landed in the right service directory (`Devices/`, `Exec/`,
+      `Features/`, `Persistence/`, `Services/<domain>/`). A new domain gets its
+      own service, not a new method bolted onto an unrelated one.
+
+## Concurrency shape
+
+- Stateful services are **actors** (`DeviceMonitor`, `ToolLocator`, `CommandLog`,
+  the `JSONStore`s). Shared mutable state that isn't an actor is a red flag.
+- Types that cross an actor or `Task` boundary are `Sendable` value types
+  (structs/enums). Reaching for a `class` or a lock is the exception and needs a
+  reason.
+- The process runner must **never block a cooperative thread** — this is
+  load-bearing, see [CONCURRENCY_AND_PITFALLS.md](CONCURRENCY_AND_PITFALLS.md).
+
+## The feature system
+
+A feature's string `id` is a contract spread across several files —
+`FeatureRegistry` (the `FeatureDef`), `FeatureNotes` (how-it-works),
+`FeatureCommands` (command reference), `FeatureEngine` (runner dispatch +
+`implementedIDs`) for actions, and `FeatureDetailView.detailByKind` + a view in
+`App` for view features. **`CLAUDE.md` → "Adding a feature — the checklist" is
+the source of truth** for the order and which steps have enforcing tests vs.
+silent failure modes.
+
+### Review checks
+
+- [ ] New feature is in `FeatureRegistry` with a stable id, keywords, and a
+      hotkey, plus a `FeatureNotes` note and a `FeatureCommands` reference (all
+      three have enforcing tests — flag a gap in review so it isn't a CI surprise).
+- [ ] **Actions** wire `FeatureEngine.dispatch` *and* `implementedIDs`
+      *and* an arg-vector test asserting the exact adb arguments. A feature in
+      `implementedIDs` with no dispatch case, or vice versa, is caught by tests —
+      but the arg-vector test (correct/quoted arguments) is on the author.
+- [ ] **View features** add the `detailByKind` case (a missing case renders
+      "Coming Soon" *silently* — no test catches it) and `implementedIDs`.
+- [ ] If absorbed by a hub (`react-native`, `simulate`, `connection`,
+      `apk-studio`), it's in `absorbedByHub` and its keywords fold into the hub
+      (a test enforces the hub matches each member's primary keyword). It must
+      not also appear as a standalone catalog/sidebar/search row.
+- [ ] `view` features that run adb directly wrap user-initiated calls in
+      `CommandLog.userInitiated(feature:)` so the Recent tab works; background
+      polling stays out of it.
+- [ ] Parsers are **pure and static** (`static func parseX(_:) -> …`, no I/O) so
+      they're tested directly.
+
+## When the architecture should bend
+
+It mostly shouldn't. But: a genuinely UI-only concern (a view-model that holds
+no logic, a SwiftUI animation helper) belongs in `App`. The test is "could this
+run in `swift test` without a UI?" — if yes and it's logic, it's `ADBKit`; if
+it's purely presentation, it's `App`. When unsure, put it in `ADBKit` behind a
+test.

--- a/docs/review/CODE_QUALITY.md
+++ b/docs/review/CODE_QUALITY.md
@@ -1,0 +1,75 @@
+# Code Quality
+
+Style and hygiene for Swift in this repo. CI enforces a warning-free build; this
+doc covers the things the compiler won't flag.
+
+## Zero warnings
+
+The project treats compiler warnings as errors-in-waiting. `make build` must be
+clean. If a warning genuinely can't be removed, silence it locally with a
+comment explaining why — never leave it unaddressed and never blanket-suppress.
+
+A PR that adds a warning is not done.
+
+## Hard limits
+
+Same limits the rest of the codebase holds to:
+
+- ≤100 lines per function; cyclomatic complexity ≤8. A long function is usually
+  hiding two functions.
+- ≤5 positional parameters. Past that, take a struct.
+- 100-char lines.
+- **Absolute imports only** — no relative `..` paths.
+
+These are review prompts, not a linter. A 120-line function that's genuinely one
+flat sequence is better split for review even if it "reads fine".
+
+## Swift idiom
+
+- **`let...else` for early returns**; keep the happy path unindented. Pyramids of
+  `if let` nesting are a refactor signal.
+- **Enums for state**, not boolean-flag soups. A feature that's
+  `isLoading`/`isError`/`hasData` should be one enum.
+- **Value types by default.** Reach for `class` only when identity or reference
+  semantics are actually needed.
+- **Exhaustive `switch`** — no `default:` catch-all on an enum you own, so adding
+  a case forces you to handle it. The `"\r\n" is one Character` class of bug is
+  exactly what a wildcard hides.
+- Newtypes over bare primitives where it prevents mix-ups (a serial, an app id,
+  a pid).
+
+## Naming
+
+- Names say what, not how. Match the surrounding code's vocabulary — a new
+  service should read like the existing services.
+- No `raw_`/`parsed_` prefix pairs; shadow the variable through its
+  transformation.
+- Test names describe the behavior under test (`parsesCRLFLogcatOutput`), not
+  the method (`testParse`).
+
+## Comments and dead code
+
+- Code should be self-documenting. If a comment explains *what* the code does,
+  the code needs refactoring, not the comment.
+- Comments that explain *why* (a non-obvious constraint, a workaround for a
+  platform quirk) are valuable — keep those.
+- **No commented-out code.** Delete it; git remembers.
+- **Replace, don't deprecate.** When new code supersedes old, remove the old —
+  no shims, no dual paths left "just in case". Dead code misleads readers.
+
+## Error handling
+
+- Fail fast with actionable messages: what operation, what input, what to do.
+- Never swallow an error silently. `AdbClient` deliberately returns a structured
+  `AdbResult` (it doesn't throw on non-zero exit) — surface the failure to the
+  caller, don't `try?` it away.
+- Don't `fatalError`/`assert` on input you don't control (device output, user
+  input, file contents). Handle it.
+
+## Review checklist
+
+- [ ] Build is warning-free.
+- [ ] No function over the limits without a reason that's visible in review.
+- [ ] No commented-out code; no leftover dead/old implementation.
+- [ ] Errors carry context and aren't silently dropped.
+- [ ] Naming matches the neighborhood; no `..` imports.

--- a/docs/review/CONCURRENCY_AND_PITFALLS.md
+++ b/docs/review/CONCURRENCY_AND_PITFALLS.md
@@ -1,0 +1,96 @@
+# Concurrency & Pitfalls
+
+The bug traps this codebase has already paid for. Each one caused a real defect;
+each is a thing to actively check in review, not just be vaguely aware of. If a
+PR touches the area, confirm it didn't re-open the trap.
+
+## The process runner must never block a cooperative thread
+
+`SystemProcessRunner` uses `terminationHandler` + `readabilityHandler` — **not**
+`waitUntilExit()`. A blocking `waitUntilExit` starves the Swift concurrency
+thread pool and freezes the whole app under load.
+
+- A 16-concurrent-process canary test guards this. Don't regress it.
+- Review check: any new process-spawning code path must be non-blocking. A
+  `waitUntilExit`, a synchronous `Data(contentsOf:)` on a pipe, or a semaphore
+  wait inside an async context is a defect.
+
+## `"\r\n"` is ONE Swift Character
+
+Splitting adb/emulator/console output on `"\n"` silently fails on CRLF — you get
+one giant line and the parser returns nothing or garbage. Use
+`.components(separatedBy: .newlines)`.
+
+- Review check: any `.split(separator: "\n")` / `.components(separatedBy: "\n")`
+  on device output is suspect. There should be a CRLF test.
+
+## Cancellation kills the child
+
+`SystemProcessRunner.run` wraps its body in `withTaskCancellationHandler`, so
+cancelling the calling `.task` (navigation away, a `.task(id:)` re-key)
+terminates the adb child instead of orphaning it until timeout. Keep
+long-running adb work in a cancellable `Task` so this fires.
+
+- Review check: new long-running adb work runs inside a cancellable `Task`, not
+  detached or fire-and-forget.
+
+## Device-side shell quoting (the security boundary)
+
+Anything going through `adb shell` is joined with spaces and run by the device's
+`sh`. **Every** user-controlled value — path, URL, SSID, hostname, proxy,
+locale, free text — **must** go through `shellQuote()`. A missing `shellQuote`
+is command injection, not just a breakage. Caller-side validation (e.g. a
+`host:port` check) is UX, not security — don't rely on it to reject
+metacharacters.
+
+- `adb push`/`pull`/`exec-out` use the sync protocol — no shell, no quoting.
+  Don't quote those; double-quoting breaks them.
+- There's no linter for this. Add an arg-vector test asserting the **quoted**
+  form (see `OverridesServiceTests`).
+- Review check: new `adb shell` arguments built from variable data are quoted
+  and have a test; new push/pull/exec-out paths are not quoted.
+
+## `.task(id:)` keys must include readiness
+
+A `.task(id:)` keyed only on a device serial won't re-fire when a device goes
+from unauthorized → authorized (same serial, new state). Key on readiness too
+(e.g. `targetSerials.first`). And guard `!Task.isCancelled` before writing a
+fetched result into `@State` — a cancelled task writing stale data is a classic
+race.
+
+- Review check: device-dependent `.task(id:)` includes a readiness component;
+  async results are cancellation-checked before assignment.
+
+## CommandLog discipline
+
+The Recent tab filters `CommandLog` by feature id.
+
+- A `view` feature that runs adb directly must wrap **user-initiated** calls in
+  `CommandLog.userInitiated(feature: <id>)`, or its Recent tab stays empty.
+- Background polling must stay **out** of that scope — wrapping it floods the log.
+- Review check: new user actions are wrapped; new polling loops are not.
+
+## SwiftUI layout traps (also see UI_UX.md)
+
+- Empty states under a toolbar need `.frame(maxWidth/maxHeight: .infinity)` or
+  the VStack centers and the toolbar floats mid-window.
+- `HSplitView` ignores SwiftUI safe-area insets (NSSplitView-backed) — content
+  renders under the device bar. Use a plain HStack split.
+- The ⌘=/⌘- zoom is a `scaleEffect` on RootView, bypassed at 1.0× (the transform
+  breaks `.help` tooltips and hover/chart selection underneath). Don't "simplify"
+  it into always-on.
+
+## Persistence safety
+
+`JSONStore` writes atomically and sets aside a corrupt file as `.corrupt` rather
+than crashing. Don't replace it with a naive write. A new persisted type goes
+through a `Stores` entry, not ad-hoc file I/O. See
+[IMPACT_ANALYSIS.md](IMPACT_ANALYSIS.md) for schema-change blast radius.
+
+## Review checklist
+
+- [ ] No blocking call in an async/process path; the canary test still passes.
+- [ ] Device output is newline-split with `.newlines`, with a CRLF test.
+- [ ] `adb shell` args quoted with `shellQuote()`; push/pull paths not quoted.
+- [ ] `.task(id:)` keys include readiness; async writes are cancellation-guarded.
+- [ ] User actions wrap `CommandLog.userInitiated`; polling does not.

--- a/docs/review/IMPACT_ANALYSIS.md
+++ b/docs/review/IMPACT_ANALYSIS.md
@@ -1,0 +1,79 @@
+# Impact Area Analysis
+
+Most defects in a mature app aren't in the lines you changed — they're in the
+thing downstream of the lines you changed. Before approving, ask: *what else
+consumes this?* This doc is the map of the high-blast-radius areas and how to
+reason about them.
+
+## How to do an impact pass
+
+1. Find the callers. For a changed `ADBKit` type, who imports it? A change to a
+   shared service (`AdbClient`, `ToolLocator`, `DeviceMonitor`, a parser) ripples
+   to every feature that uses it.
+2. Ask what state it touches: in-memory only, or persisted to disk?
+3. Ask what it's part of: a single feature, the registry, the release pipeline?
+4. The PR description must name the impact area (the template has a section). If
+   it says "isolated to one feature", verify that's true — grep the type's
+   callers.
+
+## High-blast-radius areas
+
+### Shared `ADBKit` services
+
+`AdbClient`, `ToolLocator`, `DeviceMonitor`, `CommandLog`, and the per-domain
+services are used across many features. A behavior change here (argv shape,
+result structure, polling cadence, error semantics) affects all of them.
+
+- Changing `AdbResult` handling, the device poll interval, or tool resolution
+  order is **never** a one-feature change. Check every consumer.
+
+### Persisted state (`Persistence/` + `Stores`)
+
+State lives in `~/Library/Application Support/Droidective/*.json` via
+`JSONStore`. A schema change to a persisted type hits **existing users'
+on-disk data**.
+
+- Adding a field: ensure decoding tolerates its absence in old files
+  (optional / default). `JSONStore` quarantines a file it can't decode as
+  `.corrupt` — that means *silent data loss for the user* if you break the
+  schema. Verify old data still loads.
+- Renaming/removing a field is a migration, not an edit. There's precedent:
+  `LayoutState.adoptAllEnabled()` (one-time) and `adoptNewDefaults()` (auto-enable
+  newly-shipped features via `knownIds`). A new persisted change needs the
+  equivalent thought.
+- **Test it with real data** — `HOME=` does not sandbox this; launching can read
+  and rewrite the real files. Back up the JSON before first-run/layout/role tests.
+
+### The feature registry
+
+`FeatureRegistry` is consumed by the sidebar, search, the ⌘K palette, the
+catalog count, hotkeys, hub absorption, and `FeatureEngine` dispatch. Adding or
+moving a feature touches all of them.
+
+- A new feature must be enabled-by-default (the catalog is opt-*out*),
+  hotkey-able, noted, searchable, and — if hub-absorbed — filtered from the
+  standalone display surfaces. Several tests enforce slices of this; the impact
+  is wider than the one file you edited.
+- Changing `catalogFeatureIDs` / `absorbedFeatureIDs` / `defaultEnabledIDs`
+  changes the Home "All N features" count and what existing users see.
+
+### Bundled tools & release pipeline
+
+scrcpy-server and the static ffmpeg are bundled in `App/Resources/`, versioned by
+`BundledTools`, refreshed by `scripts/update-bundled-tools.sh`. The release path
+(sign → notarize → DMG → appcast → Homebrew cask) runs on `v*` tags.
+
+- Touching bundled binaries, signing, the appcast, or `RELEASING.md` affects
+  *distribution*, not just the build. Read `RELEASING.md`; a broken appcast
+  breaks auto-update for every existing install.
+- The appcast in `site/appcast.xml` is the single source of truth and is
+  committed back to `main` by the release job — don't hand-edit it in a feature
+  PR.
+
+## Review checklist
+
+- [ ] Callers of any changed shared type were checked, not assumed.
+- [ ] Persisted-schema changes load old on-disk data (or carry a migration).
+- [ ] Registry changes account for sidebar/search/palette/hotkeys/count/hubs.
+- [ ] Release/bundled/appcast changes were weighed against `RELEASING.md`.
+- [ ] The PR's stated impact area matches what the diff actually reaches.

--- a/docs/review/SECURITY.md
+++ b/docs/review/SECURITY.md
@@ -1,0 +1,92 @@
+# Security
+
+Droidective is an **open-source, public repo** that spawns local tools (adb,
+scrcpy, emulator, ffmpeg, brew) and runs commands against a connected device. The
+threat model is small but real: leaked secrets in git history, shell injection
+through device-side commands, and unsafe file operations on the user's machine.
+
+## Secrets — the public-repo rule
+
+Never commit credentials, API keys, tokens, or DSNs. This repo is public; a
+committed secret is a leaked secret even after a later removal.
+
+- Telemetry keys (Sentry DSN, PostHog key) are **build-time injected**:
+  Info.plist ← build settings ← CI secrets / a gitignored `.env.telemetry`.
+  Signing config comes from a gitignored `.env.signing`. They are never in
+  source.
+- A **gitleaks** pre-commit hook (`.pre-commit-config.yaml`, `.gitleaks.toml`)
+  blocks staged secrets. Install it: `prek install`. CI/contributors rely on it —
+  don't disable it to push.
+- Review check: no DSN/key/token literal in the diff; no `.env.*` file staged;
+  `prek run` passes.
+
+## On-device command injection
+
+Everything through `adb shell` is joined with spaces and run by the device's
+`sh`. **Every** user-controlled value (path, URL, SSID, hostname, proxy, locale,
+package name, free text) **must** go through `shellQuote()`. This is the security
+boundary — caller-side validation (a `host:port` check) is UX, not security, and
+must not be relied on to reject metacharacters.
+
+- `adb push`/`pull`/`exec-out` use the sync protocol (no shell) — don't quote
+  those.
+- There's no linter for this; a missing `shellQuote` is command injection. Add
+  an arg-vector test asserting the quoted form (see `OverridesServiceTests`).
+- Review check: any `adb shell` argument built from a variable is quoted and
+  tested; a new command path that interpolates user/device data without quoting
+  is a defect. See [CONCURRENCY_AND_PITFALLS.md](CONCURRENCY_AND_PITFALLS.md).
+
+## Secrets handed to local tools
+
+The APK toolchain shells out to signing tools. A keystore password must reach
+`apksigner` via a **0600 temp file, never argv** (argv is world-readable via
+`ps`) — `ApkSigningService` does this; a new code path that puts a credential on
+a command line is a defect.
+
+## Downloaded tools (provenance)
+
+`ManagedToolStore` downloads jadx, apktool, uber-apk-signer, frida, and a Temurin
+JRE from their GitHub releases into `Application Support/tools`. It **verifies
+the asset digest** before extracting and version-tracks each tool.
+
+- Review check: a new managed tool verifies its download digest before use;
+  download URLs point at the expected upstream release, not a mutable redirect.
+
+## File operations
+
+The app reads and writes the user's filesystem (pulls, screenshots, recordings,
+exports, persisted state).
+
+- Pulls/saves go to a user-chosen location (`askSaveLocation`/`askSaveFolder`),
+  defaulting to `~/Downloads/Droidective` — don't write to arbitrary paths
+  without asking.
+- Persisted state writes atomically via `JSONStore` and quarantines corrupt
+  files — don't bypass it with raw writes that can truncate user data on crash.
+- Don't widen what the app touches on disk without reason; the sandbox is off
+  (it must spawn external tools), so there's no OS backstop — the code is the
+  backstop.
+
+## External tools & supply chain
+
+- The app resolves adb/scrcpy/brew/ffmpeg/emulator via `ToolLocator`. Don't add a
+  new external binary dependency without justification — each is attack surface.
+- Bundled binaries (scrcpy-server, static ffmpeg) are refreshed by a script and
+  versioned in one place (`BundledTools`); a new or bumped binary is reviewed for
+  provenance (GPLv3 ffmpeg is noted in `THIRD_PARTY_NOTICES.md`).
+- New SwiftPM dependencies need a reason — justify the addition, not just the
+  feature it enables.
+
+## No AI attribution
+
+Unrelated to security but enforced repo-wide and easy to leak into a commit:
+zero AI attribution in committed content — no co-author trailer, no "Generated
+with…", no "claude" in commit messages, PR bodies, or source. Check the diff and
+the commit messages.
+
+## Review checklist
+
+- [ ] No secrets, keys, tokens, or `.env.*` in the diff; `prek`/gitleaks passes.
+- [ ] `adb shell` arguments from variable data are `shellQuote()`d.
+- [ ] File writes go to asked/known locations and through `JSONStore` for state.
+- [ ] No new external binary or SwiftPM dependency without justification.
+- [ ] No AI attribution in commits, PR body, or source.

--- a/docs/review/TESTING.md
+++ b/docs/review/TESTING.md
@@ -1,0 +1,72 @@
+# Testing
+
+The whole architecture exists to make logic testable without a device:
+`ADBKit` is a pure SwiftPM package, run with `cd ADBKit && swift test`. The test
+suite is the contract — keep it green and keep it meaningful.
+
+## What must have a test
+
+- **Every parser.** adb/getprop/dumpsys/`/proc` output → structured value. This
+  is where bugs live (CRLF, locale, empty output, missing fields).
+- **Every command construction.** The exact argv handed to adb, including
+  quoting of device-side shell input.
+- **Every error path the code handles.** If the code branches on a failure
+  (device offline, tool not found, malformed output), a test triggers that
+  branch.
+- **New feature wiring.** A feature must be in `FeatureRegistry`, have a
+  `FeatureNotes` note and a `FeatureCommands` reference, and (if hub-absorbed)
+  fold its keywords into the hub — there are tests enforcing each
+  (`everyFeatureHasAHowToNote`, `everyFeatureHasACommandReference`,
+  `hubsStaySearchableByTheirMembersPrimaryKeyword`, and the feature count). Don't
+  remove them to make a PR pass.
+- **Action arg-vectors.** An implemented action needs a test asserting the
+  *exact* adb argument vector, including the quoted form of any user value
+  (see `FeatureEngineTests`, `OverridesServiceTests`). The dispatch/`implementedIDs`
+  link is test-guarded; the *arguments* are only as correct as your arg-vector
+  test.
+
+## How to test it
+
+- **Mock the boundary, not the logic.** Use `MockProcessRunner` (the
+  `ProcessRunning` protocol) to feed canned process output and assert on the
+  parsed result and the argv. Don't mock the parser you're testing.
+- Mock only what's slow (process/network/filesystem), non-deterministic (time,
+  randomness), or external. Pure functions get real inputs.
+- **Test behavior, not implementation.** If a refactor that preserves behavior
+  breaks a test, the test was asserting on internals — fix the test. Assert on
+  what the function returns/does, not which private method it called.
+- **Test the edges.** Empty input, a single line, CRLF (`"\r\n"`), missing
+  fields, a device that's unauthorized/offline, output in an unexpected locale,
+  truncated dumpsys. The happy path is the least interesting test.
+
+## Verify the test actually catches the bug
+
+A test that passes whether or not the code is correct is worse than no test —
+it's false confidence. Before relying on a new test: break the code, confirm
+the test fails, then fix it. For parsers and serialization especially, this is
+non-negotiable.
+
+## What tests do *not* cover
+
+`swift test` runs no UI and talks to no device. It cannot tell you that a view
+renders correctly, that a real device produces the output your parser expects,
+or that a hotkey fires. Those are verified by **running the app** — see
+[UI_UX.md](UI_UX.md) and the PR pre-flight checklist. A green suite is necessary,
+not sufficient.
+
+## The process-threading canary
+
+There is a test that runs 16 concurrent processes to guard that
+`SystemProcessRunner` never blocks a cooperative thread (see
+[CONCURRENCY_AND_PITFALLS.md](CONCURRENCY_AND_PITFALLS.md)). **Don't delete or
+weaken it** to make unrelated work pass. If it fails, the runner regressed — fix
+the runner.
+
+## Review checklist
+
+- [ ] New parsing/command logic has tests, and they assert on behavior.
+- [ ] Edge and error cases are covered, not just the happy path.
+- [ ] Mocks are at boundaries only; the thing under test isn't mocked.
+- [ ] No enforcement test (FeatureNotes, hub keywords, the 16-process canary) was
+      removed or hollowed out to go green.
+- [ ] If the change is a bug fix, there's a test that fails without the fix.

--- a/docs/review/UI_UX.md
+++ b/docs/review/UI_UX.md
@@ -1,0 +1,81 @@
+# UI / UX
+
+Droidective is a Raycast-style command palette: a searchable feature sidebar, a
+persistent device bar, a detail pane per feature. UI lives entirely in `App/`
+and consumes `ADBKit` — a view never computes or shells out (see
+[ARCHITECTURE.md](ARCHITECTURE.md)).
+
+**You cannot review UI without running it.** `swift test` renders nothing.
+`make run` builds, relaunches, and opens the app; verify the change live before
+signing off.
+
+## Layout correctness
+
+These are the specific traps that have bitten this app — check them when a PR
+touches layout:
+
+- **Empty states under a toolbar** must `.frame(maxWidth: .infinity,
+  maxHeight: .infinity)`, or the content centers and the toolbar floats in the
+  middle of the window.
+- **Don't use `HSplitView`** for the main split — it's NSSplitView-backed and
+  ignores SwiftUI safe-area insets, so content renders under the device bar. Use
+  a plain HStack split.
+- **Pull-progress / safe-area strips** live in RootView's safe-area inset, not
+  inside the device bar view.
+- A hidden-title-bar window still reserves a 32pt title bar — account for it with
+  a full-bleed material ZStack and content that respects the safe area (this was
+  the ⌘K palette dead-strip bug).
+- The ⌘=/⌘- font zoom is a `scaleEffect`, not dynamic type — macOS ignores
+  SwiftUI `dynamicTypeSize` for rendering. It's bypassed at 1.0× on purpose.
+
+## Feature UX contract
+
+Every feature ships a complete, consistent experience:
+
+- [ ] A **how-it-works note** (`FeatureNotes`) renders inline beneath the
+      content, and a **command reference** (`FeatureCommands`) powers the
+      Commands tab. Every feature has both; tests enforce them.
+- [ ] For a `view` feature, the `FeatureDetailView.detailByKind` case exists —
+      a missing case renders a **"Coming Soon"** placeholder *silently* (no test
+      catches it), so confirm the real view shows.
+- [ ] A **hotkey** is registered (every feature has one; hub-absorbed features
+      appear under "Hidden features" in the Hotkeys tab).
+- [ ] **Discoverable in search** — keywords are set; hub members fold their
+      keywords into the hub so the hub surfaces for the member's terms.
+- [ ] **Recent tab works** — user-initiated adb calls are wrapped in
+      `CommandLog.userInitiated(feature:)` (see
+      [CONCURRENCY_AND_PITFALLS.md](CONCURRENCY_AND_PITFALLS.md)).
+- [ ] **Pulls ask for a save location** (`askSaveLocation`/`askSaveFolder`),
+      defaulting to `~/Downloads/Droidective`.
+
+## Interaction feel
+
+- **Loading / empty / error are distinct states**, each handled — not a spinner
+  that hangs forever on a failed adb call. Surface the failure with a message
+  the user can act on.
+- **Destructive actions** (uninstall, clear data, force-stop) confirm before
+  acting.
+- **No layout jump** when data arrives — reserve space or animate.
+- Match the existing panels' spacing, typography, and control style. A new panel
+  should feel like it shipped with the others, not like a bolt-on.
+
+## Verifying UI in review
+
+1. `make run` (build → relaunch → open). Never review against a stale build.
+2. Exercise the change against a real device *and* an emulator if the behavior
+   differs (USB vs. wireless, app presence, permissions).
+3. Check the empty/error states deliberately — disconnect the device, point at
+   an app that isn't installed, feed it nothing.
+4. For drag/canvas/annotation flows that can't be driven by automation, build it
+   and hand interactive testing to a human — don't claim a visual pass you
+   didn't do.
+5. Attach a screenshot or GIF to the PR for any visible change.
+
+## Review checklist
+
+- [ ] You ran the app and saw the change.
+- [ ] Loading/empty/error states all handled and tested live.
+- [ ] No toolbar-floats / under-device-bar / title-bar-strip regression.
+- [ ] FeatureNotes + hotkey + search keywords + Recent-tab wiring present.
+- [ ] Destructive actions confirm; pulls ask for a destination.
+- [ ] Screenshot/GIF attached for visible changes.


### PR DESCRIPTION
## What changed

Adds an engineering docs set under `docs/` covering how to open a PR and how to
review one, plus a GitHub PR template. No code changes.

- `docs/README.md` — index of the docs.
- `docs/PULL_REQUESTS.md` — scoping, branching, commit conventions, the
  pre-flight checklist, PR-description standard, and the CI gates.
- `.github/PULL_REQUEST_TEMPLATE.md` — auto-fills the PR body with that checklist.
- `docs/CODE_REVIEW.md` — the review process and the order to apply it, linking
  the topic standards below.
- `docs/review/` — one file per review lens: `ARCHITECTURE.md`,
  `CODE_QUALITY.md`, `TESTING.md`, `CONCURRENCY_AND_PITFALLS.md`, `UI_UX.md`,
  `IMPACT_ANALYSIS.md`, `SECURITY.md`.
- `CONTRIBUTING.md` — points at the new docs.

The content is derived from this repo's actual conventions (the ADBKit/App
boundary, the "Adding a feature" checklist, the known pitfalls, the CI gates,
the secret-handling rules), not generic boilerplate.

## Why

The project had a short `CONTRIBUTING.md` but no detailed PR or review standard.
This gives a reviewable, topic-split reference so non-trivial changes are
authored and reviewed against the same bar.

## Impact area

Docs only — no code, tests, or build changes. CI runs unaffected.

## How verified

Docs-only change; `swift test`/build unaffected. Reviewed each file for accuracy
against the current `CLAUDE.md` (53 features, the feature checklist, the
managed-tool toolchain) and fixed cross-references.

## Checklist

- [x] No secrets, no AI attribution, no relative imports
- [x] Docs reflect the current codebase, not stale facts
