### PR TITLE
Fix a batch of UI bugs and add a shared smart-tailing log scroller

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppIconService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppIconService.swift
@@ -40,17 +40,6 @@ public struct AppIconService: Sendable {
         return entries
     }
 
-    /// The entry names out of `unzip -l` output (sizes dropped).
-    public static func parseUnzipListing(_ output: String) -> [String] {
-        parseUnzipEntries(output).map(\.name)
-    }
-
-    /// Name-only convenience — used by the tests; the caller uses the size-aware
-    /// overload so the last-resort fallback can pick the largest raster.
-    public static func pickIconEntry(_ names: [String]) -> String? {
-        pickIconEntry(names.map { IconEntry(name: $0, size: 0) })
-    }
-
     /// Choose the best launcher-icon entry from an APK's file listing. Prefers a
     /// raster `ic_launcher` at the highest density, then round / foreground /
     /// other launcher rasters. When no name matches (resource shrinking flattens

--- a/ADBKit/Sources/ADBKit/Services/AppIconService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppIconService.swift
@@ -18,33 +18,59 @@ public struct AppIconService: Sendable {
         ("hdpi", 3), ("mdpi", 2), ("ldpi", 1), ("nodpi", 0), ("anydpi", 0),
     ]
 
-    /// Parse the `Name` column out of `unzip -l` output, skipping the header,
-    /// separator, and total lines. Each entry line is
-    /// "  <length>  <date>  <time>   <name>" — the header/total lines don't
-    /// start with a numeric length and are dropped.
-    public static func parseUnzipListing(_ output: String) -> [String] {
-        var names: [String] = []
-        for rawLine in output.split(whereSeparator: \.isNewline) {
-            let fields = rawLine.split(separator: " ", omittingEmptySubsequences: true)
-            guard fields.count >= 4, Int(fields[0]) != nil else { continue }
-            let name = fields[3...].joined(separator: " ")
-            if !name.isEmpty {
-                names.append(name)
-            }
-        }
-        return names
+    /// One row of `unzip -l` output: the entry path and its uncompressed size.
+    public struct IconEntry: Sendable, Equatable {
+        public let name: String
+        public let size: Int
     }
 
-    /// Choose the best launcher-icon entry from an APK's file listing. Prefers
-    /// a raster `ic_launcher` at the highest density, then round / foreground /
-    /// any mipmap raster. Returns nil when only vector (.xml) icons exist — the
-    /// caller falls back to a monogram.
-    public static func pickIconEntry(_ entries: [String]) -> String? {
+    /// Parse `unzip -l` rows into (name, size), skipping the header, separator,
+    /// and total lines. Each entry line is "  <length>  <date>  <time>   <name>"
+    /// — header/total lines don't start with a numeric length and are dropped.
+    public static func parseUnzipEntries(_ output: String) -> [IconEntry] {
+        var entries: [IconEntry] = []
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            let fields = rawLine.split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count >= 4, let size = Int(fields[0]) else { continue }
+            let name = fields[3...].joined(separator: " ")
+            if !name.isEmpty {
+                entries.append(IconEntry(name: name, size: size))
+            }
+        }
+        return entries
+    }
+
+    /// The entry names out of `unzip -l` output (sizes dropped).
+    public static func parseUnzipListing(_ output: String) -> [String] {
+        parseUnzipEntries(output).map(\.name)
+    }
+
+    /// Name-only convenience — used by the tests; the caller uses the size-aware
+    /// overload so the last-resort fallback can pick the largest raster.
+    public static func pickIconEntry(_ names: [String]) -> String? {
+        pickIconEntry(names.map { IconEntry(name: $0, size: 0) })
+    }
+
+    /// Choose the best launcher-icon entry from an APK's file listing. Prefers a
+    /// raster `ic_launcher` at the highest density, then round / foreground /
+    /// other launcher rasters. When no name matches (resource shrinking flattens
+    /// names to e.g. `res/xY.png`), falls back to the largest raster living in a
+    /// density resource directory. Returns nil only when the APK ships no raster
+    /// at all (vector-only adaptive icons) — the caller then shows a monogram.
+    public static func pickIconEntry(_ entries: [IconEntry]) -> String? {
         var best: (entry: String, score: Int)?
+        var largestRaster: (entry: String, size: Int)?
         for entry in entries {
-            let lower = entry.lowercased()
+            let lower = entry.name.lowercased()
             guard lower.hasSuffix(".png") || lower.hasSuffix(".webp") else { continue }
             let name = (lower as NSString).lastPathComponent
+            // A raster in an icon density dir is a fallback candidate even when
+            // its name matches nothing (obfuscated/flattened resource names).
+            if lower.contains("/mipmap") || lower.contains("/drawable") {
+                if entry.size > (largestRaster?.size ?? 0) {
+                    largestRaster = (entry.name, entry.size)
+                }
+            }
             let baseScore: Int
             if name == "ic_launcher.png" || name == "ic_launcher.webp" {
                 baseScore = 1000
@@ -54,6 +80,9 @@ public struct AppIconService: Sendable {
                 baseScore = 700
             } else if name.contains("ic_launcher") {
                 baseScore = 750
+            } else if name.contains("launcher") || name.contains("app_icon")
+                || name == "icon.png" || name == "icon.webp" {
+                baseScore = 500
             } else if lower.contains("/mipmap") && name.contains("icon") {
                 baseScore = 300
             } else if lower.contains("/mipmap") {
@@ -63,10 +92,10 @@ public struct AppIconService: Sendable {
             }
             let score = baseScore + density(lower)
             if best == nil || score > best!.score {
-                best = (entry, score)
+                best = (entry.name, score)
             }
         }
-        return best?.entry
+        return best?.entry ?? largestRaster?.entry
     }
 
     static func density(_ path: String) -> Int {
@@ -89,7 +118,7 @@ public struct AppIconService: Sendable {
         ), listing.succeeded else {
             return nil
         }
-        guard let entry = Self.pickIconEntry(Self.parseUnzipListing(listing.stdout)) else {
+        guard let entry = Self.pickIconEntry(Self.parseUnzipEntries(listing.stdout)) else {
             Self.cache(packageId: packageId, data: Data()) // sentinel: no raster icon
             return nil
         }

--- a/ADBKit/Sources/ADBKit/Services/EmulatorService.swift
+++ b/ADBKit/Sources/ADBKit/Services/EmulatorService.swift
@@ -68,7 +68,10 @@ public struct EmulatorService: Sendable {
         }
     }
 
-    /// Launch detached — the emulator outlives the app.
+    /// Launch fully decoupled from the app: the emulator is spawned into its own
+    /// session (`POSIX_SPAWN_SETSID`), so it's a standalone process — not in
+    /// Droidective's process group, unaffected by signals aimed at the app, and
+    /// cleanly outliving it. Its window and Dock icon are the emulator's own.
     public func launch(avd: String, options: LaunchOptions = LaunchOptions()) async -> FeatureResult {
         guard let emulatorPath = await locator.resolve(.emulator) else {
             return FeatureResult(ok: false, message: "Android emulator not found — install it via Android Studio's SDK Manager.")
@@ -81,22 +84,60 @@ public struct EmulatorService: Sendable {
             arguments.append("-wipe-data")
         }
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: emulatorPath)
-        process.arguments = arguments
         var environment = ProcessInfo.processInfo.environment
         let sdkRoot = (emulatorPath as NSString).deletingLastPathComponent
         environment["ANDROID_HOME"] = environment["ANDROID_HOME"] ?? (sdkRoot as NSString).deletingLastPathComponent
-        process.environment = environment
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            return FeatureResult(ok: true, message: "Launching \(avd)…")
-        } catch {
-            return FeatureResult(ok: false, message: "Couldn't launch the emulator: \(error.localizedDescription)")
+
+        return Self.spawnDetached(path: emulatorPath, arguments: arguments, environment: environment)
+            ? FeatureResult(ok: true, message: "Launching \(avd)…")
+            : FeatureResult(ok: false, message: "Couldn't launch the emulator.")
+    }
+
+    /// Spawn a long-lived GUI process in its own session, detached from this app.
+    /// `POSIX_SPAWN_SETSID` makes the child a session/process-group leader, so it
+    /// never receives signals sent to the app's group and survives independently;
+    /// stdio is routed to `/dev/null` so it neither inherits nor holds the app's
+    /// descriptors. Returns false if the spawn fails.
+    static func spawnDetached(path: String, arguments: [String], environment: [String: String]) -> Bool {
+        var attr: posix_spawnattr_t?
+        posix_spawnattr_init(&attr)
+        defer { posix_spawnattr_destroy(&attr) }
+        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETSID))
+
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 1, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 2, "/dev/null", O_WRONLY, 0)
+
+        // Duplicate every argv/envp string, bailing (and freeing what we took) if
+        // any allocation fails — a mid-array nil would otherwise make posix_spawn
+        // silently truncate the arguments instead of failing loudly.
+        var allocations: [UnsafeMutablePointer<CChar>] = []
+        defer { for pointer in allocations { free(pointer) } }
+        func dup(_ string: String) -> UnsafeMutablePointer<CChar>? {
+            guard let copy = strdup(string) else { return nil }
+            allocations.append(copy)
+            return copy
         }
+
+        var argv: [UnsafeMutablePointer<CChar>?] = []
+        for argument in [path] + arguments {
+            guard let copy = dup(argument) else { return false }
+            argv.append(copy)
+        }
+        argv.append(nil)
+
+        var envp: [UnsafeMutablePointer<CChar>?] = []
+        for (key, value) in environment {
+            guard let copy = dup("\(key)=\(value)") else { return false }
+            envp.append(copy)
+        }
+        envp.append(nil)
+
+        var pid: pid_t = 0
+        return posix_spawn(&pid, path, &fileActions, &attr, argv, envp) == 0
     }
 
     /// Graceful shutdown via the emulator console.

--- a/ADBKit/Tests/ADBKitTests/AppIconServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppIconServiceTests.swift
@@ -64,4 +64,48 @@ import Testing
         ]
         #expect(AppIconService.pickIconEntry(entries) == nil)
     }
