### PR TITLE
Add tabbed features with VS Code-style split panes

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/TabState.swift
+++ b/ADBKit/Sources/ADBKit/Features/TabState.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The open feature tabs and which one is active. Pure value type, kept out of
+/// the SwiftUI layer (like `SidebarOrdering`) so the open/close/cycle math is
+/// unit-tested without a UI or a device.
+///
+/// Tabs are *strictly distinct features*: a feature's id identifies its tab, so
+/// opening a feature that's already open just refocuses it — there are never two
+/// tabs for the same feature. At most `maxTabs` are open at once.
+public struct TabState: Sendable, Equatable {
+    /// The hard cap on simultaneously open tabs.
+    public static let maxTabs = 10
+
+    /// Open tabs (feature ids) in strip order, left to right.
+    public private(set) var openTabs: [String]
+    /// The foreground tab — always one of `openTabs`, or nil only when none are
+    /// open.
+    public private(set) var activeTab: String?
+
+    /// Build a state, normalizing `activeTab` to an open tab (or the first open
+    /// tab) so a stale persisted value can't point at a closed tab.
+    public init(openTabs: [String] = [], activeTab: String? = nil) {
+        self.openTabs = openTabs
+        self.activeTab = activeTab.flatMap { openTabs.contains($0) ? $0 : nil } ?? openTabs.first
+    }
+
+    /// Open `id`, or refocus it if already open. Returns false only when a *new*
+    /// tab can't be opened because the cap is reached — the caller surfaces a
+    /// hint. Refocusing an already-open tab always succeeds.
+    @discardableResult
+    public mutating func open(_ id: String) -> Bool {
+        if openTabs.contains(id) {
+            activeTab = id
+            return true
+        }
+        guard openTabs.count < Self.maxTabs else { return false }
+        openTabs.append(id)
+        activeTab = id
+        return true
+    }
+
+    /// Close `id`. If it was the active tab, focus the neighbor that slid into
+    /// its slot (its old right neighbor), or the new last tab when the rightmost
+    /// closed. `activeTab` becomes nil only when no tabs remain.
+    public mutating func close(_ id: String) {
+        guard let index = openTabs.firstIndex(of: id) else { return }
+        let wasActive = activeTab == id
+        openTabs.remove(at: index)
+        guard wasActive else { return }
+        activeTab = openTabs.isEmpty ? nil : openTabs[min(index, openTabs.count - 1)]
+    }
+
+    /// Activate the next tab to the right, wrapping to the first.
+    public mutating func activateNext() { cycle(by: 1) }
+    /// Activate the previous tab to the left, wrapping to the last.
+    public mutating func activatePrevious() { cycle(by: -1) }
+
+    private mutating func cycle(by offset: Int) {
+        guard !openTabs.isEmpty else { return }
+        let current = activeTab.flatMap { openTabs.firstIndex(of: $0) } ?? 0
+        activeTab = openTabs[(current + offset + openTabs.count) % openTabs.count]
+    }
+
+    /// Adopt a new left-to-right order (a permutation of the open tabs) from a
+    /// drag-reorder. Keeps the active tab. Ignored unless `newOrder` is exactly
+    /// the current set of tabs.
+    public mutating func reorder(_ newOrder: [String]) {
+        guard newOrder.count == openTabs.count, Set(newOrder) == Set(openTabs) else { return }
+        openTabs = newOrder
+    }
+
+    /// Activate the tab at a 0-based index (⌘1–⌘9). No-op when out of range.
+    public mutating func activate(index: Int) {
+        guard openTabs.indices.contains(index) else { return }
+        activeTab = openTabs[index]
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/Workspace.swift
+++ b/ADBKit/Sources/ADBKit/Features/Workspace.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// The editor-group workspace: one or two panes (`TabState` groups) side by
+/// side, plus which one holds focus. Pure value type kept out of the SwiftUI
+/// layer (like `TabState`/`SidebarOrdering`) so the fiddly multi-group rules —
+/// collapsing an emptied pane, shifting indices, the total-tab cap, global id
+/// uniqueness, keeping a pane focused, and never leaving the workspace empty —
+/// are unit-tested without a UI or a device.
+///
+/// A feature id is open in at most one group, so moving a tab between panes is a
+/// move, not a copy. `fallback` is the id seeded when the workspace would
+/// otherwise be empty (the app passes "home") — kept as data so this type stays
+/// free of any UI/registry knowledge.
+public struct Workspace: Sendable, Equatable {
+    /// The hard cap on simultaneously open tabs, summed across both panes.
+    public static let maxTabs = TabState.maxTabs
+
+    /// The tab seeded when the last tab would close (never leave an empty pane).
+    public let fallback: String
+    /// The open panes, left to right — always 1 or 2.
+    public private(set) var groups: [TabState]
+    /// Which pane holds focus (index into `groups`) — new tabs, close, and cycle
+    /// act on it. Always a valid index.
+    public private(set) var focusedGroup: Int
+
+    /// A fresh workspace with a single pane showing `fallback`.
+    public init(fallback: String) {
+        self.fallback = fallback
+        groups = [TabState(openTabs: [fallback], activeTab: fallback)]
+        focusedGroup = 0
+    }
+
+    /// Rebuild from persisted panes, enforcing every invariant: at most two
+    /// panes, `maxTabs` tabs total, ids valid (`isValidID`) and globally unique,
+    /// a non-empty result (seed `fallback`), and an in-range `focusedGroup`.
+    public init(
+        restoring persisted: [TabGroupState],
+        focusedGroup: Int?,
+        fallback: String,
+        isValidID: (String) -> Bool
+    ) {
+        self.fallback = fallback
+        var restored: [TabState] = []
+        var seen = Set<String>()
+        var budget = Self.maxTabs
+        for group in persisted.prefix(2) {
+            guard budget > 0 else { break }
+            let valid = group.tabs.filter { isValidID($0) && seen.insert($0).inserted }
+            let kept = Array(valid.prefix(budget))
+            guard !kept.isEmpty else { continue }
+            budget -= kept.count
+            restored.append(TabState(openTabs: kept, activeTab: group.activeTab))
+        }
+        groups = restored.isEmpty ? [TabState(openTabs: [fallback], activeTab: fallback)] : restored
+        self.focusedGroup = min(max(focusedGroup ?? 0, 0), groups.count - 1)
+    }
+
+    // MARK: - Reads
+
+    /// The focused pane's active tab — drives the device bar, sidebar highlight,
+    /// and window title.
+    public var activeTab: String? {
+        groups.indices.contains(focusedGroup) ? groups[focusedGroup].activeTab : nil
+    }
+    /// Every pane's active tab (both fronts).
+    public var activeTabs: Set<String> { Set(groups.compactMap(\.activeTab)) }
+    /// True when split into two panes.
+    public var isSplit: Bool { groups.count > 1 }
+    /// Total open tabs across all panes.
+    public var totalTabs: Int { groups.reduce(0) { $0 + $1.openTabs.count } }
+
+    public func openTabs(inGroup index: Int) -> [String] {
+        groups.indices.contains(index) ? groups[index].openTabs : []
+    }
+    public func activeTab(inGroup index: Int) -> String? {
+        groups.indices.contains(index) ? groups[index].activeTab : nil
+    }
+    public func groupIndex(of id: String) -> Int? {
+        groups.firstIndex { $0.openTabs.contains(id) }
+    }
+
+    // MARK: - Mutations
+
+    /// Open `id`, or refocus it wherever it's already open. A not-yet-open id
+    /// lands in the focused pane. Returns false only when a *new* tab is blocked
+    /// by the total cap (the caller surfaces a hint); refocusing always succeeds.
+    @discardableResult
+    public mutating func open(_ id: String) -> Bool {
+        if let group = groupIndex(of: id) {
+            focusedGroup = group
+            groups[group].open(id)
+            return true
+        }
+        guard totalTabs < Self.maxTabs else { return false }
+        groups[focusedGroup].open(id)
+        return true
+    }
+
+    /// Close `id` (in whichever pane holds it). Collapses an emptied second pane;
+    /// reopens `fallback` if the last pane would empty; keeps focus in range.
+    public mutating func close(_ id: String) {
+        guard let group = groupIndex(of: id) else { return }
+        groups[group].close(id)
+        guard groups[group].openTabs.isEmpty else { return }
+        if groups.count > 1 {
+            groups.remove(at: group)
+            focusedGroup = min(focusedGroup, groups.count - 1)
+        } else {
+            groups[group].open(fallback) // never leave the workspace empty
+        }
+    }
+
+    /// Move `id` into pane `dest` (append + activate). Collapses the source pane
+    /// if it empties. Undoes itself if `dest` is unexpectedly full so no tab is
+    /// stranded. No-op for the same pane or an invalid `dest`.
+    public mutating func move(_ id: String, toGroup dest: Int) {
+        guard let src = groupIndex(of: id), src != dest, groups.indices.contains(dest) else { return }
+        groups[src].close(id)
+        guard groups[dest].open(id) else {
+            groups[src].open(id)
+            return
+        }
+        if groups[src].openTabs.isEmpty { groups.remove(at: src) }
+        focusedGroup = groupIndex(of: id) ?? focusedGroup
+    }
+
+    /// Split the workspace: move `id` into a new second pane. Requires its pane
+    /// to hold more than one tab (something must stay behind) and no existing
+    /// split.
+    public mutating func split(_ id: String) {
+        guard groups.count == 1, let src = groupIndex(of: id), groups[src].openTabs.count > 1 else { return }
+        groups[src].close(id)
+        groups.append(TabState(openTabs: [id], activeTab: id))
+        focusedGroup = 1
+    }
+
+    /// Reorder `id` within its own pane so it sits before `targetID` (nil = end).
+    public mutating func reorder(_ id: String, before targetID: String?) {
+        guard let group = groupIndex(of: id) else { return }
+        let order = targetID.map { SidebarOrdering.move(id, before: $0, in: groups[group].openTabs) }
+            ?? SidebarOrdering.moveToEnd(id, in: groups[group].openTabs)
+        groups[group].reorder(order)
+    }
+
+    /// Resolve a strip/pane drop: reorder within the same pane, or move to `dest`
+    /// and position at the drop target.
+    public mutating func drop(_ id: String, intoGroup dest: Int, before targetID: String?) {
+        guard let src = groupIndex(of: id) else { return }
+        if src == dest {
+            if let targetID { reorder(id, before: targetID) }
+        } else {
+            move(id, toGroup: dest)
+            if let targetID { reorder(id, before: targetID) }
+        }
+    }
+
+    /// Activate the next / previous tab within the focused pane (wraps).
+    public mutating func cycleForward() {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activateNext()
+    }
+    public mutating func cycleBackward() {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activatePrevious()
+    }
+    /// Activate the tab at a 0-based index in the focused pane.
+    public mutating func activate(index: Int) {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activate(index: index)
+    }
+    /// Give a pane focus (clicking one of its tabs, or its + button).
+    public mutating func focus(_ index: Int) {
+        if groups.indices.contains(index) { focusedGroup = index }
+    }
+
+    /// Collapse to a single pane showing `fallback` (e.g. after a role change).
+    public mutating func reset() {
+        groups = [TabState(openTabs: [fallback], activeTab: fallback)]
+        focusedGroup = 0
+    }
+}

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -52,6 +52,17 @@ public struct CustomCommand: Codable, Sendable, Equatable, Identifiable {
     }
 }
 
+/// One editor group (a split pane): its open tabs and the active one.
+public struct TabGroupState: Codable, Sendable, Equatable {
+    public var tabs: [String]
+    public var activeTab: String?
+
+    public init(tabs: [String], activeTab: String?) {
+        self.tabs = tabs
+        self.activeTab = activeTab
+    }
+}
+
 /// Feature customization. Hotkey bindings are persisted by the
 /// KeyboardShortcuts library itself, so they don't live here.
 public struct LayoutState: Codable, Sendable, Equatable {
@@ -101,6 +112,14 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// the user's role turns on for them without re-running the picker. Optional
     /// so older files decode.
     public var seededRoleIds: [String]?
+    /// Open editor groups (VS Code-style split panes), each with its own tabs
+    /// and active tab: one group = no split, two = a left/right split. Restored
+    /// on launch; live sessions (recordings/streams) don't resume — a reopened
+    /// tab is idle. Optional so older files decode (they seed a single Home tab).
+    public var tabGroups: [TabGroupState]?
+    /// Which group holds keyboard focus (index into `tabGroups`). Optional so
+    /// older files decode.
+    public var focusedGroup: Int?
 
     public init(
         enabledIds: [String]? = nil,
@@ -114,7 +133,9 @@ public struct LayoutState: Codable, Sendable, Equatable {
         didEnableAll: Bool? = nil,
         selectedRole: String? = nil,
         roleChosen: Bool? = nil,
-        seededRoleIds: [String]? = nil
+        seededRoleIds: [String]? = nil,
+        tabGroups: [TabGroupState]? = nil,
+        focusedGroup: Int? = nil
     ) {
         self.enabledIds = enabledIds
         self.favorites = favorites
@@ -128,6 +149,8 @@ public struct LayoutState: Codable, Sendable, Equatable {
         self.selectedRole = selectedRole
         self.seededRoleIds = seededRoleIds
         self.roleChosen = roleChosen
+        self.tabGroups = tabGroups
+        self.focusedGroup = focusedGroup
     }
 
     /// The effective enabled set: explicit user choice or registry defaults,

--- a/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
@@ -50,6 +50,39 @@ import Testing
         #expect(bundles.map(\.packageId) == ["com.example", "com.other"])
     }
 
+    @Test func roundTripsTabGroups() async throws {
+        let dir = try tempDir()
+        let store = JSONStore(filename: "layout.json", default: LayoutState(), directory: dir)
+        try await store.update {
+            $0.tabGroups = [
+                TabGroupState(tabs: ["home", "logcat"], activeTab: "logcat"),
+                TabGroupState(tabs: ["performance"], activeTab: "performance"),
+            ]
+            $0.focusedGroup = 1
+        }
+
+        let fresh = JSONStore(filename: "layout.json", default: LayoutState(), directory: dir)
+        let loaded = await fresh.load()
+        #expect(loaded.tabGroups?.count == 2)
+        #expect(loaded.tabGroups?.first?.tabs == ["home", "logcat"])
+        #expect(loaded.tabGroups?.first?.activeTab == "logcat")
+        #expect(loaded.tabGroups?.last?.tabs == ["performance"])
+        #expect(loaded.focusedGroup == 1)
+    }
+
+    @Test func layoutWrittenBeforeTabsDecodesWithNilTabs() async throws {
+        // A layout.json from a build predating tabs must still decode — the new
+        // fields are simply absent (nil), so the app seeds a default tab set.
+        let dir = try tempDir()
+        let legacy = #"{"favorites": ["screenshot"], "enabledIds": null}"#
+        try Data(legacy.utf8).write(to: dir.appendingPathComponent("layout.json"))
+        let store = JSONStore(filename: "layout.json", default: LayoutState(), directory: dir)
+        let loaded = await store.load()
+        #expect(loaded.favorites == ["screenshot"])
+        #expect(loaded.tabGroups == nil)
+        #expect(loaded.focusedGroup == nil)
+    }
+
     @Test func decodesReferenceAppPrefsShape() async throws {
         let dir = try tempDir()
         let referenceShape = #"{"selectedSerial": "X", "runOnAll": false, "selectedBundleId": null}"#

--- a/ADBKit/Tests/ADBKitTests/TabStateTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TabStateTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct TabStateTests {
+    @Test func opensAndActivatesNewTabs() {
+        var tabs = TabState()
+        let a = tabs.open("a")
+        let b = tabs.open("b")
+        #expect(a)
+        #expect(b)
+        #expect(tabs.openTabs == ["a", "b"])
+        #expect(tabs.activeTab == "b")
+    }
+
+    @Test func openingAnOpenTabRefocusesWithoutDuplicating() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "c")
+        let reopened = tabs.open("a")
+        #expect(reopened)
+        #expect(tabs.openTabs == ["a", "b", "c"]) // no duplicate
+        #expect(tabs.activeTab == "a")
+    }
+
+    @Test func openRefusesANewTabAtTheCapButStillRefocusesOpenOnes() {
+        let ids = (0..<TabState.maxTabs).map { "f\($0)" }
+        var tabs = TabState(openTabs: ids, activeTab: ids.last)
+        let overflow = tabs.open("overflow")            // new tab blocked at cap
+        #expect(overflow == false)
+        #expect(tabs.openTabs == ids)
+        let refocus = tabs.open("f0")                    // already-open still focuses
+        #expect(refocus)
+        #expect(tabs.activeTab == "f0")
+    }
+
+    @Test func closingActiveTabFocusesTheRightNeighbor() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "b")
+        tabs.close("b")
+        #expect(tabs.openTabs == ["a", "c"])
+        #expect(tabs.activeTab == "c") // the tab that slid into b's slot
+    }
+
+    @Test func closingTheRightmostActiveTabFocusesTheNewLast() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "c")
+        tabs.close("c")
+        #expect(tabs.openTabs == ["a", "b"])
+        #expect(tabs.activeTab == "b")
+    }
+
+    @Test func closingAnInactiveTabKeepsTheActiveOne() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "c")
+        tabs.close("a")
+        #expect(tabs.openTabs == ["b", "c"])
+        #expect(tabs.activeTab == "c")
+    }
+
+    @Test func closingTheLastTabClearsTheActiveTab() {
+        var tabs = TabState(openTabs: ["a"], activeTab: "a")
+        tabs.close("a")
+        #expect(tabs.openTabs.isEmpty)
+        #expect(tabs.activeTab == nil)
+    }
+
+    @Test func closingAnAbsentTabIsANoOp() {
+        var tabs = TabState(openTabs: ["a", "b"], activeTab: "a")
+        tabs.close("zzz")
+        #expect(tabs.openTabs == ["a", "b"])
+        #expect(tabs.activeTab == "a")
+    }
+
+    @Test func cyclingWrapsAround() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "c")
+        tabs.activateNext()
+        #expect(tabs.activeTab == "a") // wrap to first
+        tabs.activatePrevious()
+        #expect(tabs.activeTab == "c") // wrap back to last
+        tabs.activatePrevious()
+        #expect(tabs.activeTab == "b")
+    }
+
+    @Test func cyclingWithNoTabsIsANoOp() {
+        var tabs = TabState()
+        tabs.activateNext()
+        #expect(tabs.activeTab == nil)
+    }
+
+    @Test func reorderAdoptsAPermutationAndKeepsActive() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "b")
+        tabs.reorder(["c", "a", "b"])
+        #expect(tabs.openTabs == ["c", "a", "b"])
+        #expect(tabs.activeTab == "b") // active unchanged by reordering
+    }
+
+    @Test func reorderIgnoresNonPermutations() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "a")
+        tabs.reorder(["a", "b"])            // missing c
+        tabs.reorder(["a", "b", "c", "d"])  // extra d
+        tabs.reorder(["a", "b", "x"])       // swapped id
+        #expect(tabs.openTabs == ["a", "b", "c"]) // unchanged
+    }
+
+    @Test func activateByIndexJumpsToThatTab() {
+        var tabs = TabState(openTabs: ["a", "b", "c"], activeTab: "a")
+        tabs.activate(index: 2)
+        #expect(tabs.activeTab == "c")
+        tabs.activate(index: 9) // out of range
+        #expect(tabs.activeTab == "c")
+    }
+
+    @Test func initNormalizesAStaleActiveTab() {
+        // A persisted activeTab pointing at a tab that's no longer open falls
+        // back to the first open tab.
+        let tabs = TabState(openTabs: ["a", "b"], activeTab: "gone")
+        #expect(tabs.activeTab == "a")
+    }
+
+    @Test func initWithNoActiveTabPicksTheFirst() {
+        let tabs = TabState(openTabs: ["a", "b"], activeTab: nil)
+        #expect(tabs.activeTab == "a")
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/WorkspaceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WorkspaceTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct WorkspaceTests {
+    private func make(_ groups: [[String]], focused: Int = 0) -> Workspace {
+        Workspace(
+            restoring: groups.map { TabGroupState(tabs: $0, activeTab: $0.first) },
+            focusedGroup: focused,
+            fallback: "home",
+            isValidID: { _ in true }
+        )
+    }
+
+    // MARK: - open / focus-or-create + cap
+
+    @Test func opensNewTabsInTheFocusedPane() {
+        var ws = Workspace(fallback: "home")
+        let ok = ws.open("logcat")
+        #expect(ok)
+        #expect(ws.openTabs(inGroup: 0) == ["home", "logcat"])
+        #expect(ws.activeTab == "logcat")
+    }
+
+    @Test func openingATabInTheOtherPaneFocusesThatPane() {
+        var ws = make([["home", "logcat"], ["performance"]], focused: 0)
+        let ok = ws.open("performance") // lives in pane 1
+        #expect(ok)
+        #expect(ws.focusedGroup == 1)
+        #expect(ws.activeTab == "performance")
+    }
+
+    @Test func openRefusesANewTabAtTheTotalCapButStillRefocuses() {
+        let first = (0..<6).map { "a\($0)" }
+        let second = (0..<4).map { "b\($0)" } // 6 + 4 = 10 total (the cap)
+        var ws = make([first, second], focused: 0)
+        #expect(ws.totalTabs == Workspace.maxTabs)
+        let blocked = ws.open("overflow")
+        #expect(blocked == false)
+        #expect(ws.totalTabs == Workspace.maxTabs) // nothing added
+        let refocus = ws.open("b0") // already open → allowed
+        #expect(refocus)
+        #expect(ws.focusedGroup == 1)
+    }
+
+    // MARK: - close / collapse / never-empty
+
+    @Test func closingTheLastTabReopensTheFallback() {
+        var ws = Workspace(fallback: "home")
+        ws.close("home")
+        #expect(ws.groups.count == 1)
+        #expect(ws.openTabs(inGroup: 0) == ["home"]) // never empty
+    }
+
+    @Test func closingASecondPanesLastTabCollapsesTheSplit() {
+        var ws = make([["home", "logcat"], ["performance"]], focused: 1)
+        ws.close("performance")
+        #expect(ws.isSplit == false)
+        #expect(ws.openTabs(inGroup: 0) == ["home", "logcat"])
+        #expect(ws.focusedGroup == 0) // clamped back into range
+    }
+
+    @Test func closingTheFirstPanesLastTabPromotesTheOther() {
+        var ws = make([["home"], ["logcat", "performance"]], focused: 0)
+        ws.close("home")
+        #expect(ws.isSplit == false)
+        #expect(ws.openTabs(inGroup: 0) == ["logcat", "performance"])
+        #expect(ws.focusedGroup == 0)
+    }
+
+    // MARK: - move / split
+
+    @Test func moveAcrossPanesCollapsesTheEmptiedSourceAndFollowsFocus() {
+        var ws = make([["home"], ["logcat", "performance"]], focused: 1)
+        ws.move("home", toGroup: 1) // source (pane 0) empties → collapses
+        #expect(ws.isSplit == false)
+        #expect(Set(ws.openTabs(inGroup: 0)) == ["home", "logcat", "performance"])
+        #expect(ws.focusedGroup == 0)
+        #expect(ws.activeTab == "home") // moved tab is active in its new pane
+    }
+
+    @Test func moveKeepsBothPanesWhenSourceStillHasTabs() {
+        var ws = make([["home", "logcat"], ["performance"]], focused: 0)
+        ws.move("logcat", toGroup: 1)
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.openTabs(inGroup: 1) == ["performance", "logcat"])
+        #expect(ws.focusedGroup == 1)
+    }
+
+    @Test func splitMovesATabIntoANewPaneButNeedsSomethingToLeaveBehind() {
+        var ws = make([["home", "logcat"]])
+        ws.split("logcat")
+        #expect(ws.isSplit)
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.openTabs(inGroup: 1) == ["logcat"])
+        #expect(ws.focusedGroup == 1)
+    }
+
+    @Test func splitIsANoOpForALoneTabOrWhenAlreadySplit() {
+        var lone = make([["home"]])
+        lone.split("home")
+        #expect(lone.isSplit == false) // nothing would be left behind
+
+        var alreadySplit = make([["home", "logcat"], ["performance"]])
+        alreadySplit.split("logcat")
+        #expect(alreadySplit.groups.count == 2) // no third pane
+    }
+
+    // MARK: - reorder / drop
+
+    @Test func dropReordersWithinTheSamePane() {
+        var ws = make([["a", "b", "c"]])
+        ws.drop("a", intoGroup: 0, before: "c")
+        #expect(ws.openTabs(inGroup: 0) == ["b", "a", "c"])
+    }
+
+    @Test func dropAcrossPanesMovesAndPositions() {
+        var ws = make([["home", "logcat"], ["x", "y"]], focused: 0)
+        ws.drop("logcat", intoGroup: 1, before: "y")
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.openTabs(inGroup: 1) == ["x", "logcat", "y"])
+    }
+
+    // MARK: - cycle only touches the focused pane
+
+    @Test func cycleStaysWithinTheFocusedPane() {
+        var ws = make([["a", "b"], ["x", "y", "z"]], focused: 1)
+        ws.cycleForward() // pane 1 active was x → y
+        #expect(ws.activeTab == "y")
+        #expect(ws.activeTab(inGroup: 0) == "a") // other pane untouched
+    }
+
+    // MARK: - restore invariants
+
+    @Test func restoreDedupesIdsAcrossPanes() {
+        let ws = make([["home", "logcat"], ["logcat", "performance"]])
+        // "logcat" kept only in the first pane.
+        #expect(ws.openTabs(inGroup: 0) == ["home", "logcat"])
+        #expect(ws.openTabs(inGroup: 1) == ["performance"])
+    }
+
+    @Test func restoreTrimsToTheTotalCapAndTwoPanes() {
+        let groups = [
+            (0..<8).map { "a\($0)" },
+            (0..<8).map { "b\($0)" },
+            ["c0"], // third pane dropped entirely
+        ]
+        let ws = make(groups)
+        #expect(ws.groups.count == 2)
+        #expect(ws.totalTabs == Workspace.maxTabs) // 8 + 2, trimmed
+        #expect(ws.openTabs(inGroup: 0).count == 8)
+        #expect(ws.openTabs(inGroup: 1).count == 2)
+    }
+
+    @Test func restoreDropsInvalidIdsAndSeedsFallbackWhenNothingSurvives() {
+        let ws = Workspace(
+            restoring: [TabGroupState(tabs: ["ghost", "gone"], activeTab: "ghost")],
+            focusedGroup: 5,
+            fallback: "home",
+            isValidID: { $0 == "home" } // nothing valid survives
+        )
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.focusedGroup == 0) // out-of-range focus clamped
+    }
+
+    @Test func resetCollapsesToASingleFallbackPane() {
+        var ws = make([["home", "logcat"], ["performance"]], focused: 1)
+        ws.reset()
+        #expect(ws.groups.count == 1)
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.focusedGroup == 0)
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -51,6 +51,9 @@ struct ADTApp: App {
     /// re-keys RootView (`.id`), forcing every `.brandAccent` to re-resolve.
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
 
+    /// ⌃1…⌃9 accelerators for jumping straight to a tab by position.
+    private static let tabDigitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
     /// The sidebar and notifications panel are fixed-width, so opening the
     /// notifications panel on a narrow window would otherwise crush the detail
     /// pane to uselessness (the welcome title wrapping one letter per line).
@@ -96,6 +99,35 @@ struct ADTApp: App {
         .windowStyle(.automatic)
         .commands {
             ScreenshotEditCommandsMenu()
+
+            CommandMenu("Tab") {
+                // ⌘T / ⌘K both open the search palette; the chosen feature opens
+                // in a tab (a new one, or refocuses it if already open).
+                Button("New Tab") {
+                    appState.activateMainWindow()
+                    appState.openPalette?()
+                }
+                .keyboardShortcut("t", modifiers: .command)
+
+                Button("Close Tab") { appState.closeActiveTab() }
+                    .keyboardShortcut("w", modifiers: .command)
+
+                Divider()
+
+                // Control-based so they don't fight the form fields' Tab focus
+                // traversal or the palette's ⌘1–9 result jumps.
+                Button("Next Tab") { appState.selectNextTab() }
+                    .keyboardShortcut(.tab, modifiers: .control)
+                Button("Previous Tab") { appState.selectPreviousTab() }
+                    .keyboardShortcut(.tab, modifiers: [.control, .shift])
+
+                Divider()
+
+                ForEach(Array(Self.tabDigitKeys.enumerated()), id: \.offset) { index, key in
+                    Button("Show Tab \(index + 1)") { appState.selectTab(index: index) }
+                        .keyboardShortcut(key, modifiers: .control)
+                }
+            }
 
             CommandGroup(replacing: .appInfo) {
                 Button("About Droidective") {

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -8,16 +8,17 @@ struct FeatureDetailView: View {
     let featureID: String?
 
     var body: some View {
+        // The window title is set once by the tab host from the active tab —
+        // not here — because every open tab is mounted at once and per-view
+        // `.navigationTitle`s would fight over the one window title.
         if featureID == "home" {
             HomeView()
         } else if featureID == "about" {
             AboutView()
         } else if featureID == "catalog" {
             CatalogView()
-                .navigationTitle("Feature Catalog")
         } else if let featureID, let feature = FeatureRegistry.byID[featureID] {
             featureBody(for: feature)
-                .navigationTitle(feature.title)
         } else {
             HomeView()
         }

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 /// a per-interface breakdown, and JSON/CSV export.
 struct NetworkView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
+    @Environment(\.tabIsActive) private var tabIsActive
 
     struct Sample: Identifiable {
         let id = UUID()
@@ -46,18 +48,22 @@ struct NetworkView: View {
                 setLive(false)
                 setLive(true)
             }
+            // Pause the live sampler when this tab is hidden (a recording keeps
+            // sampling — it's capturing data the user wants), and resume when it
+            // comes back to the foreground.
+            .onChange(of: tabIsActive) { syncSampler() }
             .onChange(of: recorded.isEmpty) { _, empty in
                 if empty {
                     state.clearExitGuard(exitGuardID)
                 } else {
                     state.setExitGuard(.init(
-                        id: exitGuardID, style: .recording,
+                        id: exitGuardID, featureID: tabFeatureID, style: .recording,
                         title: "Recording not exported",
                         message: "This network recording hasn’t been exported. Save it first, or discard it."))
                 }
             }
             .onChange(of: state.pendingExit?.saving) { _, saving in
-                guard saving == true else { return }
+                guard saving == true, state.pendingExitConcerns(tabFeatureID) else { return }
                 stopRecording()
                 if recorded.isEmpty || export() { state.finishExitSave() } else { state.cancelExit() }
             }
@@ -286,7 +292,9 @@ struct NetworkView: View {
 
     // MARK: - Live / recording
 
-    /// Toggle the live stream. Turning it off also stops any recording.
+    /// Toggle the live stream (user intent). Turning it off also stops any
+    /// recording. The sampler itself is driven by `syncSampler`, which also
+    /// accounts for whether this tab is on screen.
     private func setLive(_ on: Bool) {
         if on {
             guard serial != nil, !isLive else { return }
@@ -294,10 +302,25 @@ struct NetworkView: View {
             liveStart = Date()
             liveSamples = []
             interfaces = []
-            launchSampler()
         } else {
             stopRecording()
             isLive = false
+        }
+        syncSampler()
+    }
+
+    /// The sampler runs while recording (capture must continue even when the tab
+    /// is hidden) or while live *and* this tab is on screen — a hidden live view
+    /// pauses to spare the device.
+    private var shouldSample: Bool {
+        serial != nil && (isRecording || (isLive && tabIsActive))
+    }
+
+    /// Start or stop the polling Task to match `shouldSample`.
+    private func syncSampler() {
+        if shouldSample {
+            if sampler == nil { launchSampler() }
+        } else {
             sampler?.cancel()
             sampler = nil
         }

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// charted, and exportable as JSON + CSV.
 struct PerformanceView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
 
     enum Phase { case idle, recording, paused }
     enum SortKey: String, CaseIterable { case ram = "RAM", cpu = "CPU", name = "Name" }
@@ -86,13 +87,13 @@ struct PerformanceView: View {
                 state.clearExitGuard(exitGuardID)
             } else {
                 state.setExitGuard(.init(
-                    id: exitGuardID, style: .recording,
+                    id: exitGuardID, featureID: tabFeatureID, style: .recording,
                     title: "Recording not exported",
                     message: "This performance recording hasn’t been exported. Save it first, or discard it."))
             }
         }
         .onChange(of: state.pendingExit?.saving) { _, saving in
-            guard saving == true else { return }
+            guard saving == true, state.pendingExitConcerns(tabFeatureID) else { return }
             stop()
             if samples.isEmpty || export() { state.finishExitSave() } else { state.cancelExit() }
         }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -403,8 +403,6 @@ struct ReactotronView: View {
         VStack(spacing: 0) {
             topTabs
             Divider()
-            statusBar
-            Divider()
             content
         }
         // The session is owned by AppState, so it persists across feature
@@ -435,7 +433,15 @@ struct ReactotronView: View {
     // MARK: - Tabs
 
     private var topTabs: some View {
-        HStack {
+        HStack(spacing: 8) {
+            // Connection state folded in here as a dot (full status on hover) —
+            // the detailed "Listening on :9090…" guidance lives in the timeline's
+            // empty state, so a dedicated status bar would just repeat it.
+            Circle()
+                .fill(session.connection.color)
+                .frame(width: 7, height: 7)
+                .help(session.connection.text(app: session.connectedApp))
+
             Picker("View", selection: $tab) {
                 Text("Timeline").tag(RtTab.timeline)
                 Text(session.commands.isEmpty ? "Commands" : "Commands (\(session.commands.count))").tag(RtTab.commands)
@@ -445,7 +451,24 @@ struct ReactotronView: View {
             .pickerStyle(.segmented)
             .labelsHidden()
             .frame(maxWidth: 320)
+
             Spacer()
+
+            if session.clients.count > 1 {
+                Picker("App", selection: Binding(
+                    get: { session.selectedClient },
+                    set: { session.selectedClient = $0 }
+                )) {
+                    Text("All apps").tag(Int?.none)
+                    ForEach(session.clients) { client in
+                        Text(client.label).tag(Int?.some(client.id))
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .controlSize(.small)
+                .fixedSize()
+            }
             RestartAppMenu()
                 .controlSize(.small)
                 .help("Force-stop and relaunch an app so it reconnects")
@@ -469,6 +492,10 @@ struct ReactotronView: View {
     private var timelineControls: some View {
         HStack(spacing: 12) {
             Spacer()
+
+            Text("\(session.displayedItems.count) events")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
 
             Button {
                 split.toggle()
@@ -512,41 +539,6 @@ struct ReactotronView: View {
             showOnboarding: showOnboarding,
             onExport: { session.export($0) }
         )
-    }
-
-    private var statusBar: some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(session.connection.color)
-                .frame(width: 7, height: 7)
-            Text(session.connection.text(app: session.connectedApp))
-                .font(.caption)
-                .foregroundStyle(.textMuted)
-            if session.clients.count > 1 {
-                Picker("App", selection: Binding(
-                    get: { session.selectedClient },
-                    set: { session.selectedClient = $0 }
-                )) {
-                    Text("All apps").tag(Int?.none)
-                    ForEach(session.clients) { client in
-                        Text(client.label).tag(Int?.some(client.id))
-                    }
-                }
-                .pickerStyle(.menu)
-                .labelsHidden()
-                .controlSize(.small)
-                .fixedSize()
-            }
-            Spacer()
-            if tab == .timeline {
-                Text("\(session.displayedItems.count) events")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(Color.bgSurface)
     }
 
     // MARK: - Custom commands

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 /// (→ video editor on stop) without interrupting the live, controllable mirror.
 struct ScreenMirrorView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
+    @Environment(\.tabIsActive) private var tabIsActive
     @State private var model: MirrorViewModel?
     /// Identifies this view's leave guard so a stale clear can't wipe another's.
     @State private var exitGuardID = UUID()
@@ -38,7 +40,20 @@ struct ScreenMirrorView: View {
         .recordingDecision(url: pendingRecording) { url in model?.finishedRecording = url }
         .imageDecision(image: pendingScreenshot) { image in model?.editingScreenshot = image }
         .task(id: state.targetSerials.first) {
-            await reconnect(to: state.targetSerials.first)
+            // Only stream while this tab is on screen; a hidden mirror is heavy
+            // video encode for nothing. (Returning re-keys via tabIsActive below.)
+            if tabIsActive { await reconnect(to: state.targetSerials.first) }
+        }
+        .onChange(of: tabIsActive) { _, active in
+            if active {
+                if model == nil { Task { await reconnect(to: state.targetSerials.first) } }
+            } else if model?.isRecording != true {
+                // Pause the live mirror while hidden — unless it's recording,
+                // which must keep capturing.
+                let leaving = model
+                model = nil
+                Task { await leaving?.stop() }
+            }
         }
         .onChange(of: model?.recordingError) { _, message in
             guard let message else { return }
@@ -48,7 +63,7 @@ struct ScreenMirrorView: View {
         .onChange(of: model?.isRecording) { _, recording in
             if recording == true {
                 state.setExitGuard(.init(
-                    id: exitGuardID, style: .recording,
+                    id: exitGuardID, featureID: tabFeatureID, style: .recording,
                     title: "Recording in progress",
                     message: "Leaving will stop the screen recording. Save it first, or discard it."))
             } else {
@@ -56,7 +71,9 @@ struct ScreenMirrorView: View {
             }
         }
         .onChange(of: state.pendingExit?.saving) { _, saving in
-            if saving == true, model?.isRecording == true { Task { await saveRecordingForLeave() } }
+            if saving == true, model?.isRecording == true, state.pendingExitConcerns(tabFeatureID) {
+                Task { await saveRecordingForLeave() }
+            }
         }
         .onDisappear {
             state.clearExitGuard(exitGuardID)

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// in the video editor.
 struct ScreenRecordView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @State private var recorder: ScreenRecorder?
     @State private var isRecording = false
     @State private var isPaused = false
@@ -50,7 +51,9 @@ struct ScreenRecordView: View {
         }
         .recordingDecision(url: $decisionURL) { recordedURL = $0 }
         .onChange(of: state.pendingExit?.saving) { _, saving in
-            if saving == true, isRecording { Task { await saveRecordingForLeave() } }
+            if saving == true, isRecording, state.pendingExitConcerns(tabFeatureID) {
+                Task { await saveRecordingForLeave() }
+            }
         }
         .onDisappear {
             limitTask?.cancel()
@@ -235,7 +238,7 @@ struct ScreenRecordView: View {
             // mounted on a device switch, so .onDisappear never fires to abort it).
             state.recordingActive = true
             state.setExitGuard(.init(
-                id: exitGuardID, style: .recording,
+                id: exitGuardID, featureID: tabFeatureID, style: .recording,
                 title: "Recording in progress",
                 message: "Leaving will stop the screen recording. Save it first, or discard it."))
             scheduleTimeLimit(options.timeLimitSeconds)

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// to disk until the user saves or copies.
 struct ScreenshotEditorView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     /// Discard the current capture and return to the capture controls.
     let onClose: () -> Void
 
@@ -149,7 +150,7 @@ struct ScreenshotEditorView: View {
         .onChange(of: dirty) { _, isDirty in
             if isDirty {
                 state.setExitGuard(.init(
-                    id: exitGuardID, style: .edits,
+                    id: exitGuardID, featureID: tabFeatureID, style: .edits,
                     title: "Unsaved screenshot",
                     message: "Your annotations and edits haven’t been saved. Leaving discards them."))
             } else {

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -79,6 +79,7 @@ struct EditToggleStyle: ToggleStyle {
 /// uses the native player UI. Nothing is written until Export.
 struct VideoEditorPane: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     let source: VideoSource
     let onClose: () -> Void
 
@@ -136,7 +137,7 @@ struct VideoEditorPane: View {
         .onChange(of: hasUnsavedEdits) { _, dirty in
             if dirty {
                 state.setExitGuard(.init(
-                    id: exitGuardID, style: .edits,
+                    id: exitGuardID, featureID: tabFeatureID, style: .edits,
                     title: "Unsaved video edits",
                     message: "Your trim, rotate, crop, and other edits haven’t been exported. Leaving discards them."))
             } else {

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -228,7 +228,7 @@ struct DeviceBarView: View {
     /// commands (commands may require one) and logcat (its app filter is
     /// driven by saved bundles) are included.
     private var bundleRowVisible: Bool {
-        guard let id = state.selectedFeatureID,
+        guard let id = state.activeTabID,
               let feature = FeatureRegistry.byID[id] else { return false }
         return feature.needsBundle
             || feature.id == "custom-commands"

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -269,6 +269,16 @@ struct RootView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)
+        // A tab drag released over dead space (the sidebar, device bar, an empty
+        // strip area — anything that isn't a pane/chip/split target) never fires
+        // a drop delegate, which would leave `draggingTabID` set and the
+        // split-create overlay stuck blocking the pane. Catch those here and
+        // clear it. Only a target while a tab drag is in flight; returns false so
+        // it never swallows a real drop (inner targets are hit first).
+        .onDrop(of: [.text], delegate: TabDragCancelCatch(
+            isDragging: state.draggingTabID != nil,
+            clear: { state.draggingTabID = nil }
+        ))
     }
 
     /// The editor area: one pane, or two side by side split by a draggable seam.
@@ -391,6 +401,22 @@ struct TabPaneDrop: DropDelegate {
         guard let id = draggingID else { return false }
         onDrop(id)
         return true
+    }
+}
+
+/// Root-level catch for a tab drag released over dead space: clears the drag
+/// state so the split-create overlay can't get stuck. A target only while a tab
+/// drag is in flight (so it never interferes with sidebar reordering, which
+/// leaves `draggingTabID` nil), and returns false so real drops on inner targets
+/// still win.
+struct TabDragCancelCatch: DropDelegate {
+    let isDragging: Bool
+    let clear: () -> Void
+
+    func validateDrop(info: DropInfo) -> Bool { isDragging }
+    func performDrop(info: DropInfo) -> Bool {
+        clear()
+        return false
     }
 }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -6,6 +6,11 @@ struct RootView: View {
     @Environment(AppState.self) private var state
     @Environment(\.openWindow) private var openWindow
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
+    /// Left-pane fraction (0…1) of the editor split; the layout clamps it so
+    /// neither pane collapses.
+    @AppStorage("tabSplitFraction") private var splitFraction = 0.5
+    /// True while a dragged tab hovers the split-create zone of the sole pane.
+    @State private var splitZoneTargeted = false
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
@@ -51,6 +56,9 @@ struct RootView: View {
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
             .background(WindowAccessor { window in
+                // Tag the main window so the ⌘W monitor can tell it apart from
+                // Settings / the palette panel.
+                window.identifier = NSUserInterfaceItemIdentifier(RootView.mainWindowID)
                 // Fill the screen's usable area on launch — a regular maximized
                 // window, not a native full-screen Space.
                 if let screen = window.screen ?? NSScreen.main {
@@ -89,7 +97,7 @@ struct RootView: View {
             }
             .onChange(of: colorScheme) { _, _ in updateDockIcon() }
             .confirmationDialog(
-                state.exitGuard?.title ?? "",
+                state.pendingGuard?.title ?? "",
                 isPresented: Binding(
                     get: { showExitDialog },
                     set: { shown in
@@ -97,7 +105,7 @@ struct RootView: View {
                     }
                 ),
                 titleVisibility: .visible,
-                presenting: state.exitGuard
+                presenting: state.pendingGuard
             ) { info in
                 exitDialogButtons(for: info)
             } message: { info in
@@ -117,6 +125,7 @@ struct RootView: View {
         applyStoredTheme()
         updateDockIcon()
         HotkeyManager.install(state: state)
+        installCloseTabMonitor()
         switch LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
             consentAsked: consentAsked, starPromptShown: starPromptShown,
@@ -135,6 +144,29 @@ struct RootView: View {
             presentStar = true
         case nil:
             break
+        }
+    }
+
+    /// Identifier stamped on the main window so `installCloseTabMonitor` can
+    /// scope ⌘W to it and leave Settings / the palette panel alone.
+    fileprivate static let mainWindowID = "droidective-main"
+    private static var closeTabMonitorInstalled = false
+
+    /// ⌘W closes the active tab, not the window. A local key-down monitor
+    /// intercepts ⌘W for the main window before AppKit's default Close-Window
+    /// runs (local monitors see the event first and can swallow it); the red
+    /// traffic-light button still closes the whole window. Installed once.
+    private func installCloseTabMonitor() {
+        guard !RootView.closeTabMonitorInstalled else { return }
+        RootView.closeTabMonitorInstalled = true
+        let state = self.state
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  event.charactersIgnoringModifiers == "w",
+                  NSApp.keyWindow?.identifier?.rawValue == RootView.mainWindowID
+            else { return event }
+            state.closeActiveTab()
+            return nil
         }
     }
 
@@ -210,15 +242,16 @@ struct RootView: View {
                 ResizeHandle(value: $sidebarWidth, range: 300...460)
             }
             VStack(spacing: 0) {
-                // The catalog has no device context, so its device bar is hidden.
-                if state.selectedFeatureID != "catalog" {
+                // Device bar on top (shared across panes); each pane's own tab
+                // strip sits below it, inside the pane — VS Code-style.
+                if state.activeTabID != "catalog" {
                     DeviceBarView()
                     if let operation = state.runningOperation {
                         OperationProgressStrip(operation: operation)
                     }
                 }
                 HStack(spacing: 0) {
-                    FeatureDetailView(featureID: state.selectedFeatureID)
+                    panesArea
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .overlay(alignment: .topTrailing) { ToastOverlay() }
                     if state.showNotifications {
@@ -236,6 +269,154 @@ struct RootView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(.textMain)
+    }
+
+    /// The editor area: one pane, or two side by side split by a draggable seam.
+    private var panesArea: some View {
+        GeometryReader { geo in
+            let leftW = splitLeftWidth(geo.size.width)
+            HStack(spacing: 0) {
+                pane(0).frame(width: state.isSplit ? leftW : geo.size.width)
+                if state.isSplit {
+                    SplitDivider(fraction: $splitFraction, totalWidth: geo.size.width)
+                        .frame(width: 8)
+                    pane(1).frame(maxWidth: .infinity)
+                }
+            }
+            .navigationTitle(activeTitle)
+        }
+    }
+
+    /// One editor pane: its own tab strip above its mounted tabs. Accepts a
+    /// dragged tab dropped onto it (moving it into this pane's group), and — when
+    /// there's only one pane — offers a trailing zone that splits on drop.
+    private func pane(_ index: Int) -> some View {
+        VStack(spacing: 0) {
+            TabStripView(group: index)
+            TabHostView(group: index)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onDrop(of: [.text], delegate: TabPaneDrop(
+            draggingID: state.draggingTabID,
+            onDrop: { id in state.dropTab(id, intoGroup: index, before: nil); state.draggingTabID = nil }
+        ))
+        .overlay(alignment: .trailing) {
+            if !state.isSplit, state.draggingTabID != nil { splitCreateZone }
+        }
+    }
+
+    /// Right-half drop zone shown on the sole pane while dragging a tab — drop
+    /// here to open it in a new split pane. Fills the half where the new pane
+    /// will land so the target is obvious.
+    private var splitCreateZone: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(.brandAccent.opacity(splitZoneTargeted ? 0.28 : 0.14))
+                .overlay(alignment: .leading) {
+                    Rectangle().fill(.brandAccent).frame(width: 2) // the seam it'll create
+                }
+                .overlay {
+                    Label("Drop to split", systemImage: "rectangle.split.2x1")
+                        .font(.headline)
+                        .foregroundStyle(.brandAccent)
+                }
+                .frame(width: geo.size.width / 2, height: geo.size.height)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .onDrop(of: [.text], delegate: TabPaneDrop(
+                    draggingID: state.draggingTabID,
+                    onDrop: { id in state.splitTab(id); state.draggingTabID = nil },
+                    onTargetedChange: { splitZoneTargeted = $0 }
+                ))
+        }
+    }
+
+    private func splitLeftWidth(_ totalW: CGFloat) -> CGFloat {
+        let dividerW: CGFloat = 8
+        let minPane: CGFloat = 320
+        let available = totalW - dividerW
+        return min(max(available * splitFraction, minPane), max(minPane, available - minPane))
+    }
+
+    private var activeTitle: String {
+        guard let id = state.activeTabID else { return "" }
+        if id == "catalog" { return "Feature Catalog" }
+        return FeatureRegistry.byID[id]?.title ?? ""
+    }
+}
+
+/// Hosts one editor group's tabs. All the group's tabs stay mounted in a ZStack
+/// — so an active recording or a live log stream keeps running when you switch
+/// to another tab in the same pane, and a tab keeps its view state when you come
+/// back — with only the group's active tab visible and interactive. Each tab is
+/// handed its feature id and whether it's on screen via the environment, which
+/// device-heavy live views (network/CPU polling, the mirror) use to pause while
+/// hidden. (Moving a tab to the other pane recreates it, so a recording stops if
+/// dragged across panes — switching within a pane is the keep-alive path.)
+struct TabHostView: View {
+    @Environment(AppState.self) private var state
+    let group: Int
+
+    var body: some View {
+        let ids = state.openTabIDs(inGroup: group)
+        let active = state.activeTab(inGroup: group)
+        ZStack {
+            ForEach(ids, id: \.self) { id in
+                FeatureDetailView(featureID: id)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .environment(\.tabFeatureID, id)
+                    .environment(\.tabIsActive, id == active)
+                    .opacity(id == active ? 1 : 0)
+                    .allowsHitTesting(id == active)
+                    .accessibilityHidden(id != active)
+                    .zIndex(id == active ? 1 : 0)
+            }
+        }
+    }
+}
+
+/// Accepts a tab dragged from a strip onto a pane (or the split-create zone).
+/// The dragged id lives in `AppState.draggingTabID`; the dropped `.text` item
+/// only triggers the drop. `onTargetedChange` drives an optional hover highlight.
+struct TabPaneDrop: DropDelegate {
+    let draggingID: String?
+    let onDrop: (String) -> Void
+    var onTargetedChange: ((Bool) -> Void)?
+
+    func validateDrop(info: DropInfo) -> Bool { draggingID != nil }
+    func dropEntered(info: DropInfo) { onTargetedChange?(true) }
+    func dropExited(info: DropInfo) { onTargetedChange?(false) }
+    func performDrop(info: DropInfo) -> Bool {
+        onTargetedChange?(false)
+        guard let id = draggingID else { return false }
+        onDrop(id)
+        return true
+    }
+}
+
+/// The draggable seam between the two split panes. Stores a fraction (0…1) of
+/// the total width so the split survives window resizes; the host clamps it so
+/// neither pane collapses.
+private struct SplitDivider: View {
+    @Binding var fraction: Double
+    let totalWidth: CGFloat
+    @State private var startFraction: Double?
+
+    var body: some View {
+        Color.clear
+            .overlay { Rectangle().fill(Color.borderSubtle).frame(width: 1) }
+            .contentShape(Rectangle())
+            .onHover { $0 ? NSCursor.resizeLeftRight.set() : NSCursor.arrow.set() }
+            .gesture(
+                DragGesture()
+                    .onChanged { gesture in
+                        let base = startFraction ?? fraction
+                        if startFraction == nil { startFraction = fraction }
+                        let delta = totalWidth > 0 ? gesture.translation.width / totalWidth : 0
+                        fraction = min(0.8, max(0.2, base + delta))
+                    }
+                    .onEnded { _ in startFraction = nil }
+            )
     }
 }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -305,15 +305,18 @@ struct RootView: View {
             TabStripView(group: index)
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Split-drop zone lives over the CONTENT only — never over the
+                // tab strip — so dragging a tab within the strip reorders it and
+                // only a drag down into the content's right half splits.
+                .overlay(alignment: .trailing) {
+                    if !state.isSplit, state.draggingTabID != nil { splitCreateZone }
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onDrop(of: [.text], delegate: TabPaneDrop(
             draggingID: state.draggingTabID,
             onDrop: { id in state.dropTab(id, intoGroup: index, before: nil); state.draggingTabID = nil }
         ))
-        .overlay(alignment: .trailing) {
-            if !state.isSplit, state.draggingTabID != nil { splitCreateZone }
-        }
     }
 
     /// Right-half drop zone shown on the sole pane while dragging a tab — drop

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -9,8 +9,6 @@ struct RootView: View {
     /// Left-pane fraction (0…1) of the editor split; the layout clamps it so
     /// neither pane collapses.
     @AppStorage("tabSplitFraction") private var splitFraction = 0.5
-    /// True while a dragged tab hovers the split-create zone of the sole pane.
-    @State private var splitZoneTargeted = false
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("telemetryConsentAsked") private var consentAsked = false
@@ -286,61 +284,14 @@ struct RootView: View {
         GeometryReader { geo in
             let leftW = splitLeftWidth(geo.size.width)
             HStack(spacing: 0) {
-                pane(0).frame(width: state.isSplit ? leftW : geo.size.width)
+                EditorPane(index: 0).frame(width: state.isSplit ? leftW : geo.size.width)
                 if state.isSplit {
                     SplitDivider(fraction: $splitFraction, totalWidth: geo.size.width)
                         .frame(width: 8)
-                    pane(1).frame(maxWidth: .infinity)
+                    EditorPane(index: 1).frame(maxWidth: .infinity)
                 }
             }
             .navigationTitle(activeTitle)
-        }
-    }
-
-    /// One editor pane: its own tab strip above its mounted tabs. Accepts a
-    /// dragged tab dropped onto it (moving it into this pane's group), and — when
-    /// there's only one pane — offers a trailing zone that splits on drop.
-    private func pane(_ index: Int) -> some View {
-        VStack(spacing: 0) {
-            TabStripView(group: index)
-            TabHostView(group: index)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // Split-drop zone lives over the CONTENT only — never over the
-                // tab strip — so dragging a tab within the strip reorders it and
-                // only a drag down into the content's right half splits.
-                .overlay(alignment: .trailing) {
-                    if !state.isSplit, state.draggingTabID != nil { splitCreateZone }
-                }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onDrop(of: [.text], delegate: TabPaneDrop(
-            draggingID: state.draggingTabID,
-            onDrop: { id in state.dropTab(id, intoGroup: index, before: nil); state.draggingTabID = nil }
-        ))
-    }
-
-    /// Right-half drop zone shown on the sole pane while dragging a tab — drop
-    /// here to open it in a new split pane. Fills the half where the new pane
-    /// will land so the target is obvious.
-    private var splitCreateZone: some View {
-        GeometryReader { geo in
-            Rectangle()
-                .fill(.brandAccent.opacity(splitZoneTargeted ? 0.28 : 0.14))
-                .overlay(alignment: .leading) {
-                    Rectangle().fill(.brandAccent).frame(width: 2) // the seam it'll create
-                }
-                .overlay {
-                    Label("Drop to split", systemImage: "rectangle.split.2x1")
-                        .font(.headline)
-                        .foregroundStyle(.brandAccent)
-                }
-                .frame(width: geo.size.width / 2, height: geo.size.height)
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .onDrop(of: [.text], delegate: TabPaneDrop(
-                    draggingID: state.draggingTabID,
-                    onDrop: { id in state.splitTab(id); state.draggingTabID = nil },
-                    onTargetedChange: { splitZoneTargeted = $0 }
-                ))
         }
     }
 
@@ -404,6 +355,59 @@ struct TabPaneDrop: DropDelegate {
         guard let id = draggingID else { return false }
         onDrop(id)
         return true
+    }
+}
+
+/// One editor pane: its tab strip above its mounted tabs. Dropping a dragged tab
+/// on the *content* moves it into this pane (when split) or splits the workspace
+/// (when not). The split preview appears only while the drag is actually over
+/// the content — dragging within the strip reorders (with its own guideline) and
+/// shows no split preview.
+private struct EditorPane: View {
+    @Environment(AppState.self) private var state
+    let index: Int
+    @State private var contentTargeted = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabStripView(group: index)
+            TabHostView(group: index)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onDrop(of: [.text], delegate: TabPaneDrop(
+                    draggingID: state.draggingTabID,
+                    onDrop: { id in
+                        if state.isSplit {
+                            state.moveTab(id, toGroup: index)
+                        } else {
+                            state.splitTab(id)
+                        }
+                        state.draggingTabID = nil
+                    },
+                    onTargetedChange: { contentTargeted = $0 }
+                ))
+                .overlay(alignment: .trailing) {
+                    if !state.isSplit, contentTargeted { splitPreview }
+                }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Non-interactive right-half wash showing where the new split pane will land
+    /// (the content's drop target performs the actual split).
+    private var splitPreview: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(.brandAccent.opacity(0.16))
+                .overlay(alignment: .leading) { Rectangle().fill(.brandAccent).frame(width: 2) }
+                .overlay {
+                    Label("Drop to split", systemImage: "rectangle.split.2x1")
+                        .font(.headline)
+                        .foregroundStyle(.brandAccent)
+                }
+                .frame(width: geo.size.width / 2, height: geo.size.height)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .allowsHitTesting(false)
+        }
     }
 }
 

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -234,8 +234,11 @@ struct SidebarPaletteView: View {
             }
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
-            .onChange(of: state.selectedFeatureID) { _, id in
-                proxy.scrollTo(id, anchor: .center)
+            .onChange(of: state.searchHighlightID) { _, id in
+                if let id { proxy.scrollTo(id, anchor: .center) }
+            }
+            .onChange(of: state.activeTabID) { _, id in
+                if let id { proxy.scrollTo(id, anchor: .center) }
             }
             }
 
@@ -245,6 +248,17 @@ struct SidebarPaletteView: View {
         .background(.bgSurface)
         .background { shortcutButtons }
         .onChange(of: state.focusSearchToken) { searchFocused = true }
+        // Keyboard highlight: keep the top result highlighted as the query
+        // changes, and drop the highlight when the field loses focus (only the
+        // active tab's pill remains).
+        .onChange(of: state.searchText) { state.searchHighlightID = orderedMatches.first?.id }
+        .onChange(of: searchFocused) { _, focused in
+            if focused {
+                if state.searchHighlightID == nil { state.searchHighlightID = orderedMatches.first?.id }
+            } else {
+                state.searchHighlightID = nil
+            }
+        }
         .onAppear {
             // Track ⌘ so the row hints can appear/disappear as it's held.
             flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
@@ -269,7 +283,7 @@ struct SidebarPaletteView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .foregroundStyle(state.selectedFeatureID == "home" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+            .foregroundStyle(state.activeTabID == "home" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
             .help("Home — overview & getting started")
 
             Button {
@@ -283,7 +297,7 @@ struct SidebarPaletteView: View {
                 .lineLimit(1)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(state.selectedFeatureID == "catalog" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+            .foregroundStyle(state.activeTabID == "catalog" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
 
             Spacer()
 
@@ -296,7 +310,7 @@ struct SidebarPaletteView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .foregroundStyle(state.selectedFeatureID == "about" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+            .foregroundStyle(state.activeTabID == "about" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
             .help("About & Feedback — version, report an issue, star on GitHub")
 
             SettingsLink {
@@ -553,7 +567,7 @@ struct SidebarPaletteView: View {
     /// ⏎ in the search field: fire the top instant action with no screen, else
     /// open the top match's detail.
     private func runTopMatch() {
-        let target = orderedMatches.first { $0.id == state.selectedFeatureID } ?? orderedMatches.first
+        let target = orderedMatches.first { $0.id == state.searchHighlightID } ?? orderedMatches.first
         guard let target else { return }
         if target.firesWithoutScreen {
             Task { await state.run(feature: target, params: [:]) }
@@ -563,12 +577,15 @@ struct SidebarPaletteView: View {
         }
     }
 
+    /// Move the keyboard highlight through the results — does *not* open a tab
+    /// per keystroke (that would spawn a tab for every arrow press); ⏎ opens the
+    /// highlighted one.
     private func moveSelection(by offset: Int) {
         let matches = orderedMatches
         guard !matches.isEmpty else { return }
-        let currentIndex = matches.firstIndex { $0.id == state.selectedFeatureID }
+        let currentIndex = matches.firstIndex { $0.id == state.searchHighlightID }
         let next = ((currentIndex ?? -1) + offset + matches.count) % matches.count
-        state.requestFeature(matches[next].id)
+        state.searchHighlightID = matches[next].id
     }
 }
 
@@ -603,7 +620,11 @@ struct FeatureRowView: View {
 
     private var isPinned: Bool { state.layout.favorites.contains(feature.id) }
     private var isEnabled: Bool { state.layout.effectiveEnabledIDs.contains(feature.id) }
-    private var isSelected: Bool { state.selectedFeatureID == feature.id }
+    /// Highlighted when it's the front tab of either pane, or the keyboard-nav
+    /// highlight while searching.
+    private var isSelected: Bool {
+        state.activeTabIDs.contains(feature.id) || state.searchHighlightID == feature.id
+    }
 
     /// Clicking a row selects it — except an instant action that fires without
     /// a screen, which just runs (feedback is the toast + clipboard) and leaves

--- a/App/Sources/Root/TabEnvironment.swift
+++ b/App/Sources/Root/TabEnvironment.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Per-tab context handed down by the tab host (`TabHostView`). Open tabs all
+/// stay mounted at once, so a view can't assume it's the one on screen — these
+/// tell it which tab it lives in and whether that tab is currently visible.
+
+private struct TabIsActiveKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+private struct TabFeatureIDKey: EnvironmentKey {
+    static let defaultValue = ""
+}
+
+extension EnvironmentValues {
+    /// True when this view's tab is the foreground (visible) one. Backgrounded
+    /// tabs stay mounted, so device-heavy *live* views (network/CPU polling, the
+    /// screen mirror) read this to pause while hidden. Recordings and log streams
+    /// deliberately ignore it and keep running. Defaults to true for views shown
+    /// outside the tab host (Settings, sheets), which must never pause.
+    var tabIsActive: Bool {
+        get { self[TabIsActiveKey.self] }
+        set { self[TabIsActiveKey.self] = newValue }
+    }
+
+    /// The feature id of the tab this view belongs to. A view registering a
+    /// leave guard tags it with this so closing the right tab is what prompts —
+    /// needed because the screenshot/video editors embed inside several
+    /// different tabs (screen-record, scrcpy, their own).
+    var tabFeatureID: String {
+        get { self[TabFeatureIDKey.self] }
+        set { self[TabFeatureIDKey.self] = newValue }
+    }
+}

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -1,0 +1,251 @@
+import ADBKit
+import SwiftUI
+
+/// One editor pane's tab strip. Tabs scroll sideways when they overflow (‹ ›
+/// arrows appear); the active one is highlighted and kept in view. A recording
+/// tab shows a pulsing red dot. A trailing + opens the search palette. Tabs drag
+/// to reorder within the pane, or onto the other pane / the split zone to move.
+struct TabStripView: View {
+    @Environment(AppState.self) private var state
+    /// Which editor group (pane) this strip drives.
+    let group: Int
+    /// Measured widths for overflow detection and drop-side (before/after) math.
+    @State private var chipWidths: [String: CGFloat] = [:]
+    @State private var contentWidth: CGFloat = 0
+    @State private var viewportWidth: CGFloat = 0
+    /// Index the ‹ › arrows last scrolled to — stepped on each press.
+    @State private var scrollAnchor = 0
+
+    private var tabIDs: [String] { state.openTabIDs(inGroup: group) }
+    private var activeID: String? { state.activeTab(inGroup: group) }
+    /// The tabs are wider than the visible strip — show the ‹ › scroll arrows.
+    private var overflowing: Bool { contentWidth > viewportWidth + 1 }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            HStack(spacing: 0) {
+                if overflowing {
+                    scrollArrow("chevron.left", by: -1, help: "Scroll tabs left", proxy)
+                    Divider().frame(height: 20)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 4) {
+                        ForEach(tabIDs, id: \.self) { id in
+                            chip(id)
+                        }
+                        newTabButton
+                    }
+                    .padding(.horizontal, 8)
+                    .frame(maxHeight: .infinity)
+                    .background(widthReader { contentWidth = $0 })
+                }
+                .frame(maxWidth: .infinity)
+                .background(widthReader { viewportWidth = $0 })
+                .onChange(of: activeID) { _, id in
+                    // Bring this pane's active tab into view when it changes off-screen.
+                    guard let id else { return }
+                    if let index = tabIDs.firstIndex(of: id) { scrollAnchor = index }
+                    withAnimation(.easeInOut(duration: 0.15)) { proxy.scrollTo(id, anchor: .center) }
+                }
+
+                if overflowing {
+                    Divider().frame(height: 20)
+                    scrollArrow("chevron.right", by: 1, help: "Scroll tabs right", proxy)
+                }
+            }
+        }
+        .frame(height: 36)
+        .background(.bgSurface)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    /// Nudge the horizontal scroll by a few tabs (single click) — reveals hidden
+    /// tabs without changing which tab is focused.
+    private func scrollArrow(_ icon: String, by direction: Int, help: String, _ proxy: ScrollViewProxy) -> some View {
+        Button {
+            let ids = tabIDs
+            guard !ids.isEmpty else { return }
+            scrollAnchor = min(max(scrollAnchor + direction * 3, 0), ids.count - 1)
+            withAnimation(.easeInOut(duration: 0.2)) { proxy.scrollTo(ids[scrollAnchor], anchor: .leading) }
+        } label: {
+            Image(systemName: icon)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.textMuted)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func chip(_ id: String) -> some View {
+        TabChip(
+            title: Self.title(id),
+            icon: Self.icon(id),
+            isActive: id == activeID,
+            isRecording: state.tabIsRecording(id),
+            onSelect: { state.requestFeature(id) },
+            onClose: { state.closeTab(id) }
+        )
+        .id(id)
+        .background(widthReader { chipWidths[id] = $0 })
+        .onDrag {
+            state.draggingTabID = id
+            return NSItemProvider(object: id as NSString)
+        }
+        .onDrop(of: [.text], delegate: TabReorderDrop(
+            targetID: id,
+            width: chipWidths[id] ?? 0,
+            order: tabIDs,
+            draggingID: state.draggingTabID,
+            move: { dragged, before in state.dropTab(dragged, intoGroup: group, before: before) },
+            end: { state.draggingTabID = nil }
+        ))
+        .contextMenu { tabMenu(for: id) }
+    }
+
+    /// Reports a view's width via a background GeometryReader (the pattern the
+    /// sidebar uses to measure rows).
+    private func widthReader(_ update: @escaping (CGFloat) -> Void) -> some View {
+        GeometryReader { geo in
+            Color.clear.onChange(of: geo.size.width, initial: true) { _, width in update(width) }
+        }
+    }
+
+    /// Right-click menu for a tab: move it across the split, or close it.
+    @ViewBuilder
+    private func tabMenu(for id: String) -> some View {
+        if state.isSplit {
+            Button("Move to Other Pane") { state.moveTab(id, toGroup: group == 0 ? 1 : 0) }
+        } else {
+            Button("Split: Move to New Pane") { state.splitTab(id) }
+        }
+        Divider()
+        Button("Close Tab") { state.closeTab(id) }
+    }
+
+    private var newTabButton: some View {
+        Button { state.openPalette?() } label: {
+            Image(systemName: "plus")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.textMuted)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("New tab (⌘T)")
+    }
+
+    /// Title shown on a tab chip — the registry title, or the standalone
+    /// Home / Manage Features / About screens which aren't registry features.
+    static func title(_ id: String) -> String {
+        switch id {
+        case "home": return "Home"
+        case "catalog": return "Manage Features"
+        case "about": return "About"
+        default: return FeatureRegistry.byID[id]?.title ?? id
+        }
+    }
+
+    static func icon(_ id: String) -> String {
+        switch id {
+        case "home": return "house"
+        case "catalog": return "square.grid.2x2"
+        case "about": return "info.circle"
+        default: return FeatureRegistry.byID[id]?.icon ?? "square"
+        }
+    }
+}
+
+/// One tab in the strip. The close button appears on hover (or when active) but
+/// its width is always reserved, so the chip doesn't jump as the pointer moves.
+private struct TabChip: View {
+    let title: String
+    let icon: String
+    let isActive: Bool
+    let isRecording: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            leading
+            Text(title)
+                .font(.callout)
+                .lineLimit(1)
+                .foregroundStyle(isActive ? AnyShapeStyle(.textMain) : AnyShapeStyle(.textMuted))
+            closeButton
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 5)
+        .frame(height: 28)
+        .frame(maxWidth: 190)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(isActive ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect() }
+        .onHover { hovering = $0 }
+    }
+
+    @ViewBuilder private var leading: some View {
+        if isRecording {
+            // Pulsing red dot while the tab is recording (screen / mirror /
+            // performance / network capture).
+            Image(systemName: "circle.fill")
+                .font(.system(size: 8))
+                .foregroundStyle(.red)
+                .symbolEffect(.pulse, options: .repeating)
+        } else {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(isActive ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+        }
+    }
+
+    @ViewBuilder private var closeButton: some View {
+        if hovering || isActive {
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.textMuted)
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Close tab (⌘W)")
+        } else {
+            Color.clear.frame(width: 16, height: 16)
+        }
+    }
+}
+
+/// Drop delegate for reordering tabs: dropping a dragged tab on a chip's left
+/// half inserts it before that chip, on the right half after it. `move` is a
+/// no-op when the ids resolve to the same slot (handled by `SidebarOrdering`).
+private struct TabReorderDrop: DropDelegate {
+    let targetID: String
+    let width: CGFloat
+    let order: [String]
+    let draggingID: String?
+    let move: (_ dragged: String, _ beforeTargetID: String?) -> Void
+    let end: () -> Void
+
+    func validateDrop(info: DropInfo) -> Bool { draggingID != nil }
+
+    func performDrop(info: DropInfo) -> Bool {
+        defer { end() }
+        guard let dragged = draggingID, dragged != targetID else { return false }
+        let dropAfter = width > 0 && info.location.x > width / 2
+        if dropAfter, let index = order.firstIndex(of: targetID) {
+            // After the target = before the tab that follows it (or to the end).
+            move(dragged, order.indices.contains(index + 1) ? order[index + 1] : nil)
+        } else {
+            move(dragged, targetID)
+        }
+        return true
+    }
+}

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -126,7 +126,12 @@ struct TabStripView: View {
     }
 
     private var newTabButton: some View {
-        Button { state.openPalette?() } label: {
+        Button {
+            // Focus this pane first so the chosen feature opens here, not in
+            // whichever pane happened to be focused.
+            state.focusGroup(group)
+            state.openPalette?()
+        } label: {
             Image(systemName: "plus")
                 .font(.callout.weight(.medium))
                 .foregroundStyle(.textMuted)

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -15,6 +15,8 @@ struct TabStripView: View {
     @State private var viewportWidth: CGFloat = 0
     /// Index the ‹ › arrows last scrolled to — stepped on each press.
     @State private var scrollAnchor = 0
+    /// Where the insertion guideline shows during a reorder drag (nil = none).
+    @State private var dropSlot: TabDropSlot?
 
     private var tabIDs: [String] { state.openTabIDs(inGroup: group) }
     private var activeID: String? { state.activeTab(inGroup: group) }
@@ -90,6 +92,8 @@ struct TabStripView: View {
         )
         .id(id)
         .background(widthReader { chipWidths[id] = $0 })
+        .overlay(alignment: .leading) { guideline(visible: dropSlot == TabDropSlot(targetID: id, after: false)) }
+        .overlay(alignment: .trailing) { guideline(visible: dropSlot == TabDropSlot(targetID: id, after: true)) }
         .onDrag {
             state.draggingTabID = id
             return NSItemProvider(object: id as NSString)
@@ -99,10 +103,20 @@ struct TabStripView: View {
             width: chipWidths[id] ?? 0,
             order: tabIDs,
             draggingID: state.draggingTabID,
+            setSlot: { dropSlot = $0 },
             move: { dragged, before in state.dropTab(dragged, intoGroup: group, before: before) },
             end: { state.draggingTabID = nil }
         ))
         .contextMenu { tabMenu(for: id) }
+    }
+
+    /// A thin accent bar between chips marking where a reordered tab will land.
+    @ViewBuilder private func guideline(visible: Bool) -> some View {
+        if visible {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(Color.brandAccent)
+                .frame(width: 2, height: 22)
+        }
     }
 
     /// Reports a view's width via a background GeometryReader (the pattern the
@@ -228,21 +242,36 @@ private struct TabChip: View {
     }
 }
 
+/// Where the strip's insertion guideline sits: before or after a target chip.
+struct TabDropSlot: Equatable {
+    let targetID: String
+    let after: Bool
+}
+
 /// Drop delegate for reordering tabs: dropping a dragged tab on a chip's left
-/// half inserts it before that chip, on the right half after it. `move` is a
-/// no-op when the ids resolve to the same slot (handled by `SidebarOrdering`).
+/// half inserts it before that chip, on the right half after it, and reports the
+/// insertion slot so the strip can draw a guideline. `move` is a no-op when the
+/// ids resolve to the same slot (handled by `SidebarOrdering`).
 private struct TabReorderDrop: DropDelegate {
     let targetID: String
     let width: CGFloat
     let order: [String]
     let draggingID: String?
+    let setSlot: (TabDropSlot?) -> Void
     let move: (_ dragged: String, _ beforeTargetID: String?) -> Void
     let end: () -> Void
 
     func validateDrop(info: DropInfo) -> Bool { draggingID != nil }
+    func dropEntered(info: DropInfo) { setSlot(slot(info)) }
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        setSlot(slot(info))
+        return DropProposal(operation: .move)
+    }
+    func dropExited(info: DropInfo) { setSlot(nil) }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { end() }
+        setSlot(nil)
+        end()
         guard let dragged = draggingID, dragged != targetID else { return false }
         let dropAfter = width > 0 && info.location.x > width / 2
         if dropAfter, let index = order.firstIndex(of: targetID) {
@@ -252,5 +281,11 @@ private struct TabReorderDrop: DropDelegate {
             move(dragged, targetID)
         }
         return true
+    }
+
+    /// The slot under the cursor — nil while over the dragged chip itself.
+    private func slot(_ info: DropInfo) -> TabDropSlot? {
+        guard draggingID != targetID else { return nil }
+        return TabDropSlot(targetID: targetID, after: width > 0 && info.location.x > width / 2)
     }
 }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -599,6 +599,12 @@ final class AppState {
         closeTab(id)
     }
 
+    /// Give an editor group keyboard focus — its `+` button focuses it so a new
+    /// tab lands in that pane; new tabs, ⌘W, and ⌃⇥ act on the focused group.
+    func focusGroup(_ index: Int) {
+        if groups.indices.contains(index) { focusedGroup = index }
+    }
+
     func selectNextTab() {
         guard groups.indices.contains(focusedGroup) else { return }
         groups[focusedGroup].activateNext()
@@ -631,9 +637,14 @@ final class AppState {
     func moveTab(_ id: String, toGroup dest: Int) {
         guard let src = groupIndex(of: id), src != dest, groups.indices.contains(dest) else { return }
         groups[src].close(id)
-        groups[dest].open(id)
+        guard groups[dest].open(id) else {
+            // Destination is full — undo the close so the tab isn't lost. Only
+            // reachable if the total cap was somehow already exceeded.
+            groups[src].open(id)
+            return
+        }
         if groups[src].openTabs.isEmpty { groups.remove(at: src) }
-        focusedGroup = groupIndex(of: id) ?? 0
+        focusedGroup = groupIndex(of: id) ?? focusedGroup
         persistTabs()
     }
 
@@ -687,12 +698,19 @@ final class AppState {
     private func restoreTabs(from layout: LayoutState) {
         var restored: [TabState] = []
         var seen = Set<String>()
-        for group in layout.tabGroups ?? [] {
+        var budget = TabState.maxTabs
+        // At most two groups (panes), globally-unique ids, and no more than
+        // `maxTabs` total — trimmed here so a hand-edited or legacy layout can't
+        // restore an over-cap state (which would later strand a tab in moveTab).
+        for group in (layout.tabGroups ?? []).prefix(2) {
+            guard budget > 0 else { break }
             let valid = group.tabs.filter { Self.isValidTabID($0) && seen.insert($0).inserted }
-            guard !valid.isEmpty else { continue }
-            restored.append(TabState(openTabs: valid, activeTab: group.activeTab))
+            let kept = Array(valid.prefix(budget))
+            guard !kept.isEmpty else { continue }
+            budget -= kept.count
+            restored.append(TabState(openTabs: kept, activeTab: group.activeTab))
         }
-        groups = restored.isEmpty ? [TabState(openTabs: ["home"], activeTab: "home")] : Array(restored.prefix(2))
+        groups = restored.isEmpty ? [TabState(openTabs: ["home"], activeTab: "home")] : restored
         focusedGroup = min(max(layout.focusedGroup ?? 0, 0), groups.count - 1)
     }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -69,10 +69,52 @@ final class AppState {
     private(set) var selectedSerial: String?
     var runOnAll = false
     var searchText = ""
-    /// Switch via `requestFeature(_:)`, not direct assignment — that routes the
-    /// change through the leave guard so an active recording / unsaved edit isn't
-    /// silently discarded.
-    private(set) var selectedFeatureID: String?
+    /// The sidebar/palette's keyboard-navigation highlight (↑/↓ while searching).
+    /// Transient (not persisted) and separate from the active tab, so arrowing
+    /// through results moves a highlight without opening a tab per keystroke —
+    /// only ⏎ / click / ⌘<n> opens one.
+    var searchHighlightID: String?
+    /// The open editor groups (VS Code-style split panes): one group = no split,
+    /// two = a left/right split. Each group owns its tabs and active tab. A
+    /// feature is open in at most one group, so dragging a tab between panes
+    /// MOVES it. Mutate via the tab methods below (never directly) so changes
+    /// persist and the `TabState.maxTabs` total cap holds. Tabs stay mounted, so
+    /// switching within a pane never destroys in-flight work — the leave guard
+    /// fires on *closing* a tab (or quitting), not on switching.
+    private(set) var groups: [TabState] = [TabState(openTabs: ["home"], activeTab: "home")]
+
+    /// Which group has keyboard focus — new tabs, ⌘W, and ⌃⇥ act on it.
+    private(set) var focusedGroup = 0
+
+    /// The tab id being dragged in a strip, or nil when no drag is in flight —
+    /// shared so a pane can offer a drop target for moving/splitting tabs.
+    var draggingTabID: String?
+
+    /// The focused group's active tab: drives the device bar, sidebar highlight,
+    /// and window title.
+    var activeTabID: String? {
+        groups.indices.contains(focusedGroup) ? groups[focusedGroup].activeTab : nil
+    }
+
+    /// Both panes' active tabs — the sidebar highlights all of them.
+    var activeTabIDs: Set<String> { Set(groups.compactMap(\.activeTab)) }
+
+    /// True when the workspace is split into two panes.
+    var isSplit: Bool { groups.count > 1 }
+
+    /// The open tabs of group `index` (empty if that group doesn't exist).
+    func openTabIDs(inGroup index: Int) -> [String] {
+        groups.indices.contains(index) ? groups[index].openTabs : []
+    }
+    /// The active tab of group `index`.
+    func activeTab(inGroup index: Int) -> String? {
+        groups.indices.contains(index) ? groups[index].activeTab : nil
+    }
+
+    private var totalOpenTabs: Int { groups.reduce(0) { $0 + $1.openTabs.count } }
+    private func groupIndex(of id: String) -> Int? {
+        groups.firstIndex { $0.openTabs.contains(id) }
+    }
     var layout = LayoutState()
     /// Per-feature usage tally (persisted), used to re-rank the launchpad's
     /// curated feature order by how the user actually works.
@@ -100,12 +142,14 @@ final class AppState {
     /// device and bundle pickers so the captured series stays consistent.
     var recordingActive = false
 
-    /// Registered by a view holding work that navigating away would destroy —
-    /// an active screen recording or unsaved editor edits. While set,
-    /// feature/device switches and app-quit route through `pendingExit` instead
-    /// of proceeding. See `setExitGuard` / `requestFeature`.
-    private(set) var exitGuard: ExitGuard?
-    /// A navigation deferred until the user resolves the active `exitGuard`.
+    /// Views holding losable work (an active recording, unsaved editor edits)
+    /// register a guard here, keyed by the owning tab's feature id, so closing
+    /// that tab — or switching device / quitting — routes through `pendingExit`
+    /// for confirmation instead of silently discarding the work. Open tabs stay
+    /// mounted, so switching tabs is always safe and never consults this.
+    private(set) var exitGuards: [String: ExitGuard] = [:]
+    /// A navigation deferred until the user resolves the relevant `exitGuards`
+    /// entry (close a guarded tab, switch device, or quit with work in flight).
     private(set) var pendingExit: PendingExit?
     /// The command bar's Terminal tab — a real PTY-backed shell, shared
     /// app-wide so it persists across features.
@@ -275,9 +319,6 @@ final class AppState {
         selectedSerial = prefs.selectedSerial
         runOnAll = prefs.runOnAll
         selectedBundleId = prefs.selectedBundleId
-        // The launchpad (Home) is the consistent entry point — land there on
-        // every launch rather than reopening the last-used feature.
-        selectedFeatureID = "home"
         let loadedLayout = await env.stores.layout.load()
         // A brand-new user can pick a role — which seeds `layout` — while these
         // async store loads are still in flight; don't clobber that seed.
@@ -289,6 +330,10 @@ final class AppState {
             if layoutChanged {
                 persistLayout()
             }
+            // Reopen the tabs from the last session (idle — recordings/streams
+            // don't resume). Falls back to a single Home tab for a new user or a
+            // layout written before tabs existed.
+            restoreTabs(from: layout)
         }
         usageStats = await env.stores.usage.load()
         bundles = await env.stores.bundles.load()
@@ -459,6 +504,9 @@ final class AppState {
     struct ExitGuard: Equatable, Identifiable {
         enum Style: Equatable { case recording, edits }
         let id: UUID
+        /// The feature id of the tab that owns this guard, so closing a tab can
+        /// tell whether *its* work is the work at stake.
+        var featureID: String
         var style: Style
         var title: String
         var message: String
@@ -466,7 +514,7 @@ final class AppState {
 
     /// A navigation held back until the user resolves the active `ExitGuard`.
     struct PendingExit: Equatable {
-        enum Target: Equatable { case feature(String), device(String), quit }
+        enum Target: Equatable { case closeTab(String), device(String), quit }
         var target: Target
         /// Flips true when the user chooses "Stop & save": the active view runs
         /// its own save, then calls `finishExitSave()`. The dialog hides while
@@ -474,33 +522,191 @@ final class AppState {
         var saving = false
     }
 
-    /// Register (or replace) the active leave guard. A protected view calls this
-    /// when losable work begins, and `clearExitGuard` when it ends.
-    func setExitGuard(_ value: ExitGuard) { exitGuard = value }
+    /// Register (or replace) the leave guard for a tab. A protected view calls
+    /// this when losable work begins, and `clearExitGuard` when it ends.
+    func setExitGuard(_ value: ExitGuard) { exitGuards[value.featureID] = value }
 
-    /// Clear the guard only if it's still the one identified by `id`, so a
-    /// torn-down view can't wipe a guard a newer view just registered.
+    /// Clear the guard identified by `id`, wherever it's keyed — so a torn-down
+    /// view can't wipe a guard a newer view just registered (ids are unique).
     func clearExitGuard(_ id: UUID) {
-        if exitGuard?.id == id { exitGuard = nil }
+        exitGuards = exitGuards.filter { $0.value.id != id }
     }
 
-    /// Switch the selected feature, or hold the switch behind a confirmation
-    /// when a leave guard is active. Every feature switch (sidebar, palette,
-    /// menu, hotkeys) routes through here.
-    func requestFeature(_ id: String) {
-        guard id != selectedFeatureID else { return }
-        if exitGuard == nil {
-            selectedFeatureID = id
-        } else {
-            pendingExit = PendingExit(target: .feature(id))
+    /// The guard the pending leave confirmation is about: the closing tab's
+    /// guard, or any active guard when switching device / quitting.
+    var pendingGuard: ExitGuard? {
+        switch pendingExit?.target {
+        case .closeTab(let id): return exitGuards[id]
+        case .device, .quit: return exitGuards.values.first
+        case nil: return nil
         }
+    }
+
+    /// Whether the pending leave would destroy `featureID`'s work — true for a
+    /// close of that exact tab, or any device-switch / quit (which leaves every
+    /// tab). A guarded view's save-on-leave gates on this so closing one tab
+    /// can't make a different tab save.
+    func pendingExitConcerns(_ featureID: String) -> Bool {
+        switch pendingExit?.target {
+        case .closeTab(let id): return id == featureID
+        case .device, .quit: return true
+        case nil: return false
+        }
+    }
+
+    /// Whether a tab is actively recording — drives its red pulse in the tab
+    /// strip. A `.recording` guard is registered exactly while screen/mirror
+    /// recording or while a performance/network capture holds unexported samples.
+    func tabIsRecording(_ id: String) -> Bool {
+        exitGuards[id]?.style == .recording
+    }
+
+    /// Open `id`, or refocus it wherever it's already open. Every feature open
+    /// (sidebar, palette, menu, hotkeys, Finder) routes through here; a not-yet-
+    /// open feature lands in the focused group. Switching is always safe (tabs
+    /// stay mounted), so there's no leave guard — only the `TabState.maxTabs`
+    /// total cap, which surfaces a toast when a new tab can't open.
+    func requestFeature(_ id: String) {
+        if let group = groupIndex(of: id) {
+            focusedGroup = group
+            groups[group].open(id)
+        } else {
+            guard totalOpenTabs < TabState.maxTabs else {
+                showToast(Toast(
+                    message: "You can have up to \(TabState.maxTabs) tabs open — close one first.",
+                    ok: false))
+                return
+            }
+            groups[focusedGroup].open(id)
+        }
+        persistTabs()
+    }
+
+    /// Close a tab (in whichever group holds it). A tab whose view holds losable
+    /// work routes through the leave confirmation first, since closing unmounts
+    /// the view (which would destroy that work). Closing any other is immediate.
+    func closeTab(_ id: String) {
+        if exitGuards[id] != nil {
+            pendingExit = PendingExit(target: .closeTab(id))
+        } else {
+            performClose(id)
+        }
+    }
+
+    /// Close the focused group's active tab (⌘W).
+    func closeActiveTab() {
+        guard groups.indices.contains(focusedGroup), let id = groups[focusedGroup].activeTab else { return }
+        closeTab(id)
+    }
+
+    func selectNextTab() {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activateNext()
+        persistTabs()
+    }
+    func selectPreviousTab() {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activatePrevious()
+        persistTabs()
+    }
+    /// Activate the tab at a 0-based index in the focused group (⌃1–⌃9).
+    func selectTab(index: Int) {
+        guard groups.indices.contains(focusedGroup) else { return }
+        groups[focusedGroup].activate(index: index)
+        persistTabs()
+    }
+
+    /// Drag-reorder a tab within its own group so it sits before `targetID`
+    /// (nil = to the end).
+    func reorderTab(_ id: String, before targetID: String?) {
+        guard let group = groupIndex(of: id) else { return }
+        let order = targetID.map { SidebarOrdering.move(id, before: $0, in: groups[group].openTabs) }
+            ?? SidebarOrdering.moveToEnd(id, in: groups[group].openTabs)
+        groups[group].reorder(order)
+        persistTabs()
+    }
+
+    /// Move `id` into group `dest` (append + activate there) — dragging a tab to
+    /// the other pane. Collapses the source group if it empties.
+    func moveTab(_ id: String, toGroup dest: Int) {
+        guard let src = groupIndex(of: id), src != dest, groups.indices.contains(dest) else { return }
+        groups[src].close(id)
+        groups[dest].open(id)
+        if groups[src].openTabs.isEmpty { groups.remove(at: src) }
+        focusedGroup = groupIndex(of: id) ?? 0
+        persistTabs()
+    }
+
+    /// Resolve a strip/pane drop: reorder within the same group, or move to the
+    /// other group and then position it at the drop target.
+    func dropTab(_ id: String, intoGroup dest: Int, before targetID: String?) {
+        guard let src = groupIndex(of: id) else { return }
+        if src == dest {
+            if let targetID { reorderTab(id, before: targetID) }
+        } else {
+            moveTab(id, toGroup: dest)
+            if let targetID { reorderTab(id, before: targetID) }
+        }
+    }
+
+    /// Split the workspace: move `id` into a new second pane. Requires its group
+    /// to hold more than one tab (something must stay behind). No-op if already
+    /// split.
+    func splitTab(_ id: String) {
+        guard groups.count == 1, let src = groupIndex(of: id), groups[src].openTabs.count > 1 else { return }
+        groups[src].close(id)
+        groups.append(TabState(openTabs: [id], activeTab: id))
+        focusedGroup = 1
+        persistTabs()
+    }
+
+    private func performClose(_ id: String) {
+        guard let group = groupIndex(of: id) else { return }
+        groups[group].close(id)
+        if groups[group].openTabs.isEmpty {
+            if groups.count > 1 {
+                groups.remove(at: group)
+                focusedGroup = min(focusedGroup, groups.count - 1)
+            } else {
+                groups[group].open("home") // never leave the workspace empty
+            }
+        }
+        persistTabs()
+    }
+
+    private func persistTabs() {
+        layout.tabGroups = groups.map { TabGroupState(tabs: $0.openTabs, activeTab: $0.activeTab) }
+        layout.focusedGroup = focusedGroup
+        persistLayout()
+    }
+
+    /// Reopen persisted editor groups (idle — live sessions don't resume),
+    /// dropping ids no longer in the registry, enforcing global uniqueness across
+    /// panes, and seeding a single Home tab when there's nothing valid to restore
+    /// (new users / layouts written before tabs existed).
+    private func restoreTabs(from layout: LayoutState) {
+        var restored: [TabState] = []
+        var seen = Set<String>()
+        for group in layout.tabGroups ?? [] {
+            let valid = group.tabs.filter { Self.isValidTabID($0) && seen.insert($0).inserted }
+            guard !valid.isEmpty else { continue }
+            restored.append(TabState(openTabs: valid, activeTab: group.activeTab))
+        }
+        groups = restored.isEmpty ? [TabState(openTabs: ["home"], activeTab: "home")] : Array(restored.prefix(2))
+        focusedGroup = min(max(layout.focusedGroup ?? 0, 0), groups.count - 1)
+    }
+
+    /// Ids that can back a tab: every registry feature plus the standalone
+    /// Home / About / Catalog screens.
+    private static func isValidTabID(_ id: String) -> Bool {
+        FeatureRegistry.byID[id] != nil || ["home", "about", "catalog"].contains(id)
     }
 
     /// Switch the active device, or hold it behind a confirmation when a guard
     /// is active.
     func requestDevice(_ serial: String) {
         guard serial != selectedSerial else { return }
-        if exitGuard == nil {
+        if exitGuards.isEmpty {
             selectedSerial = serial
             persistSelection()
         } else {
@@ -512,15 +718,23 @@ final class AppState {
     /// means losable work is in flight — the leave prompt is shown and the
     /// resolution drives termination (see `quitNow` / `cancelExit`).
     func requestQuit() -> Bool {
-        guard exitGuard != nil else { return true }
+        guard !exitGuards.isEmpty else { return true }
         pendingExit = PendingExit(target: .quit)
         return false
     }
 
-    /// "Discard" / "Discard changes": drop the work and run the deferred
-    /// navigation. The leaving view's `.onDisappear` aborts recorders / frees
-    /// edits, so nothing extra is needed here.
-    func discardAndExit() { performPendingExit() }
+    /// "Discard" / "Discard changes": drop the at-risk work and run the deferred
+    /// navigation. A tab close clears just that tab's guard (and its view aborts
+    /// in `.onDisappear` as it unmounts); a device-switch / quit leaves every
+    /// tab, so clear them all and let each view abort.
+    func discardAndExit() {
+        switch pendingExit?.target {
+        case .closeTab(let id): exitGuards[id] = nil
+        case .device, .quit: exitGuards.removeAll()
+        case nil: break
+        }
+        performPendingExit()
+    }
 
     /// "Keep recording" / "Keep editing": abandon the pending navigation.
     func cancelExit() {
@@ -538,10 +752,9 @@ final class AppState {
 
     private func performPendingExit() {
         guard let pending = pendingExit else { return }
-        exitGuard = nil
         pendingExit = nil
         switch pending.target {
-        case .feature(let id): selectedFeatureID = id
+        case .closeTab(let id): performClose(id)
         case .device(let serial): selectedSerial = serial; persistSelection()
         case .quit: quitNow()
         }
@@ -781,9 +994,13 @@ final class AppState {
             layout.seedEverything()
         }
         roleChosenThisSession = true
+        // Start the freshly-chosen role on a single Home tab, no split.
+        groups = [TabState(openTabs: ["home"], activeTab: "home")]
+        focusedGroup = 0
+        layout.tabGroups = [TabGroupState(tabs: ["home"], activeTab: "home")]
+        layout.focusedGroup = 0
         persistLayout()
         presentRolePicker = false
-        selectedFeatureID = "home"
     }
 
     /// The user's current role, nil when they chose "show me everything".

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -74,47 +74,31 @@ final class AppState {
     /// through results moves a highlight without opening a tab per keystroke —
     /// only ⏎ / click / ⌘<n> opens one.
     var searchHighlightID: String?
-    /// The open editor groups (VS Code-style split panes): one group = no split,
-    /// two = a left/right split. Each group owns its tabs and active tab. A
-    /// feature is open in at most one group, so dragging a tab between panes
-    /// MOVES it. Mutate via the tab methods below (never directly) so changes
-    /// persist and the `TabState.maxTabs` total cap holds. Tabs stay mounted, so
-    /// switching within a pane never destroys in-flight work — the leave guard
-    /// fires on *closing* a tab (or quitting), not on switching.
-    private(set) var groups: [TabState] = [TabState(openTabs: ["home"], activeTab: "home")]
-
-    /// Which group has keyboard focus — new tabs, ⌘W, and ⌃⇥ act on it.
-    private(set) var focusedGroup = 0
+    /// The editor-group workspace (VS Code-style split panes): one pane = no
+    /// split, two = a left/right split. Each pane owns its tabs and active tab; a
+    /// feature is open in at most one pane, so dragging a tab between panes MOVES
+    /// it. All the multi-pane rules (collapse, cap, uniqueness, focus, never
+    /// empty) live in the pure, tested `Workspace`; mutate via the methods below
+    /// so each change persists. Tabs stay mounted, so switching within a pane
+    /// never destroys in-flight work — the leave guard fires on *closing* a tab
+    /// (or quitting), not on switching.
+    private(set) var workspace = Workspace(fallback: "home")
 
     /// The tab id being dragged in a strip, or nil when no drag is in flight —
     /// shared so a pane can offer a drop target for moving/splitting tabs.
     var draggingTabID: String?
 
-    /// The focused group's active tab: drives the device bar, sidebar highlight,
+    /// The focused pane's active tab: drives the device bar, sidebar highlight,
     /// and window title.
-    var activeTabID: String? {
-        groups.indices.contains(focusedGroup) ? groups[focusedGroup].activeTab : nil
-    }
-
+    var activeTabID: String? { workspace.activeTab }
     /// Both panes' active tabs — the sidebar highlights all of them.
-    var activeTabIDs: Set<String> { Set(groups.compactMap(\.activeTab)) }
-
+    var activeTabIDs: Set<String> { workspace.activeTabs }
     /// True when the workspace is split into two panes.
-    var isSplit: Bool { groups.count > 1 }
-
-    /// The open tabs of group `index` (empty if that group doesn't exist).
-    func openTabIDs(inGroup index: Int) -> [String] {
-        groups.indices.contains(index) ? groups[index].openTabs : []
-    }
-    /// The active tab of group `index`.
-    func activeTab(inGroup index: Int) -> String? {
-        groups.indices.contains(index) ? groups[index].activeTab : nil
-    }
-
-    private var totalOpenTabs: Int { groups.reduce(0) { $0 + $1.openTabs.count } }
-    private func groupIndex(of id: String) -> Int? {
-        groups.firstIndex { $0.openTabs.contains(id) }
-    }
+    var isSplit: Bool { workspace.isSplit }
+    /// The open tabs of pane `index` (empty if that pane doesn't exist).
+    func openTabIDs(inGroup index: Int) -> [String] { workspace.openTabs(inGroup: index) }
+    /// The active tab of pane `index`.
+    func activeTab(inGroup index: Int) -> String? { workspace.activeTab(inGroup: index) }
     var layout = LayoutState()
     /// Per-feature usage tally (persisted), used to re-rank the launchpad's
     /// curated feature order by how the user actually works.
@@ -567,22 +551,16 @@ final class AppState {
     /// stay mounted), so there's no leave guard — only the `TabState.maxTabs`
     /// total cap, which surfaces a toast when a new tab can't open.
     func requestFeature(_ id: String) {
-        if let group = groupIndex(of: id) {
-            focusedGroup = group
-            groups[group].open(id)
-        } else {
-            guard totalOpenTabs < TabState.maxTabs else {
-                showToast(Toast(
-                    message: "You can have up to \(TabState.maxTabs) tabs open — close one first.",
-                    ok: false))
-                return
-            }
-            groups[focusedGroup].open(id)
+        guard workspace.open(id) else {
+            showToast(Toast(
+                message: "You can have up to \(Workspace.maxTabs) tabs open — close one first.",
+                ok: false))
+            return
         }
         persistTabs()
     }
 
-    /// Close a tab (in whichever group holds it). A tab whose view holds losable
+    /// Close a tab (in whichever pane holds it). A tab whose view holds losable
     /// work routes through the leave confirmation first, since closing unmounts
     /// the view (which would destroy that work). Closing any other is immediate.
     func closeTab(_ id: String) {
@@ -593,125 +571,65 @@ final class AppState {
         }
     }
 
-    /// Close the focused group's active tab (⌘W).
+    /// Close the focused pane's active tab (⌘W).
     func closeActiveTab() {
-        guard groups.indices.contains(focusedGroup), let id = groups[focusedGroup].activeTab else { return }
-        closeTab(id)
+        if let id = workspace.activeTab { closeTab(id) }
     }
 
-    /// Give an editor group keyboard focus — its `+` button focuses it so a new
-    /// tab lands in that pane; new tabs, ⌘W, and ⌃⇥ act on the focused group.
-    func focusGroup(_ index: Int) {
-        if groups.indices.contains(index) { focusedGroup = index }
-    }
+    /// Give a pane keyboard focus — its `+` focuses it so a new tab lands there.
+    func focusGroup(_ index: Int) { workspace.focus(index); persistTabs() }
 
-    func selectNextTab() {
-        guard groups.indices.contains(focusedGroup) else { return }
-        groups[focusedGroup].activateNext()
-        persistTabs()
-    }
-    func selectPreviousTab() {
-        guard groups.indices.contains(focusedGroup) else { return }
-        groups[focusedGroup].activatePrevious()
-        persistTabs()
-    }
-    /// Activate the tab at a 0-based index in the focused group (⌃1–⌃9).
-    func selectTab(index: Int) {
-        guard groups.indices.contains(focusedGroup) else { return }
-        groups[focusedGroup].activate(index: index)
-        persistTabs()
-    }
+    func selectNextTab() { workspace.cycleForward(); persistTabs() }
+    func selectPreviousTab() { workspace.cycleBackward(); persistTabs() }
+    /// Activate the tab at a 0-based index in the focused pane (⌃1–⌃9).
+    func selectTab(index: Int) { workspace.activate(index: index); persistTabs() }
 
-    /// Drag-reorder a tab within its own group so it sits before `targetID`
-    /// (nil = to the end).
+    /// Drag-reorder a tab within its own pane so it sits before `targetID`.
     func reorderTab(_ id: String, before targetID: String?) {
-        guard let group = groupIndex(of: id) else { return }
-        let order = targetID.map { SidebarOrdering.move(id, before: $0, in: groups[group].openTabs) }
-            ?? SidebarOrdering.moveToEnd(id, in: groups[group].openTabs)
-        groups[group].reorder(order)
+        workspace.reorder(id, before: targetID)
         persistTabs()
     }
 
-    /// Move `id` into group `dest` (append + activate there) — dragging a tab to
-    /// the other pane. Collapses the source group if it empties.
+    /// Move `id` into pane `dest` — dragging a tab to the other pane.
     func moveTab(_ id: String, toGroup dest: Int) {
-        guard let src = groupIndex(of: id), src != dest, groups.indices.contains(dest) else { return }
-        groups[src].close(id)
-        guard groups[dest].open(id) else {
-            // Destination is full — undo the close so the tab isn't lost. Only
-            // reachable if the total cap was somehow already exceeded.
-            groups[src].open(id)
-            return
-        }
-        if groups[src].openTabs.isEmpty { groups.remove(at: src) }
-        focusedGroup = groupIndex(of: id) ?? focusedGroup
+        workspace.move(id, toGroup: dest)
         persistTabs()
     }
 
-    /// Resolve a strip/pane drop: reorder within the same group, or move to the
-    /// other group and then position it at the drop target.
+    /// Resolve a strip/pane drop: reorder within the same pane, or move to the
+    /// other pane and position it at the drop target.
     func dropTab(_ id: String, intoGroup dest: Int, before targetID: String?) {
-        guard let src = groupIndex(of: id) else { return }
-        if src == dest {
-            if let targetID { reorderTab(id, before: targetID) }
-        } else {
-            moveTab(id, toGroup: dest)
-            if let targetID { reorderTab(id, before: targetID) }
-        }
+        workspace.drop(id, intoGroup: dest, before: targetID)
+        persistTabs()
     }
 
-    /// Split the workspace: move `id` into a new second pane. Requires its group
-    /// to hold more than one tab (something must stay behind). No-op if already
-    /// split.
+    /// Split the workspace: move `id` into a new second pane.
     func splitTab(_ id: String) {
-        guard groups.count == 1, let src = groupIndex(of: id), groups[src].openTabs.count > 1 else { return }
-        groups[src].close(id)
-        groups.append(TabState(openTabs: [id], activeTab: id))
-        focusedGroup = 1
+        workspace.split(id)
         persistTabs()
     }
 
     private func performClose(_ id: String) {
-        guard let group = groupIndex(of: id) else { return }
-        groups[group].close(id)
-        if groups[group].openTabs.isEmpty {
-            if groups.count > 1 {
-                groups.remove(at: group)
-                focusedGroup = min(focusedGroup, groups.count - 1)
-            } else {
-                groups[group].open("home") // never leave the workspace empty
-            }
-        }
+        workspace.close(id)
         persistTabs()
     }
 
     private func persistTabs() {
-        layout.tabGroups = groups.map { TabGroupState(tabs: $0.openTabs, activeTab: $0.activeTab) }
-        layout.focusedGroup = focusedGroup
+        layout.tabGroups = workspace.groups.map { TabGroupState(tabs: $0.openTabs, activeTab: $0.activeTab) }
+        layout.focusedGroup = workspace.focusedGroup
         persistLayout()
     }
 
-    /// Reopen persisted editor groups (idle — live sessions don't resume),
-    /// dropping ids no longer in the registry, enforcing global uniqueness across
-    /// panes, and seeding a single Home tab when there's nothing valid to restore
-    /// (new users / layouts written before tabs existed).
+    /// Reopen persisted panes (idle — live sessions don't resume). All the
+    /// trimming/validation invariants live in `Workspace`; this just supplies the
+    /// registry validity check and the Home fallback.
     private func restoreTabs(from layout: LayoutState) {
-        var restored: [TabState] = []
-        var seen = Set<String>()
-        var budget = TabState.maxTabs
-        // At most two groups (panes), globally-unique ids, and no more than
-        // `maxTabs` total — trimmed here so a hand-edited or legacy layout can't
-        // restore an over-cap state (which would later strand a tab in moveTab).
-        for group in (layout.tabGroups ?? []).prefix(2) {
-            guard budget > 0 else { break }
-            let valid = group.tabs.filter { Self.isValidTabID($0) && seen.insert($0).inserted }
-            let kept = Array(valid.prefix(budget))
-            guard !kept.isEmpty else { continue }
-            budget -= kept.count
-            restored.append(TabState(openTabs: kept, activeTab: group.activeTab))
-        }
-        groups = restored.isEmpty ? [TabState(openTabs: ["home"], activeTab: "home")] : restored
-        focusedGroup = min(max(layout.focusedGroup ?? 0, 0), groups.count - 1)
+        workspace = Workspace(
+            restoring: layout.tabGroups ?? [],
+            focusedGroup: layout.focusedGroup,
+            fallback: "home",
+            isValidID: Self.isValidTabID
+        )
     }
 
     /// Ids that can back a tab: every registry feature plus the standalone
@@ -1013,11 +931,8 @@ final class AppState {
         }
         roleChosenThisSession = true
         // Start the freshly-chosen role on a single Home tab, no split.
-        groups = [TabState(openTabs: ["home"], activeTab: "home")]
-        focusedGroup = 0
-        layout.tabGroups = [TabGroupState(tabs: ["home"], activeTab: "home")]
-        layout.focusedGroup = 0
-        persistLayout()
+        workspace.reset()
+        persistTabs()
         presentRolePicker = false
     }
 


### PR DESCRIPTION
Opens features in tabs instead of the single detail pane, with a VS Code-style split.

## What's new
- **Tabs** — features open as tabs in a strip below the device bar. ⌘T (or ⌘K, or the strip's `+`) opens the search palette; the pick lands in a tab (a new one, or refocuses it if already open). A feature is open at most once; up to 10 tabs.
- **Split** — one or two editor groups (panes) side by side, each with its own tab strip and active tab. When unsplit, drag a tab onto the right "Drop to split" half to create the split (or right-click → *Split: Move to New Pane*). With two panes, drag a tab from one strip onto the other pane, or right-click → *Move to Other Pane*, to move it across. A draggable seam resizes the panes (persisted); closing a pane's last tab collapses the split.
- **Drag** — reorder within a strip, or move across panes.
- **Overflow** — when tabs don't fit, `‹ ›` at the strip ends scroll it (they don't change the active tab).
- **Keyboard** — ⌘T new tab, ⌘W close active tab, ⌃⇥ / ⌃⇧⇥ next/prev within the focused pane, ⌃1–9 jump.
- **Persistence** — open tabs, active tab, and the split restore on launch (idle — live sessions don't resume).

## Device load (keep-alive vs suspend)
All open tabs stay mounted, so switching within a pane preserves view state and keeps work running. To avoid N× device load:
- Recordings (screen / mirror / performance / network capture) and log streams (Reactotron) keep running while their tab is hidden.
- The live network/CPU pollers and the screen mirror pause while their tab is hidden and resume on return.

Recording tabs show a red pulse in the strip.

## Leave guard
Generalized from a single guard to per-tab (keyed by feature id). Closing a tab with in-flight work — or switching device / quitting — prompts; switching tabs no longer does, since the work stays mounted.

## Reactotron
Removed one of its stacked top bars: the connection status folds into the Timeline/Commands/State/REPL row as a dot (full text on hover), and the event count moves into the timeline controls row.

## Notes
- Moving a tab *across panes* recreates its view (a recording would stop); switching *within* a pane is the keep-alive path.
- Pure tab logic (`TabState`) and the persistence shape are unit-tested in ADBKit.

## Testing
- `cd ADBKit && swift test` — 455 tests green.
- `make build` — clean (warnings-as-errors).
- Launched and smoke-tested on macOS 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
