### PR TITLE
Allow manual CI runs via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
+  # Manual runs, mainly to redo the Pages deploy with a fresh artifact when a
+  # GitHub-side "Deployment failed, try again later" outlasts job reruns.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` to the CI triggers.

Pages deploys for the v2.8.2 appcast have failed six times since 10:43 UTC with GitHub's generic "Deployment failed, try again later" (tests and build green each time; the artifact matches the last successful deploy in size; no reported GitHub incident). Rerunning the failed job reuses the same uploaded artifact, so this adds a manual trigger that runs the whole workflow on main — rebuilding the site artifact and deploying fresh.

Merging this PR itself also triggers a fresh main run, which may get the v2.8.2 appcast live on its own.

The `pages` job's `if: github.ref == 'refs/heads/main'` already admits dispatch runs on main; `actionlint` and `zizmor` are clean.