### PR TITLE
Cache JS console search text and filter incrementally

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// A normalized, case-insensitive console filter/find query. Build once per
+/// filter change and match against text that was lowercased once at ingest —
+/// never re-lowercase entries per keystroke or per flush.
+public struct ConsoleQuery: Equatable, Sendable {
+    public let normalized: String
+
+    public init(_ raw: String) {
+        normalized = raw.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
+    public var isEmpty: Bool { normalized.isEmpty }
+
+    /// Whether the query occurs in `cachedLowercasedText` (which the caller
+    /// lowercased once when the entry was created). An empty query matches all.
+    public func matches(_ cachedLowercasedText: String) -> Bool {
+        normalized.isEmpty || cachedLowercasedText.contains(normalized)
+    }
+}
+
+/// A capped, append-only feed plus its filtered projection, maintained
+/// incrementally: appending a batch evaluates the predicate on that batch only,
+/// and a `nil` predicate (no active filter) mirrors the feed with no per-entry
+/// work at all. The projection is recomputed from scratch only when the filter
+/// itself changes (`refilter`). This keeps a high-rate feed (e.g. a console
+/// replay burst flushing every frame) O(batch) per flush instead of O(buffer).
+///
+/// Entries must be appended in strictly increasing `id` order — cap eviction
+/// relies on it to drop evicted rows from the projection's front.
+public struct FilteredLogBuffer<Entry: Identifiable> where Entry.ID: Comparable {
+    public private(set) var entries: [Entry] = []
+    public private(set) var filtered: [Entry] = []
+    private let capacity: Int
+
+    public init(capacity: Int) {
+        self.capacity = max(1, capacity)
+    }
+
+    /// Append a batch, extending `filtered` with just the batch's matches.
+    /// `isIncluded` must be the same filter the current projection was built
+    /// with; pass `nil` when no filter is active (the fast path).
+    public mutating func append(_ batch: [Entry], isIncluded: ((Entry) -> Bool)?) {
+        entries.append(contentsOf: batch)
+        if let isIncluded {
+            filtered.append(contentsOf: batch.filter(isIncluded))
+        } else {
+            filtered = entries
+        }
+        evictOverflow()
+    }
+
+    /// Recompute the projection over the whole buffer — for when the filter
+    /// itself changed, not for appends.
+    public mutating func refilter(isIncluded: ((Entry) -> Bool)?) {
+        if let isIncluded {
+            filtered = entries.filter(isIncluded)
+        } else {
+            filtered = entries
+        }
+    }
+
+    public mutating func removeAll() {
+        entries.removeAll()
+        filtered.removeAll()
+    }
+
+    private mutating func evictOverflow() {
+        let overflow = entries.count - capacity
+        guard overflow > 0 else { return }
+        let lastEvictedID = entries[overflow - 1].id
+        entries.removeFirst(overflow)
+        let evictedFromFiltered = filtered.prefix { $0.id <= lastEvictedID }.count
+        if evictedFromFiltered > 0 { filtered.removeFirst(evictedFromFiltered) }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleFilteringTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleFilteringTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+private struct Row: Identifiable, Equatable {
+    let id: Int
+    let text: String
+
+    init(_ id: Int, _ text: String = "") {
+        self.id = id
+        self.text = text.lowercased()
+    }
+}
+
+@Suite struct FilteredLogBufferTests {
+    @Test func emptyFilterFastPathMirrorsEntries() {
+        var buffer = FilteredLogBuffer<Row>(capacity: 10)
+        buffer.append([Row(1), Row(2)], isIncluded: nil)
+        buffer.append([Row(3)], isIncluded: nil)
+        #expect(buffer.filtered == buffer.entries)
+        #expect(buffer.entries.map(\.id) == [1, 2, 3])
+    }
+
+    @Test func emptyFilterFastPathMirrorsEntriesAcrossEviction() {
+        var buffer = FilteredLogBuffer<Row>(capacity: 3)
+        buffer.append([Row(1), Row(2), Row(3), Row(4)], isIncluded: nil)
+        buffer.append([Row(5)], isIncluded: nil)
+        #expect(buffer.entries.map(\.id) == [3, 4, 5])
+        #expect(buffer.filtered == buffer.entries)
+    }
+
+    @Test func incrementalAppendMatchesFullRecompute() {
+        let isEven: (Row) -> Bool = { $0.id.isMultiple(of: 2) }
+        var buffer = FilteredLogBuffer<Row>(capacity: 100)
+        for batch in [[Row(1), Row(2)], [Row(3)], [Row(4), Row(5), Row(6)], []] {
+            buffer.append(batch, isIncluded: isEven)
+        }
+        #expect(buffer.filtered == buffer.entries.filter(isEven))
+        #expect(buffer.filtered.map(\.id) == [2, 4, 6])
+    }
+
+    @Test func capEvictionDropsEvictedRowsFromFiltered() {
+        let isEven: (Row) -> Bool = { $0.id.isMultiple(of: 2) }
+        var buffer = FilteredLogBuffer<Row>(capacity: 4)
+        buffer.append((1 ... 4).map { Row($0) }, isIncluded: isEven)
+        #expect(buffer.filtered.map(\.id) == [2, 4])
+        // 5...8 evict 1...4; the projection must lose 2 and 4 and gain 6 and 8.
+        buffer.append((5 ... 8).map { Row($0) }, isIncluded: isEven)
+        #expect(buffer.entries.map(\.id) == [5, 6, 7, 8])
+        #expect(buffer.filtered == buffer.entries.filter(isEven))
+        #expect(buffer.filtered.map(\.id) == [6, 8])
+    }
+
+    @Test func partialEvictionKeepsSurvivingMatches() {
+        let isOdd: (Row) -> Bool = { !$0.id.isMultiple(of: 2) }
+        var buffer = FilteredLogBuffer<Row>(capacity: 3)
+        buffer.append((1 ... 5).map { Row($0) }, isIncluded: isOdd)
+        // Entries 1 and 2 evicted; survivors are 3, 4, 5.
+        #expect(buffer.entries.map(\.id) == [3, 4, 5])
+        #expect(buffer.filtered.map(\.id) == [3, 5])
+    }
+
+    @Test func refilterRecomputesTheProjection() {
+        var buffer = FilteredLogBuffer<Row>(capacity: 10)
+        buffer.append((1 ... 5).map { Row($0) }, isIncluded: nil)
+        buffer.refilter { $0.id > 3 }
+        #expect(buffer.filtered.map(\.id) == [4, 5])
+        buffer.refilter(isIncluded: nil)
+        #expect(buffer.filtered == buffer.entries)
+    }
+
+    @Test func removeAllEmptiesBothProjections() {
+        var buffer = FilteredLogBuffer<Row>(capacity: 10)
+        buffer.append([Row(1), Row(2)], isIncluded: nil)
+        buffer.removeAll()
+        #expect(buffer.entries.isEmpty)
+        #expect(buffer.filtered.isEmpty)
+    }
+
+    @Test func textQueryIncrementalAppendMatchesFullRecompute() {
+        let query = ConsoleQuery("Error")
+        let match: (Row) -> Bool = { query.matches($0.text) }
+        var buffer = FilteredLogBuffer<Row>(capacity: 4)
+        buffer.append([Row(1, "network ERROR: 500"), Row(2, "ok")], isIncluded: match)
+        buffer.append([Row(3, "an error again"), Row(4, "fine"), Row(5, "Error at start")], isIncluded: match)
+        #expect(buffer.filtered == buffer.entries.filter(match))
+        #expect(buffer.filtered.map(\.id) == [3, 5])
+    }
+}
+
+@Suite struct ConsoleQueryTests {
+    @Test func emptyQueryMatchesEverything() {
+        let query = ConsoleQuery("")
+        #expect(query.isEmpty)
+        #expect(query.matches("anything"))
+        #expect(query.matches(""))
+    }
+
+    @Test func whitespaceOnlyQueryIsEmpty() {
+        #expect(ConsoleQuery("   ").isEmpty)
+        #expect(ConsoleQuery("  hi  ").normalized == "hi")
+    }
+
+    @Test func matchingIsCaseInsensitive() {
+        // The cached side is lowercased at ingest; the query side at creation.
+        #expect(ConsoleQuery("WARN").matches("deprecation warning".lowercased()))
+        #expect(ConsoleQuery("fetch").matches("Fetch failed: timeout".lowercased()))
+        #expect(!ConsoleQuery("fetch").matches("nothing here".lowercased()))
+    }
+
+    @Test func matchesAcrossAndBesideCRLF() {
+        let text = "First line\r\nSecond LINE".lowercased()
+        #expect(ConsoleQuery("first").matches(text))
+        #expect(ConsoleQuery("Second line").matches(text))
+        // "\r\n" is a single Character; a plain-"\n" query must not match it.
+        #expect(!ConsoleQuery("line\nsecond").matches(text))
+        #expect(ConsoleQuery("line\r\nsecond").matches(text))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -71,6 +71,17 @@ struct JSEntry: Identifiable {
     let id: Int
     let kind: Kind
     let at: Date
+    /// Lowercased plain-text rendering, derived once at creation so the filter
+    /// and ⌘F never re-tokenize the value tree per flush (a Sentry-reported
+    /// main-thread hang during console bursts).
+    let searchableText: String
+
+    init(id: Int, kind: Kind, at: Date) {
+        self.id = id
+        self.kind = kind
+        self.at = at
+        searchableText = jsEntryPlainText(kind).lowercased()
+    }
 }
 
 // MARK: - Session
@@ -87,12 +98,14 @@ final class JSConsoleSession {
     private static let timestampsKey = "jsConsoleShowTimestamps"
     private static let newestFirstKey = "jsConsoleNewestFirst"
 
-    fileprivate var entries: [JSEntry] = []
-    /// The filtered (level + text) feed, kept in sync imperatively so each render
-    /// reads it in O(1) instead of refiltering the whole buffer — the fix for the
-    /// connect-burst render stall. Chronological (oldest first); the view reverses
-    /// it lazily for the inverted scroll.
-    private(set) var filteredEntries: [JSEntry] = []
+    /// The capped feed plus its filtered (level + text) projection, maintained
+    /// incrementally (ADBKit's `FilteredLogBuffer`): a flush filters only the new
+    /// batch against searchable text cached per entry, and a full recompute
+    /// happens only when the filter itself changes — so a console burst costs
+    /// O(batch) per flush, not O(buffer × object size). Chronological (oldest
+    /// first); the view reverses it lazily for the inverted scroll.
+    private var buffer = FilteredLogBuffer<JSEntry>(capacity: JSConsoleSession.maxEntries)
+    var filteredEntries: [JSEntry] { buffer.filtered }
     fileprivate var phase: JSPhase = .searching
     fileprivate var targets: [CDPTarget] = []
     fileprivate var connectedTarget: CDPTarget?
@@ -100,8 +113,8 @@ final class JSConsoleSession {
     /// The Metro dev-server port. It varies per app, so it's user-editable and
     /// persisted; changing it re-discovers on the new port.
     var port: Int { didSet { UserDefaults.standard.set(port, forKey: Self.portKey) } }
-    var searchText = "" { didSet { rebuildFiltered() } }
-    var hiddenLevels: Set<JSLevel> = [] { didSet { rebuildFiltered() } }
+    var searchText = "" { didSet { refilter() } }
+    var hiddenLevels: Set<JSLevel> = [] { didSet { refilter() } }
     var showTimestamps: Bool { didSet { UserDefaults.standard.set(showTimestamps, forKey: Self.timestampsKey) } }
     /// Newest-first puts new logs at the top (anchored there); otherwise the feed
     /// tails at the bottom. Persisted for the JS console only.
@@ -129,7 +142,7 @@ final class JSConsoleSession {
     private var activateGeneration = 0
     private var nextEntryId = 1
     /// Stream events buffered between flushes; never observed (a flush writes the
-    /// observed `entries`/`filteredEntries`), so a replay burst doesn't render.
+    /// observed `buffer`), so a replay burst doesn't render.
     @ObservationIgnored private var pendingEntries: [JSEntry] = []
     @ObservationIgnored private var flushTask: Task<Void, Never>?
     @ObservationIgnored private var welcomeTask: Task<Void, Never>?
@@ -435,25 +448,33 @@ final class JSConsoleSession {
 
     // MARK: Derived feed (cached)
 
-    private func computeFiltered() -> [JSEntry] {
-        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
-        return entries.filter { entry in
-            if case let .log(level, _, _) = entry.kind, hiddenLevels.contains(level) { return false }
-            if query.isEmpty { return true }
-            return jsEntryPlainText(entry.kind).lowercased().contains(query)
+    /// The active row filter, or nil when everything passes — the fast path:
+    /// appends then skip per-entry matching entirely.
+    private var activeFilter: ((JSEntry) -> Bool)? {
+        let query = ConsoleQuery(searchText)
+        let hidden = hiddenLevels
+        guard !query.isEmpty || !hidden.isEmpty else { return nil }
+        return { entry in
+            if case let .log(level, _, _) = entry.kind, hidden.contains(level) { return false }
+            return query.matches(entry.searchableText)
         }
     }
 
-    private func rebuildFiltered() {
-        filteredEntries = computeFiltered()
+    /// Full recompute — only for when the filter itself changes (query text,
+    /// level chips) or the feed is cleared; appends go through `appendEntries`.
+    private func refilter() {
+        buffer.refilter(isIncluded: activeFilter)
         rebuildFindMatches()
     }
 
     private func rebuildFindMatches() {
-        let query = findText.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !query.isEmpty else { findMatchIDs = []; return }
-        findMatchIDs = filteredEntries
-            .filter { jsEntryPlainText($0.kind).lowercased().contains(query) }
+        let query = ConsoleQuery(findText)
+        guard !query.isEmpty else {
+            if !findMatchIDs.isEmpty { findMatchIDs = [] }
+            return
+        }
+        findMatchIDs = buffer.filtered
+            .filter { query.matches($0.searchableText) }
             .map(\.id)
     }
 
@@ -496,19 +517,16 @@ final class JSConsoleSession {
     }
 
     private func appendEntries(_ newEntries: [JSEntry]) {
-        entries.append(contentsOf: newEntries)
-        if entries.count > Self.maxEntries {
-            entries.removeFirst(entries.count - Self.maxEntries)
-        }
-        rebuildFiltered()
+        buffer.append(newEntries, isIncluded: activeFilter)
+        rebuildFindMatches()
     }
 
     private func clearFeedEntries() {
         flushTask?.cancel()
         flushTask = nil
         pendingEntries.removeAll(keepingCapacity: true)
-        entries.removeAll()
-        rebuildFiltered()
+        buffer.removeAll()
+        findMatchIDs = []
     }
 
     // MARK: Welcome banner
@@ -1230,8 +1248,9 @@ private struct JSCodeEditor: NSViewRepresentable {
 // MARK: - Rendering helpers
 
 /// Plain-text rendering of one console entry — the single source for the search
-/// filter, find, and copy, so they never drift. `RemoteObject.inlineSummary`
-/// (pure, in ADBKit) does the value rendering.
+/// filter, find (both via `JSEntry.searchableText`, cached at ingest), and copy,
+/// so they never drift. `RemoteObject.inlineSummary` (pure, in ADBKit) does the
+/// value rendering.
 func jsEntryPlainText(_ kind: JSEntry.Kind) -> String {
     switch kind {
     case let .input(text): text


### PR DESCRIPTION
Fixes the main-thread hangs behind Sentry DROIDECTIVE-MAC-Q/P/N.

Every 16ms flush re-filtered all buffered entries (cap 2000) and re-derived each entry's plain text (recursive RemoteObject token walk + .lowercased()) — quadratic during a console burst.

- New ADBKit `FilteredLogBuffer` + `ConsoleQuery`: search text is lowercased once at ingest; each flush filters only the new batch; full recompute only when the query or level filters change, with correct cap-eviction handling.
- `JSEntry` caches its searchable text at init; ⌘F match rebuild uses the cached text.
- 12 unit tests, including incremental-append ≡ full-recompute equivalence and CRLF cases.