### PR TITLE
Fix intermittent blank editor in the decompiler

### DIFF
--- a/App/Sources/FeatureDetail/Views/CodeEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/CodeEditorView.swift
@@ -21,6 +21,9 @@ struct CodeEditorView: NSViewRepresentable {
         webView.underPageBackgroundColor = NSColor(red: 0.157, green: 0.173, blue: 0.204, alpha: 1) // #282c34
         webView.navigationDelegate = context.coordinator
         context.coordinator.webView = webView
+        // Seed the desired content so it's applied once the page finishes loading,
+        // even if SwiftUI hasn't called updateNSView yet.
+        context.coordinator.request(content: content, language: language, line: line)
         if let url = Bundle.main.url(forResource: "codemirror-editor", withExtension: "html"),
            let html = try? String(contentsOf: url, encoding: .utf8) {
             webView.loadHTMLString(html, baseURL: nil)
@@ -29,29 +32,62 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
-        context.coordinator.load(content: content, language: language, line: line)
+        context.coordinator.request(content: content, language: language, line: line)
         context.coordinator.find(token: findToken)
     }
 
+    /// Pushes content into the web view over the fire-and-forget
+    /// `evaluateJavaScript` bridge — which fails transiently while the page is
+    /// mid-load or mid-layout. A dropped push used to leave the editor blank
+    /// until the file was reselected, so the coordinator holds the *desired*
+    /// state, marks it applied only once the JS call **succeeds**, re-applies
+    /// whenever the page finishes loading, and retries briefly on error.
     final class Coordinator: NSObject, WKNavigationDelegate {
         weak var webView: WKWebView?
         private var ready = false
-        private var pending: (String, String, Int)?
-        private var loaded: (String, String, Int)?
+        private var desired: (content: String, language: String, line: Int)?
+        private var applied: (content: String, language: String, line: Int)?
+        private var attempts = 0
+        private let maxAttempts = 20
         private var lastFindToken = 0
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             ready = true
-            if let (text, language, line) = pending {
-                pending = nil
-                run(text, language, line)
-            }
+            apply()
         }
 
-        func load(content: String, language: String, line: Int) {
-            guard loaded?.0 != content || loaded?.1 != language || loaded?.2 != line else { return }
-            loaded = (content, language, line)
-            if ready { run(content, language, line) } else { pending = (content, language, line) }
+        /// Record the latest content the view wants shown and try to apply it.
+        func request(content: String, language: String, line: Int) {
+            if desired?.content != content || desired?.language != language || desired?.line != line {
+                desired = (content, language, line)
+                attempts = 0
+            }
+            apply()
+        }
+
+        /// Push `desired` into the editor if it isn't already there. JSON-encodes
+        /// the content so any characters survive the bridge; only on a successful
+        /// call is it remembered as applied, otherwise it retries shortly.
+        private func apply() {
+            guard ready, let webView, let want = desired,
+                  applied?.content != want.content || applied?.language != want.language || applied?.line != want.line,
+                  attempts < maxAttempts,
+                  let data = try? JSONEncoder().encode(want.content),
+                  let json = String(data: data, encoding: .utf8)
+            else { return }
+            attempts += 1
+            webView.evaluateJavaScript("window.cmLoad(\(json), \"\(want.language)\", \(want.line))") { [weak self] _, error in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    if error == nil {
+                        self.applied = want
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                            MainActor.assumeIsolated { self?.apply() }
+                        }
+                    }
+                }
+            }
         }
 
         func find(token: Int) {
@@ -59,15 +95,6 @@ struct CodeEditorView: NSViewRepresentable {
             lastFindToken = token
             guard ready, token > 0 else { return }
             webView?.evaluateJavaScript("window.cmFind()")
-        }
-
-        /// Encode `content` as a JS string literal via JSON so any characters in
-        /// the source survive the bridge.
-        private func run(_ content: String, _ language: String, _ line: Int) {
-            guard let webView,
-                  let data = try? JSONEncoder().encode(content),
-                  let json = String(data: data, encoding: .utf8) else { return }
-            webView.evaluateJavaScript("window.cmLoad(\(json), \"\(language)\", \(line))")
         }
     }
 }


### PR DESCRIPTION
Opening a file in the APK Studio Decompile browser sometimes showed a completely blank editor.

`CodeEditorView` pushed source into the bundled CodeMirror web view with a fire-and-forget `evaluateJavaScript` and no completion handler, and recorded the content as "loaded" before the call ran. A push that failed transiently — the web view mid-load or mid-layout — was swallowed silently and never retried, so the file stayed blank until the user selected another file and came back. A push issued before the page finished loading could also be missed.

The coordinator now holds the desired `(content, language, line)` as the source of truth, seeds it in `makeNSView`, re-applies it whenever the page finishes loading, marks it applied only once the JS call succeeds, and retries briefly on error.

Verified against the real bundled editor: content requested before the page is ready applies on load, reuse updates immediately, and a simulated transient `cmLoad` error recovers via retry (the old code left that blank). File size was ruled out separately — the editor renders content up to ~1.8 MB. 409 ADBKit tests green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