+
+    @Test func matchesLauncherAndIconNameSynonyms() {
+        // Apps that don't use the ic_launcher convention still resolve.
+        #expect(AppIconService.pickIconEntry(["res/mipmap-xhdpi-v4/app_icon.png"])
+            == "res/mipmap-xhdpi-v4/app_icon.png")
+        #expect(AppIconService.pickIconEntry(["res/drawable-hdpi/launcher.webp"])
+            == "res/drawable-hdpi/launcher.webp")
+    }
+
+    @Test func fallsBackToLargestRasterWhenNamesAreObfuscated() {
+        // Resource shrinking flattens names — no ic_launcher/mipmap/icon match,
+        // so the biggest raster in a density dir wins over smaller ones.
+        let entries = [
+            AppIconService.IconEntry(name: "res/xA.png", size: 900),
+            AppIconService.IconEntry(name: "res/xB.png", size: 12000),
+            AppIconService.IconEntry(name: "res/xB.webp", size: 400),
+            AppIconService.IconEntry(name: "classes.dex", size: 50000),
+        ]
+        // Flat `res/` entries aren't density dirs → no fallback, no crash.
+        #expect(AppIconService.pickIconEntry(entries) == nil)
+
+        let densityEntries = [
+            AppIconService.IconEntry(name: "res/drawable-xxhdpi-v4/xA.png", size: 900),
+            AppIconService.IconEntry(name: "res/drawable-xxhdpi-v4/xB.png", size: 12000),
+            AppIconService.IconEntry(name: "classes.dex", size: 50000),
+        ]
+        #expect(AppIconService.pickIconEntry(densityEntries) == "res/drawable-xxhdpi-v4/xB.png")
+    }
+
+    @Test func parsesEntrySizes() {
+        let output = """
+        Archive:  /data/app/com.example-abc==/base.apk
+          Length      Date    Time    Name
+        ---------  ---------- -----   ----
+             4317  01-01-81 01:01   res/drawable-mdpi-v4/ic_launcher.png
+            23633  01-01-81 01:01   res/drawable-xxxhdpi-v4/ic_launcher.png
+        ---------                     -------
+            27950                     2 files
+        """
+        let entries = AppIconService.parseUnzipEntries(output)
+        #expect(entries.count == 2)
+        #expect(entries.first == AppIconService.IconEntry(name: "res/drawable-mdpi-v4/ic_launcher.png", size: 4317))
+        #expect(entries.last?.size == 23633)
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/AppIconServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppIconServiceTests.swift
@@ -2,6 +2,12 @@ import Testing
 @testable import ADBKit
 
 @Suite struct AppIconParsingTests {
+    /// Name-only convenience for the cases that don't exercise the size-aware
+    /// fallback: wrap bare paths as zero-size entries and call the real picker.
+    private func pick(_ names: [String]) -> String? {
+        AppIconService.pickIconEntry(names.map { AppIconService.IconEntry(name: $0, size: 0) })
+    }
+
     @Test func parsesNamesFromUnzipListing() {
         let output = """
         Archive:  /data/app/com.example-abc==/base.apk
@@ -13,7 +19,7 @@ import Testing
         ---------                     -------
             28462                     3 files
         """
-        let names = AppIconService.parseUnzipListing(output)
+        let names = AppIconService.parseUnzipEntries(output).map(\.name)
         #expect(names.contains("res/drawable-mdpi-v4/ic_launcher.png"))
         #expect(names.contains("res/drawable-xxxhdpi-v4/ic_launcher.png"))
         #expect(names.contains("AndroidManifest.xml"))
@@ -29,7 +35,7 @@ import Testing
             "res/drawable-xhdpi-v4/ic_launcher.png",
             "res/drawable-hdpi-v4/ic_launcher.png",
         ]
-        #expect(AppIconService.pickIconEntry(entries) == "res/drawable-xxxhdpi-v4/ic_launcher.png")
+        #expect(pick(entries) == "res/drawable-xxxhdpi-v4/ic_launcher.png")
     }
 
     @Test func prefersPlainLauncherOverRoundAndForeground() {
@@ -43,7 +49,7 @@ import Testing
             "res/mipmap-hdpi-v4/ic_launcher.png",
         ]
         // Highest-density *plain* ic_launcher wins over round/foreground.
-        #expect(AppIconService.pickIconEntry(entries) == "res/mipmap-hdpi-v4/ic_launcher.png")
+        #expect(pick(entries) == "res/mipmap-hdpi-v4/ic_launcher.png")
     }
 
     @Test func handlesWebpIcons() {
@@ -52,7 +58,7 @@ import Testing
             "res/mipmap-xhdpi-v4/ic_launcher.webp",
             "res/mipmap-hdpi-v4/ic_launcher.webp",
         ]
-        #expect(AppIconService.pickIconEntry(entries) == "res/mipmap-xhdpi-v4/ic_launcher.webp")
+        #expect(pick(entries) == "res/mipmap-xhdpi-v4/ic_launcher.webp")
     }
 
     @Test func returnsNilWhenOnlyVectorIcons() {
@@ -62,14 +68,14 @@ import Testing
             "AndroidManifest.xml",
             "classes.dex",
         ]
-        #expect(AppIconService.pickIconEntry(entries) == nil)
+        #expect(pick(entries) == nil)
     }
 
     @Test func matchesLauncherAndIconNameSynonyms() {
         // Apps that don't use the ic_launcher convention still resolve.
-        #expect(AppIconService.pickIconEntry(["res/mipmap-xhdpi-v4/app_icon.png"])
+        #expect(pick(["res/mipmap-xhdpi-v4/app_icon.png"])
             == "res/mipmap-xhdpi-v4/app_icon.png")
-        #expect(AppIconService.pickIconEntry(["res/drawable-hdpi/launcher.webp"])
+        #expect(pick(["res/drawable-hdpi/launcher.webp"])
             == "res/drawable-hdpi/launcher.webp")
     }
 

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -60,12 +60,18 @@ struct ADTApp: App {
     /// Grow the window's minimum width with whichever side panels are showing,
     /// so the detail pane always keeps at least `detailMinWidth`.
     private var minWindowWidth: CGFloat {
-        let detailMinWidth: CGFloat = 360
+        // A split needs room for two usable panes side by side (2 × 320 + the
+        // seam); a single pane needs one. Without this the split overflows when
+        // the window is small.
+        let detailMinWidth: CGFloat = appState.isSplit ? 648 : 360
         let notifications: CGFloat = appState.showNotifications ? 321 : 0
         let sidebar: CGFloat = appState.sidebarVisible
             ? CGFloat(min(max(sidebarWidth, 300), 460))
             : 0
-        return max(760, sidebar + detailMinWidth + notifications)
+        // The content is laid out at window ÷ fontScale then scaled up, so the
+        // window must be fontScale× wider to give the layout the same logical
+        // room — otherwise zooming in (⌘=) crushes the panes.
+        return max(760, sidebar + detailMinWidth + notifications) * appState.fontScale
     }
 
     init() {

--- a/App/Sources/FeatureDetail/CommandReferenceViews.swift
+++ b/App/Sources/FeatureDetail/CommandReferenceViews.swift
@@ -21,8 +21,9 @@ struct CommandCopyButton: View {
             Image(systemName: copied ? "checkmark" : "doc.on.doc")
                 .foregroundStyle(copied ? Color.brandAccent : Color.textMuted)
         }
-        .buttonStyle(.borderless)
-        .controlSize(.small)
+        // Inline beside caption-sized command text — the small token keeps it on
+        // the text baseline instead of inflating the row.
+        .buttonStyle(IconButtonStyle(size: .small))
         .help("Copy command")
     }
 }
