### PR TITLE
Keep screen mirror running when device audio capture fails

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorAudioFallback.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorAudioFallback.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Decides whether a mirror session that just ended should be reconnected
+/// without audio.
+///
+/// scrcpy starts its audio encoder while bringing the session up. On devices
+/// that can't capture audio — most emulators, where `AudioRecord` can't be
+/// created — that encoder fails *before* the first video frame and scrcpy aborts
+/// the whole session, video included. So when audio was requested and the
+/// session died before ever streaming a frame, audio is the likely culprit and a
+/// video-only reconnect keeps mirroring working. If video had already streamed,
+/// the session ended for some other reason and must not be silently restarted.
+public enum MirrorAudioFallback {
+    public static func shouldRetryWithoutAudio(audioRequested: Bool, everStreamed: Bool) -> Bool {
+        audioRequested && !everStreamed
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MirrorAudioFallbackTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorAudioFallbackTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct MirrorAudioFallbackTests {
+    @Test func retriesWhenAudioOnAndNeverStreamed() {
+        #expect(MirrorAudioFallback.shouldRetryWithoutAudio(
+            audioRequested: true, everStreamed: false))
+    }
+
+    @Test func noRetryOnceVideoStreamed() {
+        #expect(!MirrorAudioFallback.shouldRetryWithoutAudio(
+            audioRequested: true, everStreamed: true))
+    }
+
+    @Test func noRetryWhenAudioWasNotRequested() {
+        // Already video-only: nothing to fall back to (and avoids a retry loop).
+        #expect(!MirrorAudioFallback.shouldRetryWithoutAudio(
+            audioRequested: false, everStreamed: false))
+        #expect(!MirrorAudioFallback.shouldRetryWithoutAudio(
+            audioRequested: false, everStreamed: true))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -56,6 +56,14 @@ final class MirrorViewModel {
     /// encoder emits them rarely.)
     private var screenRecorder: ScreenRecorder?
     private var sendControl: (@Sendable (ScrcpyControlMessage) -> Void)?
+    /// Whether to request device audio. Cleared after one failed start so the
+    /// mirror reconnects video-only on devices that can't capture audio (most
+    /// emulators) — scrcpy aborts the whole session, video included, when its
+    /// audio encoder can't start. See `MirrorAudioFallback`.
+    private var requestAudio = true
+    /// Set once video frames begin flowing; gates the video-only fallback so a
+    /// session that streamed and later stopped isn't silently restarted.
+    private var didStream = false
 
     init(adb: AdbClient, locator: ToolLocator, serial: String) {
         self.adb = adb
@@ -65,6 +73,7 @@ final class MirrorViewModel {
 
     func start() async {
         status = .connecting
+        didStream = false
         // Prefer the bundled server (self-contained); fall back to an installed
         // scrcpy only if the bundled resource is somehow missing.
         let server: ScrcpyServerInfo?
@@ -78,12 +87,13 @@ final class MirrorViewModel {
             return
         }
         self.server = server
-        // Interactive mirror: control + audio on. Cap the size for smooth,
-        // low-latency display. Recording started mid-stream forces a fresh key
-        // frame via RESET_VIDEO (see MirrorSession.startRecording).
+        // Interactive mirror: control on, audio when the device can supply it.
+        // Cap the size for smooth, low-latency display. Recording started
+        // mid-stream forces a fresh key frame via RESET_VIDEO (see
+        // MirrorSession.startRecording).
         let params = ScrcpyServerParams(
             scid: UInt32.random(in: 1 ... 0x7fff_ffff),
-            audio: true, control: true, maxSize: 1280)
+            audio: requestAudio, control: true, maxSize: 1280)
         let config = MirrorTransport.Configuration(
             serial: serial, params: params,
             serverVersion: server.version, localJarPath: server.jarPath)
@@ -136,19 +146,36 @@ final class MirrorViewModel {
                     }
                     if self.status == .connecting {
                         self.status = .streaming
+                        self.didStream = true
                         // The transport (incl. the control socket) is connected
                         // once frames flow — fetch the control sender now, not
                         // right after start() when it isn't wired yet.
                         self.sendControl = await self.session?.controlSender()
                     }
                 }
-                self?.status = .stopped
+                await self?.sessionEnded(failure: nil)
             } catch is CancellationError {
                 // expected on stop()
             } catch {
-                self?.status = .failed(error.localizedDescription)
+                await self?.sessionEnded(failure: error.localizedDescription)
             }
         }
+    }
+
+    /// The display stream ended (the device closed it, or it errored — not a
+    /// user-initiated stop, which cancels the task). If audio was requested and
+    /// no frame ever streamed, scrcpy likely aborted the session because the
+    /// device couldn't capture audio, so reconnect once video-only. Otherwise
+    /// surface the terminal state.
+    private func sessionEnded(failure: String?) async {
+        if MirrorAudioFallback.shouldRetryWithoutAudio(
+            audioRequested: requestAudio, everStreamed: didStream) {
+            requestAudio = false
+            await stop()
+            await start()
+            return
+        }
+        status = failure.map(Status.failed) ?? .stopped
     }
 
     func stop() async {


### PR DESCRIPTION
## Problem

Issue #80: on an Android 16 emulator the screen mirror connects, then stops immediately.

Root cause: the in-app mirror requests device audio unconditionally (`MirrorViewModel` set `audio: true`). The bundled scrcpy v4.0 server can't create an `AudioRecord` on the emulator:

```
java.lang.UnsupportedOperationException: Cannot create AudioRecord
  at com.genymobile.scrcpy.audio.AudioDirectCapture.createAudioRecord
```

scrcpy reports an audio configuration error and **aborts the whole session — video included** — so the mirror stops. Our audio decoder already tolerates the config-error codec id, but scrcpy still tears the video socket down.

## Fix

We bundle the scrcpy binary and can't change its crash behaviour, so the fallback is app-side: request audio as before, but if an audio-enabled session ends **before any video frame streamed**, reconnect once video-only. scrcpy's audio encoder fails at capture start — before video flows — so "audio on + no frame yet" reliably points at audio capture, and a video-only reconnect keeps mirroring working on emulators (and any device without output capture). The retry is one-shot: once audio is dropped it can't loop. Devices that *can* capture audio are unaffected.

- `ADBKit/.../Mirror/MirrorAudioFallback.swift` — pure `shouldRetryWithoutAudio(audioRequested:everStreamed:)` decision, so the rule lives in ADBKit and is unit-tested.
- `MirrorAudioFallbackTests.swift` — covers the decision table.
- `MirrorViewModel.swift` — request audio via a `requestAudio` flag, track whether video streamed, and reconnect video-only via the helper when a first start dies before streaming.

## Testing

- `cd ADBKit && swift test` — 409 tests pass (3 new).
- App build verified locally to compile; note the repo currently hits a pre-existing Swift 6.2 (Xcode 26) type-check timeout in `RootView.body` unrelated to this change — CI builds on Swift 6.0 and is unaffected.

Closes #80