### PR TITLE
Prepare v2.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ through Sparkle (and `brew upgrade` defers to that).
 ADBKit/   Swift package — all logic, zero UI dependencies (swift test)
   Exec/         adb process execution, tool location, scoped command log
   Devices/      discovery (2s polling), getprop, hardware/usage overview
-  Features/     declarative 53-feature registry + runners + how-to notes
+  Features/     declarative 54-feature registry + runners + how-to notes
   Services/     logcat streaming, overrides, file/apps explorers, capture,
                 screen record, crash, bug report, wireless, emulators,
                 performance + network monitors, APK inspect/sign/decompile,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,48 @@
+## Droidective v2.8.0
+
+A feature release that adds a tabbed workspace with split panes and a React
+Native JS Console, curates the "Run on all devices" toggle, and fixes a round of
+light-mode and layout issues.
+
+### New features
+
+- **Tabbed workspace with split panes** — open features in tabs (up to ten)
+  instead of one detail pane at a time. Tabs stay mounted while hidden, so a
+  screen recording or a live view keeps running in the background. Split the
+  window into two panes and drag tabs between them, reorder tabs by dragging, and
+  navigate with ⌘T, ⌘W, ⌃Tab, and ⌃1–9. The open tabs and the split layout are
+  restored on the next launch.
+- **React Native JS Console** — a console over the Hermes runtime via the Chrome
+  DevTools Protocol: it connects to a Metro target, streams `console.*` output
+  with syntax-highlighted objects, and evaluates expressions against the running
+  app.
+
+### Improvements
+
+- **Curated "Run on all devices"** — the toggle now appears only for the features
+  where running on every device makes sense (send text, React Native, Simulate,
+  install app) and is hidden elsewhere.
+- **Live mirror follows the active device** — switching the device while
+  mirroring re-targets the mirror instead of staying on the previous one.
+- **Command palette opens centered**, the **sidebar search shows all matches** and
+  locks the group/reorder controls while a query is active, and the **close button
+  on toasts and the notification panel** is a single restyled control.
+
+### Fixes
+
+- **Light-mode colors** — named colors resolve per color scheme, and foreground
+  text now picks black or white by the background's luminance, so labels no longer
+  render white-on-white on light or bright-accent backgrounds (device pill,
+  palette rows, copy buttons, toggle styles).
+- **Simulate** shows an empty state when no device is connected; **Home** feature
+  cards keep their height with short text; **System Restrictions** cards are
+  visible in light mode and no longer reload the whole list on each toggle.
+- Fully tappable rows for **Settings** disclosures and **Screen Record** advanced
+  options; **form action pickers** fill the available width; the **notification
+  panel** slide no longer janks the layout.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.7.1
 
 A bug-fix release: screen mirroring no longer stops when a device can't capture

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.7.1"
+        MARKETING_VERSION: "2.8.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Droidective — All-in-One Android &amp; React Native Debugging Tool for macOS</title>
-  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 53 tools in all, no terminal required." />
+  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 54 tools in all, no terminal required." />
   <meta name="keywords" content="adb tool, android debugging tool, all in one android dev tool, react native debugger, scrcpy gui mac, android developer tool macos, logcat viewer mac, adb gui, mobile dev tool, android emulator manager, react native debugging" />
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
@@ -20,14 +20,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 53 tools, one keystroke away." />
+  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 54 tools, one keystroke away." />
   <meta property="og:url" content="https://droidective.com/" />
   <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 53 tools, one keystroke away. Free & open source." />
+  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 54 tools, one keystroke away. Free & open source." />
   <meta name="twitter:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -41,10 +41,10 @@
     "name": "Droidective",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS 14.0 or later",
-    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 53 tools in all.",
+    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 54 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "2.7.1",
+    "softwareVersion": "2.8.0",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -489,7 +489,7 @@
         <p class="lede">
           Droidective is a native macOS command palette for <strong>Android &amp; React Native</strong>
           debugging over adb. Mirror screens, tail logcat, browse device files, fake any state, and watch
-          performance live — <strong>53 tools</strong>, no terminal required.
+          performance live — <strong>54 tools</strong>, no terminal required.
         </p>
         <div class="cta-row">
           <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
@@ -573,7 +573,7 @@
       <div>
         <span class="eyebrow">the palette</span>
         <h3>One keystroke to everything</h3>
-        <p>Hit <code>⌘K</code> from any screen and fuzzy-search all 53 tools. The device bar follows you, so every command targets the device you mean.</p>
+        <p>Hit <code>⌘K</code> from any screen and fuzzy-search all 54 tools. The device bar follows you, so every command targets the device you mean.</p>
         <ul class="ticks">
           <li><b>Pin favorites</b> and bind global hotkeys</li>
           <li><b>Target one device</b> or fan out to all of them</li>
