### PR TITLE
Prepare v2.8.2 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+## Droidective v2.8.2
+
+A patch release that fixes the JS Console's reconnect behavior against Metro
+and adds anonymous app performance monitoring.
+
+### Fixes
+
+- **JS Console reconnect storm** — a race in the CDP client killed each new
+  connection moments after it opened and left the old socket running, so the
+  console reconnected every couple of seconds, Metro logged a stream of
+  connection-established messages, and leaked debugger connections piled up
+  until a JS reload cleared them. Connections are now generation-guarded, every
+  close path shuts its socket, and the handshake times out instead of hanging
+  on a dead target — the console connects once and stays connected.
+- Changing the Metro port can no longer commit a connection that was still in
+  flight against the old port.
+
+### Improvements
+
+- **Performance self-monitoring** — the app now watches its own CPU and memory
+  use and, when something stays over the limit, reports it to the anonymous
+  diagnostics along with which features were open — so resource hogs get found
+  and fixed. Sends only feature names and resource numbers; opt-out any time in
+  Settings → Privacy.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.8.1
 
 A release that adds a built-in Terminal and shell-kind custom commands, a

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.8.1"
+        MARKETING_VERSION: "2.8.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 55 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "2.8.1",
+    "softwareVersion": "2.8.2",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -495,7 +495,7 @@
           <a class="btn btn-primary" data-dl-latest href="https://github.com/Droidective/Droidective/releases/latest"><svg class="ic"><use href="#ic-dl"/></svg> Download for macOS</a>
           <a class="btn btn-ghost" href="https://github.com/Droidective/Droidective"><svg class="ic"><use href="#ic-star"/></svg> Star on GitHub</a>
         </div>
-        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.8.1</span></p>
+        <p class="fineprint">$ <span>requires Android adb · auto-updates via Sparkle · v2.8.2</span></p>
       </div>
 
       <div class="palette reveal" aria-hidden="true">
@@ -715,11 +715,15 @@ Pixel 8     device</pre>
     <div class="section-head center reveal">
       <span class="eyebrow">changelog</span>
       <h2>Shipped, and still moving.</h2>
-      <p>Fourteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
+      <p>Fifteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.</p>
     </div>
     <div class="timeline reveal">
       <div class="rel latest">
-        <div class="rel-head"><span class="rel-ver">v2.8.1</span><span class="rel-tag">latest</span><span class="rel-date">Jul 2026</span></div>
+        <div class="rel-head"><span class="rel-ver">v2.8.2</span><span class="rel-tag">latest</span><span class="rel-date">Jul 2026</span></div>
+        <p><b>JS Console reconnect fix</b> — a race killed each fresh Metro connection and leaked the old socket, so the console reconnected in a loop and spammed the dev server; connections are now generation-guarded with a bounded handshake, so it connects once and stays connected. Plus <b>anonymous performance self-monitoring</b> — sustained high CPU or memory in the app is reported with the features open at the time (opt-out in Settings → Privacy).</p>
+      </div>
+      <div class="rel">
+        <div class="rel-head"><span class="rel-ver">v2.8.1</span><span class="rel-date">Jul 2026</span></div>
         <p><b>Built-in Terminal</b> — multi-tab PTY login shells with the selected device exported as ANDROID_SERIAL — plus <b>shell custom commands</b> through zsh, a <b>Security / Pentest role</b> with reworked per-role sidebars, a <b>Device Info</b> rework, and a round of performance fixes (launch hang, Reactotron memory, JS console search).</p>
       </div>
       <div class="rel">


### PR DESCRIPTION
Version bump to 2.8.2 plus release notes and site changelog for the release.

## Ships (already on main via #98)

- **JS Console reconnect storm fix** — a race in the CDP client killed each new connection and leaked the old socket, so the console reconnected every ~2s and spammed Metro with connection-established messages. Connections are now generation-guarded, every close path cancels its socket, and the handshake times out instead of hanging on a dead target.
- **App performance telemetry** — sustained high CPU/RAM in the app itself is reported to Sentry and PostHog with the features open at the time; consent-gated, disclosed on the privacy page.

## This PR

- `project.yml` — `MARKETING_VERSION` 2.8.1 → 2.8.2
- `RELEASE_NOTES.md` — v2.8.2 section at the top
- `site/index.html` — changelog entry, JSON-LD `softwareVersion`, footer version, release count

The appcast is untouched — CI regenerates and signs it on the tag.

After merge, tagging `v2.8.2` triggers the release build (Developer ID signed, notarized, published + appcast update).