### PR TITLE
Fix Frida server start hang and single-ABI arch detection

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/FridaService.swift
+++ b/ADBKit/Sources/ADBKit/Services/FridaService.swift
@@ -71,10 +71,15 @@ public struct FridaService: Sendable {
         ["shell", "chmod", "755", shellQuote(serverRemotePath)]
     }
 
-    /// `su -c '<path> &'` launches the server in the background so the adb call
-    /// returns instead of blocking on the long-lived process.
+    /// Launch frida-server detached so the `adb shell` call returns at once.
+    /// A bare `&` is not enough: the backgrounded server inherits the shell's
+    /// stdout/stderr, so adb's shell service never sees EOF and the call hangs
+    /// until it times out — and the cancelled adb child takes the server down
+    /// with it. `setsid` plus redirecting all three std streams to /dev/null
+    /// severs it from the adb pipe and the shell's session, so the call returns
+    /// immediately and the server survives.
     static func startArguments() -> [String] {
-        ["shell", "su", "-c", shellQuote("\(serverRemotePath) &")]
+        ["shell", "su", "-c", shellQuote("setsid \(serverRemotePath) </dev/null >/dev/null 2>&1 &")]
     }
 
     static func stopArguments() -> [String] {

--- a/ADBKit/Sources/ADBKit/Services/FridaService.swift
+++ b/ADBKit/Sources/ADBKit/Services/FridaService.swift
@@ -4,7 +4,10 @@ import Foundation
 /// asset names (`frida-server-<ver>-android-<arch>.xz`).
 public enum FridaArch {
     public static func from(abilist: String) -> String? {
-        for abi in abilist.components(separatedBy: ",").map({ $0.trimmingCharacters(in: .whitespaces) }) {
+        // Trim newlines too: raw `getprop` output keeps its trailing "\n", and a
+        // single-ABI list (64-bit-only devices, e.g. "arm64-v8a") has no comma to
+        // separate it off, so ".whitespaces" alone would leave "arm64-v8a\n".
+        for abi in abilist.components(separatedBy: ",").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) }) {
             switch abi {
             case "arm64-v8a": return "arm64"
             case "armeabi-v7a", "armeabi": return "arm"

--- a/ADBKit/Tests/ADBKitTests/FridaServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FridaServiceTests.swift
@@ -9,6 +9,11 @@ import Testing
         #expect(FridaArch.from(abilist: "x86_64,x86") == "x86_64")
         #expect(FridaArch.from(abilist: "x86") == "x86")
         #expect(FridaArch.from(abilist: "mips,unknown") == nil)
+        // Raw getprop output keeps a trailing newline; a single-ABI list (common
+        // on 64-bit-only devices) has no comma to strip it, so the trim must
+        // cover newlines, not just spaces.
+        #expect(FridaArch.from(abilist: "arm64-v8a\n") == "arm64")
+        #expect(FridaArch.from(abilist: "x86_64\n") == "x86_64")
     }
 
     @Test func serverArgumentsQuoteDeviceShellValues() {

--- a/ADBKit/Tests/ADBKitTests/FridaServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FridaServiceTests.swift
@@ -15,7 +15,8 @@ import Testing
         #expect(FridaService.pushArguments(localPath: "/tmp/frida-server")
             == ["push", "/tmp/frida-server", "/data/local/tmp/frida-server"])
         #expect(FridaService.chmodArguments() == ["shell", "chmod", "755", "'/data/local/tmp/frida-server'"])
-        #expect(FridaService.startArguments() == ["shell", "su", "-c", "'/data/local/tmp/frida-server &'"])
+        #expect(FridaService.startArguments()
+            == ["shell", "su", "-c", "'setsid /data/local/tmp/frida-server </dev/null >/dev/null 2>&1 &'"])
         #expect(FridaService.stopArguments() == ["shell", "su", "-c", "'pkill -f frida-server'"])
         #expect(FridaService.statusArguments() == ["shell", "pidof", "frida-server"])
     }


### PR DESCRIPTION
Two bugs kept the Frida feature from working against a rooted device.

**frida-server never stayed running.** `startArguments()` launched it with `su -c '<path> &'`. A bare `&` leaves frida-server's stdout/stderr wired to the adb shell pipe, so `adb shell` never sees EOF and blocks until `startServer`'s 10s timeout fires — and the cancelled adb child takes the server down with it. Launch it with `setsid <path> </dev/null >/dev/null 2>&1 &` so it detaches from the adb pipe and the shell session: the call returns immediately and the server keeps running. frida's own `-D` daemonize flag also blocks, so it is not a substitute.

**Architecture showed "unknown" on 64-bit-only devices.** `FridaArch.from` split `ro.product.cpu.abilist` on commas and trimmed each token with `.whitespaces`, which excludes newlines. A single-ABI device reports `arm64-v8a` with getprop's trailing `\n` and no comma to separate it, so `arm64-v8a\n` never matched and arch detection returned nil, blocking download/start. Multi-ABI lists worked only because the first comma-split token was already clean. Trim with `.whitespacesAndNewlines` and cover the single-ABI form in the test.

Verified on a Magisk-rooted emulator through the real ADBKit code path: arch resolves to arm64, frida-server downloads/decompresses/pushes/starts (the start call returns in ~0.06s, was hanging), and `frida-ps -U` lists device processes. 409 ADBKit tests green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
