### PR TITLE
Add performance self-telemetry and fix the JS console reconnect storm

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -39,6 +39,13 @@ public actor JSConsoleClient {
     private var pending: [Int: CheckedContinuation<JSONValue?, Error>] = [:]
     private var earlyResults: [Int: Result<JSONValue?, Error>] = [:]
     private var nextId = 1
+    /// Bumped by every teardown. The receive loop, heartbeat, and in-flight
+    /// sends belong to the generation they started under; a stale one returns
+    /// instead of touching a successor connection's state — without this, the
+    /// old receive loop's close error (its socket is cancelled mid-`receive`
+    /// during a reconnect) tore down the *new* connection and leaked its
+    /// still-open socket, so Metro piled up zombie debugger connections.
+    private var generation = 0
 
     public init() {}
 
@@ -60,24 +67,44 @@ public actor JSConsoleClient {
     /// event stream; it finishes when the connection closes or `disconnect()` is
     /// called. Re-entrant: a previous connection is torn down first. Throws if
     /// the connection can't be established (so the caller can retry), detected
-    /// via `Runtime.enable` — `Log.enable` is best-effort for older peers.
-    public func connect(to url: URL) async throws -> AsyncStream<Event> {
-        teardown(reason: "reconnecting")
+    /// via `Runtime.enable` — `Log.enable` is best-effort for older peers. The
+    /// handshake is bounded by `handshakeTimeout`: a proxy that accepts the
+    /// socket for a dead page never answers `Runtime.enable`, and an unbounded
+    /// wait would wedge the caller's reconnect loop.
+    public func connect(
+        to url: URL,
+        handshakeTimeout: Duration = .seconds(10)
+    ) async throws -> AsyncStream<Event> {
+        teardown(reason: "reconnecting", notify: true)
         let task = URLSession.shared.webSocketTask(with: Self.debuggerRequest(for: url))
         self.task = task
+        let generation = generation
         let (stream, continuation) = AsyncStream.makeStream(of: Event.self)
         self.continuation = continuation
         task.resume()
-        startReceiveLoop()
-        startHeartbeat()
+        startReceiveLoop(generation: generation)
+        startHeartbeat(generation: generation)
+        let watchdog = Task { [weak self] in
+            try? await Task.sleep(for: handshakeTimeout)
+            guard !Task.isCancelled else { return }
+            await self?.handshakeTimedOut(generation: generation)
+        }
+        defer { watchdog.cancel() }
         do {
             _ = try await send(method: "Runtime.enable", params: [:])
         } catch {
-            teardown(reason: "connect failed")
+            if generation == self.generation { teardown(reason: "connect failed", notify: false) }
             throw error
         }
         _ = try? await send(method: "Log.enable", params: [:])
         return stream
+    }
+
+    /// The handshake outlasted its timeout: tear the connection down, which
+    /// also fails the pending `Runtime.enable` and unblocks `connect`.
+    private func handshakeTimedOut(generation: Int) {
+        guard generation == self.generation else { return }
+        teardown(reason: "Timed out waiting for the JS runtime.", notify: false)
     }
 
     public func evaluate(_ expression: String) async throws -> EvalOutcome {
@@ -108,13 +135,14 @@ public actor JSConsoleClient {
     }
 
     public func disconnect() {
-        teardown(reason: "disconnected")
+        teardown(reason: "disconnected", notify: true)
     }
 
     // MARK: - Request / response
 
     private func send(method: String, params: [String: JSONValue]) async throws -> JSONValue? {
         guard let task else { throw ClientError.notConnected }
+        let generation = generation
         let id = nextId
         nextId += 1
         let envelope = CDP.request(id: id, method: method, params: params)
@@ -132,11 +160,12 @@ public actor JSConsoleClient {
         return try await withCheckedThrowingContinuation { continuation in
             if let early = earlyResults.removeValue(forKey: id) {
                 continuation.resume(with: early)
-            } else if self.task != nil {
+            } else if generation == self.generation, self.task != nil {
                 pending[id] = continuation
             } else {
-                // The socket closed during the send await (teardown/handleClosed
-                // already drained `pending`), so nothing would ever resume this.
+                // The connection this request went out on closed (or was
+                // replaced) during the send await — its `pending` map was
+                // drained, so nothing would ever resume this.
                 continuation.resume(throwing: ClientError.notConnected)
             }
         }
@@ -152,20 +181,28 @@ public actor JSConsoleClient {
 
     // MARK: - Receive loop
 
-    private func startReceiveLoop() {
+    private func startReceiveLoop(generation: Int) {
         receiveTask = Task { [weak self] in
-            await self?.receiveLoop()
+            await self?.receiveLoop(generation: generation)
         }
     }
 
-    private func receiveLoop() async {
+    /// Reads until the socket dies. Every touch of actor state is gated on the
+    /// generation: cancelling this loop's socket suspends-then-throws its
+    /// `receive()`, and by the time that error lands a reconnect may already
+    /// own `task`/`continuation` — a stale loop must return, not "close" the
+    /// successor.
+    private func receiveLoop(generation: Int) async {
         while !Task.isCancelled {
-            guard let task else { return }
+            guard generation == self.generation, let task else { return }
             do {
                 let message = try await task.receive()
+                guard generation == self.generation else { return }
                 handle(message)
             } catch {
-                handleClosed("\(error.localizedDescription)")
+                if generation == self.generation {
+                    handleClosed("\(error.localizedDescription)")
+                }
                 return
             }
         }
@@ -212,7 +249,9 @@ public actor JSConsoleClient {
 
     private func handleClosed(_ reason: String) {
         guard continuation != nil else { return }
+        generation += 1
         cancelTasks()
+        task?.cancel(with: .goingAway, reason: nil)
         task = nil
         failPending(ClientError.transport(reason))
         continuation?.yield(.closed(reason: reason))
@@ -225,17 +264,18 @@ public actor JSConsoleClient {
     /// The Metro inspector proxy pings on an interval and drops a peer that
     /// doesn't pong; `URLSessionWebSocketTask` doesn't reliably reply on its own,
     /// so send our own ping under that window to hold the connection open.
-    private func startHeartbeat() {
+    private func startHeartbeat(generation: Int) {
         heartbeatTask = Task { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(15))
                 if Task.isCancelled { return }
-                await self?.ping()
+                await self?.ping(generation: generation)
             }
         }
     }
 
-    private func ping() {
+    private func ping(generation: Int) {
+        guard generation == self.generation else { return }
         task?.sendPing { _ in }
     }
 
@@ -248,11 +288,17 @@ public actor JSConsoleClient {
         heartbeatTask = nil
     }
 
-    private func teardown(reason: String) {
+    /// Close the current connection. `notify` yields a final `.closed` so a
+    /// still-attached consumer (e.g. when a stray disconnect races a fresh
+    /// connection) learns the stream is over instead of waiting forever on a
+    /// silently-finished feed.
+    private func teardown(reason: String, notify: Bool) {
+        generation += 1
         cancelTasks()
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         failPending(ClientError.notConnected)
+        if notify { continuation?.yield(.closed(reason: reason)) }
         continuation?.finish()
         continuation = nil
     }

--- a/ADBKit/Sources/ADBKit/Support/ProcessStats.swift
+++ b/ADBKit/Sources/ADBKit/Support/ProcessStats.swift
@@ -1,0 +1,29 @@
+import Darwin
+import Foundation
+
+/// Reads the current process's own resource usage — cumulative CPU time and
+/// physical memory footprint — via `proc_pid_rusage`, for `ResourceWatchdog`.
+public enum ProcessStats {
+    /// Seconds per mach absolute-time tick, from the host timebase.
+    private static let machTickSeconds: Double = {
+        var timebase = mach_timebase_info_data_t()
+        mach_timebase_info(&timebase)
+        return Double(timebase.numer) / Double(timebase.denom) / 1_000_000_000
+    }()
+
+    /// A snapshot of this process's usage, or nil if the kernel call fails.
+    public static func sample() -> ResourceSample? {
+        var info = rusage_info_current()
+        let status = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: (rusage_info_t?).self, capacity: 1) { rebound in
+                proc_pid_rusage(getpid(), RUSAGE_INFO_CURRENT, rebound)
+            }
+        }
+        guard status == 0 else { return nil }
+        return ResourceSample(
+            uptime: ProcessInfo.processInfo.systemUptime,
+            cpuTimeSeconds: Double(info.ri_user_time + info.ri_system_time) * machTickSeconds,
+            footprintBytes: info.ri_phys_footprint
+        )
+    }
+}

--- a/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
+++ b/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// One reading of the app's own resource usage. `cpuTimeSeconds` is the
+/// process's *cumulative* CPU time, so the watchdog derives a CPU percentage
+/// from the delta between consecutive samples.
+public struct ResourceSample: Sendable, Equatable {
+    /// Monotonic timestamp in seconds (e.g. `ProcessInfo.systemUptime`).
+    public let uptime: TimeInterval
+    /// Cumulative user + system CPU time consumed by the process, in seconds.
+    public let cpuTimeSeconds: Double
+    /// Physical memory footprint in bytes (the Activity Monitor "Memory" number).
+    public let footprintBytes: UInt64
+
+    public init(uptime: TimeInterval, cpuTimeSeconds: Double, footprintBytes: UInt64) {
+        self.uptime = uptime
+        self.cpuTimeSeconds = cpuTimeSeconds
+        self.footprintBytes = footprintBytes
+    }
+}
+
+public enum ResourceMetric: String, Sendable {
+    case cpu
+    case memory
+}
+
+/// Emitted by `ResourceWatchdog` when usage crosses, or recovers from, a limit.
+/// Values are CPU percent (100 = one core) for `.cpu` and bytes for `.memory`.
+public enum ResourceEvent: Sendable, Equatable {
+    /// Usage stayed over the limit for the sustained window; `value` is the
+    /// reading that confirmed it.
+    case began(metric: ResourceMetric, value: Double, limit: Double)
+    /// The episode ended: usage dropped back below the reset level.
+    case ended(metric: ResourceMetric, peak: Double, seconds: Double)
+}
+
+/// Pure state machine turning a stream of `ResourceSample`s into begin/end
+/// events for sustained CPU and memory overuse. Debounces with a consecutive-
+/// sample count, tracks the episode peak, and rate-limits repeat alerts per
+/// metric with a cooldown. No I/O — the App layer samples on a timer and
+/// forwards events to telemetry.
+public struct ResourceWatchdog: Sendable {
+    public struct Limits: Sendable {
+        /// CPU percentage (100 = one fully busy core) that counts as overuse.
+        public var cpuPercent: Double
+        /// Memory footprint in bytes that counts as overuse.
+        public var memoryBytes: Double
+        /// Consecutive over-limit samples required before an episode begins.
+        public var sustainedSamples: Int
+        /// An episode ends once usage falls below `limit * resetFraction`.
+        public var resetFraction: Double
+        /// Minimum seconds between `began` events for the same metric.
+        public var cooldownSeconds: Double
+
+        public init(
+            cpuPercent: Double = 200,
+            memoryBytes: Double = 1_500 * 1_048_576,
+            sustainedSamples: Int = 3,
+            resetFraction: Double = 0.8,
+            cooldownSeconds: Double = 1_800
+        ) {
+            self.cpuPercent = cpuPercent
+            self.memoryBytes = memoryBytes
+            self.sustainedSamples = sustainedSamples
+            self.resetFraction = resetFraction
+            self.cooldownSeconds = cooldownSeconds
+        }
+    }
+
+    private struct MetricState {
+        var strikes = 0
+        var episodeStart: TimeInterval?
+        var peak: Double = 0
+        var lastBegan: TimeInterval?
+    }
+
+    public let limits: Limits
+    private var previous: ResourceSample?
+    private var cpu = MetricState()
+    private var memory = MetricState()
+
+    public init(limits: Limits = Limits()) {
+        self.limits = limits
+    }
+
+    /// Feed the next sample; returns the threshold events it triggered.
+    public mutating func ingest(_ sample: ResourceSample) -> [ResourceEvent] {
+        var events: [ResourceEvent] = []
+        if let percent = cpuPercent(for: sample) {
+            Self.step(.cpu, state: &cpu, value: percent, limit: limits.cpuPercent,
+                      limits: limits, at: sample.uptime, into: &events)
+        }
+        Self.step(.memory, state: &memory, value: Double(sample.footprintBytes),
+                  limit: limits.memoryBytes, limits: limits, at: sample.uptime, into: &events)
+        previous = sample
+        return events
+    }
+
+    /// CPU% from the cumulative-time delta; nil for the first sample or a
+    /// non-advancing clock.
+    private func cpuPercent(for sample: ResourceSample) -> Double? {
+        guard let previous, sample.uptime > previous.uptime else { return nil }
+        let used = max(0, sample.cpuTimeSeconds - previous.cpuTimeSeconds)
+        return used / (sample.uptime - previous.uptime) * 100
+    }
+
+    private static func step(
+        _ metric: ResourceMetric,
+        state: inout MetricState,
+        value: Double,
+        limit: Double,
+        limits: Limits,
+        at time: TimeInterval,
+        into events: inout [ResourceEvent]
+    ) {
+        if let start = state.episodeStart {
+            state.peak = max(state.peak, value)
+            if value < limit * limits.resetFraction {
+                events.append(.ended(metric: metric, peak: state.peak, seconds: time - start))
+                state.episodeStart = nil
+                state.strikes = 0
+            }
+            return
+        }
+        guard value >= limit else {
+            state.strikes = 0
+            return
+        }
+        state.strikes += 1
+        guard state.strikes >= limits.sustainedSamples else { return }
+        if let last = state.lastBegan, time - last < limits.cooldownSeconds { return }
+        state.episodeStart = time
+        state.peak = value
+        state.lastBegan = time
+        events.append(.began(metric: metric, value: value, limit: limit))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
@@ -55,6 +55,64 @@ import Testing
     }
 
     @Test(.timeLimit(.minutes(1)))
+    func reconnectingReplacesTheConnectionWithoutKillingIt() async throws {
+        // Regression: tearing down the old socket wakes its receive loop with a
+        // close error *after* the new connection is installed; without the
+        // generation guard that error "closed" the new connection too, so every
+        // reconnect died instantly and the retry loop spammed Metro with fresh
+        // (and leaked) sockets.
+        let serverA = CDPTestServer()
+        let portA = try await serverA.start()
+        let serverB = CDPTestServer()
+        let portB = try await serverB.start()
+        defer { Task { await serverA.stop(); await serverB.stop() } }
+
+        let client = JSConsoleClient()
+        let urlA = try #require(URL(string: "ws://127.0.0.1:\(portA)"))
+        let streamA = try await client.connect(to: urlA)
+        _ = try await client.evaluate("1")
+
+        let urlB = try #require(URL(string: "ws://127.0.0.1:\(portB)"))
+        let streamB = try await client.connect(to: urlB)
+
+        // The old stream ends; the new connection survives and keeps working.
+        for await _ in streamA {}
+        let outcome = try await client.evaluate("2 + 2")
+        guard case let .value(object) = outcome else {
+            Issue.record("expected a value after reconnect, got \(outcome)")
+            return
+        }
+        #expect(object.description == "4")
+
+        // Events still flow on the new connection.
+        await serverB.pushConsoleLog("after-reconnect")
+        var received: ConsoleAPICall?
+        for await event in streamB {
+            if case let .console(call) = event { received = call; break }
+        }
+        #expect(received?.args.first?.value?.stringValue == "after-reconnect")
+        await client.disconnect()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func handshakeTimeoutFailsTheConnectInsteadOfHanging() async throws {
+        // A proxy accepts the socket for a dead page but never answers
+        // Runtime.enable; the connect must give up so the caller's reconnect
+        // loop isn't wedged forever.
+        let server = CDPTestServer()
+        let port = try await server.start()
+        await server.setMuted(true)
+        defer { Task { await server.stop() } }
+
+        let client = JSConsoleClient()
+        let url = try #require(URL(string: "ws://127.0.0.1:\(port)"))
+        await #expect(throws: JSConsoleClient.ClientError.self) {
+            _ = try await client.connect(to: url, handshakeTimeout: .milliseconds(300))
+        }
+        #expect(await !client.isConnected)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
     func closingTheSocketSurfacesClosedAndEndsTheStream() async throws {
         let server = CDPTestServer()
         let port = try await server.start()
@@ -87,6 +145,11 @@ private actor CDPTestServer {
     private var listener: NWListener?
     private var connection: ConnectionBox?
     private var readyContinuation: CheckedContinuation<UInt16, Error>?
+    /// When muted, requests are read but never answered — a proxy holding a
+    /// socket open for a page that will never respond.
+    private var muted = false
+
+    func setMuted(_ muted: Bool) { self.muted = muted }
 
     func start() async throws -> UInt16 {
         let parameters = NWParameters.tcp
@@ -164,7 +227,8 @@ private actor CDPTestServer {
     }
 
     private func handleFrame(_ data: Data) {
-        guard let root = try? JSONDecoder().decode(JSONValue.self, from: data),
+        guard !muted,
+              let root = try? JSONDecoder().decode(JSONValue.self, from: data),
               let id = root["id"]?.intValue,
               let method = root["method"]?.stringValue else { return }
         send(.object(["id": .number(Double(id)), "result": replyResult(for: method)]))

--- a/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct ResourceWatchdogTests {
+    private let mb: Double = 1_048_576
+
+    /// A sample with a calm memory footprint so only the CPU metric is in play.
+    private func cpuSample(at uptime: Double, cpuTime: Double) -> ResourceSample {
+        ResourceSample(uptime: uptime, cpuTimeSeconds: cpuTime, footprintBytes: 100 * 1_048_576)
+    }
+
+    /// A sample with no CPU progress so only the memory metric is in play.
+    private func memorySample(at uptime: Double, footprintMB: Double) -> ResourceSample {
+        ResourceSample(uptime: uptime, cpuTimeSeconds: 0, footprintBytes: UInt64(footprintMB * mb))
+    }
+
+    // MARK: - CPU% derivation
+
+    @Test func cpuPercentComesFromCumulativeTimeDelta() {
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1))
+        #expect(dog.ingest(cpuSample(at: 0, cpuTime: 0)).isEmpty)  // first sample: no delta yet
+        let events = dog.ingest(cpuSample(at: 5, cpuTime: 15))     // 15s CPU over 5s wall = 300%
+        #expect(events == [.began(metric: .cpu, value: 300, limit: 200)])
+    }
+
+    @Test func nonAdvancingClockProducesNoCPUReading() {
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 1, sustainedSamples: 1))
+        _ = dog.ingest(cpuSample(at: 5, cpuTime: 0))
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 100)).isEmpty)
+    }
+
+    @Test func cpuBelowLimitStaysQuiet() {
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1))
+        _ = dog.ingest(cpuSample(at: 0, cpuTime: 0))
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 5)).isEmpty)  // 100% < 200%
+    }
+
+    // MARK: - Sustained-sample debounce
+
+    @Test func memoryFiresOnlyAfterSustainedSamples() {
+        var dog = ResourceWatchdog(limits: .init(memoryBytes: 1_000 * mb, sustainedSamples: 3))
+        #expect(dog.ingest(memorySample(at: 0, footprintMB: 1_200)).isEmpty)
+        #expect(dog.ingest(memorySample(at: 5, footprintMB: 1_200)).isEmpty)
+        let events = dog.ingest(memorySample(at: 10, footprintMB: 1_300))
+        #expect(events == [.began(metric: .memory, value: 1_300 * mb, limit: 1_000 * mb)])
+    }
+
+    @Test func dipBelowLimitResetsTheStrikeCount() {
+        var dog = ResourceWatchdog(limits: .init(memoryBytes: 1_000 * mb, sustainedSamples: 3))
+        _ = dog.ingest(memorySample(at: 0, footprintMB: 1_200))
+        _ = dog.ingest(memorySample(at: 5, footprintMB: 1_200))
+        _ = dog.ingest(memorySample(at: 10, footprintMB: 900))    // dip: strikes reset
+        _ = dog.ingest(memorySample(at: 15, footprintMB: 1_200))
+        #expect(dog.ingest(memorySample(at: 20, footprintMB: 1_200)).isEmpty)
+        #expect(dog.ingest(memorySample(at: 25, footprintMB: 1_200))
+            == [.began(metric: .memory, value: 1_200 * mb, limit: 1_000 * mb)])
+    }
+
+    @Test func firesOncePerEpisodeWhileUsageStaysHigh() {
+        var dog = ResourceWatchdog(limits: .init(memoryBytes: 1_000 * mb, sustainedSamples: 1))
+        #expect(dog.ingest(memorySample(at: 0, footprintMB: 1_500)).count == 1)
+        #expect(dog.ingest(memorySample(at: 5, footprintMB: 1_600)).isEmpty)
+        #expect(dog.ingest(memorySample(at: 10, footprintMB: 1_700)).isEmpty)
+    }
+
+    // MARK: - Recovery
+
+    @Test func recoveryCarriesPeakAndDuration() {
+        var dog = ResourceWatchdog(limits: .init(memoryBytes: 1_000 * mb, sustainedSamples: 1, resetFraction: 0.8))
+        _ = dog.ingest(memorySample(at: 10, footprintMB: 1_200))  // began at t=10
+        _ = dog.ingest(memorySample(at: 20, footprintMB: 2_000))  // peak
+        let events = dog.ingest(memorySample(at: 30, footprintMB: 500))
+        #expect(events == [.ended(metric: .memory, peak: 2_000 * mb, seconds: 20)])
+    }
+
+    @Test func episodePersistsBetweenResetLevelAndLimit() {
+        var dog = ResourceWatchdog(limits: .init(memoryBytes: 1_000 * mb, sustainedSamples: 1, resetFraction: 0.8))
+        _ = dog.ingest(memorySample(at: 0, footprintMB: 1_200))
+        // 900 MB is under the 1 000 MB limit but over the 800 MB reset level.
+        #expect(dog.ingest(memorySample(at: 5, footprintMB: 900)).isEmpty)
+        #expect(dog.ingest(memorySample(at: 10, footprintMB: 700))
+            == [.ended(metric: .memory, peak: 1_200 * mb, seconds: 10)])
+    }
+
+    // MARK: - Cooldown
+
+    @Test func cooldownSuppressesARepeatIncident() {
+        var dog = ResourceWatchdog(limits: .init(
+            memoryBytes: 1_000 * mb, sustainedSamples: 1, cooldownSeconds: 100))
+        _ = dog.ingest(memorySample(at: 0, footprintMB: 1_200))   // began
+        _ = dog.ingest(memorySample(at: 10, footprintMB: 500))    // ended
+        #expect(dog.ingest(memorySample(at: 20, footprintMB: 1_200)).isEmpty)  // within cooldown
+        #expect(dog.ingest(memorySample(at: 110, footprintMB: 1_200))
+            == [.began(metric: .memory, value: 1_200 * mb, limit: 1_000 * mb)])
+    }
+
+    // MARK: - Independence
+
+    @Test func cpuAndMemoryEpisodesAreIndependent() {
+        var dog = ResourceWatchdog(limits: .init(
+            cpuPercent: 200, memoryBytes: 1_000 * mb, sustainedSamples: 1))
+        _ = dog.ingest(ResourceSample(uptime: 0, cpuTimeSeconds: 0, footprintBytes: UInt64(1_500 * mb)))
+        // Memory fired on the first sample; the second brings CPU over its limit too.
+        let events = dog.ingest(ResourceSample(uptime: 5, cpuTimeSeconds: 15, footprintBytes: UInt64(1_500 * mb)))
+        #expect(events == [.began(metric: .cpu, value: 300, limit: 200)])
+    }
+}
+
+@Suite struct ProcessStatsTests {
+    @Test func sampleReportsPlausibleValuesForThisProcess() throws {
+        let first = try #require(ProcessStats.sample())
+        let second = try #require(ProcessStats.sample())
+        #expect(first.footprintBytes > 1_048_576)  // a running test process exceeds 1 MB
+        #expect(first.cpuTimeSeconds > 0)
+        #expect(second.cpuTimeSeconds >= first.cpuTimeSeconds)
+        #expect(second.uptime >= first.uptime)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -401,8 +401,11 @@ final class JSConsoleSession {
         guard (1 ... 65535).contains(newPort), newPort != port else { return }
         // Reset the discovery state synchronously so the running loop (which
         // re-reads `port`) can't apply a stale-port result; the socket close is
-        // async cleanup that the loop already guards against.
+        // async cleanup that the loop already guards against. Bumping the
+        // connect generation also stops a connect that's mid-await against the
+        // old port from committing its target after the switch.
         port = newPort
+        connectGeneration += 1
         consumeTask?.cancel()
         consumeTask = nil
         welcomeTask?.cancel()

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -158,6 +158,14 @@ struct RootView: View {
         migrateDefaultsIfNeeded()
         applyStoredTheme()
         updateDockIcon()
+        // Watch the app's own CPU/RAM and report sustained spikes to telemetry
+        // with the features open at the time (consent-gated in Telemetry).
+        PerformanceMonitor.shared.start { [state] in
+            PerformanceMonitor.FeatureContext(
+                activeFeature: state.activeTabID,
+                openFeatures: state.openFeatureIDs
+            )
+        }
         HotkeyManager.install(state: state)
         installCloseTabMonitor()
         switch LaunchPrompt.next(

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -97,6 +97,9 @@ final class AppState {
     var isSplit: Bool { workspace.isSplit }
     /// The open tabs of pane `index` (empty if that pane doesn't exist).
     func openTabIDs(inGroup index: Int) -> [String] { workspace.openTabs(inGroup: index) }
+    /// Every open tab across both panes — the performance monitor sends these
+    /// with a resource incident so spikes are attributable to a feature.
+    var openFeatureIDs: [String] { workspace.groups.flatMap(\.openTabs) }
     /// The active tab of pane `index`.
     func activeTab(inGroup index: Int) -> String? { workspace.activeTab(inGroup: index) }
     var layout = LayoutState()

--- a/App/Sources/Telemetry/PerformanceMonitor.swift
+++ b/App/Sources/Telemetry/PerformanceMonitor.swift
@@ -1,0 +1,39 @@
+import ADBKit
+import Foundation
+
+/// Watches the app's *own* CPU and memory footprint and reports sustained
+/// overuse to telemetry — a Sentry warning grouped per metric + feature and a
+/// PostHog event — tagged with the features open at the time so spikes are
+/// attributable. The threshold logic is ADBKit's `ResourceWatchdog` (pure,
+/// tested); this owns only the timer and the feature context.
+@MainActor
+final class PerformanceMonitor {
+    static let shared = PerformanceMonitor()
+    private init() {}
+
+    /// Which features were on screen when an incident fired: the focused tab
+    /// plus every open tab across both panes.
+    struct FeatureContext {
+        let activeFeature: String?
+        let openFeatures: [String]
+    }
+
+    private var poller: Task<Void, Never>?
+    private var watchdog = ResourceWatchdog()
+
+    /// Begin sampling every `interval`. `context` is read on the main actor
+    /// only when an event fires, so it can reach into AppState safely.
+    func start(interval: Duration = .seconds(5), context: @escaping @MainActor () -> FeatureContext) {
+        guard poller == nil else { return }
+        poller = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard let self else { return }
+                guard let sample = ProcessStats.sample() else { continue }
+                for event in self.watchdog.ingest(sample) {
+                    Telemetry.shared.reportResourceEvent(event, context: context())
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -1,3 +1,4 @@
+import ADBKit
 import Foundation
 import PostHog
 import Sentry
@@ -50,6 +51,75 @@ final class Telemetry {
     func track(_ event: String, _ properties: [String: Any] = [:]) {
         guard analyticsEnabled, postHogReady else { return }
         PostHogSDK.shared.capture(event, properties: properties)
+    }
+
+    // MARK: - Performance incidents
+
+    /// Report sustained app resource overuse (or its recovery) from the
+    /// performance monitor. An incident becomes a PostHog `app_perf_incident`
+    /// event and a Sentry warning fingerprinted per metric + active feature,
+    /// so each resource hog groups into its own issue; recovery sends the
+    /// peak/duration follow-up and leaves a Sentry breadcrumb. Each sink
+    /// respects its own consent toggle. Only feature ids and resource numbers
+    /// are sent — nothing device- or user-identifying.
+    func reportResourceEvent(_ event: ResourceEvent, context: PerformanceMonitor.FeatureContext) {
+        let feature = context.activeFeature ?? "none"
+        switch event {
+        case .began(let metric, let value, let limit):
+            track("app_perf_incident", [
+                "metric": metric.rawValue,
+                "value": chartValue(metric, value),
+                "limit": chartValue(metric, limit),
+                "feature": feature,
+                "open_features": context.openFeatures,
+            ])
+            guard crashReportingEnabled, sentryRunning else { return }
+            let sentryEvent = Sentry.Event(level: .warning)
+            sentryEvent.message = SentryMessage(
+                formatted: "High \(label(metric)): \(readable(metric, value)) while \(feature) is active")
+            sentryEvent.fingerprint = ["app-perf", metric.rawValue, feature]
+            sentryEvent.tags = ["perf_metric": metric.rawValue, "perf_feature": feature]
+            sentryEvent.extra = [
+                "value": readable(metric, value),
+                "limit": readable(metric, limit),
+                "open_features": context.openFeatures.joined(separator: ", "),
+            ]
+            SentrySDK.capture(event: sentryEvent)
+        case .ended(let metric, let peak, let seconds):
+            track("app_perf_recovered", [
+                "metric": metric.rawValue,
+                "peak": chartValue(metric, peak),
+                "duration_seconds": Int(seconds.rounded()),
+                "feature": feature,
+            ])
+            guard crashReportingEnabled, sentryRunning else { return }
+            let crumb = Breadcrumb(level: .info, category: "app.perf")
+            crumb.message =
+                "\(label(metric)) recovered — peak \(readable(metric, peak)) over \(Int(seconds.rounded()))s"
+            SentrySDK.addBreadcrumb(crumb)
+        }
+    }
+
+    /// Chartable number for PostHog: CPU in percent, memory in MB.
+    private func chartValue(_ metric: ResourceMetric, _ value: Double) -> Int {
+        switch metric {
+        case .cpu: Int(value.rounded())
+        case .memory: Int((value / 1_048_576).rounded())
+        }
+    }
+
+    private func readable(_ metric: ResourceMetric, _ value: Double) -> String {
+        switch metric {
+        case .cpu: "\(Int(value.rounded()))%"
+        case .memory: ByteCountFormatter.string(fromByteCount: Int64(value), countStyle: .memory)
+        }
+    }
+
+    private func label(_ metric: ResourceMetric) -> String {
+        switch metric {
+        case .cpu: "CPU"
+        case .memory: "memory"
+        }
     }
 
     // MARK: - Sentry (crashes + performance)

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -68,16 +68,17 @@
       </div>
 
       <h2>The app</h2>
-      <p>Droidective collects two kinds of anonymous data, both <strong>on by default</strong> and switchable off any time in <code>Settings → Privacy</code> (a first-run notice explains this):</p>
+      <p>Droidective collects three kinds of anonymous data, all <strong>on by default</strong> and switchable off any time in <code>Settings → Privacy</code> (a first-run notice explains this):</p>
       <table>
         <tr><th>What</th><th>Tool</th><th>Why</th></tr>
         <tr><td>Crash &amp; error reports</td><td>Sentry</td><td>Find and fix crashes</td></tr>
         <tr><td>Feature-usage events</td><td>PostHog</td><td>See which tools are used so the app improves</td></tr>
+        <tr><td>Performance signals — sustained high CPU or memory in the app itself, with the features open at the time</td><td>Sentry + PostHog</td><td>Find and fix resource hogs</td></tr>
       </table>
       <p><strong>“Anonymous” means it:</strong></p>
       <ul>
         <li>never creates a profile or identifies you — PostHog person profiles are disabled;</li>
-        <li>never sends device serial numbers, package or app IDs, file paths, IP addresses, or the contents of any command — only <em>which</em> tool or feature was used;</li>
+        <li>never sends device serial numbers, package or app IDs, file paths, IP addresses, or the contents of any command — only <em>which</em> tool or feature was used, plus the app’s own CPU/memory numbers when it misbehaves;</li>
         <li>sends no personal information to Sentry (<code>sendDefaultPii</code> is off).</li>
       </ul>
 


### PR DESCRIPTION
## App performance telemetry (Sentry + PostHog)

The app now watches its own CPU and memory footprint and reports sustained overuse, tagged with the features open at the time so spikes are attributable.

- `ResourceWatchdog` (ADBKit, pure state machine): 5s samples of the process's cumulative CPU time and physical footprint via `proc_pid_rusage`. An episode begins after 3 consecutive samples over the limit (200% CPU / 1.5 GB), ends when usage falls below 80% of the limit, and repeats are rate-limited by a 30-minute per-metric cooldown.
- Sentry gets a warning fingerprinted per metric + active feature, so each resource hog groups into its own issue; recovery leaves a breadcrumb with peak and duration.
- PostHog gets `app_perf_incident` / `app_perf_recovered` events (CPU in percent, memory in MB) with the active feature and all open tabs.
- Each sink respects its existing consent toggle; the privacy page discloses the new signal. Only feature ids and resource numbers are sent.

## JS console reconnect storm fix

Tearing down the old socket during a reconnect woke its receive loop with a close error after the new connection was installed; the loop's close handler then tore down the new connection's state and dropped its socket without cancelling it. Every reconnect died instantly, the 2s discovery retry opened another socket, and Metro accumulated leaked debugger connections while logging a connection per attempt.

- `JSConsoleClient` tags each connection with a generation: the receive loop, heartbeat, and in-flight sends only touch state belonging to their own generation, and every close path cancels the socket.
- The `Runtime.enable` handshake gets a 10s timeout so a proxy holding a socket open for a dead page can't wedge the reconnect loop.
- Teardown yields a final `.closed` so a raced disconnect can't leave the view on a silently dead stream; changing the Metro port invalidates a mid-flight connect so it can't commit a stale-port target.

## Tests

- 13 new tests (526 total green): watchdog threshold/debounce/cooldown/recovery cases, a live sampler check, a loopback reconnect regression test that fails against the unguarded client (verified by mutation), and a handshake-timeout test against a muted CDP server.
- Build is warning-free (warnings-as-errors).