@@ -148,8 +149,7 @@ struct FeatureCommandLog: View {
                     } label: {
                         Image(systemName: "arrow.clockwise")
                     }
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
+                    .buttonStyle(IconButtonStyle())
                     .help("Refresh")
                     if !entries.isEmpty {
                         Button(role: .destructive) {
@@ -157,8 +157,7 @@ struct FeatureCommandLog: View {
                         } label: {
                             Image(systemName: "trash")
                         }
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
+                        .buttonStyle(IconButtonStyle())
                         .help("Clear this feature's history")
                     }
                 }
@@ -237,10 +236,8 @@ struct FeatureCommandBar: View {
                     } label: {
                         Image(systemName: "trash")
                             .foregroundStyle(.textMuted)
-                            .frame(width: 30, height: 26)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(IconButtonStyle())
                     .help("Kill the terminal & minimize")
                 }
 
@@ -250,10 +247,8 @@ struct FeatureCommandBar: View {
                     } label: {
                         Image(systemName: showFeatureNotes ? "info.circle.fill" : "info.circle")
                             .foregroundStyle(showFeatureNotes ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
-                            .frame(width: 30, height: 26)
-                            .contentShape(Rectangle())
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(IconButtonStyle())
                     .help(showFeatureNotes ? "Hide the how-it-works note" : "Show the how-it-works note")
                 }
 
@@ -261,12 +256,9 @@ struct FeatureCommandBar: View {
                     toggleExpanded()
                 } label: {
                     Image(systemName: state.commandBarExpanded ? "chevron.down" : "chevron.up")
-                        .font(.body.weight(.semibold))
                         .foregroundStyle(.textMuted)
-                        .frame(width: 34, height: 26)
-                        .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(IconButtonStyle())
                 .help(state.commandBarExpanded ? "Minimize command bar (⌘J)" : "Expand command bar (⌘J)")
             }
             .padding(.horizontal, 12)

--- a/App/Sources/FeatureDetail/HubKit.swift
+++ b/App/Sources/FeatureDetail/HubKit.swift
@@ -90,9 +90,10 @@ struct HubField: View {
     }
 }
 
