### PR TITLE
Fix feature-tab bugs: run-all curation, mirror device-follow, search & UI polish

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -211,6 +211,11 @@ public struct FeatureDef: Sendable, Identifiable {
     public let needsScrcpy: Bool
     /// Disabled unless ffmpeg is installed.
     public let needsFfmpeg: Bool
+    /// Offers a "Run on all devices" toggle. Only true for features whose
+    /// fan-out is meaningful and implemented (the Simulate & React Native hubs
+    /// dispatch through the fan-out `run` path; Send Text and Install App fan
+    /// out too). Single-device / interactive-session features leave it false.
+    public let supportsRunAll: Bool
     public let isStateOverride: Bool
     public let overrideKind: OverrideKind?
     public let isDestructive: Bool
@@ -232,6 +237,7 @@ public struct FeatureDef: Sendable, Identifiable {
         needsDevice: Bool = true,
         needsScrcpy: Bool = false,
         needsFfmpeg: Bool = false,
+        supportsRunAll: Bool = false,
         isStateOverride: Bool = false,
         overrideKind: OverrideKind? = nil,
         isDestructive: Bool = false,
@@ -251,6 +257,7 @@ public struct FeatureDef: Sendable, Identifiable {
         self.needsDevice = needsDevice
         self.needsScrcpy = needsScrcpy
         self.needsFfmpeg = needsFfmpeg
+        self.supportsRunAll = supportsRunAll
         self.isStateOverride = isStateOverride
         self.overrideKind = overrideKind
         self.isDestructive = isDestructive

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -27,6 +27,7 @@ public enum FeatureRegistry {
             subtitle: "Type text, URLs, or symbols on the device",
             keywords: ["type", "paste", "input", "keyboard", "url"],
             category: .input, icon: "keyboard", kind: .formAction,
+            supportsRunAll: true,
             fields: [
                 FieldDef(name: "text", label: "Text", control: .text, placeholder: "Text, URL, or special characters…")
             ]
@@ -106,7 +107,8 @@ public enum FeatureRegistry {
                 "refresh", "js", "bundle", "url", "intent", "scheme", "universal",
                 "kill", "restore", "background", "dev host", "debug server",
             ],
-            category: .reactNative, icon: "atom", kind: .view, needsDevice: false
+            category: .reactNative, icon: "atom", kind: .view, needsDevice: false,
+            supportsRunAll: true
         ),
         FeatureDef(
             id: "open-dev-menu", title: "Open Dev Menu",
@@ -237,7 +239,8 @@ public enum FeatureRegistry {
                 "wifi", "data", "airplane", "offline", "proxy", "charles", "proxyman",
                 "mitmproxy", "http",
             ],
-            category: .deviceState, icon: "slider.horizontal.3", kind: .view, needsDevice: false
+            category: .deviceState, icon: "slider.horizontal.3", kind: .view, needsDevice: false,
+            supportsRunAll: true
         ),
         FeatureDef(
             id: "fake-battery", title: "Fake Battery",
@@ -343,7 +346,8 @@ public enum FeatureRegistry {
                 "install", "apk", "sideload", "side load", "drag", "drop",
                 "install app", "add app", "package",
             ],
-            category: .appManagement, icon: "arrow.down.app", kind: .view
+            category: .appManagement, icon: "arrow.down.app", kind: .view,
+            supportsRunAll: true
         ),
         FeatureDef(
             id: "apk-studio", title: "APK Studio",
@@ -528,6 +532,14 @@ public enum FeatureRegistry {
     /// Features the user manages individually in the catalog and sidebar:
     /// everything except hub members. The hub screens themselves are included.
     public static let catalogFeatureIDs: [String] = all.map(\.id).filter { !absorbedFeatureIDs.contains($0) }
+
+    /// Features that offer a "Run on all devices" toggle. Fan-out is meaningful
+    /// and implemented for these — the Simulate and React Native hubs dispatch
+    /// their actions through the fan-out `run` path, and Send Text and Install
+    /// App fan out too. Single-device / interactive-session features (mirror,
+    /// file explorer, logcat, …) are intentionally excluded. `FeatureRegistryTests`
+    /// keeps this in lockstep with the `supportsRunAll` flag.
+    public static let runAllFeatureIDs: Set<String> = Set(all.filter(\.supportsRunAll).map(\.id))
 
     /// Curated, ordered catalog features per role — the focused set a newcomer
     /// gets after picking a role on first launch. The order is the recommended

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -180,6 +180,32 @@ import Testing
         #expect(FeatureRegistry.byID.count == 54)
     }
 
+    @Test func runAllIsTheCuratedFanOutSet() {
+        let runAll = FeatureRegistry.runAllFeatureIDs
+        #expect(!runAll.isEmpty)
+        // The stored flag and the derived set never drift apart.
+        for feature in FeatureRegistry.all {
+            #expect(feature.supportsRunAll == runAll.contains(feature.id))
+        }
+        // Every run-all id is a real feature.
+        for id in runAll {
+            #expect(FeatureRegistry.byID[id] != nil, "run-all id \(id) not in registry")
+        }
+        // The curated product decision: the two hubs that dispatch fan-out
+        // actions plus the two standalone fan-out features.
+        #expect(runAll == ["simulate", "react-native", "send-text", "install-app"])
+        // Single-device / interactive-session features must never be run-all —
+        // their fan-out is meaningless or unimplemented.
+        let singleDevice: Set<String> = [
+            "scrcpy", "screen-record", "file-explorer", "sandbox-browser", "logcat",
+            "crash-catcher", "performance", "network-speed", "device-info", "wifi",
+            "private-dns", "root-status", "system-restrictions", "meminfo", "apps",
+            "reactotron", "js-console", "emulators", "custom-commands", "frida-console",
+            "apk-studio", "screenshot",
+        ]
+        #expect(runAll.isDisjoint(with: singleDevice))
+    }
+
     @Test func everyCatalogFeatureIsEnabledByDefault() {
         // Every feature is on out of the box — the default set is exactly the
         // catalog (non-absorbed) features. Hub members are folded into their

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -39,10 +39,18 @@ struct ScreenMirrorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .recordingDecision(url: pendingRecording) { url in model?.finishedRecording = url }
         .imageDecision(image: pendingScreenshot) { image in model?.editingScreenshot = image }
-        .task(id: state.targetSerials.first) {
-            // Only stream while this tab is on screen; a hidden mirror is heavy
-            // video encode for nothing. (Returning re-keys via tabIsActive below.)
-            if tabIsActive { await reconnect(to: state.targetSerials.first) }
+        .task {
+            // Connect if the mirror is the tab on screen when it's first
+            // mounted; a hidden tab connects lazily once it becomes active
+            // (below). A hidden mirror is heavy video encode for nothing.
+            if tabIsActive, model == nil { await reconnect(to: state.targetSerials.first) }
+        }
+        .onChange(of: state.targetSerials.first) { _, serial in
+            // Follow the selected device: switching it re-targets the live
+            // mirror — but never mid-recording, which stays on its device
+            // (leaving to switch is gated by the recording exit guard).
+            guard tabIsActive, model?.isRecording != true else { return }
+            Task { await reconnect(to: serial) }
         }
         .onChange(of: tabIsActive) { _, active in
             if active {

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -56,7 +56,7 @@ struct DeviceBarView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack(spacing: 10) {
-                    if state.readyDeviceCount > 1 {
+                    if state.readyDeviceCount > 1, state.activeFeatureSupportsRunAll {
                         Toggle(isOn: $state.runOnAll) {
                             Label("Run on all", systemImage: "square.stack.3d.up.fill")
                         }
@@ -64,7 +64,7 @@ struct DeviceBarView: View {
                         .controlSize(.mini)
                         .disabled(state.recordingActive)
                         .onChange(of: state.runOnAll) { state.persistSelection() }
-                        .help("Run actions on every connected device")
+                        .help("Run this feature on every connected device")
                     }
 
                     Button {
@@ -169,7 +169,7 @@ struct DeviceBarView: View {
         }
         .fixedSize()
         .controlSize(.large)
-        .disabled(state.runOnAll || state.recordingActive)
+        .disabled(state.effectiveRunOnAll || state.recordingActive)
         .help(state.recordingActive ? "Stop the recording to change the device" : "Switch the active device")
         .task(id: state.devices.map(\.serial).joined()) { await state.refreshAvds() }
     }

--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -40,17 +40,7 @@ struct NotificationPanelView: View {
                     .foregroundStyle(.textMuted)
                     .help("Clear all notifications")
             }
-            Button {
-                state.toggleNotifications()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.body)
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.textMuted)
-            .help("Close notifications")
+            CloseButton(help: "Close notifications") { state.toggleNotifications() }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 11)
@@ -115,14 +105,7 @@ private struct NotificationRow: View {
             }
             Spacer(minLength: 0)
             if hovering {
-                Button { state.dismissNotification(note.id) } label: {
-                    Image(systemName: "xmark")
-                        .font(.caption)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.textMuted)
-                .help("Dismiss")
+                CloseButton(help: "Dismiss") { state.dismissNotification(note.id) }
             }
         }
         .padding(.horizontal, 14)

--- a/App/Sources/Root/PalettePanel.swift
+++ b/App/Sources/Root/PalettePanel.swift
@@ -49,6 +49,13 @@ final class PaletteController {
         panel.isMovableByWindowBackground = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
+        // Lay the SwiftUI content out first so `.preferredContentSize` has
+        // produced the real 520×height frame before we center. Otherwise
+        // `positionInitially` centers the pre-layout placeholder width and the
+        // palette lands off-center.
+        hosting.view.layoutSubtreeIfNeeded()
+        panel.setContentSize(hosting.view.fittingSize)
+
         positionInitially(panel)
         panel.makeKeyAndOrderFront(nil)
 
@@ -57,7 +64,7 @@ final class PaletteController {
         ) { [weak self] _ in MainActor.assumeIsolated { self?.close() } }
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification, object: panel, queue: .main
-        ) { [weak self] _ in MainActor.assumeIsolated { self?.keepTopAnchored() } }
+        ) { [weak self] _ in MainActor.assumeIsolated { self?.keepCentered() } }
 
         self.panel = panel
     }
@@ -84,12 +91,19 @@ final class PaletteController {
         anchorMaxY = panel.frame.maxY
     }
 
-    private func keepTopAnchored() {
-        guard let panel else { return }
-        var frame = panel.frame
-        if abs(frame.maxY - anchorMaxY) > 0.5 {
-            frame.origin.y = anchorMaxY - frame.height
-            panel.setFrameOrigin(frame.origin)
+    /// Keep the top edge anchored (so the search field doesn't jump as the
+    /// results list grows) while staying horizontally centered on the current
+    /// screen — the results list resizing the panel would otherwise leave a
+    /// first-frame miscenter uncorrected on the X axis.
+    private func keepCentered() {
+        guard let panel, let screen = panel.screen ?? NSScreen.main else { return }
+        var origin = panel.frame.origin
+        let x = screen.visibleFrame.midX - panel.frame.width / 2
+        let y = anchorMaxY - panel.frame.height
+        if abs(origin.x - x) > 0.5 || abs(origin.y - y) > 0.5 {
+            origin.x = x
+            origin.y = y
+            panel.setFrameOrigin(origin)
         }
     }
 }

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -197,6 +197,12 @@ struct SidebarPaletteView: View {
                             FeatureRowView(feature: feature, shortcutIndex: shortcutRank[feature.id])
                         }
                     }
+                    // Distinct identity per body branch: the search, grouped, and
+                    // flat sections all occupy the same List slot, and without
+                    // this SwiftUI recycles one branch's lazy rows into the next
+                    // on a browse→search transition — which dropped rows (e.g.
+                    // "Mirror Screen") from the flat→search switch.
+                    .id("sidebar-search")
                 } else if groupSidebar {
                     // Custom drag-and-drop (not List.onMove, which raced the row
                     // tap gestures and dropped intermittently). In reorder mode a
@@ -208,6 +214,7 @@ struct SidebarPaletteView: View {
                             groupedRow(row, shortcutRank: shortcutRank)
                         }
                     }
+                    .id("sidebar-grouped")
                 } else {
                     // Ungrouped: the flat order (its own `flatOrder`, independent
                     // of groups). Same custom drag/drop as grouped — List.onMove
@@ -217,6 +224,7 @@ struct SidebarPaletteView: View {
                             flatRow(feature, shortcutRank: shortcutRank)
                         }
                     }
+                    .id("sidebar-flat")
                 }
 
                 // Disabled features surface only while searching — usable from
@@ -339,6 +347,11 @@ struct SidebarPaletteView: View {
         }
     }
 
+    /// A search query flattens the list to ranked results, so grouping and
+    /// manual reordering don't apply — their controls are disabled while a query
+    /// is active and re-enable the moment it's cleared.
+    private var isSearching: Bool { !state.searchText.isEmpty }
+
     /// Toggles category grouping in the sidebar. Accent-tinted when grouping is
     /// on; switching off reveals the user's flat drag-to-reorder list.
     private var groupToggleButton: some View {
@@ -352,13 +365,15 @@ struct SidebarPaletteView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(reorderMode)
-        .opacity(reorderMode ? 0.4 : 1)
-        .help(reorderMode
-            ? "Finish reordering to switch grouping"
-            : (groupSidebar
-                ? "Grouped by category — click for a flat, reorderable list"
-                : "Flat list — click to group by category"))
+        .disabled(reorderMode || isSearching)
+        .opacity((reorderMode || isSearching) ? 0.4 : 1)
+        .help(isSearching
+            ? "Clear the search to change grouping"
+            : (reorderMode
+                ? "Finish reordering to switch grouping"
+                : (groupSidebar
+                    ? "Grouped by category — click for a flat, reorderable list"
+                    : "Flat list — click to group by category")))
     }
 
     /// Enters/leaves reorder mode. While on, rows jiggle and can be dragged to
@@ -379,7 +394,11 @@ struct SidebarPaletteView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(reorderMode ? "Done reordering" : "Reorder features — drag rows to rearrange")
+        .disabled(isSearching)
+        .opacity(isSearching ? 0.4 : 1)
+        .help(isSearching
+            ? "Clear the search to reorder features"
+            : (reorderMode ? "Done reordering" : "Reorder features — drag rows to rearrange"))
     }
 
     /// The grouped sidebar flattened to a single list: each non-empty category

--- a/App/Sources/Root/ToastOverlay.swift
+++ b/App/Sources/Root/ToastOverlay.swift
@@ -49,14 +49,7 @@ private struct ToastView: View {
                 .controlSize(.small)
             }
 
-            Button { state.dismissToast(toast.id) } label: {
-                Image(systemName: "xmark")
-                    .font(.caption)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.textMuted)
-            .help("Dismiss")
+            CloseButton(help: "Dismiss") { state.dismissToast(toast.id) }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -71,6 +64,32 @@ private struct ToastView: View {
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(radius: 10, y: 3)
         .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
+
+/// A quiet dismiss button: an `xmark` that grows a subtle circular hover
+/// highlight over an 18×18 hit target, darkening from muted to the main text
+/// color on hover. Shared by the toasts and the notifications panel so every
+/// close affordance matches.
+struct CloseButton: View {
+    let help: String
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(hovering ? AnyShapeStyle(.textMain) : AnyShapeStyle(.textMuted))
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(.textMuted.opacity(hovering ? 0.18 : 0)))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help(help)
     }
 }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -456,7 +456,7 @@ final class AppState {
     var targetSerials: [String] {
         let ready = devices.filter(\.isReady)
         let selected = ready.first { $0.serial == selectedSerial }
-        if runOnAll {
+        if effectiveRunOnAll {
             var serials = ready.map(\.serial)
             if let selected, let index = serials.firstIndex(of: selected.serial) {
                 serials.swapAt(0, index)
@@ -465,6 +465,20 @@ final class AppState {
         }
         return selected.map { [$0.serial] } ?? []
     }
+
+    /// Whether the focused tab's feature offers "Run on all devices". The toggle
+    /// only appears — and only takes effect — for this curated set (see
+    /// `FeatureRegistry.runAllFeatureIDs`); everything else is single-device.
+    var activeFeatureSupportsRunAll: Bool {
+        guard let id = activeTabID, let feature = FeatureRegistry.byID[id] else { return false }
+        return feature.supportsRunAll
+    }
+
+    /// Run-on-all actually in effect: the toggle is on AND the active feature
+    /// supports it. Gating fan-out here (not just on the raw `runOnAll`) means a
+    /// toggle left on from a supported feature can never silently fan out onto a
+    /// single-device one.
+    var effectiveRunOnAll: Bool { runOnAll && activeFeatureSupportsRunAll }
 
     func refreshDevices() {
         Task { await env.monitor.invalidate() }


### PR DESCRIPTION
Fixes a batch of bugs found while testing the tabbed-features build.

## Run on all devices — curate & fix (bug 1)
The "Run on all" toggle showed on every screen with 2+ devices, but fan-out only actually happens for features that dispatch through `AppState.run` (or a view that loops `targetSerials`). Elsewhere it was inert or nonsensical, and it disabled the device picker with no effect.

- Add `supportsRunAll` to `FeatureDef`; set it on the curated set that fans out meaningfully: the **Simulate** and **React Native** hubs (both dispatch their actions through `run`), **Send Text**, and **Install App**.
- The toggle now appears only for those features, and fan-out is gated on a new `effectiveRunOnAll = runOnAll && activeFeatureSupportsRunAll` — a toggle left on for a supported feature can never silently fan out onto a single-device one. The device picker's disable also uses `effectiveRunOnAll`.
- A registry invariant test (`runAllIsTheCuratedFanOutSet`) locks the curated set and keeps it disjoint from the single-device features.

Note: `js-console` and the `apps` hub previously consumed the full `targetSerials` array when the global toggle was on, so they no longer fan out to every device (their toggle is now hidden). That matches "show run-all only for curated features"; say if either should join the curated set.

## Live mirror follows the selected device (bug 2)
Switching the device in the bar left the mirror on the previous device. The reconnect now runs off an explicit `onChange(of: targetSerials.first)` (rather than relying on a `.task(id:)` re-firing inside the mounted-tab ZStack), guarded on the tab being active and **not recording** — a recording stays on its device.

## Close button restyle (bug 3)
The bare `xmark` on toasts and the notifications panel (header + rows) is replaced with a shared `CloseButton`: an X that grows a subtle circular hover highlight over an 18×18 hit target.

## Command palette centering (bug 4)
The ⌘K palette centered against its pre-layout placeholder width and landed off-center. It now lays the content out before centering and re-centers the X axis on resize (keeping the top edge anchored).

## Sidebar search (bugs 5 & 6)
- The search, grouped, and flat body branches now have distinct `Section` identities, so SwiftUI stops recycling one branch's lazy rows into another on a browse→search transition — which dropped rows like **Mirror Screen** from the flat→search switch.
- The group and reorder controls are disabled while a query is active (search shows a flat ranked list where grouping/manual order don't apply).

## Verification
- `cd ADBKit && swift test` — 456 tests green (includes the new run-all invariant).
- `make build` — clean, zero warnings.
- UI behaviors (mirror device-follow, palette centering, close-button hover, sidebar search in both modes) need a quick hand-check on the running app — automation is blocked in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)