### PR TITLE
Cap Reactotron timeline by bytes and release big graphs off-main

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -24,11 +24,13 @@ public actor ReactotronServer {
         }
     }
 
-    /// Events surfaced to the UI as the server runs.
+    /// Events surfaced to the UI as the server runs. `frameBytes` is the wire
+    /// size of the frame a command was decoded from, so the timeline can keep
+    /// its retained payloads within a byte budget.
     public enum Event: Sendable {
         case listening(port: UInt16)
-        case connected(connectionId: Int, intro: ReactotronCommand)
-        case command(connectionId: Int, command: ReactotronCommand)
+        case connected(connectionId: Int, intro: ReactotronCommand, frameBytes: Int)
+        case command(connectionId: Int, command: ReactotronCommand, frameBytes: Int)
         case disconnected(connectionId: Int)
         case failed(reason: String, portInUse: Bool)
     }
@@ -83,7 +85,11 @@ public actor ReactotronServer {
         }
         self.listener = listener
 
-        let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
+        // Bounded so a chatty client can't queue an unbounded backlog of
+        // full-payload events while the consumer (the main actor) is busy —
+        // under heavy backpressure the oldest events drop instead.
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: Event.self, bufferingPolicy: .bufferingNewest(512))
         self.continuation = continuation
 
         listener.stateUpdateHandler = { [weak self] state in
@@ -190,17 +196,19 @@ public actor ReactotronServer {
     private func handleFrame(connectionId id: Int, data: Data) {
         guard let command = try? ReactotronCommand.decode(data) else {
             let raw = String(data: data, encoding: .utf8) ?? "<\(data.count) bytes>"
+            let preview = String(raw.prefix(300))
             continuation?.yield(.command(
                 connectionId: id,
-                command: ReactotronCommand(type: "(undecodable)", payload: .string(String(raw.prefix(300))))
+                command: ReactotronCommand(type: "(undecodable)", payload: .string(preview)),
+                frameBytes: preview.utf8.count
             ))
             return
         }
         if command.commandType == .clientIntro {
             completeHandshake(connectionId: id, intro: command)
-            continuation?.yield(.connected(connectionId: id, intro: command))
+            continuation?.yield(.connected(connectionId: id, intro: command, frameBytes: data.count))
         } else {
-            continuation?.yield(.command(connectionId: id, command: command))
+            continuation?.yield(.command(connectionId: id, command: command, frameBytes: data.count))
         }
     }
 

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Budget for the Reactotron timeline ring buffer.
+///
+/// RN clients stream frames of arbitrary size (api.response bodies, base64
+/// display images, big state payloads), so a count cap alone still lets the
+/// retained timeline reach gigabytes — and freeing that graph inline hangs the
+/// main thread for seconds (a giant nested-dictionary release cascade). The
+/// timeline is therefore bounded by count *and* cumulative frame bytes,
+/// trimmed oldest-first in batches.
+public enum ReactotronTimeline {
+    /// Most items the timeline retains.
+    public static let maxItems = 2000
+    /// Most cumulative wire bytes the timeline retains. The decoded Swift
+    /// graph is proportional to the wire size (typically a small multiple).
+    public static let maxTotalBytes = 128 * 1024 * 1024
+
+    /// How many items to drop from the front so the buffer fits its caps.
+    ///
+    /// Trims with hysteresis — once a cap is exceeded it trims down to 7/8 of
+    /// that cap — so steady-state appends trim in batches instead of shifting
+    /// the array on every append. The newest item is always kept, even when it
+    /// alone exceeds the byte budget.
+    ///
+    /// - Parameters:
+    ///   - sizes: Per-item byte sizes, oldest first. Only the dropped prefix
+    ///     is walked, so a lazy view over the buffer is fine.
+    ///   - count: Current item count.
+    ///   - totalBytes: Current sum of `sizes`.
+    ///   - maxCount: Count cap (defaults to `maxItems`).
+    ///   - maxBytes: Byte cap (defaults to `maxTotalBytes`).
+    public static func dropCount(
+        sizes: some Sequence<Int>,
+        count: Int,
+        totalBytes: Int,
+        maxCount: Int = maxItems,
+        maxBytes: Int = maxTotalBytes
+    ) -> Int {
+        guard count > maxCount || totalBytes > maxBytes else { return 0 }
+        let targetCount = maxCount - maxCount / 8
+        let targetBytes = maxBytes - maxBytes / 8
+        var drop = 0
+        var kept = count
+        var bytes = totalBytes
+        var iterator = sizes.makeIterator()
+        while kept > 1, kept > targetCount || bytes > targetBytes {
+            guard let size = iterator.next() else { break }
+            drop += 1
+            kept -= 1
+            bytes -= size
+        }
+        return drop
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
@@ -23,29 +23,31 @@ import Testing
         task.resume()
         defer { task.cancel(with: .goingAway, reason: nil) }
 
-        try await task.send(.string(
+        let introFrame =
             #"{"type":"client.intro","payload":{"name":"SimApp"},"important":false,"date":"d","deltaTime":0}"#
-        ))
+        try await task.send(.string(introFrame))
 
         let connected = try await nextEvent(&iterator)
-        guard case let .connected(_, intro) = connected else {
+        guard case let .connected(_, intro, introBytes) = connected else {
             Issue.record("expected .connected, got \(connected)"); return
         }
         #expect(intro.commandType == .clientIntro)
+        #expect(introBytes == introFrame.utf8.count)
 
         // The server completes the handshake with setClientId + subscriptions.
         let replies = [try await receiveText(task), try await receiveText(task)].joined(separator: " ")
         #expect(replies.contains("setClientId"))
         #expect(replies.contains("state.values.subscribe"))
 
-        try await task.send(.string(
+        let logFrame =
             #"{"type":"log","payload":{"level":"warn","message":"hi"},"important":false,"date":"d","deltaTime":1}"#
-        ))
+        try await task.send(.string(logFrame))
         let command = try await nextEvent(&iterator)
-        guard case let .command(_, decoded) = command else {
+        guard case let .command(_, decoded, logBytes) = command else {
             Issue.record("expected .command, got \(command)"); return
         }
         #expect(decoded.commandType == .log)
+        #expect(logBytes == logFrame.utf8.count)
 
         // Server → client: a broadcast frame reaches the connected client.
         await server.broadcast(type: "custom", payload: .string("ping"))

--- a/ADBKit/Tests/ADBKitTests/ReactotronTimelineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronTimelineTests.swift
@@ -1,0 +1,80 @@
+import Testing
+@testable import ADBKit
+
+/// Cap enforcement for the Reactotron timeline ring buffer: appends past
+/// either cap trim oldest-first, in batches, and always keep the newest item.
+@Suite struct ReactotronTimelineTests {
+    @Test func underBothCapsDropsNothing() {
+        let drop = ReactotronTimeline.dropCount(
+            sizes: Array(repeating: 10, count: 50), count: 50, totalBytes: 500,
+            maxCount: 100, maxBytes: 10_000
+        )
+        #expect(drop == 0)
+    }
+
+    @Test func exactlyAtTheCapsDropsNothing() {
+        let drop = ReactotronTimeline.dropCount(
+            sizes: Array(repeating: 100, count: 100), count: 100, totalBytes: 10_000,
+            maxCount: 100, maxBytes: 10_000
+        )
+        #expect(drop == 0)
+    }
+
+    @Test func countOverflowTrimsOldestInABatchNotOneByOne() {
+        // One item over the cap trims down to the 7/8 low-water mark in a
+        // single batch, so steady-state appends don't shift the buffer every time.
+        let count = 101
+        let drop = ReactotronTimeline.dropCount(
+            sizes: Array(repeating: 1, count: count), count: count, totalBytes: count,
+            maxCount: 100, maxBytes: 1_000_000
+        )
+        #expect(drop == count - (100 - 100 / 8))
+        #expect(drop > 1)
+    }
+
+    @Test func byteOverflowTrimsOldestUntilUnderBudget() {
+        // 10 × 30 bytes = 300 against a 100-byte budget: trim to the 87-byte
+        // low-water mark → 8 oldest dropped, 2 newest (60 bytes) kept.
+        let sizes = Array(repeating: 30, count: 10)
+        let drop = ReactotronTimeline.dropCount(
+            sizes: sizes, count: 10, totalBytes: 300, maxCount: 1000, maxBytes: 100
+        )
+        #expect(drop == 8)
+        #expect(300 - sizes.prefix(drop).reduce(0, +) <= 100)
+    }
+
+    @Test func oversizedNewestItemIsAlwaysKept() {
+        // A single frame bigger than the whole budget evicts everything older
+        // but is itself retained — the buffer never trims to empty.
+        let twoItems = ReactotronTimeline.dropCount(
+            sizes: [500, 900], count: 2, totalBytes: 1400, maxCount: 10, maxBytes: 100
+        )
+        #expect(twoItems == 1)
+        let single = ReactotronTimeline.dropCount(
+            sizes: [900], count: 1, totalBytes: 900, maxCount: 10, maxBytes: 100
+        )
+        #expect(single == 0)
+    }
+
+    @Test func appendLoopKeepsBufferWithinCapsAndKeepsNewest() {
+        // Drive the session's append/trim loop shape: after every append the
+        // buffer honors both caps and the newest element survives.
+        var sizes: [Int] = []
+        var total = 0
+        for value in 0 ..< 5000 {
+            sizes.append(value % 100)
+            total += value % 100
+            let drop = ReactotronTimeline.dropCount(
+                sizes: sizes, count: sizes.count, totalBytes: total,
+                maxCount: 200, maxBytes: 5000
+            )
+            if drop > 0 {
+                total -= sizes.prefix(drop).reduce(0, +)
+                sizes.removeFirst(drop)
+            }
+            #expect(sizes.count <= 200)
+            #expect(total <= 5000)
+            #expect(sizes.last == value % 100)
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -17,6 +17,11 @@ final class ReactotronSession {
     /// Cumulative wire bytes of `items`, maintained alongside it so the byte
     /// budget doesn't re-sum the buffer on every append.
     private var itemsBytes = 0
+    // Anonymous usage stats (numbers only, no payload contents) reported per
+    // session so the timeline caps can be sized against real workloads.
+    private var peakItemsBytes = 0
+    private var peakItemCount = 0
+    private var evictedItemCount = 0
     fileprivate var commands: [RegisteredCommand] = []
     fileprivate var connection: RtConnection = .idle
     fileprivate var connectedApp: String?
@@ -113,6 +118,7 @@ final class ReactotronSession {
     }
 
     private func reset() {
+        flushUsageStats()
         // The timeline/store graphs can be huge (gigabytes of nested JSON
         // payloads); hand them to a background task instead of freeing them
         // inline, which hangs the main thread for the whole release cascade.
@@ -405,10 +411,13 @@ final class ReactotronSession {
     private func append(_ item: RtItem) {
         items.append(item)
         itemsBytes += item.frameBytes
+        peakItemsBytes = max(peakItemsBytes, itemsBytes)
+        peakItemCount = max(peakItemCount, items.count)
         let drop = ReactotronTimeline.dropCount(
             sizes: items.lazy.map(\.frameBytes), count: items.count, totalBytes: itemsBytes
         )
         guard drop > 0 else { return }
+        evictedItemCount += drop
         let dropped = Array(items[..<drop])
         items.removeFirst(drop)
         itemsBytes -= dropped.reduce(0) { $0 + $1.frameBytes }
@@ -428,6 +437,24 @@ final class ReactotronSession {
         let dropped = Array(snapshots[..<(snapshots.count - Self.maxSnapshots)])
         snapshots.removeFirst(snapshots.count - Self.maxSnapshots)
         Self.discardInBackground(dropped)
+    }
+
+    /// Report how full the timeline got this session — peak bytes/items and how
+    /// many items the caps evicted — so `ReactotronTimeline`'s budgets can be
+    /// sized against real workloads. Numbers only; no payload contents.
+    private func flushUsageStats() {
+        if peakItemsBytes > 0 {
+            Telemetry.shared.track("reactotron_timeline_usage", [
+                "peak_bytes": peakItemsBytes,
+                "peak_items": peakItemCount,
+                "evicted_items": evictedItemCount,
+                "max_bytes": ReactotronTimeline.maxTotalBytes,
+                "max_items": ReactotronTimeline.maxItems,
+            ])
+        }
+        peakItemsBytes = 0
+        peakItemCount = 0
+        evictedItemCount = 0
     }
 
     /// Free a possibly-huge value graph (nested JSON dictionaries/arrays) off

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -9,9 +9,14 @@ import SwiftUI
 @MainActor
 @Observable
 final class ReactotronSession {
-    static let maxItems = 2000
+    /// Saved store snapshots kept per session — each is a full store copy, so
+    /// the count is capped and the oldest drops first.
+    static let maxSnapshots = 20
 
     fileprivate var items: [RtItem] = []
+    /// Cumulative wire bytes of `items`, maintained alongside it so the byte
+    /// budget doesn't re-sum the buffer on every append.
+    private var itemsBytes = 0
     fileprivate var commands: [RegisteredCommand] = []
     fileprivate var connection: RtConnection = .idle
     fileprivate var connectedApp: String?
@@ -108,7 +113,12 @@ final class ReactotronSession {
     }
 
     private func reset() {
+        // The timeline/store graphs can be huge (gigabytes of nested JSON
+        // payloads); hand them to a background task instead of freeing them
+        // inline, which hangs the main thread for the whole release cascade.
+        Self.discardInBackground((items, snapshots, storeState, subscriptionValues))
         items.removeAll()
+        itemsBytes = 0
         commands.removeAll()
         subscriptionPaths.removeAll()
         subscriptionValues.removeAll()
@@ -253,8 +263,18 @@ final class ReactotronSession {
         }
     }
 
-    func clearTimeline() { items.removeAll() }
-    fileprivate func deleteSnapshot(_ snapshot: Snapshot) { snapshots.removeAll { $0.id == snapshot.id } }
+    func clearTimeline() {
+        let cleared = items
+        items = []
+        itemsBytes = 0
+        Self.discardInBackground(cleared)
+    }
+
+    fileprivate func deleteSnapshot(_ snapshot: Snapshot) {
+        let previous = snapshots
+        snapshots = previous.filter { $0.id != snapshot.id }
+        Self.discardInBackground(previous)
+    }
 
     fileprivate func export(_ itemsToExport: [RtItem]) {
         guard let file = app?.askSaveLocation(
@@ -276,7 +296,7 @@ final class ReactotronSession {
         switch event {
         case .listening:
             if clients.isEmpty { connection = .listening }
-        case let .connected(connectionId, intro):
+        case let .connected(connectionId, intro, frameBytes):
             let parsed = ReactotronEvent(command: intro)
             var name = "App"
             var platform: String?
@@ -288,14 +308,20 @@ final class ReactotronSession {
             clients.append(ClientInfo(id: connectionId, name: name, platform: platform))
             refreshConnectionState()
             if !subscriptionPaths.isEmpty { sendSubscriptions() }
-            append(RtItem(event: parsed, command: intro, connectionId: connectionId, important: false))
-        case let .command(connectionId, command):
+            append(RtItem(
+                event: parsed, command: intro, connectionId: connectionId,
+                important: false, frameBytes: frameBytes
+            ))
+        case let .command(connectionId, command, frameBytes):
             let parsed = ReactotronEvent(command: command)
             switch parsed {
             case .clear:
                 // Scope to the sending client so one app's clear doesn't wipe
                 // another connected app's timeline.
-                items.removeAll { $0.connectionId == connectionId }
+                let previous = items
+                items = previous.filter { $0.connectionId != connectionId }
+                itemsBytes = items.reduce(0) { $0 + $1.frameBytes }
+                Self.discardInBackground(previous)
                 return
             case let .customCommandRegister(id, name, title, description, args):
                 registerCommand(RegisteredCommand(id: id, command: name, title: title, description: description, args: args))
@@ -307,23 +333,23 @@ final class ReactotronSession {
                 }
             case let .stateBackup(snapshotState):
                 if let snapshotState {
-                    storeState = snapshotState
+                    replaceStoreState(snapshotState)
                     awaitingStateTree = false
                     if pendingSnapshot {
-                        snapshots.append(Snapshot(state: snapshotState))
+                        appendSnapshot(Snapshot(state: snapshotState))
                         pendingSnapshot = false
                     }
                 }
                 return
             case let .stateKeysResponse(path, keys):
                 if isWholeStorePath(path), let keys {
-                    storeState = keys
+                    replaceStoreState(keys)
                     awaitingStateTree = false
                 }
                 return
             case let .stateValuesResponse(path, value):
                 if isWholeStorePath(path), let value {
-                    storeState = value
+                    replaceStoreState(value)
                     awaitingStateTree = false
                 }
                 return
@@ -336,7 +362,10 @@ final class ReactotronSession {
             default:
                 break
             }
-            append(RtItem(event: parsed, command: command, connectionId: connectionId, important: command.isImportant))
+            append(RtItem(
+                event: parsed, command: command, connectionId: connectionId,
+                important: command.isImportant, frameBytes: frameBytes
+            ))
         case let .disconnected(connectionId):
             clients.removeAll { $0.id == connectionId }
             if selectedClient == connectionId { selectedClient = nil }
@@ -369,11 +398,44 @@ final class ReactotronSession {
         }
     }
 
+    /// Ring-buffer append bounded by count *and* cumulative frame bytes
+    /// (`ReactotronTimeline`), so a client streaming huge payloads can't grow
+    /// the retained timeline into gigabytes. Trims oldest-first in batches and
+    /// frees the dropped items off the main actor.
     private func append(_ item: RtItem) {
         items.append(item)
-        if items.count > Self.maxItems {
-            items.removeFirst(items.count - Self.maxItems)
-        }
+        itemsBytes += item.frameBytes
+        let drop = ReactotronTimeline.dropCount(
+            sizes: items.lazy.map(\.frameBytes), count: items.count, totalBytes: itemsBytes
+        )
+        guard drop > 0 else { return }
+        let dropped = Array(items[..<drop])
+        items.removeFirst(drop)
+        itemsBytes -= dropped.reduce(0) { $0 + $1.frameBytes }
+        Self.discardInBackground(dropped)
+    }
+
+    /// Replace the browsed store tree, releasing the old graph off the main actor.
+    private func replaceStoreState(_ state: JSONValue) {
+        if let old = storeState { Self.discardInBackground(old) }
+        storeState = state
+    }
+
+    /// Keep at most `maxSnapshots` store snapshots, dropping the oldest.
+    private func appendSnapshot(_ snapshot: Snapshot) {
+        snapshots.append(snapshot)
+        guard snapshots.count > Self.maxSnapshots else { return }
+        let dropped = Array(snapshots[..<(snapshots.count - Self.maxSnapshots)])
+        snapshots.removeFirst(snapshots.count - Self.maxSnapshots)
+        Self.discardInBackground(dropped)
+    }
+
+    /// Free a possibly-huge value graph (nested JSON dictionaries/arrays) off
+    /// the main actor: the detached task holds the last reference, so the
+    /// release cascade — seconds long for a multi-gigabyte timeline — doesn't
+    /// block the UI.
+    private nonisolated static func discardInBackground<T: Sendable>(_ garbage: T) {
+        Task.detached(priority: .utility) { _ = garbage }
     }
 }
 
@@ -830,12 +892,15 @@ private enum RtConnection: Equatable {
 
 // MARK: - Timeline item
 
-private struct RtItem: Identifiable {
+private struct RtItem: Identifiable, Sendable {
     let id = UUID()
     let event: ReactotronEvent
     let command: ReactotronCommand
     let connectionId: Int
     let important: Bool
+    /// Wire size of the frame this item was decoded from — drives the
+    /// timeline's byte budget.
+    let frameBytes: Int
     let receivedAt = Date()
 
     var searchText: String {
@@ -852,7 +917,7 @@ private struct RegisteredCommand: Identifiable {
     let args: [ReactotronCommandArg]
 }
 
-private struct Snapshot: Identifiable {
+private struct Snapshot: Identifiable, Sendable {
     let id = UUID()
     let state: JSONValue
     let takenAt = Date()


### PR DESCRIPTION
Fixes the 5GB memory blow-up and hangs behind Sentry DROIDECTIVE-MAC-C (10 events) and MAC-D.

The Reactotron timeline was count-capped (2000) but byte-unbounded: each retained frame is an arbitrary-size JSON graph (api.response bodies, base64 images), so a chatty session reached gigabytes, and freeing that graph inline hung the main thread for seconds. An audit of every other accumulation buffer (logcat, crash catcher, performance, network, command log, process output) found them already bounded.

- New `ReactotronTimeline` budget: 128MB cumulative wire bytes + 2000 items, oldest-first hysteresis batch trim.
- Store snapshots capped at 20; server event stream buffers newest 512.
- Dropped/cleared/replaced graphs are released in a detached background task so multi-GB deinit never runs on the main actor.
- Each session reports peak timeline bytes/items and eviction counts as an anonymous analytics event so the budgets can be sized against real workloads.
- 7 unit tests.