### PR TITLE
Defer decompile cache deletion off the quit path

### DIFF
--- a/ADBKit/Sources/ADBKit/Persistence/CacheTrash.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/CacheTrash.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Constant-time disposal for throwaway cache directories.
+///
+/// Deleting the decompiled-APK cache tree (tens of thousands of jadx/apktool
+/// files) with `FileManager.removeItem` walks it file by file — seconds of
+/// wall time, which hung quit when it ran in `applicationWillTerminate`
+/// (Sentry DROIDECTIVE-MAC-R). Instead, `setAside` renames the directory to a
+/// uniquely named `<name>.trash-<uuid>` sibling — a single `rename()`, constant
+/// time regardless of contents — and `sweep` deletes any such leftovers later,
+/// off the critical path (next launch, in a detached task).
+public enum CacheTrash {
+    /// Atomically renames `directory` to `<name>.trash-<uuid>` next to it.
+    ///
+    /// Constant time regardless of the tree's size. A missing directory is a
+    /// no-op; a failed rename leaves the directory in place for a later
+    /// attempt. Returns the trash URL, or nil if nothing was moved.
+    @discardableResult
+    public static func setAside(_ directory: URL) -> URL? {
+        let trashURL = directory.deletingLastPathComponent().appendingPathComponent(
+            "\(directory.lastPathComponent)\(trashInfix)\(UUID().uuidString)", isDirectory: true
+        )
+        do {
+            try FileManager.default.moveItem(at: directory, to: trashURL)
+        } catch {
+            return nil
+        }
+        return trashURL
+    }
+
+    /// Deletes every `<name>.trash-*` sibling of `directory`, leaving the live
+    /// directory (and everything else in the parent) alone. A missing parent is
+    /// a no-op. Tree deletion is slow — call this off the main actor.
+    public static func sweep(around directory: URL) {
+        let parent = directory.deletingLastPathComponent()
+        let prefix = directory.lastPathComponent + trashInfix
+        guard let siblings = try? FileManager.default.contentsOfDirectory(
+            at: parent, includingPropertiesForKeys: nil
+        ) else { return }
+        for sibling in siblings where sibling.lastPathComponent.hasPrefix(prefix) {
+            try? FileManager.default.removeItem(at: sibling)
+        }
+    }
+
+    private static let trashInfix = ".trash-"
+}

