### PR TITLE
Prepare v2.8.1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,64 @@
+## Droidective v2.8.1
+
+A release that adds a built-in Terminal and shell-kind custom commands, a
+Security / Pentest role with reworked per-role sidebars, and a round of
+performance and stability fixes.
+
+### New features
+
+- **Terminal** — real multi-tab login shells (PTY-backed via SwiftTerm) inside
+  the app. The device selected when a shell opens is exported as
+  `ANDROID_SERIAL`, so plain adb commands target it without `-s`. Tabs are
+  renameable (double-click, right-click, or ⇧⌘R), ⌘N opens a shell from
+  anywhere, ⌘W peels one at a time, ⇧⌘[ / ⇧⌘] cycle, and typing `exit` closes
+  the tab. Sessions and scrollback survive switching features, and closing the
+  feature tab — or quitting — with live shells asks first.
+- **Shell custom commands** — a custom command now runs either as adb
+  (tokenized arguments, never a shell) or as a Terminal command line through
+  `zsh -lc`, so plain command lines and script files behave like in Terminal.
+  `{bundleId}` and `{serial}` substitute in both, a file picker inserts a
+  script path, and shell runs are recorded on the command log.
+- **Security / Pentest role** — a new role with a curated sidebar; the
+  per-role feature lists were reworked and sidebar groups follow the role's
+  order.
+
+### Improvements
+
+- **Sidebar** — ⌘1–⌘0 jump to the first ten rows (with hints and a Go menu),
+  and pinning is discoverable: a hover pin on every row and a pinned marker.
+- **Device Info** — identity header, live memory/storage/battery/app gauges,
+  curated property groups, and a searchable getprop dump.
+- **Device bar** — a single row with the bundle picker next to the device pill.
+- The 10-tab workspace cap is gone, and the bottom Recent/Commands bar was
+  removed — the how-it-works note toggles from Settings ▸ Appearance and the
+  Command Log lives in Settings.
+- **Performance** — the launch hang from decoding the dock icon on the main
+  thread is fixed, the Reactotron timeline is capped by bytes (big payloads
+  released off the main thread), JS console search filters incrementally, and
+  the decompile cache is deleted off the quit path.
+- Log views share a smart-tailing scroller that follows the bottom until you
+  scroll up.
+
+### Fixes
+
+- **Reactotron** — a failed server start (e.g. the port is taken) shows an
+  error state with Retry and can actually restart; previously the dead server
+  handle stuck.
+- **React Native** — Process Death backgrounds the app, kills it, and verifies
+  with pidof (with a foreground-app fallback); the dev-server host runner
+  reverse-tunnels localhost, sets `metro.host` where the device allows it, and
+  rejects `http://` / IPv6 input instead of misreporting success.
+- **Tab strip** — the ‹ › arrows derive the first visible tab from measured
+  geometry, so the first click after a trackpad scroll works.
+- **Frida** — architecture detection works on single-ABI devices.
+- **APK Studio** — the decompile source viewer no longer renders blank when an
+  editor push is dropped.
+- Role changes stop every open tab's background work (also fixing a Reactotron
+  server leak), and a closed shell can't be respawned by a SwiftUI teardown
+  pass.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.8.0
 
 A feature release that adds a tabbed workspace with split panes and a React

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.8.0"
+        MARKETING_VERSION: "2.8.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Droidective — All-in-One Android &amp; React Native Debugging Tool for macOS</title>
-  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 54 tools in all, no terminal required." />
+  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 55 tools in all, no terminal required." />
   <meta name="keywords" content="adb tool, android debugging tool, all in one android dev tool, react native debugger, scrcpy gui mac, android developer tool macos, logcat viewer mac, adb gui, mobile dev tool, android emulator manager, react native debugging" />
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
@@ -20,14 +20,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 54 tools, one keystroke away." />
+  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 55 tools, one keystroke away." />
   <meta property="og:url" content="https://droidective.com/" />
   <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 54 tools, one keystroke away. Free & open source." />
+  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 55 tools, one keystroke away. Free & open source." />
   <meta name="twitter:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -41,10 +41,10 @@
     "name": "Droidective",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS 14.0 or later",
-    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 54 tools in all.",
+    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 55 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "2.8.0",
+    "softwareVersion": "2.8.1",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -489,13 +489,13 @@
         <p class="lede">
           Droidective is a native macOS command palette for <strong>Android &amp; React Native</strong>
           debugging over adb. Mirror screens, tail logcat, browse device files, fake any state, and watch