@@ -635,8 +635,8 @@
         <figcaption><b>Device info</b>RAM, storage, battery health, CPU, and every getprop — searchable.</figcaption>
       </figure>
       <figure>
-        <div class="shot"><img src="assets/screenshot-catalog.webp" alt="Droidective feature catalog listing all 53 tools with on/off toggles" loading="lazy" /></div>
-        <figcaption><b>Feature catalog</b>Toggle, reorder, and pin any of the 53 tools.</figcaption>
+        <div class="shot"><img src="assets/screenshot-catalog.webp" alt="Droidective feature catalog listing all 54 tools with on/off toggles" loading="lazy" /></div>
+        <figcaption><b>Feature catalog</b>Toggle, reorder, and pin any of the 54 tools.</figcaption>
       </figure>
     </div>
   </section>
@@ -665,7 +665,7 @@ Pixel 8     device</pre>
       <div class="step reveal">
         <span class="step-n">03 / go</span>
         <h4>Press ⌘K and run</h4>
-        <p>Search any of the 53 tools and run it. The Setup Doctor confirms your toolchain on first launch.</p>
+        <p>Search any of the 54 tools and run it. The Setup Doctor confirms your toolchain on first launch.</p>
         <pre><span class="c">⌘K</span> mirror screen   ↩</pre>
       </div>
     </div>
@@ -715,11 +715,15 @@ Pixel 8     device</pre>
     <div class="section-head center reveal">
       <span class="eyebrow">changelog</span>
       <h2>Shipped, and still moving.</h2>
-      <p>Twelve releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
+      <p>Thirteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
     </div>
     <div class="timeline reveal">
       <div class="rel latest">
-        <div class="rel-head"><span class="rel-ver">v2.7.1</span><span class="rel-tag">latest</span><span class="rel-date">Jun 2026</span></div>
+        <div class="rel-head"><span class="rel-ver">v2.8.0</span><span class="rel-tag">latest</span><span class="rel-date">Jul 2026</span></div>
+        <p><b>Tabbed workspace with split panes</b> — open features in tabs, keep them running while hidden, and split the window in two — plus a <b>React Native JS Console</b> over the Hermes CDP, a curated <b>Run on all devices</b> toggle, and a round of <b>light-mode fixes</b>.</p>
+      </div>
+      <div class="rel">
+        <div class="rel-head"><span class="rel-ver">v2.7.1</span><span class="rel-date">Jun 2026</span></div>
         <p><b>Screen mirroring on emulators</b> — scrcpy aborted the whole mirror (video included) when a device couldn't capture audio, which is most emulators; the in-app mirror now detects that and reconnects video-only, so it keeps working.</p>
       </div>
       <div class="rel">


### PR DESCRIPTION
Prepares the v2.8.0 release. Rolls up everything on `main` since v2.7.1 into a versioned release: the tabbed workspace with split panes (#87), the React Native JS Console (#86), the feature-tab fixes (#88), and the light-mode/UI bugfixes (#77).

## Changes in this PR

- Bump `MARKETING_VERSION` 2.7.1 → 2.8.0 (`project.yml`)
- Add the `## Droidective v2.8.0` section to `RELEASE_NOTES.md`
- Site (`site/index.html`): `softwareVersion` → 2.8.0, new changelog entry, tool count 53 → 54, releases count updated
- README registry count 53 → 54
- `site/appcast.xml` intentionally **not** touched — CI regenerates and commits it on tag

## Prepare checklist

- [x] `cd ADBKit && swift test` green — 473 tests in 84 suites
- [x] App target and the strict AppTests bundle both build (Xcode 26.2 / Swift 6.2.3)
- [ ] App runs and the changed features verified live against a device/emulator
- [x] `MARKETING_VERSION` bumped to 2.8.0
- [x] `## Droidective v2.8.0` added to `RELEASE_NOTES.md`
- [x] Feature counts updated (registry 53 → 54 in README; CLAUDE.md already at 54; marketing count in site)
- [ ] Screenshots refreshed — the tabbed UI changed the layout; `assets/screenshot-home` / `screenshot-catalog` may need regenerating
- [x] README / CLAUDE.md reflect the new features

## Release (after this merges — not done here)

Tag from `main` to trigger CI (build, sign, notarize, publish DMG + appcast):

```
git tag v2.8.0 && git push origin v2.8.0
```