--- a/ADBKit/Tests/ADBKitTests/CacheTrashTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CacheTrashTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct CacheTrashTests {
+    private func tempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("adbkit-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func setAsideRenamesTheDirectoryWithContentsIntact() throws {
+        let parent = try tempDir()
+        let cache = parent.appendingPathComponent("decompiled", isDirectory: true)
+        let nested = cache.appendingPathComponent("com.example/classes", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data("class A {}".utf8).write(to: nested.appendingPathComponent("A.java"))
+
+        let trashed = CacheTrash.setAside(cache)
+
+        let trashURL = try #require(trashed)
+        #expect(!FileManager.default.fileExists(atPath: cache.path))
+        #expect(trashURL.deletingLastPathComponent().path == parent.path)
+        #expect(trashURL.lastPathComponent.hasPrefix("decompiled.trash-"))
+        // A rename, not a copy: the tree arrives whole at the new name.
+        let movedFile = trashURL.appendingPathComponent("com.example/classes/A.java")
+        #expect(FileManager.default.fileExists(atPath: movedFile.path))
+    }
+
+    @Test func setAsideOfMissingDirectoryIsANoOp() throws {
+        let parent = try tempDir()
+        let cache = parent.appendingPathComponent("decompiled", isDirectory: true)
+
+        #expect(CacheTrash.setAside(cache) == nil)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+    }
+
+    @Test func repeatedSetAsideProducesDistinctTrashSiblings() throws {
+        let parent = try tempDir()
+        let cache = parent.appendingPathComponent("decompiled", isDirectory: true)
+        var trashURLs: [URL] = []
+        for _ in 0..<2 {
+            try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+            trashURLs.append(try #require(CacheTrash.setAside(cache)))
+        }
+
+        #expect(trashURLs[0].lastPathComponent != trashURLs[1].lastPathComponent)
+        for url in trashURLs {
+            #expect(FileManager.default.fileExists(atPath: url.path))
+        }
+    }
+
+    @Test func sweepRemovesOnlyMatchingTrashSiblings() throws {
+        let parent = try tempDir()
+        let cache = parent.appendingPathComponent("decompiled", isDirectory: true)
+        let survivors = [
+            cache,
+            parent.appendingPathComponent("decompiled-live", isDirectory: true),
+            parent.appendingPathComponent("other.trash-123", isDirectory: true),
+        ]
+        let trash = [
+            parent.appendingPathComponent("decompiled.trash-\(UUID().uuidString)", isDirectory: true),
+            parent.appendingPathComponent("decompiled.trash-\(UUID().uuidString)", isDirectory: true),
+        ]
+        for dir in survivors + trash {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data("x".utf8).write(to: dir.appendingPathComponent("file.txt"))
+        }
+
+        CacheTrash.sweep(around: cache)
+
+        for dir in survivors {
+            #expect(FileManager.default.fileExists(atPath: dir.path))
+            #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("file.txt").path))
+        }
+        for dir in trash {
+            #expect(!FileManager.default.fileExists(atPath: dir.path))
+        }
+    }
+
+    @Test func sweepOfNonexistentParentIsANoOp() throws {
+        let parent = try tempDir().appendingPathComponent("never-created", isDirectory: true)
+        let cache = parent.appendingPathComponent("decompiled", isDirectory: true)
+
+        CacheTrash.sweep(around: cache)
+
+        #expect(!FileManager.default.fileExists(atPath: parent.path))
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -14,6 +14,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         InstallInbox.shared.receive(apks)
     }
 
+    /// Delete any decompiled-cache directories the previous quit set aside
+    /// (see `applicationWillTerminate`). The tree walk is slow, so it runs
+    /// detached — never on the main thread's launch path.
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        Task.detached(priority: .utility) {
+            CacheTrash.sweep(around: AppPaths.decompiledCacheDir)
+        }
+    }
+
     /// Block quit when losable work is in flight (an active recording / unsaved
     /// edit) to show the leave prompt; otherwise stop a kept-alive Reactotron
     /// session so we don't orphan the listener or the reverse tunnel. Both defer
@@ -32,12 +41,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// On quit, wipe the decompiled cache. The APK Studio session is in-memory
-    /// (gone with the process) and its decompiled output is regenerable, so it
-    /// shouldn't linger in ~/Library/Caches between runs. Downloaded tools live
-    /// in Application Support and are kept — they're expensive to re-fetch.
+    /// On quit, discard the decompiled cache. The APK Studio session is
+    /// in-memory (gone with the process) and its decompiled output is
+    /// regenerable, so it shouldn't linger in ~/Library/Caches between runs.
+    /// Downloaded tools live in Application Support and are kept — they're
+    /// expensive to re-fetch. Deleting the tree here hung quit for seconds
+    /// (tens of thousands of jadx files, unlinked one by one on the main
+    /// thread — Sentry DROIDECTIVE-MAC-R), so it's a constant-time rename; the
+    /// next launch sweeps the renamed leftovers in the background.
     func applicationWillTerminate(_ notification: Notification) {
-        try? FileManager.default.removeItem(at: AppPaths.decompiledCacheDir)
+        CacheTrash.setAside(AppPaths.decompiledCacheDir)
     }
 }
 

--- a/App/Sources/Settings/ManagedToolsSettingsView.swift
+++ b/App/Sources/Settings/ManagedToolsSettingsView.swift
@@ -203,9 +203,15 @@ struct ManagedToolsSettingsView: View {
         }
     }
 
+    /// Rename the cache aside (constant time), then delete the renamed tree
+    /// detached — a full decompile tree unlinked on the main actor would hang
+    /// the Settings window for seconds.
     private func clearCache() {
-        try? FileManager.default.removeItem(at: AppPaths.decompiledCacheDir)
+        CacheTrash.setAside(AppPaths.decompiledCacheDir)
         cacheSize = 0
+        Task.detached(priority: .utility) {
+            CacheTrash.sweep(around: AppPaths.decompiledCacheDir)
+        }
     }
 
     /// Total bytes under the decompiled cache. Pure file I/O — call it off the


### PR DESCRIPTION
Fixes the quit hang behind Sentry DROIDECTIVE-MAC-R (and shortens the teardown window where MAC-S crashed).

`applicationWillTerminate` tree-deleted `~/Library/Caches/Droidective/decompiled` (tens of thousands of jadx/apktool files) file-by-file on the main thread. Settings ▸ Tools "Clear now" had the same bug.

- New ADBKit `CacheTrash`: constant-time rename to `<name>.trash-<uuid>` at quit; leftovers swept in a background task on next launch. Both call sites use it.
- Disk space is now reclaimed on the next launch instead of at quit.
- 5 unit tests over temp dirs.