-          performance live — <strong>54 tools</strong>, no terminal required.
+          performance live — <strong>55 tools</strong>, no terminal required.
         </p>
         <div class="cta-row">
           <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
           <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
         </div>
-        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.7.1</span></p>
+        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.8.1</span></p>
       </div>
 
       <div class="palette reveal" aria-hidden="true">
@@ -573,7 +573,7 @@
       <div>
         <span class="eyebrow">the palette</span>
         <h3>One keystroke to everything</h3>
-        <p>Hit <code>⌘K</code> from any screen and fuzzy-search all 54 tools. The device bar follows you, so every command targets the device you mean.</p>
+        <p>Hit <code>⌘K</code> from any screen and fuzzy-search all 55 tools. The device bar follows you, so every command targets the device you mean.</p>
         <ul class="ticks">
           <li><b>Pin favorites</b> and bind global hotkeys</li>
           <li><b>Target one device</b> or fan out to all of them</li>
@@ -635,8 +635,8 @@
         <figcaption><b>Device info</b>RAM, storage, battery health, CPU, and every getprop — searchable.</figcaption>
       </figure>
       <figure>
-        <div class="shot"><img src="assets/screenshot-catalog.webp" alt="Droidective feature catalog listing all 54 tools with on/off toggles" loading="lazy" /></div>
-        <figcaption><b>Feature catalog</b>Toggle, reorder, and pin any of the 54 tools.</figcaption>
+        <div class="shot"><img src="assets/screenshot-catalog.webp" alt="Droidective feature catalog listing all 55 tools with on/off toggles" loading="lazy" /></div>
+        <figcaption><b>Feature catalog</b>Toggle, reorder, and pin any of the 55 tools.</figcaption>
       </figure>
     </div>
   </section>
@@ -665,7 +665,7 @@ Pixel 8     device</pre>
       <div class="step reveal">
         <span class="step-n">03 / go</span>
         <h4>Press ⌘K and run</h4>
-        <p>Search any of the 54 tools and run it. The Setup Doctor confirms your toolchain on first launch.</p>
+        <p>Search any of the 55 tools and run it. The Setup Doctor confirms your toolchain on first launch.</p>
         <pre><span class="c">⌘K</span> mirror screen   ↩</pre>
       </div>
     </div>
@@ -715,11 +715,15 @@ Pixel 8     device</pre>
     <div class="section-head center reveal">
       <span class="eyebrow">changelog</span>
       <h2>Shipped, and still moving.</h2>
-      <p>Thirteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
+      <p>Fourteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
     </div>
     <div class="timeline reveal">
       <div class="rel latest">
-        <div class="rel-head"><span class="rel-ver">v2.8.0</span><span class="rel-tag">latest</span><span class="rel-date">Jul 2026</span></div>
+        <div class="rel-head"><span class="rel-ver">v2.8.1</span><span class="rel-tag">latest</span><span class="rel-date">Jul 2026</span></div>
+        <p><b>Built-in Terminal</b> — multi-tab PTY login shells with the selected device exported as ANDROID_SERIAL — plus <b>shell custom commands</b> through zsh, a <b>Security / Pentest role</b> with reworked per-role sidebars, a <b>Device Info</b> rework, and a round of performance fixes (launch hang, Reactotron memory, JS console search).</p>
+      </div>
+      <div class="rel">
+        <div class="rel-head"><span class="rel-ver">v2.8.0</span><span class="rel-date">Jul 2026</span></div>
         <p><b>Tabbed workspace with split panes</b> — open features in tabs, keep them running while hidden, and split the window in two — plus a <b>React Native JS Console</b> over the Hermes CDP, a curated <b>Run on all devices</b> toggle, and a round of <b>light-mode fixes</b>.</p>
       </div>
       <div class="rel">


### PR DESCRIPTION
Bumps `MARKETING_VERSION` to 2.8.1, adds the v2.8.1 entry to `RELEASE_NOTES.md`, and updates the site: a new changelog entry, tool count 54 → 55, `softwareVersion`, and the footer version (which was still on v2.7.1).

Ships what is on `main` since v2.8.0: the Terminal feature, shell-kind custom commands, the Security / Pentest role and per-role sidebar rework, the Device Info rework, the command-bar removal, and the performance/stability fixes from the Sentry round (launch hang, Reactotron memory cap, JS console search, quit-path cache deletion) plus the Frida single-ABI and decompile-viewer fixes.

The appcast is untouched — CI regenerates and signs it on the tag.