-/// The standard scrollable, centered column that holds a screen's `HubSection`s
-/// — a readable max width so content never sprawls across the pane or strands
-/// in a side gutter.
+/// The standard scrollable column that holds a screen's `HubSection`s. It fills
+/// the pane width so the sections never strand in a side gutter — the earlier
+/// fixed max width left a large empty void whenever a pane was wider than it
+/// (a split pane, or the whole window under ⌘= zoom).
 struct HubColumn<Content: View>: View {
     @ViewBuilder private let content: () -> Content
 
@@ -105,8 +106,7 @@ struct HubColumn<Content: View>: View {
             VStack(alignment: .leading, spacing: 16) {
                 content()
             }
-            .frame(maxWidth: 600, alignment: .leading)
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(20)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
@@ -1,0 +1,86 @@
+import ADBKit
+import SwiftUI
+
+/// The JS Console's color palette, matched to Chrome DevTools' dark console.
+///
+/// These are *fixed* colors (not app theme tokens): the log feed is a
+/// self-contained dark console like Chrome's, so error/warning bands, value
+/// syntax colors, and text stay identical regardless of the app's light/dark
+/// theme — the way people picture "the Chrome console". Only the feed area
+/// adopts this; the surrounding bars stay on the app theme.
+enum JSConsoleTheme {
+    /// The console surface (Chrome dark `#282828`).
+    static let background = Color(red: 0.157, green: 0.157, blue: 0.157)
+    /// Default log text (Chrome `#d4d4d4`).
+    static let text = Color(red: 0.831, green: 0.831, blue: 0.839)
+    /// Timestamps, notices, muted glyphs (`#8c8c8c`).
+    static let muted = Color(red: 0.549, green: 0.549, blue: 0.549)
+
+    /// Error rows — light-red text on a dark-red band with a red left rule.
+    static let errorText = Color(red: 1.0, green: 0.502, blue: 0.502)      // #ff8080
+    static let errorBackground = Color(red: 0.204, green: 0.067, blue: 0.067) // #341111
+    static let errorRule = Color(red: 0.643, green: 0.184, blue: 0.184)    // #a42f2f
+
+    /// Warning rows — amber text on a dark-amber band with an amber left rule.
+    static let warningText = Color(red: 0.949, green: 0.753, blue: 0.302)  // #f2c04d
+    static let warningBackground = Color(red: 0.196, green: 0.184, blue: 0.059) // #322f0f
+    static let warningRule = Color(red: 0.643, green: 0.518, blue: 0.129)  // #a48421
+
+    /// Info accent (icon), otherwise info reads as normal text (Chrome `#79b8ff`).
+    static let info = Color(red: 0.475, green: 0.722, blue: 1.0)
+
+    /// ⌘F find highlights — warm yellow, stronger orange for the current match.
+    static let findMatch = Color(red: 0.961, green: 0.773, blue: 0.094)    // #f5c518
+    static let findCurrent = Color(red: 1.0, green: 0.549, blue: 0.102)    // #ff8c1a
+
+    /// Value/token syntax colors, tuned to read on the dark console surface
+    /// (VS Code Dark+ palette — the familiar dark-console value coloring).
+    static func token(_ kind: JSTokenKind) -> Color {
+        switch kind {
+        case .string: Color(red: 0.808, green: 0.569, blue: 0.471)   // #ce9178
+        case .number: Color(red: 0.475, green: 0.753, blue: 1.0)     // #79c0ff
+        case .boolean: Color(red: 0.337, green: 0.612, blue: 0.839)  // #569cd6
+        case .null, .undefined: muted
+        case .function: Color(red: 0.863, green: 0.863, blue: 0.667) // #dcdcaa
+        case .symbol: Color(red: 0.306, green: 0.788, blue: 0.690)   // #4ec9b0
+        case .key: Color(red: 0.612, green: 0.863, blue: 0.996)      // #9cdcfe
+        case .className: Color(red: 0.306, green: 0.788, blue: 0.690) // #4ec9b0
+        case .punctuation: muted
+        case .plain: text
+        }
+    }
+}
+
+extension JSLevel {
+    /// Text color for this level's message on the dark console.
+    var consoleTextColor: Color {
+        switch self {
+        case .error: JSConsoleTheme.errorText
+        case .warning: JSConsoleTheme.warningText
+        case .info: JSConsoleTheme.info
+        case .log: JSConsoleTheme.text
+        case .debug: JSConsoleTheme.muted
+        }
+    }
+
+    /// The row background band + left rule Chrome draws for errors and warnings;
+    /// nil for the levels that render on the plain console surface.
+    var consoleBand: (fill: Color, rule: Color)? {
+        switch self {
+        case .error: (JSConsoleTheme.errorBackground, JSConsoleTheme.errorRule)
+        case .warning: (JSConsoleTheme.warningBackground, JSConsoleTheme.warningRule)
+        default: nil
+        }
+    }
+
+    /// Glyph tint in the row gutter.
+    var consoleIconColor: Color {
+        switch self {
+        case .error: JSConsoleTheme.errorText
+        case .warning: JSConsoleTheme.warningText
+        case .info: JSConsoleTheme.info
+        case .log: JSConsoleTheme.muted
+        case .debug: JSConsoleTheme.muted
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -28,16 +28,6 @@ enum JSLevel: String, CaseIterable, Hashable, Sendable {
         }
     }
 
-    var color: Color {
-        switch self {
-        case .error: .red
-        case .warning: .orange
-        case .info: .blue
-        case .log: .primary
-        case .debug: .secondary
-        }
-    }
-
     var icon: String {
         switch self {
         case .error: "xmark.octagon.fill"
@@ -559,6 +549,7 @@ struct JSConsoleView: View {
     @State private var input = ""
     @State private var portText = ""
     @State private var inputHeight: CGFloat = 26
+    @State private var showLevels = false
     @FocusState private var findFocused: Bool
 
     private var session: JSConsoleSession { state.jsConsoleSession }
@@ -598,11 +589,13 @@ struct JSConsoleView: View {
                 .onKeyPress(.escape) { session.closeFind(); return .handled }
             Text(session.findCountLabel).font(.caption.monospacedDigit()).foregroundStyle(.secondary).fixedSize()
             Button { session.findPrev() } label: { Image(systemName: "chevron.up") }
+                .buttonStyle(IconButtonStyle(size: .small))
                 .disabled(session.findMatchIDs.isEmpty)
             Button { session.findNext() } label: { Image(systemName: "chevron.down") }
+                .buttonStyle(IconButtonStyle(size: .small))
                 .disabled(session.findMatchIDs.isEmpty)
             Button { session.closeFind() } label: { Image(systemName: "xmark.circle.fill") }
-                .buttonStyle(.plain)
+                .buttonStyle(IconButtonStyle(size: .small))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -695,11 +688,7 @@ struct JSConsoleView: View {
     private var filterBar: some View {
         @Bindable var session = state.jsConsoleSession
         return HStack(spacing: 8) {
-            // Inline chips when there's room; a "Levels" dropdown when narrow.
-            ViewThatFits(in: .horizontal) {
-                levelChips
-                levelsMenu
-            }
+            levelFilter
             Spacer(minLength: 8)
             HStack(spacing: 4) {
                 Image(systemName: "line.3.horizontal.decrease.circle").foregroundStyle(.secondary)
@@ -708,104 +697,138 @@ struct JSConsoleView: View {
                     .frame(minWidth: 80, maxWidth: 150)
             }
             Button { session.openFind() } label: { Image(systemName: "text.magnifyingglass") }
+                .buttonStyle(IconButtonStyle())
                 .help("Find & highlight in console (⌘F)")
                 .keyboardShortcut("f", modifiers: .command)
             Button { session.newestFirst.toggle() } label: { Image(systemName: "arrow.up.arrow.down") }
+                .buttonStyle(IconButtonStyle())
                 .help("Order: \(session.newestFirst ? "newest first" : "oldest first") — tap to flip")
             Toggle("Time", isOn: $session.showTimestamps).toggleStyle(.checkbox).font(.caption)
             Button { session.clear() } label: { Image(systemName: "trash") }
+                .buttonStyle(IconButtonStyle())
                 .help("Clear the console")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
     }
 
-    private var levelChips: some View {
-        HStack(spacing: 6) {
-            ForEach(JSLevel.allCases, id: \.self) { level in levelChip(level) }
+    /// Multi-select level filter: one dropdown that toggles several levels at
+    /// once (the popover stays open), with Show-/Hide-all shortcuts. Replaces the
+    /// old per-level chips + reopen-per-toggle menu.
+    private var levelFilter: some View {
+        let shown = JSLevel.allCases.count - session.hiddenLevels.count
+        let allShown = session.hiddenLevels.isEmpty
+        return Button {
+            showLevels.toggle()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                Text(allShown ? "All levels" : "Levels \(shown)/\(JSLevel.allCases.count)")
+                    .fixedSize()
+                Image(systemName: "chevron.down").font(.system(size: 9, weight: .semibold))
+            }
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(allShown ? 0 : 0.7), in: Capsule())
+            .overlay(Capsule().strokeBorder(.secondary.opacity(0.25)))
+            .contentShape(Capsule())
         }
+        .buttonStyle(.plain)
+        .help("Choose which log levels to show")
+        .popover(isPresented: $showLevels, arrowEdge: .bottom) { levelPicker }
     }
 
-    private var levelsMenu: some View {
+    private var levelPicker: some View {
         @Bindable var session = state.jsConsoleSession
-        let shown = JSLevel.allCases.count - session.hiddenLevels.count
-        return Menu {
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Show levels").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
             ForEach(JSLevel.allCases, id: \.self) { level in
-                Toggle(level.label, isOn: Binding(
+                Toggle(isOn: Binding(
                     get: { !session.hiddenLevels.contains(level) },
                     set: { show in
                         if show { session.hiddenLevels.remove(level) } else { session.hiddenLevels.insert(level) }
                     }
-                ))
+                )) {
+                    Label {
+                        Text(level.label)
+                    } icon: {
+                        Image(systemName: level.icon).foregroundStyle(level.consoleIconColor)
+                    }
+                }
+                .toggleStyle(.checkbox)
             }
-        } label: {
-            Label("Levels (\(shown)/\(JSLevel.allCases.count))", systemImage: "line.3.horizontal.decrease.circle")
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
+            Divider()
+            HStack {
+                Button("Show All") { session.hiddenLevels.removeAll() }
+                    .disabled(session.hiddenLevels.isEmpty)
+                Spacer()
+                Button("Hide All") { session.hiddenLevels = Set(JSLevel.allCases) }
+                    .disabled(session.hiddenLevels.count == JSLevel.allCases.count)
+            }
+            .font(.caption)
+            .buttonStyle(.link)
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
-    }
-
-    private func levelChip(_ level: JSLevel) -> some View {
-        let active = !session.hiddenLevels.contains(level)
-        return Button {
-            if active { session.hiddenLevels.insert(level) } else { session.hiddenLevels.remove(level) }
-        } label: {
-            Text(level.label)
-                .font(.caption)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(active ? level.color.opacity(0.18) : .clear, in: Capsule())
-                .foregroundStyle(active ? level.color : .secondary)
-                .overlay(Capsule().strokeBorder(active ? level.color.opacity(0.4) : .secondary.opacity(0.25)))
-        }
-        .buttonStyle(.plain)
-        .help(active ? "Hide \(level.label.lowercased())" : "Show \(level.label.lowercased())")
+        .padding(12)
+        .frame(width: 190)
     }
 
     // MARK: Log area
 
-    @ViewBuilder private var logArea: some View {
+    private var logArea: some View {
         let visible = session.filteredEntries
-        if visible.isEmpty {
-            emptyState.frame(maxWidth: .infinity, maxHeight: .infinity)
+        // The feed is a self-contained Chrome-style dark console: a fixed dark
+        // surface with forced dark scheme, so the rows, level bands, AND the empty
+        // state read the same in the app's light or dark theme.
+        return Group {
+            if visible.isEmpty {
+                emptyState.frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                scrollingLog(visible)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(JSConsoleTheme.background)
+        .environment(\.colorScheme, .dark)
+    }
+
+    /// Newest at the top in "newest first", the bottom otherwise — LogTailView
+    /// tails the correct edge, pauses when the user scrolls off, and drives the
+    /// ⌘F match into view via `focusID`. LazyVStack + `.scrollPosition` (never
+    /// `defaultScrollAnchor`) keeps the big connect-time replay burst from
+    /// laying out every row up front — the 20–30s stall the old flip trick dodged.
+    @ViewBuilder
+    private func scrollingLog(_ visible: [JSEntry]) -> some View {
+        if session.newestFirst {
+            LogTailView(entries: visible.reversed(), newestEdge: .top,
+                        focusID: session.currentFindID) { jsRow($0) }
         } else {
-            scrollingLog(visible)
+            LogTailView(entries: visible, newestEdge: .bottom,
+                        focusID: session.currentFindID) { jsRow($0) }
         }
     }
 
-    /// Inverted-scroll: the LazyVStack iterates newest-first so it only
-    /// materializes the visible (latest) rows — instant even with thousands of
-    /// logs — and a vertical flip makes them read oldest-top / newest-bottom and
-    /// rest at the bottom (Chrome's layout). Newest-first mode drops the flip, so
-    /// the newest stays on top. This avoids `defaultScrollAnchor`, which lays out
-    /// every row up front (the 20–30s stall).
-    private func scrollingLog(_ visible: [JSEntry]) -> some View {
-        let rows = visible.reversed()
-        let inverted = !session.newestFirst
-        let flip: CGFloat = inverted ? -1 : 1
-        return ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(rows) { entry in
-                        JSEntryRow(entry: entry, session: session, showTimestamp: session.showTimestamps)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 3)
-                            .id(entry.id)
-                            .scaleEffect(x: 1, y: flip, anchor: .center)
-                        Divider().opacity(0.25)
-                    }
-                }
-                .padding(.vertical, 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
+    @ViewBuilder
+    private func jsRow(_ entry: JSEntry) -> some View {
+        let band = levelBand(entry)
+        JSEntryRow(entry: entry, session: session, showTimestamp: session.showTimestamps)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(band?.fill ?? .clear)
+            .overlay(alignment: .leading) {
+                if let band { Rectangle().fill(band.rule).frame(width: 3) }
             }
-            .scaleEffect(x: 1, y: flip, anchor: .center)
-            .onChange(of: session.currentFindID) { _, id in
-                guard let id else { return }
-                withAnimation(.easeInOut(duration: 0.15)) { proxy.scrollTo(id, anchor: .center) }
-            }
+        Divider().opacity(0.18)
+    }
+
+    /// The Chrome-style row band (fill + left rule) for error and warning rows;
+    /// nil for the levels that sit on the plain console surface.
+    private func levelBand(_ entry: JSEntry) -> (fill: Color, rule: Color)? {
+        switch entry.kind {
+        case let .log(level, _, _): level.consoleBand
+        case .evalError: (JSConsoleTheme.errorBackground, JSConsoleTheme.errorRule)
+        default: nil
         }
     }
 
@@ -895,7 +918,7 @@ private struct JSEntryRow: View {
             if showTimestamp {
                 Text(entry.at, format: .dateTime.hour().minute().second())
                     .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(JSConsoleTheme.muted)
                     .padding(.top, 1)
             }
         }
@@ -925,15 +948,15 @@ private struct JSEntryRow: View {
     @ViewBuilder private var glyph: some View {
         switch entry.kind {
         case .input:
-            icon("chevron.right", .secondary)
+            icon("chevron.right", JSConsoleTheme.muted)
         case .result:
-            icon("arrow.turn.down.right", .secondary)
+            icon("arrow.turn.down.right", JSConsoleTheme.muted)
         case .evalError:
-            icon("xmark.octagon.fill", .red)
+            icon("xmark.octagon.fill", JSConsoleTheme.errorText)
         case let .log(level, _, _):
-            icon(level.icon, level.color)
+            icon(level.icon, level.consoleIconColor)
         case .notice:
-            icon("info.circle", .tertiary)
+            icon("info.circle", JSConsoleTheme.muted)
         }
     }
 
@@ -948,7 +971,7 @@ private struct JSEntryRow: View {
     @ViewBuilder private var content: some View {
         switch entry.kind {
         case let .input(text):
-            line(text, base: .secondary)
+            line(text, base: JSConsoleTheme.muted)
         case let .result(object):
             JSValueView(object: object, session: session)
         case let .evalError(details):
@@ -956,7 +979,7 @@ private struct JSEntryRow: View {
         case let .log(level, args, stack):
             logContent(level: level, args: args, stack: stack)
         case let .notice(text):
-            line(text, base: .secondary)
+            line(text, base: JSConsoleTheme.muted)
         }
     }
 
@@ -972,7 +995,7 @@ private struct JSEntryRow: View {
             // Errors/warnings keep their level tint as a signal; normal logs get
             // VSCode-style per-type syntax colors.
             if level == .error || level == .warning {
-                line(args.map(\.inlineSummary).joined(separator: " "), base: level.color)
+                line(args.map(\.inlineSummary).joined(separator: " "), base: level.consoleTextColor)
             } else {
                 coloredTokenText(argTokens(args), query: query, current: isCurrentFind)
                     .font(.system(.callout, design: .monospaced))
@@ -999,7 +1022,7 @@ private struct JSEntryRow: View {
 
     private func errorContent(_ details: ExceptionDetails) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            line(details.message, base: .red)
+            line(details.message, base: JSConsoleTheme.errorText)
             if let stack = details.stackTrace { StackView(stack: stack) }
         }
     }
@@ -1109,7 +1132,7 @@ private struct StackView: View {
             ForEach(stack.callFrames.prefix(8)) { frame in
                 Text(frame.display)
                     .font(.caption2.monospaced())
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(JSConsoleTheme.muted)
             }
         }
         .padding(.leading, 4)
@@ -1247,21 +1270,10 @@ func copyToPasteboard(_ string: String) {
     NSPasteboard.general.setString(string, forType: .string)
 }
 
-/// VSCode/Chrome-style colors per token kind. Mid-tones chosen to read on both
-/// light and dark backgrounds.
+/// Value/token colors — the Chrome dark-console palette (see `JSConsoleTheme`),
+/// since the feed renders on a fixed dark surface.
 func jsColor(_ kind: JSTokenKind) -> Color {
-    switch kind {
-    case .string: Color(red: 0.76, green: 0.30, blue: 0.27)
-    case .number: Color(red: 0.16, green: 0.44, blue: 0.84)
-    case .boolean: Color(red: 0.50, green: 0.30, blue: 0.78)
-    case .null, .undefined: .secondary
-    case .function: Color(red: 0.62, green: 0.40, blue: 0.0)
-    case .symbol: Color(red: 0.0, green: 0.50, blue: 0.45)
-    case .key: Color(red: 0.55, green: 0.18, blue: 0.55)
-    case .className: Color(red: 0.0, green: 0.50, blue: 0.45)
-    case .punctuation: .secondary
-    case .plain: .primary
-    }
+    JSConsoleTheme.token(kind)
 }
 
 /// Syntax-colored `Text` for a value's tokens, with find matches highlighted.
@@ -1301,7 +1313,7 @@ func applyFindHighlight(_ attr: inout AttributedString, query: String, current: 
     for (low, high) in offsets {
         let lower = attr.index(attr.startIndex, offsetByCharacters: low)
         let upper = attr.index(attr.startIndex, offsetByCharacters: high)
-        attr[lower ..< upper].backgroundColor = current ? .orange : .yellow
+        attr[lower ..< upper].backgroundColor = current ? JSConsoleTheme.findCurrent : JSConsoleTheme.findMatch
         attr[lower ..< upper].foregroundColor = .black
     }
 }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -132,6 +132,12 @@ final class JSConsoleSession {
     private var welcomedDeviceId: String?
     private var hasWelcomed = false
     private var serials: [String] = []
+    /// port → serials we installed a `reverse tcp:<port>` binding on, so closing
+    /// the tab can remove each. A tab *switch* keeps them — re-adding the reverse
+    /// on every switch would be surprising, and the binding is what lets the
+    /// device keep reaching Metro. Keyed by port so changing the port and
+    /// re-reversing doesn't orphan the earlier binding.
+    @ObservationIgnored private var reversedTunnels: [Int: Set<String>] = [:]
     weak var app: AppState?
 
     var isConnected: Bool { connectedTarget != nil }
@@ -404,16 +410,18 @@ final class JSConsoleSession {
         guard !serials.isEmpty else { return }
         let metroPort = port
         let serials = serials
-        let ok = await CommandLog.userInitiated(feature: "js-console") {
-            var succeeded = 0
+        let reversed = await CommandLog.userInitiated(feature: "js-console") {
+            var reversed: Set<String> = []
             for serial in serials {
                 if let result = try? await adb.run(on: serial, ["reverse", "tcp:\(metroPort)", "tcp:\(metroPort)"]),
                    result.succeeded {
-                    succeeded += 1
+                    reversed.insert(serial)
                 }
             }
-            return succeeded
+            return reversed
         }
+        if !reversed.isEmpty { reversedTunnels[metroPort, default: []].formUnion(reversed) }
+        let ok = reversed.count
         let allOK = ok == serials.count
         app?.showToast(Toast(
             message: allOK
@@ -421,6 +429,19 @@ final class JSConsoleSession {
                 : "Reversed tcp:\(metroPort) on \(ok) of \(serials.count) devices — check the others are connected.",
             ok: allOK
         ))
+    }
+
+    /// Remove the `adb reverse` bindings this console installed. Called when the
+    /// tab closes (mirrors `ReactotronService.stop`), not on a tab switch.
+    func removeReverseTunnels() async {
+        guard !reversedTunnels.isEmpty else { return }
+        let tunnels = reversedTunnels
+        reversedTunnels = [:]
+        for (metroPort, serials) in tunnels {
+            for serial in serials {
+                _ = try? await adb.run(on: serial, ["reverse", "--remove", "tcp:\(metroPort)"])
+            }
+        }
     }
 
     // MARK: Derived feed (cached)

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -16,9 +16,6 @@ struct LogcatView: View {
     @State private var search = ""
     @State private var waitingForPackage: String?
     @State private var streamingPid: Int?
-    /// True while pinned to the bottom; scrolling up unpins.
-    @State private var following = true
-    @State private var newSinceUnfollow = 0
 
     private static let levels: [(value: String, label: String)] = [
         ("All", "All levels"), ("V", "Verbose"), ("D", "Debug"),
@@ -78,6 +75,7 @@ struct LogcatView: View {
             } label: {
                 Image(systemName: paused ? "play.fill" : "pause.fill")
             }
+            .buttonStyle(IconButtonStyle())
             .help(paused ? "Resume (new lines are dropped while paused)" : "Pause")
 
             Button {
@@ -85,15 +83,16 @@ struct LogcatView: View {
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
+            .buttonStyle(IconButtonStyle())
             .help("Export buffer to ~/Downloads/Droidective")
             .disabled(lines.isEmpty)
 
             Button {
                 lines.removeAll()
-                newSinceUnfollow = 0
             } label: {
                 Image(systemName: "trash")
             }
+            .buttonStyle(IconButtonStyle())
             .help("Clear")
         }
         .controlSize(.small)
@@ -179,66 +178,27 @@ struct LogcatView: View {
     }
 
     private var logList: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(visibleLines) { line in
-                        Text(attributedDisplay(line))
-                            .font(.system(size: 11, design: .monospaced))
-                            .foregroundStyle(color(for: line.level))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .id(line.id)
-                            .contextMenu {
-                                if !line.tag.isEmpty {
-                                    Button("Filter by tag \"\(line.tag)\"") {
-                                        tagFilter = line.tag
-                                    }
-                                }
-                                Button("Copy line") {
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(line.raw, forType: .string)
-                                }
-                            }
+        // Newest lines append at the bottom; LogTailView follows them while the
+        // user is at the bottom and pauses the moment they scroll up.
+        LogTailView(entries: visibleLines, newestEdge: .bottom) { line in
+            Text(attributedDisplay(line))
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(color(for: line.level))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+                .contextMenu {
+                    if !line.tag.isEmpty {
+                        Button("Filter by tag \"\(line.tag)\"") { tagFilter = line.tag }
                     }
-                    // Bottom sentinel: visible = pinned to bottom.
-                    Color.clear
-                        .frame(height: 1)
-                        .id("logcat-bottom")
-                        .onAppear {
-                            following = true
-                            newSinceUnfollow = 0
-                        }
-                        .onDisappear { following = false }
-                }
-                .padding(8)
-            }
-            .background(.background)
-            .overlay { emptyOverlay }
-            .overlay(alignment: .bottom) {
-                if !following && newSinceUnfollow > 0 {
-                    Button {
-                        proxy.scrollTo("logcat-bottom", anchor: .bottom)
-                        following = true
-                        newSinceUnfollow = 0
-                    } label: {
-                        Label("\(newSinceUnfollow) new lines", systemImage: "arrow.down")
-                            .font(.caption.weight(.medium))
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 5)
-                            .background(Color.bgSurface, in: Capsule())
-                            .shadow(radius: 4, y: 1)
+                    Button("Copy line") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(line.raw, forType: .string)
                     }
-                    .buttonStyle(.plain)
-                    .padding(.bottom, 10)
                 }
-            }
-            .onChange(of: lines.last?.id) {
-                if following, !paused {
-                    proxy.scrollTo("logcat-bottom", anchor: .bottom)
-                }
-            }
         }
+        .background(.background)
+        .overlay { emptyOverlay }
     }
 
     /// Search matches get a highlight instead of vanishing into the filter.
@@ -372,9 +332,6 @@ struct LogcatView: View {
                 if Task.isCancelled { break }
                 if paused { continue }
                 lines.append(contentsOf: batch)
-                if !following {
-                    newSinceUnfollow += batch.count
-                }
                 if lines.count > Self.maxLines {
                     lines.removeFirst(lines.count - Self.maxLines)
                 }

--- a/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
+++ b/App/Sources/FeatureDetail/Views/PrivateDnsView.swift
@@ -32,6 +32,7 @@ struct PrivateDnsSection: View {
                     .disabled(busy || !loaded || state.targetSerials.isEmpty
                         || (mode == .hostname && hostname.trimmingCharacters(in: .whitespaces).isEmpty))
                 Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
+                    .buttonStyle(IconButtonStyle())
                     .help("Refresh")
                     .disabled(busy || state.targetSerials.isEmpty)
                 if busy { ProgressView().controlSize(.small) }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -755,7 +755,7 @@ struct ReactotronView: View {
                     Text("REPL").font(.system(size: 13, weight: .semibold))
                     Spacer()
                     Button { session.sendReplLs() } label: { Image(systemName: "arrow.clockwise") }
-                        .controlSize(.small)
+                        .buttonStyle(IconButtonStyle())
                         .help("Refresh available values")
                 }
                 Text("Evaluate JS against values your app registered with `Reactotron.repl(name, value)`.")
@@ -901,7 +901,6 @@ private struct TimelinePane: View {
 
     @State private var search = ""
     @State private var filter: RtFilter = .all
-    @State private var following = true
     @State private var newestFirst = true
 
     var body: some View {
@@ -937,16 +936,17 @@ private struct TimelinePane: View {
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
+            .buttonStyle(IconButtonStyle())
             .help("Export this pane's filtered timeline to JSON")
             .disabled(visibleItems.isEmpty)
 
             Button {
                 newestFirst.toggle()
-                following = true
             } label: {
                 Image(systemName: "arrow.up.arrow.down")
                     .foregroundStyle(newestFirst ? Color.brandAccent : Color.secondary)
             }
+            .buttonStyle(IconButtonStyle())
             .help(newestFirst ? "Newest first — click for oldest first" : "Oldest first — click for newest first")
         }
         .controlSize(.small)
@@ -966,34 +966,15 @@ private struct TimelinePane: View {
         newestFirst ? Array(visibleItems.reversed()) : visibleItems
     }
 
-    private var scrollAnchorID: String { newestFirst ? "rt-top" : "rt-bottom" }
-
     private var timeline: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    Color.clear.frame(height: 1).id("rt-top")
-                    ForEach(orderedItems) { item in
-                        RtRow(item: item)
-                        Divider()
-                    }
-                    Color.clear
-                        .frame(height: 1)
-                        .id("rt-bottom")
-                        .onAppear { if !newestFirst { following = true } }
-                        .onDisappear { if !newestFirst { following = false } }
-                }
-            }
-            .background(.background)
-            .overlay { emptyOverlay }
-            .onChange(of: items.last?.id) {
-                guard following else { return }
-                proxy.scrollTo(scrollAnchorID, anchor: newestFirst ? .top : .bottom)
-            }
-            .onChange(of: newestFirst) {
-                proxy.scrollTo(scrollAnchorID, anchor: newestFirst ? .top : .bottom)
-            }
+        // Newest events land at the top in newest-first, the bottom otherwise —
+        // LogTailView follows whichever edge and pauses when the user scrolls off.
+        LogTailView(entries: orderedItems, newestEdge: newestFirst ? .top : .bottom) { item in
+            RtRow(item: item)
+            Divider()
         }
+        .background(.background)
+        .overlay { emptyOverlay }
     }
 
     @ViewBuilder

--- a/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
+++ b/App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift
@@ -34,7 +34,7 @@ struct SystemRestrictionsView: View {
                 Button {
                     Task { await refresh() }
                 } label: { Image(systemName: "arrow.clockwise") }
-                    .buttonStyle(.borderless)
+                    .buttonStyle(IconButtonStyle())
                     .help("Refresh")
                     .disabled(refreshBusy)
             }) {

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -85,6 +85,9 @@ struct TourView: View {
             Button("Skip") { finish() }
                 .buttonStyle(.plain)
                 .foregroundStyle(.textMuted)
+                // A quiet, secondary action — suppress the accent-colored
+                // keyboard focus ring so it doesn't read as a primary button.
+                .focusEffectDisabled()
                 .opacity(isLast ? 0 : 1)
 
             Spacer()

--- a/App/Sources/FeatureDetail/Views/WiFiView.swift
+++ b/App/Sources/FeatureDetail/Views/WiFiView.swift
@@ -62,7 +62,7 @@ struct WiFiView: View {
             }
             Spacer()
             Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
-                .buttonStyle(.borderless)
+                .buttonStyle(IconButtonStyle())
                 .help("Refresh")
                 .disabled(busy)
             Toggle("", isOn: Binding(get: { status?.enabled ?? false }, set: { on in Task { await setWifi(on) } }))
@@ -153,10 +153,10 @@ struct WiFiView: View {
                 Button { toggleReveal(net.ssid) } label: {
                     Image(systemName: revealed.contains(net.ssid) ? "eye.slash" : "eye")
                 }
-                .buttonStyle(.borderless)
+                .buttonStyle(IconButtonStyle())
                 .help(revealed.contains(net.ssid) ? "Hide" : "Reveal")
                 Button { copy(password) } label: { Image(systemName: "doc.on.doc") }
-                    .buttonStyle(.borderless)
+                    .buttonStyle(IconButtonStyle())
                     .help("Copy password")
             }
         }

--- a/App/Sources/IconButton.swift
+++ b/App/Sources/IconButton.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// The app's icon-button sizing standard. Every icon-only button (toolbars,
+/// bars, inline dismiss/clear glyphs) uses one of these tokens instead of ad-hoc
+/// `.frame`/`.font`/`.controlSize` values, so glyph sizes and hit areas stay
+/// consistent across every feature. Pair with ``IconButtonStyle``.
+enum IconButtonSize {
+    /// Inline glyphs living inside a text bar or chip — clear-search, remove a
+    /// filter, close a find bar.
+    case small
+    /// The default: toolbar and status-bar action icons.
+    case medium
+    /// Prominent, standalone actions.
+    case large
+
+    /// Square clickable frame (points).
+    var side: CGFloat {
+        switch self {
+        case .small: 22
+        case .medium: 28
+        case .large: 34
+        }
+    }
+
+    /// SF Symbol point size (points).
+    var glyph: CGFloat {
+        switch self {
+        case .small: 12
+        case .medium: 14
+        case .large: 17
+        }
+    }
+}
+
+/// A borderless icon-only button: a consistent glyph size, a square hit area, and
+/// a subtle hover/press wash. The single source of truth for icon-button sizing
+/// — see ``IconButtonSize``. The glyph color is inherited (so `.brandAccent` /
+/// `.textMuted` at the call site still apply); only the geometry is standardized.
+///
+/// ```swift
+/// Button { clear() } label: { Image(systemName: "trash") }
+///     .buttonStyle(IconButtonStyle())
+/// ```
+struct IconButtonStyle: ButtonStyle {
+    var size: IconButtonSize = .medium
+
+    func makeBody(configuration: Configuration) -> some View {
+        IconButtonBody(configuration: configuration, size: size)
+    }
+}
+
+/// Backs ``IconButtonStyle`` — a small view so the hover state can live in
+/// `@State` (a `ButtonStyle` body can't hold state directly).
+private struct IconButtonBody: View {
+    let configuration: ButtonStyleConfiguration
+    let size: IconButtonSize
+    @State private var hovering = false
+
+    var body: some View {
+        configuration.label
+            .font(.system(size: size.glyph, weight: .medium))
+            .frame(width: size.side, height: size.side)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.primary.opacity(configuration.isPressed ? 0.14 : (hovering ? 0.07 : 0)))
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .onHover { hovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: hovering)
+    }
+}

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// A log viewer with directional smart-tailing, shared by every streaming feed
+/// (Logcat, Reactotron, JS Console).
+///
+/// - `entries` are in display order (top → bottom); `newestEdge` says which end
+///   new lines land on, so the same view tails *down* (newest at bottom) or *up*
+///   (newest at top) — the auto-scroll target follows the newest line.
+/// - While the user is parked at the newest edge it follows new lines; the
+///   instant they scroll away it pauses (their reading wins); returning to the
+///   edge resumes. A "jump to newest" button shows only while paused.
+/// - `focusID` scrolls an externally-selected row (e.g. a ⌘F match) into view.
+///
+/// Performance: rows are always laid out **newest-first**, so the newest line
+/// rests at the scroll view's offset 0. For `newestEdge == .bottom` the view is
+/// flipped vertically so it still *reads* oldest-top / newest-bottom. That turns
+/// tailing into "scroll to the first row" (offset 0 — cheap) instead of "scroll
+/// to the last row of a huge lazy list", which forces a full layout pass — the
+/// 20–30s stall a big connect-time replay burst would otherwise cause. Combined
+/// with `LazyVStack`, it stays smooth with a full ring buffer.
+struct LogTailView<Data: RandomAccessCollection, Row: View>: View
+    where Data.Element: Identifiable {
+
+    let entries: Data
+    var newestEdge: VerticalEdge = .bottom
+    /// Optional externally-driven scroll target (e.g. a ⌘F search match). Jumping
+    /// to it moves off the newest edge, so tailing naturally pauses until the
+    /// user returns. Callers that don't need it leave it nil.
+    var focusID: Data.Element.ID? = nil
+    @ViewBuilder var row: (Data.Element) -> Row
+
+    /// The row at the scroll's leading (offset-0) edge — the newest side. nil
+    /// before the first layout.
+    @State private var leadingID: Data.Element.ID?
+    /// True while the newest line sits at that edge (the user is tailing). Updated
+    /// only from real position changes, so an append — which moves the "newest" id
+    /// before the binding catches up — can't flip it falsely.
+    @State private var isTailing = true
+
+    /// The newest entry: `.bottom` feeds arrive at the end of `entries`, `.top`
+    /// feeds at the front. Either way it becomes the first row laid out below.
+    private var newestID: Data.Element.ID? {
+        newestEdge == .bottom ? entries.last?.id : entries.first?.id
+    }
+
+    /// -1 flips `.bottom` feeds so a newest-first layout reads newest-at-bottom.
+    private var flip: CGFloat { newestEdge == .bottom ? -1 : 1 }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) { orderedRows }
+                    .scrollTargetLayout()
+            }
+            .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest
+            .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds
+            .onAppear { leadingID = newestID }
+            .onChange(of: leadingID) { _, id in isTailing = (id == newestID) }
+            .onChange(of: newestID) { _, newest in
+                if isTailing, let newest { leadingID = newest }   // cheap: first row, offset 0
+            }
+            .onChange(of: newestEdge) { isTailing = true; leadingID = newestID }
+            .onChange(of: focusID) { _, id in
+                guard let id else { return }
+                withAnimation(.easeInOut(duration: 0.15)) { proxy.scrollTo(id, anchor: .center) }
+            }
+            .overlay(alignment: newestEdge == .bottom ? .bottomTrailing : .topTrailing) {
+                if !isTailing {
+                    jumpButton
+                        .padding(16)
+                        .transition(.scale(scale: 0.85).combined(with: .opacity))
+                }
+            }
+            .animation(.snappy(duration: 0.2), value: isTailing)
+        }
+    }
+
+    /// Rows laid out newest-first. `.bottom` feeds reverse the display order and
+    /// un-flip each row (the scroll view flip above mirrors the whole stack).
+    @ViewBuilder private var orderedRows: some View {
+        if newestEdge == .bottom {
+            ForEach(entries.reversed()) { entry in
+                row(entry).scaleEffect(x: 1, y: -1, anchor: .center)
+            }
+        } else {
+            ForEach(entries) { entry in
+                row(entry)
+            }
+        }
+    }
+
+    private var jumpButton: some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.25)) { leadingID = newestID }
+        } label: {
+            Image(systemName: newestEdge == .bottom ? "arrow.down" : "arrow.up")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(.tint, in: Circle())
+                .shadow(radius: 4, y: 2)
+        }
+        .buttonStyle(.plain)
+        .help("Jump to the newest logs")
+        .accessibilityLabel("Jump to newest")
+    }
+}

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -24,8 +24,9 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
     let entries: Data
     var newestEdge: VerticalEdge = .bottom
     /// Optional externally-driven scroll target (e.g. a ⌘F search match). Jumping
-    /// to it moves off the newest edge, so tailing naturally pauses until the
-    /// user returns. Callers that don't need it leave it nil.
+    /// to a row other than the newest pauses tailing (so an incoming line can't
+    /// yank the view back off the match); returning to the edge resumes. Callers
+    /// that don't need it leave it nil.
     var focusID: Data.Element.ID? = nil
     @ViewBuilder var row: (Data.Element) -> Row
 
@@ -62,6 +63,10 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             .onChange(of: newestEdge) { isTailing = true; leadingID = newestID }
             .onChange(of: focusID) { _, id in
                 guard let id else { return }
+                // `scrollTo` doesn't write back into `leadingID`, so stop tailing
+                // here unless the target *is* the newest row — otherwise the next
+                // append would fire the follower and snap us off the match.
+                isTailing = (id == newestID)
                 withAnimation(.easeInOut(duration: 0.15)) { proxy.scrollTo(id, anchor: .center) }
             }
             .overlay(alignment: newestEdge == .bottom ? .bottomTrailing : .topTrailing) {

--- a/App/Sources/Root/BundleManagerView.swift
+++ b/App/Sources/Root/BundleManagerView.swift
@@ -37,14 +37,14 @@ struct BundleManagerView: View {
                         } label: {
                             Image(systemName: "pencil")
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(IconButtonStyle())
                         Button {
                             state.removeBundle(id: bundle.id)
                         } label: {
                             Image(systemName: "trash")
                                 .foregroundStyle(.red)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(IconButtonStyle())
                     }
                 }
                 .frame(minHeight: 120, maxHeight: 200)

--- a/App/Sources/Root/CommandLogView.swift
+++ b/App/Sources/Root/CommandLogView.swift
@@ -19,6 +19,7 @@ struct CommandLogView: View {
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
+                .buttonStyle(IconButtonStyle())
                 Button(role: .destructive) {
                     Task {
                         await state.env.commandLog.clear()
@@ -27,6 +28,7 @@ struct CommandLogView: View {
                 } label: {
                     Image(systemName: "trash")
                 }
+                .buttonStyle(IconButtonStyle())
                 Button("Close") { dismiss() }
             }
             .padding(12)

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -19,11 +19,9 @@ struct DeviceBarView: View {
                 state.toggleSidebar()
             } label: {
                 Image(systemName: "sidebar.left")
-                    .font(.title3)
-                    .frame(width: 30, height: 24)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
+            .buttonStyle(IconButtonStyle())
             .help("Show or hide the sidebar (⌘B)")
 
             Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 8) {
@@ -75,7 +73,7 @@ struct DeviceBarView: View {
                         Image(systemName: "arrow.triangle.2.circlepath")
                             .rotationEffect(.degrees(refreshSpin))
                     }
-                    .controlSize(.small)
+                    .buttonStyle(IconButtonStyle())
                     .help("Refresh devices")
 
                     NotificationBell()

--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -127,8 +127,6 @@ struct NotificationBell: View {
             state.toggleNotifications()
         } label: {
             Image(systemName: state.showNotifications ? "bell.fill" : "bell")
-                .font(.body)
-                .frame(width: 24, height: 22)
                 .overlay(alignment: .topTrailing) {
                     if state.unreadNotifications > 0 && !state.showNotifications {
                         Text(state.unreadNotifications > 99 ? "99+" : "\(state.unreadNotifications)")
@@ -143,7 +141,7 @@ struct NotificationBell: View {
                 }
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(IconButtonStyle())
         .foregroundStyle(state.showNotifications ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
         .help(state.showNotifications ? "Hide notifications" : "Show notifications")
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -332,9 +332,12 @@ struct RootView: View {
 
     private func splitLeftWidth(_ totalW: CGFloat) -> CGFloat {
         let dividerW: CGFloat = 8
-        let minPane: CGFloat = 320
-        let available = totalW - dividerW
-        return min(max(available * splitFraction, minPane), max(minPane, available - minPane))
+        let available = max(0, totalW - dividerW)
+        // Never claim more than half the width per pane, so a tight pane area — a
+        // small window, or a high font zoom shrinking the logical width — shrinks
+        // both panes evenly instead of overflowing the right one off-screen.
+        let minPane = min(320, available / 2)
+        return min(max(available * splitFraction, minPane), available - minPane)
     }
 
     private var activeTitle: String {

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -359,12 +359,10 @@ struct SidebarPaletteView: View {
             groupSidebar.toggle()
         } label: {
             Image(systemName: groupSidebar ? "list.bullet.indent" : "list.bullet")
-                .font(.title3)
                 .foregroundStyle(groupSidebar ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
-                .frame(width: 30, height: 30)
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(IconButtonStyle())
         .disabled(reorderMode || isSearching)
         .opacity((reorderMode || isSearching) ? 0.4 : 1)
         .help(isSearching
@@ -384,16 +382,14 @@ struct SidebarPaletteView: View {
             withAnimation(.easeInOut(duration: 0.2)) { reorderMode.toggle() }
         } label: {
             Image(systemName: "arrow.up.arrow.down")
-                .font(.title3)
                 .foregroundStyle(reorderMode ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
-                .frame(width: 30, height: 30)
                 .background(
                     reorderMode ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear),
                     in: RoundedRectangle(cornerRadius: 7)
                 )
                 .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(IconButtonStyle())
         .disabled(isSearching)
         .opacity(isSearching ? 0.4 : 1)
         .help(isSearching

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -638,6 +638,9 @@ final class AppState {
         if id == "reactotron", reactotronSession.isRunning {
             Task { await reactotronSession.stop() }
         }
+        if id == "js-console" {
+            Task { await jsConsoleSession.removeReverseTunnels() }
+        }
     }
 
     private func persistTabs() {

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -625,7 +625,19 @@ final class AppState {
 
     private func performClose(_ id: String) {
         workspace.close(id)
+        stopBackgroundWork(for: id)
         persistTabs()
+    }
+
+    /// Closing a tab fully stops that feature's background work. Most features
+    /// stop when their view unmounts (their `.task` is cancelled on close), but a
+    /// few sessions are owned here and kept alive across tab *switches* — so
+    /// closing their tab has to tear them down explicitly. A feature is open in at
+    /// most one tab, so once it's closed no other tab still needs it.
+    private func stopBackgroundWork(for id: String) {
+        if id == "reactotron", reactotronSession.isRunning {
+            Task { await reactotronSession.stop() }
+        }
     }
 
     private func persistTabs() {


### PR DESCRIPTION
## Summary

A sweep of UI bug fixes, plus a shared log scroller that now backs all three streaming feeds (Logcat, Reactotron, JS console).

## Changes

**Icon-button standard (bug 1)** — new `IconButtonStyle` with `small`/`medium`/`large` tokens, applied to the icon-only action buttons across the app. Fixes the too-small Logcat toolbar buttons and unifies glyph size + hover across toolbars.

**Emulator launch (bug 2)** — `EmulatorService` now spawns the emulator via `posix_spawn` with `POSIX_SPAWN_SETSID`, so it runs in its own session, decoupled from Droidective (it outlives app quit; stdio is routed to `/dev/null`).

**Shared smart-tailing scroller (bug 3)** — new `LogTailView`, adopted by Logcat, Reactotron, and the JS console. It follows the newest edge (top or bottom, per sort order), pauses the moment the user scrolls away, and shows a jump-to-newest button. Rows lay out newest-first and the bottom case is flipped, so tailing is a cheap scroll to the first row rather than a full lazy-layout pass over a large buffer (avoids the connect-burst layout stall). Replaces the bespoke follow logic in all three views. A ⌘F focus jump pauses tailing (it stays parked on the match) until the user returns to the newest edge.

**Welcome tour (bug 4)** — the Skip button no longer shows the accent-colored focus ring.

**JS console filter + styling (bugs 5, 6)** — the per-level chips/menu are replaced by a multi-select dropdown; the feed is restyled to Chrome DevTools' dark console (row bands for error/warning, value syntax colors, muted timestamps) via a fixed `JSConsoleTheme`.

**App icons (bug 7)** — broadened extraction: drawable density dirs, `launcher`/`app_icon`/`icon` name synonyms, and a size-aware fallback that picks the largest raster in a density dir for obfuscated resource names. Adds an entry-size parser and tests.

**Split window (bug 8)** — hub screens fill the pane (dropped the fixed 600pt content cap) and the window minimum width is split- and font-scale-aware, so the split no longer breaks when resizing a pane or zooming with ⌘=.

**Tab-close teardown (enhancement)** — closing a tab stops that feature's background work: the Reactotron server and its adb reverse tunnels, and the JS console's `adb reverse` bindings (tracked per port), which were previously kept alive across tab switches.

## Tests

- ADBKit: 476 tests pass (includes new `AppIconService` cases).
- App builds clean with warnings-as-errors; verified running.

## Notes / worth a live check

- The shared scroller drops the old per-view "N new lines" count pill in favor of a plain jump-to-newest button.
- The JS console's large Hermes replay burst should land instantly (the flip keeps tailing a cheap first-row scroll). Worth confirming on a real Metro/Hermes target, along with text selection / context menus / row expansion under the flipped scroll.
