### PR TITLE
Audit remediation: security quoting, JS Console crash fix, and RN console UX

### DIFF
--- a/ADBKit/Sources/ADBKit/Devices/DeviceMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Devices/DeviceMonitor.swift
@@ -10,6 +10,7 @@ public actor DeviceMonitor {
     private var continuations: [UUID: AsyncStream<[Device]>.Continuation] = [:]
     private var pollTask: Task<Void, Never>?
     private var lastPublished: [Device]?
+    private var pollInterval: Duration = .seconds(2)
 
     public init(client: AdbClient) {
         self.client = client
@@ -50,12 +51,20 @@ public actor DeviceMonitor {
         return stream
     }
 
+    /// Adjust the polling cadence at runtime — the app widens it while
+    /// backgrounded so an idle, hidden window stops spawning `adb devices`
+    /// every 2s. Takes effect on the next loop iteration.
+    public func setPollInterval(_ interval: Duration) {
+        pollInterval = interval
+    }
+
     private func startPollingIfNeeded(interval: Duration) {
+        pollInterval = interval
         guard pollTask == nil else { return }
         pollTask = Task {
             while !Task.isCancelled {
                 await self.pollOnce()
-                try? await Task.sleep(for: interval)
+                try? await Task.sleep(for: self.pollInterval)
             }
         }
     }

--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -259,7 +259,7 @@ public struct FeatureEngine: Sendable {
             let count = max(1, Int((params["count"]?.numberValue ?? 500).rounded()))
             let result = try await client.run(
                 on: serial,
-                ["shell", "monkey", "-p", package, "-v", String(count)],
+                ["shell", "monkey", "-p", shellQuote(package), "-v", String(count)],
                 timeout: .seconds(120)
             )
             return result.succeeded

--- a/ADBKit/Sources/ADBKit/Persistence/JSONStore.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/JSONStore.swift
@@ -51,7 +51,9 @@ public actor JSONStore<T: Codable & Sendable> {
     }
 
     public func save(_ value: T) throws {
-        cached = value
+        // Cache only after the write succeeds — a throwing write must not leave
+        // the in-memory cache holding a value that never reached disk, or a
+        // later load() would return unpersisted data.
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(value)
@@ -62,6 +64,7 @@ public actor JSONStore<T: Codable & Sendable> {
             .appendingPathComponent(".\(fileURL.lastPathComponent).tmp-\(UUID().uuidString)")
         try data.write(to: tempURL)
         _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+        cached = value
     }
 
     @discardableResult

--- a/ADBKit/Sources/ADBKit/Services/AppControlService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppControlService.swift
@@ -26,7 +26,7 @@ public struct AppControlService: Sendable {
         switch action {
         case .open:
             let result = try await client.run(on: serial, [
-                "shell", "monkey", "-p", packageId, "-c", "android.intent.category.LAUNCHER", "1",
+                "shell", "monkey", "-p", shellQuote(packageId), "-c", "android.intent.category.LAUNCHER", "1",
             ])
             let combined = result.stdout + result.stderr
             let launched = result.succeeded && combined.range(of: "No activities found", options: .caseInsensitive) == nil
@@ -35,7 +35,7 @@ public struct AppControlService: Sendable {
                 : FeatureResult(ok: false, message: "Couldn't launch — no launcher activity found.")
 
         case .stop:
-            let result = try await client.run(on: serial, ["shell", "am", "force-stop", packageId])
+            let result = try await client.run(on: serial, ["shell", "am", "force-stop", shellQuote(packageId)])
             return fromResult(result, success: "Force-stopped", fallback: "Failed to force-stop")
 
         case .minimize:
@@ -43,14 +43,18 @@ public struct AppControlService: Sendable {
             return fromResult(result, success: "Sent to background", fallback: "Failed to minimize")
 
         case .clearCache:
-            let result = try await client.run(on: serial, ["shell", "pm", "clear", "--cache-only", packageId])
-            return result.succeeded
+            let result = try await client.run(on: serial, ["shell", "pm", "clear", "--cache-only", shellQuote(packageId)])
+            // `pm clear` prints "Success"/"Failed" and exits 0 either way, so the
+            // stdout text — not the exit code — is authoritative.
+            return Self.pmClearSucceeded(result)
                 ? FeatureResult(ok: true, message: "Cleared cache")
                 : FeatureResult(ok: false, message: "Clearing cache needs Android 14+ (or use Clear Data).")
 
         case .clearData:
-            let result = try await client.run(on: serial, ["shell", "pm", "clear", packageId])
-            return fromResult(result, success: "Cleared app data", fallback: "Failed to clear data")
+            let result = try await client.run(on: serial, ["shell", "pm", "clear", shellQuote(packageId)])
+            return Self.pmClearSucceeded(result)
+                ? FeatureResult(ok: true, message: "Cleared app data")
+                : FeatureResult(ok: false, message: friendlyAdbError(result, fallback: "Failed to clear data"))
 
         case .uninstall:
             let result = try await client.run(on: serial, ["uninstall", packageId])
@@ -86,6 +90,15 @@ public struct AppControlService: Sendable {
         return failed
             ? FeatureResult(ok: false, message: friendlyAdbError(result, fallback: "Couldn't launch the deep link"))
             : FeatureResult(ok: true, message: "Launched \(url)")
+    }
+
+    /// `pm clear` reports the outcome in stdout ("Success" / "Failed") while
+    /// exiting 0 in both cases, so success means the word "Success" is present
+    /// and "Failed" is not.
+    static func pmClearSucceeded(_ result: AdbResult) -> Bool {
+        let combined = result.stdout + result.stderr
+        if combined.range(of: "Failed", options: .caseInsensitive) != nil { return false }
+        return combined.range(of: "Success", options: .caseInsensitive) != nil
     }
 
     private func fromResult(_ result: AdbResult, success: String, fallback: String) -> FeatureResult {

--- a/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
@@ -79,7 +79,7 @@ public struct AppInspectionService: Sendable {
     }
 
     public func listPermissions(serial: String, packageId: String) async throws(AdbError) -> [PermissionEntry] {
-        let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", packageId])
+        let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", shellQuote(packageId)])
         return Self.parsePermissions(dump.stdout)
     }
 
@@ -87,7 +87,7 @@ public struct AppInspectionService: Sendable {
         serial: String, packageId: String, permission: String, grant: Bool
     ) async throws(AdbError) -> FeatureResult {
         let result = try await client.run(on: serial, [
-            "shell", "pm", grant ? "grant" : "revoke", packageId, permission,
+            "shell", "pm", grant ? "grant" : "revoke", shellQuote(packageId), shellQuote(permission),
         ])
         let short = permission.split(separator: ".").last.map(String.init) ?? permission
         if result.succeeded {
@@ -122,20 +122,20 @@ public struct AppInspectionService: Sendable {
     }
 
     public func getAppInfo(serial: String, packageId: String) async throws(AdbError) -> AppInfo {
-        let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", packageId])
+        let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", shellQuote(packageId)])
         var info = Self.parseAppInfo(dump.stdout, packageId: packageId)
         guard info.installed else { return info }
 
         if let apkPath = try await firstApkPath(serial: serial, packageId: packageId) {
             info.apkPath = apkPath
-            let stat = try await client.run(on: serial, ["shell", "stat", "-c", "%s", apkPath])
+            let stat = try await client.run(on: serial, ["shell", "stat", "-c", "%s", shellQuote(apkPath)])
             info.apkSizeBytes = Int(stat.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
         }
         return info
     }
 
     func firstApkPath(serial: String, packageId: String) async throws(AdbError) -> String? {
-        let output = try await client.run(on: serial, ["shell", "pm", "path", packageId])
+        let output = try await client.run(on: serial, ["shell", "pm", "path", shellQuote(packageId)])
         return output.stdout.split(whereSeparator: \.isNewline)
             .map { $0.replacingOccurrences(of: "package:", with: "").trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
@@ -219,7 +219,7 @@ public struct AppInspectionService: Sendable {
     }
 
     public func getMemInfo(serial: String, packageId: String) async throws(AdbError) -> MemInfo {
-        let output = try await client.run(on: serial, ["shell", "dumpsys", "meminfo", packageId])
+        let output = try await client.run(on: serial, ["shell", "dumpsys", "meminfo", shellQuote(packageId)])
         return Self.parseMemInfo(output.stdout)
     }
 
@@ -257,7 +257,7 @@ public struct AppInspectionService: Sendable {
     public func sandboxList(
         serial: String, packageId: String, dir: String
     ) async throws(AdbError) -> (entries: [FsEntry], debuggable: Bool) {
-        let result = try await client.run(on: serial, ["shell", "run-as", packageId, "ls", "-la", shellQuote(dir)])
+        let result = try await client.run(on: serial, ["shell", "run-as", shellQuote(packageId), "ls", "-la", shellQuote(dir)])
         if Self.isNotDebuggable(result.stderr) {
             return ([], false)
         }

--- a/ADBKit/Sources/ADBKit/Services/BugReportService.swift
+++ b/ADBKit/Sources/ADBKit/Services/BugReportService.swift
@@ -41,7 +41,7 @@ public struct BugReportService: Sendable {
         try Data(info.utf8).write(to: tmp.appendingPathComponent("device-info.txt"))
 
         if let packageId, !packageId.isEmpty {
-            let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", packageId])
+            let dump = try await client.run(on: serial, ["shell", "dumpsys", "package", shellQuote(packageId)])
             let name = dump.stdout.firstMatch(of: /versionName=(\S+)/).map { String($0.1) } ?? "?"
             let code = dump.stdout.firstMatch(of: /versionCode=(\d+)/).map { String($0.1) } ?? "?"
             try Data("versionName=\(name)\nversionCode=\(code)".utf8)

--- a/ADBKit/Sources/ADBKit/Services/CustomCommandService.swift
+++ b/ADBKit/Sources/ADBKit/Services/CustomCommandService.swift
@@ -74,13 +74,23 @@ public struct CustomCommandService: Sendable {
             .replacingOccurrences(of: "{serial}", with: serial)
     }
 
-    /// Substitute placeholders and tokenize. The leading "adb" (if typed) is
-    /// dropped — the client supplies the binary.
+    /// Tokenize, then substitute placeholders *into each token*. The leading
+    /// "adb" (if typed) is dropped — the client supplies the binary.
+    ///
+    /// Substituting after tokenizing keeps a placeholder value that contains
+    /// spaces or shell metacharacters (a free-text bundle id, a crafted serial)
+    /// as a single argv token, instead of letting it split into extra adb
+    /// arguments the way pre-tokenization substitution did.
     public static func buildArgs(
         template: String, bundleId: String?, serial: String
     ) throws(TemplateError) -> [String] {
-        let substituted = try substitute(template: template, bundleId: bundleId, serial: serial)
-        var tokens = try tokenize(substituted)
+        if template.contains("{bundleId}") && (bundleId ?? "").isEmpty {
+            throw .missingBundle
+        }
+        var tokens = try tokenize(template).map {
+            $0.replacingOccurrences(of: "{bundleId}", with: bundleId ?? "")
+                .replacingOccurrences(of: "{serial}", with: serial)
+        }
         if tokens.first == "adb" {
             tokens.removeFirst()
         }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -95,53 +95,62 @@ public enum CDP {
     """
 
     /// Runs in the device's JS context (via `callFunctionOn`, `this` = the object)
-    /// to produce a *bounded* pretty-JSON snapshot for expanding a logged value.
+    /// to produce a *bounded, ordered, type-tagged* tree for expanding a logged
+    /// value, serialized to a single JSON string (`SnapNode`).
     ///
     /// This exists because `Runtime.getProperties` crashes Hermes's VM (a native
     /// null-deref in its RemoteObject converter) when it recursively serializes
     /// some values — expanding e.g. a 200-element array killed the app. Building
-    /// the rendering entirely in JS and returning a single *string* never goes
-    /// through that native converter (the return is a primitive), so it can't
-    /// trip the bug. The depth / breadth / string caps keep a huge or deeply
-    /// nested payload from producing a multi-megabyte reply.
+    /// the tree entirely in JS and returning a single *string* never goes through
+    /// that native converter (the return is a primitive), so it can't trip the
+    /// bug. Object entries are emitted as an ordered array so insertion order is
+    /// preserved (a plain JSON object would be reordered by the decoder). The
+    /// depth / breadth / string caps keep a huge or deeply nested payload
+    /// bounded, and `truncated` marks where a level was cut.
     public static let boundedSnapshotFunction = """
     function () {
-      const MAX_DEPTH = 5, MAX_ITEMS = 100, MAX_STRING = 10000;
+      const MAX_DEPTH = 6, MAX_ITEMS = 100, MAX_STRING = 10000;
       const seen = new WeakSet();
-      const ser = (value, depth) => {
+      const prim = (type, text) => ({ type: type, text: text });
+      const build = (value, depth) => {
         const t = typeof value;
-        if (value === null) return null;
-        if (t === 'bigint') return value.toString() + 'n';
-        if (t === 'number') return Number.isFinite(value) ? value : (value > 0 ? 'Infinity' : value < 0 ? '-Infinity' : 'NaN');
-        if (t === 'boolean') return value;
-        if (t === 'string') return value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…(+' + (value.length - MAX_STRING) + ' chars)' : value;
-        if (t === 'undefined') return '[undefined]';
-        if (t === 'function') return '[Function ' + (value.name || 'anonymous') + ']';
-        if (t === 'symbol') return value.toString();
-        if (value instanceof Error) return { name: value.name, message: value.message, stack: value.stack };
-        if (value instanceof RegExp) return value.toString();
-        if (depth >= MAX_DEPTH) return Array.isArray(value) ? '[Array(' + value.length + ')]' : '[Object]';
-        if (seen.has(value)) return '[Circular]';
+        if (value === null) return { type: 'null' };
+        if (t === 'string') return prim('string', value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…(+' + (value.length - MAX_STRING) + ' chars)' : value);
+        if (t === 'number') return prim('number', Number.isFinite(value) ? String(value) : (value > 0 ? 'Infinity' : value < 0 ? '-Infinity' : 'NaN'));
+        if (t === 'boolean') return prim('boolean', String(value));
+        if (t === 'undefined') return prim('undefined', 'undefined');
+        if (t === 'bigint') return prim('bigint', value.toString() + 'n');
+        if (t === 'symbol') return prim('symbol', value.toString());
+        if (t === 'function') return prim('function', '\\u0192 ' + (value.name || 'anonymous') + '()');
+        if (value instanceof Error) return prim('string', value.stack || (value.name + ': ' + value.message));
+        if (value instanceof RegExp) return prim('string', value.toString());
+        if (depth >= MAX_DEPTH) return prim('string', Array.isArray(value) ? 'Array(' + value.length + ')' : 'Object');
+        if (seen.has(value)) return prim('string', '[Circular]');
         seen.add(value);
         try {
-          if (value instanceof Map) return { dataType: 'Map', entries: ser(Array.from(value.entries()), depth) };
-          if (value instanceof Set) return { dataType: 'Set', values: ser(Array.from(value.values()), depth) };
-          if (Array.isArray(value)) {
-            const out = [];
-            const n = Math.min(value.length, MAX_ITEMS);
-            for (let i = 0; i < n; i++) { try { out.push(ser(value[i], depth + 1)); } catch (e) { out.push('[threw ' + e + ']'); } }
-            if (value.length > MAX_ITEMS) out.push('…(+' + (value.length - MAX_ITEMS) + ' more)');
-            return out;
+          let src = value, ctor = 'Object';
+          if (value instanceof Map) src = { dataType: 'Map', entries: Array.from(value.entries()) };
+          else if (value instanceof Set) src = { dataType: 'Set', values: Array.from(value.values()) };
+          if (Array.isArray(src)) {
+            const items = [];
+            const n = Math.min(src.length, MAX_ITEMS);
+            for (let i = 0; i < n; i++) { try { items.push(build(src[i], depth + 1)); } catch (e) { items.push(prim('string', '[threw]')); } }
+            return { type: 'array', length: src.length, truncated: src.length > MAX_ITEMS, items: items };
           }
-          const out = {};
-          const keys = Object.keys(value);
+          try { ctor = (src.constructor && src.constructor.name) || 'Object'; } catch (e) {}
+          const keys = Object.keys(src);
           const n = Math.min(keys.length, MAX_ITEMS);
-          for (let i = 0; i < n; i++) { const k = keys[i]; try { out[k] = ser(value[k], depth + 1); } catch (e) { out[k] = '[threw ' + e + ']'; } }
-          if (keys.length > MAX_ITEMS) out['…'] = '(+' + (keys.length - MAX_ITEMS) + ' more)';
-          return out;
+          const entries = [];
+          for (let i = 0; i < n; i++) {
+            const k = keys[i];
+            let child;
+            try { child = build(src[k], depth + 1); } catch (e) { child = prim('string', '[threw]'); }
+            entries.push({ name: k, node: child });
+          }
+          return { type: 'object', ctor: ctor, truncated: keys.length > MAX_ITEMS, entries: entries };
         } finally { seen.delete(value); }
       };
-      try { return JSON.stringify(ser(this, 0), null, 2); } catch (e) { return String(e); }
+      try { return JSON.stringify(build(this, 0)); } catch (e) { return JSON.stringify(prim('string', String(e))); }
     }
     """
 

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -38,10 +38,15 @@ public enum CDP {
     }
 
     public static func getPropertiesParams(objectId: String) -> [String: JSONValue] {
+        // No `generatePreview`: Hermes crashes the RN app's VM when asked to
+        // generate inline previews while enumerating an object's properties
+        // (its preview generator is not crash-safe the way Chrome's is). The
+        // property values still arrive as RemoteObjects with type/description,
+        // and a nested object stays expandable via its own getProperties — we
+        // just don't get the one-line inline preview of nested children.
         [
             "objectId": .string(objectId),
             "ownProperties": .bool(true),
-            "generatePreview": .bool(true),
         ]
     }
 

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -37,19 +37,6 @@ public enum CDP {
         ]
     }
 
-    public static func getPropertiesParams(objectId: String) -> [String: JSONValue] {
-        // No `generatePreview`: Hermes crashes the RN app's VM when asked to
-        // generate inline previews while enumerating an object's properties
-        // (its preview generator is not crash-safe the way Chrome's is). The
-        // property values still arrive as RemoteObjects with type/description,
-        // and a nested object stays expandable via its own getProperties — we
-        // just don't get the one-line inline preview of nested children.
-        [
-            "objectId": .string(objectId),
-            "ownProperties": .bool(true),
-        ]
-    }
-
     public static func releaseObjectGroupParams(_ group: String) -> [String: JSONValue] {
         ["objectGroup": .string(group)]
     }
@@ -109,12 +96,18 @@ public enum CDP {
     /// bounded, and `truncated` marks where a level was cut.
     public static let boundedSnapshotFunction = """
     function () {
-      const MAX_DEPTH = 6, MAX_ITEMS = 500, MAX_STRING = 10000;
+      const MAX_DEPTH = 6, MAX_ITEMS = 500, MAX_STRING = 10000, MAX_NODES = 20000;
       const seen = new WeakSet();
+      let budget = MAX_NODES;
       const prim = (type, text) => ({ type: type, text: text });
       const build = (value, depth) => {
+        // Total-node cap: per-level caps alone (depth × breadth) are
+        // multiplicatively unbounded, so a wide-and-deep graph could still
+        // produce a huge string. Stop emitting once the whole snapshot is big.
+        if (budget <= 0) return prim('string', '…(truncated)');
+        budget--;
         const t = typeof value;
-        if (value === null) return { type: 'null' };
+        if (value === null) return prim('null', 'null');
         if (t === 'string') return prim('string', value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…(+' + (value.length - MAX_STRING) + ' chars)' : value);
         if (t === 'number') return prim('number', Number.isFinite(value) ? String(value) : (value > 0 ? 'Infinity' : value < 0 ? '-Infinity' : 'NaN'));
         if (t === 'boolean') return prim('boolean', String(value));
@@ -246,27 +239,6 @@ public struct PropertyPreview: Sendable, Equatable {
         type = json["type"]?.stringValue ?? "string"
         value = json["value"]?.stringValue
         subtype = json["subtype"]?.stringValue
-    }
-}
-
-/// One own property from `Runtime.getProperties` — the rows shown when an object
-/// is expanded.
-public struct CDPProperty: Sendable, Equatable, Identifiable {
-    public let name: String
-    public let value: RemoteObject?
-
-    public var id: String { name }
-
-    /// Parse the `result` array of a `getProperties` reply, keeping enumerable
-    /// own data properties (skipping pure getters/setters with no value) so the
-    /// expanded view shows the same fields a developer expects.
-    public static func parse(_ result: JSONValue?) -> [CDPProperty] {
-        guard let array = result?["result"]?.arrayValue else { return [] }
-        return array.compactMap { entry in
-            guard let name = entry["name"]?.stringValue else { return nil }
-            guard let value = entry["value"] else { return nil }
-            return CDPProperty(name: name, value: RemoteObject(json: value))
-        }
     }
 }
 

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -109,7 +109,7 @@ public enum CDP {
     /// bounded, and `truncated` marks where a level was cut.
     public static let boundedSnapshotFunction = """
     function () {
-      const MAX_DEPTH = 6, MAX_ITEMS = 100, MAX_STRING = 10000;
+      const MAX_DEPTH = 6, MAX_ITEMS = 500, MAX_STRING = 10000;
       const seen = new WeakSet();
       const prim = (type, text) => ({ type: type, text: text });
       const build = (value, depth) => {

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -94,6 +94,57 @@ public enum CDP {
     }
     """
 
+    /// Runs in the device's JS context (via `callFunctionOn`, `this` = the object)
+    /// to produce a *bounded* pretty-JSON snapshot for expanding a logged value.
+    ///
+    /// This exists because `Runtime.getProperties` crashes Hermes's VM (a native
+    /// null-deref in its RemoteObject converter) when it recursively serializes
+    /// some values — expanding e.g. a 200-element array killed the app. Building
+    /// the rendering entirely in JS and returning a single *string* never goes
+    /// through that native converter (the return is a primitive), so it can't
+    /// trip the bug. The depth / breadth / string caps keep a huge or deeply
+    /// nested payload from producing a multi-megabyte reply.
+    public static let boundedSnapshotFunction = """
+    function () {
+      const MAX_DEPTH = 5, MAX_ITEMS = 100, MAX_STRING = 10000;
+      const seen = new WeakSet();
+      const ser = (value, depth) => {
+        const t = typeof value;
+        if (value === null) return null;
+        if (t === 'bigint') return value.toString() + 'n';
+        if (t === 'number') return Number.isFinite(value) ? value : (value > 0 ? 'Infinity' : value < 0 ? '-Infinity' : 'NaN');
+        if (t === 'boolean') return value;
+        if (t === 'string') return value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…(+' + (value.length - MAX_STRING) + ' chars)' : value;
+        if (t === 'undefined') return '[undefined]';
+        if (t === 'function') return '[Function ' + (value.name || 'anonymous') + ']';
+        if (t === 'symbol') return value.toString();
+        if (value instanceof Error) return { name: value.name, message: value.message, stack: value.stack };
+        if (value instanceof RegExp) return value.toString();
+        if (depth >= MAX_DEPTH) return Array.isArray(value) ? '[Array(' + value.length + ')]' : '[Object]';
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+        try {
+          if (value instanceof Map) return { dataType: 'Map', entries: ser(Array.from(value.entries()), depth) };
+          if (value instanceof Set) return { dataType: 'Set', values: ser(Array.from(value.values()), depth) };
+          if (Array.isArray(value)) {
+            const out = [];
+            const n = Math.min(value.length, MAX_ITEMS);
+            for (let i = 0; i < n; i++) { try { out.push(ser(value[i], depth + 1)); } catch (e) { out.push('[threw ' + e + ']'); } }
+            if (value.length > MAX_ITEMS) out.push('…(+' + (value.length - MAX_ITEMS) + ' more)');
+            return out;
+          }
+          const out = {};
+          const keys = Object.keys(value);
+          const n = Math.min(keys.length, MAX_ITEMS);
+          for (let i = 0; i < n; i++) { const k = keys[i]; try { out[k] = ser(value[k], depth + 1); } catch (e) { out[k] = '[threw ' + e + ']'; } }
+          if (keys.length > MAX_ITEMS) out['…'] = '(+' + (keys.length - MAX_ITEMS) + ' more)';
+          return out;
+        } finally { seen.delete(value); }
+      };
+      try { return JSON.stringify(ser(this, 0), null, 2); } catch (e) { return String(e); }
+    }
+    """
+
     // MARK: - Inbound messages
 
     /// A decoded inbound frame: either a reply to one of our requests (`id`) or

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -127,6 +127,18 @@ public actor JSConsoleClient {
         return result?["result"]?["value"]?.stringValue
     }
 
+    /// A bounded pretty-JSON snapshot of an object for expanding it in the UI.
+    /// Uses `callFunctionOn` (which returns a string) instead of `getProperties`
+    /// (whose native RemoteObject converter crashes Hermes on some object
+    /// graphs). Returns nil on transport failure.
+    public func snapshotJSON(objectId: String) async -> String? {
+        let result = try? await send(
+            method: "Runtime.callFunctionOn",
+            params: CDP.callFunctionOnParams(objectId: objectId, functionDeclaration: CDP.boundedSnapshotFunction)
+        )
+        return result?["result"]?["value"]?.stringValue
+    }
+
     /// Release the `console` object group — drops the device-side handles for
     /// everything evaluated/logged so far. Called when the console is cleared so
     /// remote objects don't accumulate. Best-effort.

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -112,11 +112,6 @@ public actor JSConsoleClient {
         return EvalOutcome.from(result: result)
     }
 
-    public func getProperties(objectId: String) async throws -> [CDPProperty] {
-        let result = try await send(method: "Runtime.getProperties", params: CDP.getPropertiesParams(objectId: objectId))
-        return CDPProperty.parse(result)
-    }
-
     /// A faithful deep-JSON rendering of an object, evaluated in the runtime via
     /// `callFunctionOn` — for "Copy as JSON". Returns nil on transport failure.
     public func deepStringify(objectId: String) async -> String? {

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -161,6 +161,7 @@ public actor JSConsoleClient {
         // receive loop stashes it in `earlyResults` and we pick it up below.
         do {
             try await task.send(.string(String(decoding: data, as: UTF8.self)))
+            NetworkTrafficMeter.shared.recordSent(data.count)
         } catch {
             throw ClientError.transport("\(error.localizedDescription)")
         }
@@ -222,6 +223,7 @@ public actor JSConsoleClient {
         case let .data(payload): data = payload
         @unknown default: return
         }
+        NetworkTrafficMeter.shared.recordReceived(data.count)
         guard let incoming = CDP.parseIncoming(data) else { return }
         switch incoming {
         case let .response(id, result, error):

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
@@ -41,4 +41,17 @@ public struct SnapNode: Sendable, Decodable, Equatable {
         guard let data = json.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(SnapNode.self, from: data)
     }
+
+    /// Whether this node — or any descendant — matches `query` (already
+    /// lowercased) in a key or a primitive value, so a search within an object
+    /// can keep matching branches and prune the rest. `key` is this node's own
+    /// key (nil for array items and the root). An empty query matches everything.
+    public func matches(_ query: String, key: String? = nil) -> Bool {
+        if query.isEmpty { return true }
+        if let key, key.lowercased().contains(query) { return true }
+        if let text, text.lowercased().contains(query) { return true }
+        if let entries { return entries.contains { $0.node.matches(query, key: $0.name) } }
+        if let items { return items.contains { $0.matches(query) } }
+        return false
+    }
 }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// One node of a bounded, ordered snapshot of a JS value, built in the device
+/// runtime by `CDPProtocol.boundedSnapshotFunction` and returned as a JSON
+/// string. Expanding a logged value renders this tree client-side, so it never
+/// goes through Hermes's crash-prone `Runtime.getProperties` converter.
+///
+/// Object children are carried as an ordered `entries` array (not a JSON object)
+/// so insertion order survives decoding.
+public struct SnapNode: Sendable, Decodable, Equatable {
+    public struct Entry: Sendable, Decodable, Equatable {
+        public let name: String
+        public let node: SnapNode
+    }
+
+    /// `string` · `number` · `boolean` · `null` · `undefined` · `bigint` ·
+    /// `symbol` · `function` · `array` · `object`.
+    public let type: String
+    /// Display text for a primitive node.
+    public let text: String?
+    /// Constructor name for an object node (e.g. `Object`, `Map`).
+    public let ctor: String?
+    /// Reported element count for an array (may exceed `items.count` when truncated).
+    public let length: Int?
+    /// Whether this level was cut at the breadth cap.
+    public let truncated: Bool?
+    public let entries: [Entry]?
+    public let items: [SnapNode]?
+
+    public var isContainer: Bool { type == "array" || type == "object" }
+
+    /// Number of children not shown because the level hit the breadth cap.
+    public var hiddenCount: Int? {
+        guard truncated == true else { return nil }
+        if type == "array", let length { return max(0, length - (items?.count ?? 0)) }
+        return nil
+    }
+
+    /// Decode the JSON string produced by `boundedSnapshotFunction`.
+    public static func parse(_ json: String) -> SnapNode? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SnapNode.self, from: data)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -99,7 +99,7 @@ public actor LogcatStreamer {
 
     /// Resolve a package's running PID, or nil if it isn't running.
     public func resolvePid(serial: String, packageId: String) async throws(AdbError) -> Int? {
-        let result = try await client.run(on: serial, ["shell", "pidof", "-s", packageId])
+        let result = try await client.run(on: serial, ["shell", "pidof", "-s", shellQuote(packageId)])
         let first = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: " ").first
         return first.flatMap { Int($0) }

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -46,8 +46,13 @@ public struct LogcatFilters: Sendable, Equatable {
 
 /// Pure threadtime line parsing, testable without a device.
 public enum LogcatLineParser {
+    /// Hoisted so the regex is compiled once, not rebuilt per line — logcat
+    /// streams hundreds of lines a second. `nonisolated(unsafe)` because `Regex`
+    /// isn't `Sendable`, but matching against it is a read-only operation with
+    /// no shared mutable state, so concurrent `parse` calls are safe.
+    nonisolated(unsafe) static let threadtime = /^(\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d)\s+(\d+)\s+(\d+)\s+([VDIWEFS])\s+(.*?):\s?(.*)$/
+
     public static func parse(_ raw: String) -> LogLine {
-        let threadtime = /^(\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d)\s+(\d+)\s+(\d+)\s+([VDIWEFS])\s+(.*?):\s?(.*)$/
         guard let match = raw.wholeMatch(of: threadtime) else {
             return LogLine(raw: raw, time: "", pid: "", level: "", tag: "", message: raw)
         }

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorTransport.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorTransport.swift
@@ -311,6 +311,7 @@ public actor MirrorTransport {
     public func controlSender() -> (@Sendable (Data) -> Void)? {
         guard let box = controlBox else { return nil }
         return { data in
+            NetworkTrafficMeter.shared.recordSent(data.count)
             box.connection.send(content: data, completion: .contentProcessed { _ in })
         }
     }
@@ -331,7 +332,10 @@ public actor MirrorTransport {
     ) {
         box.connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) {
             data, _, isComplete, error in
-            if let data, !data.isEmpty { continuation.yield(data) }
+            if let data, !data.isEmpty {
+                NetworkTrafficMeter.shared.recordReceived(data.count)
+                continuation.yield(data)
+            }
             if error != nil || isComplete {
                 continuation.finish()
                 return
@@ -356,7 +360,10 @@ public actor MirrorTransport {
     ) {
         box.connection.receive(minimumIncompleteLength: 1, maximumLength: 256 * 1024) {
             data, _, isComplete, error in
-            if let data, !data.isEmpty { continuation.yield(data) }
+            if let data, !data.isEmpty {
+                NetworkTrafficMeter.shared.recordReceived(data.count)
+                continuation.yield(data)
+            }
             if let error {
                 continuation.finish(throwing: error)
                 return

--- a/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
@@ -243,8 +243,8 @@ public actor PerformanceService {
         }
 
         if let packageId, !packageId.isEmpty {
-            async let gfxString = shell(serial, ["dumpsys", "gfxinfo", packageId])
-            async let appMemString = shell(serial, ["dumpsys", "meminfo", packageId])
+            async let gfxString = shell(serial, ["dumpsys", "gfxinfo", shellQuote(packageId)])
+            async let appMemString = shell(serial, ["dumpsys", "meminfo", shellQuote(packageId)])
             if let gfx = await gfxString {
                 poll.appFps = consumeGfx(serial: serial, packageId: packageId, output: gfx)
             }

--- a/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
@@ -242,23 +242,28 @@ public actor PerformanceService {
             poll.uploadBytesPerSec = speed.up
         }
 
-        if let packageId, !packageId.isEmpty {
-            async let gfxString = shell(serial, ["dumpsys", "gfxinfo", shellQuote(packageId)])
-            async let appMemString = shell(serial, ["dumpsys", "meminfo", shellQuote(packageId)])
-            if let gfx = await gfxString {
-                poll.appFps = consumeGfx(serial: serial, packageId: packageId, output: gfx)
-            }
-            if let appMem = await appMemString {
-                poll.appPssKb = AppInspectionService.parseMemInfo(appMem).totalPssKb
-            }
-        }
-
+        // The full `dumpsys meminfo` dump (process ticks) already carries every
+        // process's PSS, so derive the watched app's PSS from it instead of
+        // firing a second, heavy per-package meminfo in the same cycle.
+        var memRows: [(pid: Int, name: String, pssKb: Int)] = []
         if includeProcesses {
             async let cpuString = shell(serial, ["dumpsys", "cpuinfo"])
             async let memProcString = shell(serial, ["dumpsys", "meminfo"])
             let cpuRows = (await cpuString).map(CpuInfoParser.parse) ?? []
-            let memRows = (await memProcString).map(MemProcParser.parse) ?? []
+            memRows = (await memProcString).map(MemProcParser.parse) ?? []
             poll.processes = Self.mergeProcesses(cpu: cpuRows, mem: memRows)
+        }
+
+        if let packageId, !packageId.isEmpty {
+            if let gfx = await shell(serial, ["dumpsys", "gfxinfo", shellQuote(packageId)]) {
+                poll.appFps = consumeGfx(serial: serial, packageId: packageId, output: gfx)
+            }
+            if let row = memRows.first(where: { $0.name == packageId }) {
+                poll.appPssKb = row.pssKb
+            } else if !includeProcesses,
+                      let appMem = await shell(serial, ["dumpsys", "meminfo", shellQuote(packageId)]) {
+                poll.appPssKb = AppInspectionService.parseMemInfo(appMem).totalPssKb
+            }
         }
         return poll
     }

--- a/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
@@ -260,8 +260,10 @@ public actor PerformanceService {
             }
             if let row = memRows.first(where: { $0.name == packageId }) {
                 poll.appPssKb = row.pssKb
-            } else if !includeProcesses,
-                      let appMem = await shell(serial, ["dumpsys", "meminfo", shellQuote(packageId)]) {
+            } else if let appMem = await shell(serial, ["dumpsys", "meminfo", shellQuote(packageId)]) {
+                // No matching row in the full dump (not a process tick, or the
+                // app runs under a different process name) — fall back to the
+                // per-package meminfo so the app's PSS still populates.
                 poll.appPssKb = AppInspectionService.parseMemInfo(appMem).totalPssKb
             }
         }

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -176,6 +176,7 @@ public actor ReactotronServer {
                 switch metadata.opcode {
                 case .text:
                     if let content {
+                        NetworkTrafficMeter.shared.recordReceived(content.count)
                         Task { await server.handleFrame(connectionId: id, data: content) }
                     }
                 case .close:

--- a/ADBKit/Sources/ADBKit/Services/SystemAppsService.swift
+++ b/ADBKit/Sources/ADBKit/Services/SystemAppsService.swift
@@ -57,16 +57,16 @@ public struct SystemAppsService: Sendable {
 
     public func setDisabled(serial: String, packageId: String, _ disabled: Bool) async throws(AdbError) -> AdbResult {
         if disabled {
-            return try await client.run(on: serial, ["shell", "pm", "disable-user", "--user", "0", packageId])
+            return try await client.run(on: serial, ["shell", "pm", "disable-user", "--user", "0", shellQuote(packageId)])
         }
-        return try await client.run(on: serial, ["shell", "pm", "enable", packageId])
+        return try await client.run(on: serial, ["shell", "pm", "enable", shellQuote(packageId)])
     }
 
     public func setRemoved(serial: String, packageId: String, _ removed: Bool) async throws(AdbError) -> AdbResult {
         if removed {
-            return try await client.run(on: serial, ["shell", "pm", "uninstall", "--user", "0", packageId])
+            return try await client.run(on: serial, ["shell", "pm", "uninstall", "--user", "0", shellQuote(packageId)])
         }
-        return try await client.run(on: serial, ["shell", "cmd", "package", "install-existing", packageId])
+        return try await client.run(on: serial, ["shell", "cmd", "package", "install-existing", shellQuote(packageId)])
     }
 
     // MARK: - Parsing

--- a/ADBKit/Sources/ADBKit/Support/NetworkTrafficMeter.swift
+++ b/ADBKit/Sources/ADBKit/Support/NetworkTrafficMeter.swift
@@ -1,0 +1,44 @@
+import Foundation
+import os
+
+/// Process-wide tally of the bytes Droidective *itself* moves over the network:
+/// the JS-console CDP WebSocket, the scrcpy mirror sockets, the Reactotron
+/// server, and managed-tool downloads. adb's own transfers run in the separate
+/// `adb` process, so they're correctly excluded — this is "this app's" traffic.
+///
+/// A single `OSAllocatedUnfairLock` add per chunk keeps it off the hot path; the
+/// debug metrics overlay reads `totals()` on a timer and turns the deltas into a
+/// throughput. Counters are cumulative and monotonic (`&+` wraps rather than
+/// traps, which the overlay's delta clamps to zero).
+public final class NetworkTrafficMeter: Sendable {
+    public static let shared = NetworkTrafficMeter()
+
+    /// Cumulative bytes received and sent since launch.
+    public struct Totals: Sendable, Equatable {
+        public var received: UInt64
+        public var sent: UInt64
+
+        public init(received: UInt64 = 0, sent: UInt64 = 0) {
+            self.received = received
+            self.sent = sent
+        }
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: Totals())
+
+    /// Internal so production uses the shared meter while tests can measure a
+    /// fresh instance without cross-test interference.
+    init() {}
+
+    public func recordReceived(_ bytes: Int) {
+        guard bytes > 0 else { return }
+        state.withLock { $0.received &+= UInt64(bytes) }
+    }
+
+    public func recordSent(_ bytes: Int) {
+        guard bytes > 0 else { return }
+        state.withLock { $0.sent &+= UInt64(bytes) }
+    }
+
+    public func totals() -> Totals { state.withLock { $0 } }
+}

--- a/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
+++ b/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
@@ -72,6 +72,7 @@ final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unc
         _ session: URLSession, downloadTask: URLSessionDownloadTask,
         didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64
     ) {
+        NetworkTrafficMeter.shared.recordReceived(Int(bytesWritten))
         guard let onProgress, totalBytesExpectedToWrite > 0 else { return }
         onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
     }

--- a/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
@@ -14,8 +14,53 @@ import Testing
         let result = try await service.control(serial: "S1", packageId: "com.app", action: .open)
         #expect(result.ok)
         #expect(runner.invocations.last?.arguments == [
-            "-s", "S1", "shell", "monkey", "-p", "com.app", "-c", "android.intent.category.LAUNCHER", "1",
+            "-s", "S1", "shell", "monkey", "-p", "'com.app'", "-c", "android.intent.category.LAUNCHER", "1",
         ])
+    }
+
+    @Test func forceStopQuotesPackageForTheDeviceShell() async throws {
+        // A package id is free text in the bundle store; a metacharacter must be
+        // quoted so `am force-stop` can't be turned into a second command.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = await makeService(runner)
+
+        _ = try await service.control(serial: "S1", packageId: "com.app; reboot", action: .stop)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "am", "force-stop", "'com.app; reboot'",
+        ])
+    }
+
+    @Test func clearDataQuotesPackageAndReadsSuccessText() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "Success")
+        let service = await makeService(runner)
+
+        let result = try await service.control(serial: "S1", packageId: "a'b", action: .clearData)
+        #expect(result.ok)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "pm", "clear", "'a'\\''b'",
+        ])
+    }
+
+    @Test func clearDataReportsFailureWhenPmClearFailsWithExitZero() async throws {
+        // `pm clear` prints "Failed" while exiting 0 — the text is authoritative.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "Failed")
+        let service = await makeService(runner)
+
+        let result = try await service.control(serial: "S1", packageId: "com.app", action: .clearData)
+        #expect(!result.ok)
+    }
+
+    @Test func clearCacheReportsFailureWhenNoSuccessText() async throws {
+        // Older devices print nothing (no --cache-only support) and exit 0.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = await makeService(runner)
+
+        let result = try await service.control(serial: "S1", packageId: "com.app", action: .clearCache)
+        #expect(!result.ok)
     }
 
     @Test func openDetectsMissingLauncherActivity() async throws {

--- a/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
@@ -1,6 +1,32 @@
 import Testing
 @testable import ADBKit
 
+@Suite struct AppInspectionArgTests {
+    @Test func setPermissionQuotesPackageAndPermission() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.setPermission(
+            serial: "S1", packageId: "com.app;x", permission: "android.permission.CAMERA", grant: true
+        )
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "pm", "grant", "'com.app;x'", "'android.permission.CAMERA'",
+        ])
+    }
+
+    @Test func sandboxListQuotesPackageAndDir() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.sandboxList(serial: "S1", packageId: "com.app", dir: "/data/x y")
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "run-as", "'com.app'", "ls", "-la", "'/data/x y'",
+        ])
+    }
+}
+
 @Suite struct PermissionParsingTests {
     @Test func parsesRuntimePermissionBlock() {
         let dump = """

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -37,6 +37,9 @@ import Testing
         let params = CDP.getPropertiesParams(objectId: "{\"id\":1}")
         #expect(params["objectId"]?.stringValue == "{\"id\":1}")
         #expect(params["ownProperties"]?.boolValue == true)
+        // Must NOT request a preview: Hermes crashes the app's VM generating
+        // previews during getProperties, so expanding an object would kill the app.
+        #expect(params["generatePreview"] == nil)
     }
 
     // MARK: - Incoming classification

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -33,6 +33,22 @@ import Testing
     @Test func malformedJSONReturnsNil() {
         #expect(SnapNode.parse("not json") == nil)
     }
+
+    @Test func matchesFindsKeysAndValuesInDescendants() {
+        let json = """
+        {"type":"object","entries":[
+          {"name":"userId","node":{"type":"number","text":"7"}},
+          {"name":"profile","node":{"type":"object","entries":[
+            {"name":"city","node":{"type":"string","text":"Berlin"}}]}}
+        ]}
+        """
+        let node = SnapNode.parse(json)!
+        #expect(node.matches("berlin"))          // nested value
+        #expect(node.matches("city"))            // nested key
+        #expect(node.matches("userid"))          // top-level key, case-insensitive
+        #expect(!node.matches("london"))         // absent
+        #expect(node.matches(""))                // empty query matches everything
+    }
 }
 
 /// Pure tests for the CDP framing: request shapes and decoding of the replies

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -82,15 +82,6 @@ import Testing
         if case let .response(id, _, _) = decoded { #expect(id == 1) } else { Issue.record("expected id round-trip") }
     }
 
-    @Test func getPropertiesRequestRequestsOwnProperties() {
-        let params = CDP.getPropertiesParams(objectId: "{\"id\":1}")
-        #expect(params["objectId"]?.stringValue == "{\"id\":1}")
-        #expect(params["ownProperties"]?.boolValue == true)
-        // Must NOT request a preview: Hermes crashes the app's VM generating
-        // previews during getProperties, so expanding an object would kill the app.
-        #expect(params["generatePreview"] == nil)
-    }
-
     // MARK: - Incoming classification
 
     @Test func classifiesResponseAndEvent() {
@@ -185,24 +176,6 @@ import Testing
         #expect(call.args.first?.value?.stringValue == "watch out")
         #expect(call.timestamp == 1_700_000_000_000)
     }
-
-    // MARK: - getProperties
-
-    @Test func parsesOwnPropertiesAndSkipsValuelessAccessors() {
-        let json = #"""
-        {"result":[
-          {"name":"id","value":{"type":"number","value":1,"description":"1"},"isOwn":true,"enumerable":true},
-          {"name":"hidden","get":{"type":"function"},"isOwn":true,"enumerable":true}
-        ]}
-        """#
-        let result = try? JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
-        let properties = CDPProperty.parse(result)
-        #expect(properties.count == 1)
-        #expect(properties.first?.name == "id")
-        #expect(properties.first?.value?.value?.doubleValue == 1)
-    }
-
-    // MARK: - Stack frames
 
     // MARK: - inlineSummary across all data types (real Hermes shapes)
 

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -2,6 +2,39 @@ import Foundation
 import Testing
 @testable import ADBKit
 
+@Suite struct SnapNodeTests {
+    @Test func parsesOrderedObjectArrayAndPrimitives() {
+        // Shape emitted by boundedSnapshotFunction: object entries stay ordered.
+        let json = """
+        {"type":"object","ctor":"Object","truncated":false,"entries":[
+          {"name":"userId","node":{"type":"number","text":"1"}},
+          {"name":"title","node":{"type":"string","text":"hi"}},
+          {"name":"tags","node":{"type":"array","length":2,"truncated":false,"items":[
+            {"type":"string","text":"a"},{"type":"string","text":"b"}]}}
+        ]}
+        """
+        let node = SnapNode.parse(json)
+        #expect(node?.type == "object")
+        #expect(node?.entries?.map(\.name) == ["userId", "title", "tags"])   // order preserved
+        #expect(node?.entries?[2].node.type == "array")
+        #expect(node?.entries?[2].node.items?.count == 2)
+        #expect(node?.entries?[2].node.isContainer == true)
+    }
+
+    @Test func reportsHiddenCountForTruncatedArray() {
+        let json = """
+        {"type":"array","length":200,"truncated":true,"items":[{"type":"number","text":"0"}]}
+        """
+        let node = SnapNode.parse(json)
+        #expect(node?.length == 200)
+        #expect(node?.hiddenCount == 199)
+    }
+
+    @Test func malformedJSONReturnsNil() {
+        #expect(SnapNode.parse("not json") == nil)
+    }
+}
+
 /// Pure tests for the CDP framing: request shapes and decoding of the replies
 /// and events a console relies on.
 @Suite struct CDPProtocolTests {

--- a/ADBKit/Tests/ADBKitTests/CustomCommandTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CustomCommandTests.swift
@@ -36,6 +36,15 @@ import Testing
         #expect(args == ["shell", "am", "force-stop", "com.app"])
     }
 
+    @Test func placeholderValueStaysOneTokenEvenWithSpaces() throws {
+        // Substitution happens after tokenization, so a value containing spaces
+        // or metacharacters can't split into extra adb arguments.
+        let args = try CustomCommandService.buildArgs(
+            template: "shell am force-stop {bundleId}", bundleId: "com.app extra;arg", serial: "S1"
+        )
+        #expect(args == ["shell", "am", "force-stop", "com.app extra;arg"])
+    }
+
     @Test func dropsLeadingAdbToken() throws {
         let args = try CustomCommandService.buildArgs(template: "adb devices", bundleId: nil, serial: "")
         #expect(args == ["devices"])

--- a/ADBKit/Tests/ADBKitTests/DnsServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DnsServiceTests.swift
@@ -1,6 +1,22 @@
 import Testing
 @testable import ADBKit
 
+@Suite struct DnsSetHostnameArgTests {
+    @Test func setHostnameQuotesTheHostname() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = DnsService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.setHostname(serial: "S1", "dns.example.com; reboot")
+        #expect(runner.invocations.contains {
+            $0.arguments == [
+                "-s", "S1", "shell", "settings", "put", "global",
+                "private_dns_specifier", "'dns.example.com; reboot'",
+            ]
+        })
+    }
+}
+
 @Suite struct DnsServiceTests {
     @Test func parsesOff() {
         let status = DnsService.parse(mode: "off", specifier: "null")

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -34,6 +34,21 @@ import Testing
         #expect(runner.invocations.last?.arguments == ["-s", "S1", "shell", "input", "keyevent", "46", "46"])
     }
 
+    @Test func monkeyQuotesThePackage() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "Events injected: 10")
+        let engine = await makeEngine(runner)
+
+        let result = await engine.run(
+            featureID: "monkey", serial: "S1",
+            params: ["packageId": .string("com.demo;rm"), "count": .number(10)]
+        )
+        #expect(result.ok)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "monkey", "-p", "'com.demo;rm'", "-v", "10",
+        ])
+    }
+
     @Test func processDeathKillsTheChosenBundleAndVerifiesDeath() async {
         let runner = MockProcessRunner()
         runner.script(argsPrefix: ["-s"], stdout: "")

--- a/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
@@ -26,11 +26,6 @@ import Testing
         #expect(object.type == "number")
         #expect(object.description == "4")
 
-        // Expand an object — the server returns one property `x`.
-        let properties = try await client.getProperties(objectId: "obj-1")
-        #expect(properties.first?.name == "x")
-        #expect(properties.first?.value?.value?.doubleValue == 1)
-
         // Deep-stringify (Copy as JSON) round-trips the runtime's JSON string.
         let json = await client.deepStringify(objectId: "obj-1")
         #expect(json == "{\n  \"x\": 1\n}")
@@ -239,14 +234,6 @@ private actor CDPTestServer {
         case "Runtime.evaluate":
             .object(["result": .object([
                 "type": .string("number"), "value": .number(4), "description": .string("4"),
-            ])])
-        case "Runtime.getProperties":
-            .object(["result": .array([
-                .object([
-                    "name": .string("x"),
-                    "value": .object(["type": .string("number"), "value": .number(1), "description": .string("1")]),
-                    "isOwn": .bool(true),
-                ]),
             ])])
         case "Runtime.callFunctionOn":
             .object(["result": .object([

--- a/ADBKit/Tests/ADBKitTests/NetworkTrafficMeterTests.swift
+++ b/ADBKit/Tests/ADBKitTests/NetworkTrafficMeterTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct NetworkTrafficMeterTests {
+    @Test func accumulatesReceivedAndSentSeparately() {
+        let meter = NetworkTrafficMeter()
+        meter.recordReceived(100)
+        meter.recordReceived(50)
+        meter.recordSent(30)
+
+        let totals = meter.totals()
+        #expect(totals.received == 150)
+        #expect(totals.sent == 30)
+    }
+
+    @Test func ignoresZeroAndNegativeAmounts() {
+        // Empty reads/writes are common (a keep-alive frame, a closed socket) and
+        // must not perturb the tally.
+        let meter = NetworkTrafficMeter()
+        meter.recordReceived(0)
+        meter.recordReceived(-10)
+        meter.recordSent(0)
+
+        let totals = meter.totals()
+        #expect(totals.received == 0)
+        #expect(totals.sent == 0)
+    }
+
+    @Test func totalsAreCumulativeAcrossReads() {
+        let meter = NetworkTrafficMeter()
+        meter.recordReceived(200)
+        _ = meter.totals()
+        meter.recordReceived(300)
+        #expect(meter.totals().received == 500)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/RootServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/RootServiceTests.swift
@@ -1,6 +1,21 @@
 import Testing
 @testable import ADBKit
 
+@Suite struct RootSuRunArgTests {
+    @Test func suRunQuotesTheWholeCommand() async throws {
+        // The free-text root command must reach `su -c` as a single quoted
+        // argument, not split on spaces by the device shell.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = RootService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.suRun(serial: "S1", "rm -rf /data/x; echo hi")
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "su", "-c", "'rm -rf /data/x; echo hi'",
+        ])
+    }
+}
+
 @Suite struct RootServiceTests {
     private static let cleanProps = [
         "ro.build.tags": "release-keys",

--- a/ADBKit/Tests/ADBKitTests/SystemAppsServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SystemAppsServiceTests.swift
@@ -1,6 +1,30 @@
 import Testing
 @testable import ADBKit
 
+@Suite struct SystemAppsArgTests {
+    @Test func disableQuotesPackage() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = SystemAppsService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.setDisabled(serial: "S1", packageId: "com.app;x", true)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "pm", "disable-user", "--user", "0", "'com.app;x'",
+        ])
+    }
+
+    @Test func uninstallForUserQuotesPackage() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = SystemAppsService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.setRemoved(serial: "S1", packageId: "com.app;x", true)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "pm", "uninstall", "--user", "0", "'com.app;x'",
+        ])
+    }
+}
+
 @Suite struct SystemAppsServiceTests {
     @Test func parsePackageListStripsPrefixAndUid() {
         let set = SystemAppsService.parsePackageList("""

--- a/ADBKit/Tests/ADBKitTests/WifiServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WifiServiceTests.swift
@@ -1,6 +1,21 @@
 import Testing
 @testable import ADBKit
 
+@Suite struct WifiConnectArgTests {
+    @Test func connectQuotesSsidAndPassword() async throws {
+        // SSIDs routinely contain spaces/quotes; both the SSID and the password
+        // must reach the device shell as single quoted arguments.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = WifiService(client: await makeTestClient(runner: runner))
+
+        _ = try await service.connect(serial: "S1", ssid: "Cafe ' x", security: "wpa2", password: "p w")
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "cmd", "wifi", "connect-network", "'Cafe '\\'' x'", "wpa2", "'p w'",
+        ])
+    }
+}
+
 @Suite struct WifiServiceTests {
     @Test func parsesConnectedStatusFromCmdWifi() {
         let status = WifiService.parseStatus(

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -57,6 +57,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct ADTApp: App {
     @State private var appState: AppState
+    @Environment(\.scenePhase) private var scenePhase
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
@@ -131,6 +132,9 @@ struct ADTApp: App {
                 // `.brandAccent` re-resolves. AppState (and its device list) is
                 // owned above this view, so the rebuild preserves it.
                 .id(accentHex)
+                .onChange(of: scenePhase) { _, phase in
+                    appState.setForeground(phase == .active)
+                }
         }
         .windowStyle(.automatic)
         .commands {

--- a/App/Sources/DevOverlay/DevMetricsOverlay.swift
+++ b/App/Sources/DevOverlay/DevMetricsOverlay.swift
@@ -1,0 +1,133 @@
+#if DEBUG
+import ADBKit
+import Observation
+import SwiftUI
+
+/// Debug-only HUD: samples Droidective's *own* memory, CPU, and network
+/// throughput once a second and drives the top-left overlay. Compiled only into
+/// Debug builds. Memory and CPU come from `ProcessStats` (CPU% derived from the
+/// cumulative-time delta, the same math `ResourceWatchdog` uses); network from
+/// `NetworkTrafficMeter`, the app's own transfer tally.
+@MainActor
+@Observable
+final class DevMetricsMonitor {
+    private(set) var memoryBytes: UInt64 = 0
+    private(set) var cpuPercent: Double = 0
+    private(set) var downBytesPerSec: Double = 0
+    private(set) var upBytesPerSec: Double = 0
+
+    private var poller: Task<Void, Never>?
+    private var lastCPU: (uptime: TimeInterval, seconds: Double)?
+    private var lastNet: (uptime: TimeInterval, totals: NetworkTrafficMeter.Totals)?
+
+    func start(interval: Duration = .seconds(1)) {
+        guard poller == nil else { return }
+        poller = Task { [weak self] in
+            while !Task.isCancelled {
+                self?.sample()
+                try? await Task.sleep(for: interval)
+            }
+        }
+    }
+
+    func stop() {
+        poller?.cancel()
+        poller = nil
+    }
+
+    private func sample() {
+        guard let s = ProcessStats.sample() else { return }
+        memoryBytes = s.footprintBytes
+        if let prev = lastCPU, s.uptime > prev.uptime {
+            let used = max(0, s.cpuTimeSeconds - prev.seconds)
+            cpuPercent = used / (s.uptime - prev.uptime) * 100
+        }
+        lastCPU = (s.uptime, s.cpuTimeSeconds)
+
+        let totals = NetworkTrafficMeter.shared.totals()
+        if let prev = lastNet, s.uptime > prev.uptime {
+            let dt = s.uptime - prev.uptime
+            downBytesPerSec = Double(totals.received.subtractingClamped(prev.totals.received)) / dt
+            upBytesPerSec = Double(totals.sent.subtractingClamped(prev.totals.sent)) / dt
+        }
+        lastNet = (s.uptime, totals)
+    }
+}
+
+private extension UInt64 {
+    /// Delta against an earlier cumulative reading, floored at zero so a counter
+    /// reset or wrap never shows as a spurious huge spike.
+    func subtractingClamped(_ other: UInt64) -> UInt64 { self >= other ? self - other : 0 }
+}
+
+/// The floating panel. Non-interactive so it can never intercept a click on the
+/// UI beneath it; hidden entirely when the Settings toggle is off. Its own
+/// monitor instance, started on appear.
+struct DevMetricsOverlay: View {
+    @AppStorage(DevMetrics.overlayEnabledKey) private var enabled = true
+    @State private var monitor = DevMetricsMonitor()
+
+    var body: some View {
+        Group {
+            if enabled {
+                panel
+                    .onAppear { monitor.start() }
+                    .onDisappear { monitor.stop() }
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: enabled)
+    }
+
+    private var panel: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            metric("MEM", DevMetrics.formatBytes(monitor.memoryBytes))
+            metric("CPU", String(format: "%.1f%%", monitor.cpuPercent))
+            metric("NET", "↓\(DevMetrics.formatRate(monitor.downBytesPerSec))  ↑\(DevMetrics.formatRate(monitor.upBytesPerSec))")
+        }
+        .font(.system(size: 10, weight: .medium, design: .monospaced))
+        .foregroundStyle(.white)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.35), radius: 6, y: 2)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func metric(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 6) {
+            Text(label).foregroundStyle(.white.opacity(0.5))
+            Text(value).monospacedDigit()
+        }
+    }
+}
+
+/// Shared constants and formatting for the debug metrics overlay, outside the
+/// `View`/monitor so the Settings toggle can reach the same defaults key.
+enum DevMetrics {
+    /// UserDefaults key backing the Settings ▸ Appearance toggle. On by default,
+    /// so a fresh Debug build shows the overlay without any setup.
+    static let overlayEnabledKey = "showDevMetricsOverlay"
+
+    static func formatBytes(_ bytes: UInt64) -> String {
+        let mb = Double(bytes) / 1_048_576
+        return mb >= 1_024
+            ? String(format: "%.2f GB", mb / 1_024)
+            : String(format: "%.0f MB", mb)
+    }
+
+    static func formatRate(_ bytesPerSec: Double) -> String {
+        let rate = max(0, bytesPerSec)
+        switch rate {
+        case ..<1_024: return String(format: "%.0f B/s", rate)
+        case ..<1_048_576: return String(format: "%.1f KB/s", rate / 1_024)
+        default: return String(format: "%.1f MB/s", rate / 1_048_576)
+        }
+    }
+}
+#endif

--- a/App/Sources/DevOverlay/DevMetricsOverlay.swift
+++ b/App/Sources/DevOverlay/DevMetricsOverlay.swift
@@ -4,7 +4,7 @@ import Observation
 import SwiftUI
 
 /// Debug-only HUD: samples Droidective's *own* memory, CPU, and network
-/// throughput once a second and drives the top-left overlay. Compiled only into
+/// throughput once a second and drives the top-right overlay. Compiled only into
 /// Debug builds. Memory and CPU come from `ProcessStats` (CPU% derived from the
 /// cumulative-time delta, the same math `ResourceWatchdog` uses); network from
 /// `NetworkTrafficMeter`, the app's own transfer tally.

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -13,6 +13,7 @@ struct CustomCommandsView: View {
     @State private var draftCommand = ""
     @State private var draftKind: CustomCommandKind = .adb
     @State private var draftNeedsBundle = false
+    @State private var pendingDelete: CustomCommand?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -77,12 +78,12 @@ struct CustomCommandsView: View {
                         }
                         .buttonStyle(.plain)
                         Button {
-                            commands.removeAll { $0.id == command.id }
-                            persist()
+                            pendingDelete = command
                         } label: {
                             Image(systemName: "trash").foregroundStyle(.red)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Delete \(command.name)")
                     }
                     .padding(.vertical, 2)
                 }
@@ -96,6 +97,22 @@ struct CustomCommandsView: View {
         .task { commands = await state.env.stores.customCommands.load() }
         .sheet(isPresented: $showEditor) { editor }
         .sheet(isPresented: $showPresets) { presetLibrary }
+        .confirmationDialog(
+            "Delete “\(pendingDelete?.name ?? "")”?",
+            isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let target = pendingDelete {
+                    commands.removeAll { $0.id == target.id }
+                    persist()
+                }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: {
+            Text("This can't be undone.")
+        }
     }
 
     private var editor: some View {

--- a/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
+++ b/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
@@ -25,6 +25,8 @@ struct DecompileBrowserView: View {
     @State private var fileText: String?
     @State private var fileLanguage = ""
     @State private var targetLine = 0
+    /// Bumped on every file open so a slow read can't overwrite a newer one.
+    @State private var fileLoadID = 0
     @State private var findToken = 0
 
     @State private var filter = ""
@@ -359,7 +361,11 @@ struct DecompileBrowserView: View {
             let dir = try await state.env.engine.decompile.decompile(
                 apkPath: apkURL.path, mode: mode, into: AppPaths.decompiledCacheDir)
             guard !Task.isCancelled else { return }
-            root = DecompileService.tree(at: dir)
+            // A decompiled APK is tens of thousands of files; walk it off the
+            // main actor so the browser doesn't beachball as it appears.
+            let tree = await Task.detached { DecompileService.tree(at: dir) }.value
+            guard !Task.isCancelled else { return }
+            root = tree
             status = nil
         } catch {
             status = error.localizedDescription
@@ -407,15 +413,27 @@ struct DecompileBrowserView: View {
         }
         let ext = (path as NSString).pathExtension.lowercased()
         fileLanguage = ext == "java" ? "java" : (ext == "xml" ? "xml" : "")
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-            fileText = "Couldn't read this file."
+        // Stat the size first — clicking a large binary (a lib/*.so,
+        // resources.arsc) must not block the main actor on a full read only to
+        // then reject it.
+        if let size = (try? FileManager.default.attributesOfItem(atPath: path))?[.size] as? Int,
+           size > 2_000_000 {
+            fileText = "File too large to preview (\(ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)))."
             return
         }
-        if data.count > 2_000_000 {
-            fileText = "File too large to preview (\(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)))."
-        } else {
-            fileText = String(data: data, encoding: .utf8)
-                ?? "Binary file — \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))."
+        fileLoadID += 1
+        let token = fileLoadID
+        fileText = nil
+        Task {
+            let text = await Task.detached { () -> String in
+                guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+                    return "Couldn't read this file."
+                }
+                return String(data: data, encoding: .utf8)
+                    ?? "Binary file — \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))."
+            }.value
+            guard token == fileLoadID else { return }
+            fileText = text
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -10,6 +10,7 @@ struct DeepLinksSection: View {
     @State private var showEditor = false
     @State private var draftLabel = ""
     @State private var draftURL = ""
+    @State private var pendingDelete: DeepLink?
 
     var body: some View {
         HubSection("Deep links", subtitle: "Saved per app — launch a URL on the device in one click.") {
@@ -41,6 +42,19 @@ struct DeepLinksSection: View {
         }
         .task(id: state.selectedBundleId) { await loadLinks() }
         .sheet(isPresented: $showEditor) { editor }
+        .confirmationDialog(
+            "Delete “\(pendingDelete?.label ?? "")”?",
+            isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let target = pendingDelete { remove(target) }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: {
+            Text("This can't be undone.")
+        }
     }
 
     private func linkRow(_ link: DeepLink) -> some View {
@@ -68,10 +82,11 @@ struct DeepLinksSection: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
-            Button { remove(link) } label: {
+            Button { pendingDelete = link } label: {
                 Image(systemName: "trash").foregroundStyle(.red)
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Delete \(link.label)")
         }
         .padding(.vertical, 7)
     }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1195,13 +1195,9 @@ private struct JSValueView: View {
             // An interactive tree rendered from a bounded snapshot fetched via
             // callFunctionOn (not getProperties, which crashes Hermes). All
             // further expansion is client-side over this snapshot — no more
-            // device round-trips.
-            //
-            // Height-bounded: a big object (up to 100 rendered rows) would
-            // otherwise reflow the whole feed on expand and — in the flipped
-            // newest-at-bottom layout — leave the viewport at the *end* of the
-            // object. Capping the height means the feed barely moves and the
-            // object's top shows first; it scrolls internally past the cap.
+            // device round-trips. The owning row scrolls its header to the top
+            // on expand (see scrollHeaderToTop) so the object reads from its
+            // start rather than the feed reflowing to its end.
             ExpandedTree(node: snapshot, session: session)
         } else if failed {
             Text("Couldn't read this value.").font(.caption).foregroundStyle(.tertiary)

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -319,12 +319,14 @@ final class JSConsoleSession {
         }
     }
 
-    /// A bounded pretty-JSON snapshot for expanding an object. Uses
+    /// A bounded, ordered snapshot tree for expanding an object. Uses
     /// `callFunctionOn` (returns a string) rather than `getProperties`, whose
     /// native converter crashes Hermes on some object graphs (e.g. a large
-    /// array). Returns a message string on failure so the row always resolves.
-    func expandedJSON(of objectId: String) async -> String {
-        await cdp.snapshotJSON(objectId: objectId) ?? "Couldn't read this value."
+    /// array). The tree is rendered client-side, so expansion never touches the
+    /// device again.
+    func snapshot(of objectId: String) async -> SnapNode? {
+        guard let json = await cdp.snapshotJSON(objectId: objectId) else { return nil }
+        return SnapNode.parse(json)
     }
 
     func clear() {
@@ -1120,7 +1122,8 @@ private struct JSValueView: View {
     let object: RemoteObject
     let session: JSConsoleSession
     @State private var expanded = false
-    @State private var expandedText: String?
+    @State private var snapshot: SnapNode?
+    @State private var failed = false
     @State private var loading = false
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
@@ -1134,7 +1137,7 @@ private struct JSValueView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Button {
                     expanded.toggle()
-                    if expanded, expandedText == nil, !loading { load() }
+                    if expanded, snapshot == nil, !loading { load() }
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -1181,15 +1184,14 @@ private struct JSValueView: View {
     @ViewBuilder private var expandedChildren: some View {
         if loading {
             ProgressView().controlSize(.small)
-        } else if let expandedText {
-            // A bounded pretty-JSON snapshot fetched via callFunctionOn (not
-            // getProperties, which crashes Hermes). Rendered read-only; the
-            // collapsed preview above stays the interactive summary.
-            highlightedText(expandedText, query: query, base: jsColor(.plain))
-                .font(.system(.callout, design: .monospaced))
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if let snapshot {
+            // An interactive tree rendered from a bounded snapshot fetched via
+            // callFunctionOn (not getProperties, which crashes Hermes). All
+            // further expansion is client-side over this snapshot — no more
+            // device round-trips.
+            SnapChildrenView(node: snapshot, session: session)
+        } else if failed {
+            Text("Couldn't read this value.").font(.caption).foregroundStyle(.tertiary)
         }
     }
 
@@ -1197,9 +1199,128 @@ private struct JSValueView: View {
         guard let objectId = object.objectId else { return }
         loading = true
         Task {
-            let text = await session.expandedJSON(of: objectId)
-            expandedText = text
+            let node = await session.snapshot(of: objectId)
+            snapshot = node
+            failed = node == nil
             loading = false
+        }
+    }
+}
+
+// MARK: - Snapshot tree (client-side, no getProperties)
+
+/// The ordered child rows of a container `SnapNode` — array items with index
+/// labels, or object entries with key labels.
+private struct SnapChildrenView: View {
+    let node: SnapNode
+    let session: JSConsoleSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if node.type == "array", let items = node.items {
+                if items.isEmpty { emptyRow }
+                ForEach(Array(items.enumerated()), id: \.offset) { index, child in
+                    SnapValueView(label: String(index), node: child, session: session)
+                }
+                if let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
+            } else if let entries = node.entries {
+                if entries.isEmpty { emptyRow }
+                ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                    SnapValueView(label: entry.name, node: entry.node, session: session)
+                }
+                if node.truncated == true { moreRow("…(more)") }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var emptyRow: some View {
+        Text(node.type == "array" ? "(empty array)" : "(no enumerable properties)")
+            .font(.caption).foregroundStyle(.tertiary)
+    }
+
+    private func moreRow(_ text: String) -> some View {
+        Text(text).font(.caption).foregroundStyle(.tertiary)
+    }
+}
+
+/// One row in the snapshot tree: a primitive `key: value`, or a collapsible
+/// container header whose children (another `SnapChildrenView`) indent below.
+private struct SnapValueView: View {
+    let label: String?
+    let node: SnapNode
+    let session: JSConsoleSession
+    @State private var expanded = false
+
+    private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
+
+    var body: some View {
+        if node.isContainer {
+            VStack(alignment: .leading, spacing: 2) {
+                Button {
+                    expanded.toggle()
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 14)
+                        labelText
+                        highlightedText(summary, query: query, base: jsColor(.className))
+                            .font(.system(.callout, design: .monospaced))
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                if expanded {
+                    SnapChildrenView(node: node, session: session).padding(.leading, 18)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                labelText
+                highlightedText(primitiveText, query: query, base: jsColor(kind))
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder private var labelText: some View {
+        if let label {
+            highlightedText("\(label):", query: query, base: jsColor(.key))
+                .font(.system(.callout, design: .monospaced))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Collapsed one-liner for a container, e.g. `Array(200)`, `{3}`, `Map {2}`.
+    private var summary: String {
+        if node.type == "array" {
+            return "Array(\(node.length ?? node.items?.count ?? 0))"
+        }
+        let count = node.entries?.count ?? 0
+        let ctor = node.ctor ?? "Object"
+        return ctor == "Object" ? "{\(count)}" : "\(ctor) {\(count)}"
+    }
+
+    private var primitiveText: String {
+        let text = node.text ?? "—"
+        return node.type == "string" ? "\"\(text)\"" : text
+    }
+
+    private var kind: JSTokenKind {
+        switch node.type {
+        case "string": return .string
+        case "number", "bigint": return .number
+        case "boolean": return .boolean
+        case "null": return .null
+        case "undefined": return .undefined
+        case "function": return .function
+        case "symbol": return .symbol
+        default: return .plain
         }
     }
 }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1142,14 +1142,8 @@ private struct JSValueView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Button {
                     expanded.toggle()
-                    if expanded, snapshot == nil, !loading { load() }
-                    if expanded, let id = scrollTargetID {
-                        // Let the expanded rows lay out, then bring the header to
-                        // the top so the object reads from its start, not its end.
-                        Task {
-                            try? await Task.sleep(for: .milliseconds(60))
-                            scrollToHeader(id)
-                        }
+                    if expanded {
+                        if snapshot == nil, !loading { load() } else { scrollHeaderToTop() }
                     }
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
@@ -1222,6 +1216,22 @@ private struct JSValueView: View {
             snapshot = node
             failed = node == nil
             loading = false
+            if node != nil { scrollHeaderToTop() }
+        }
+    }
+
+    /// Bring the object's header to the top after expanding. The child rows
+    /// aren't lazy, so a big object takes a few frames to lay out; re-issue the
+    /// scroll over a short window so it lands on the settled position, not an
+    /// early estimate (which left the viewport at the object's end).
+    private func scrollHeaderToTop() {
+        guard let id = scrollTargetID else { return }
+        Task {
+            for delay in [30, 120, 260] {
+                try? await Task.sleep(for: .milliseconds(delay))
+                guard expanded else { return }
+                scrollToHeader(id)
+            }
         }
     }
 }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1021,7 +1021,7 @@ private struct JSEntryRow: View {
         case let .input(text):
             line(text, base: JSConsoleTheme.muted)
         case let .result(object):
-            JSValueView(object: object, session: session)
+            JSValueView(object: object, session: session, scrollTargetID: entry.id)
         case let .evalError(details):
             errorContent(details)
         case let .log(level, args, stack):
@@ -1059,7 +1059,7 @@ private struct JSEntryRow: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 case let .object(arg):
-                    JSValueView(object: arg, session: session)
+                    JSValueView(object: arg, session: session, scrollTargetID: entry.id)
                 }
             }
             if level == .error, let stack { StackView(stack: stack) }
@@ -1121,6 +1121,11 @@ private struct JSEntryRow: View {
 private struct JSValueView: View {
     let object: RemoteObject
     let session: JSConsoleSession
+    /// The owning log row's id — set for a top-level object so expanding it
+    /// scrolls that row's header into view instead of leaving the viewport at
+    /// the object's end (the flipped-layout jump).
+    var scrollTargetID: AnyHashable?
+    @Environment(\.logTailScrollToHeader) private var scrollToHeader
     @State private var expanded = false
     @State private var snapshot: SnapNode?
     @State private var failed = false
@@ -1138,6 +1143,14 @@ private struct JSValueView: View {
                 Button {
                     expanded.toggle()
                     if expanded, snapshot == nil, !loading { load() }
+                    if expanded, let id = scrollTargetID {
+                        // Let the expanded rows lay out, then bring the header to
+                        // the top so the object reads from its start, not its end.
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(60))
+                            scrollToHeader(id)
+                        }
+                    }
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -1215,18 +1228,13 @@ private struct JSValueView: View {
 
 // MARK: - Snapshot tree (client-side, no getProperties)
 
-/// An expanded object/array: an optional "search in object" field over a
-/// height-bounded, internally-scrolling tree. Bounding the height keeps a big
-/// object from reflowing the whole feed on expand (which, in the flipped
-/// newest-at-bottom layout, left the viewport at the object's end).
+/// An expanded object/array: an optional "search in object" field over the
+/// tree, rendered inline (the feed grows to fit — no nested scroll). The scroll
+/// jump on expand is handled by the owning row scrolling its header into view.
 private struct ExpandedTree: View {
     let node: SnapNode
     let session: JSConsoleSession
     @State private var search = ""
-    @State private var height: CGFloat = 40
-
-    /// Max height before the object scrolls internally instead of growing the feed.
-    private static let maxHeight: CGFloat = 380
 
     /// Only worth an in-object search box once there are enough children.
     private var searchable: Bool {
@@ -1241,21 +1249,9 @@ private struct ExpandedTree: View {
                     .controlSize(.small)
                     .frame(maxWidth: 260)
             }
-            ScrollView(.vertical) {
-                SnapChildrenView(node: node, session: session, query: query)
-                    .background(GeometryReader { geo in
-                        Color.clear.preference(key: TreeHeightKey.self, value: geo.size.height)
-                    })
-            }
-            .frame(height: min(height, Self.maxHeight))
-            .onPreferenceChange(TreeHeightKey.self) { height = max(20, $0) }
+            SnapChildrenView(node: node, session: session, query: query)
         }
     }
-}
-
-private struct TreeHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 40
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }
 
 /// The ordered child rows of a container `SnapNode` — array items with index

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -319,8 +319,12 @@ final class JSConsoleSession {
         }
     }
 
-    func properties(of objectId: String) async -> [CDPProperty] {
-        (try? await cdp.getProperties(objectId: objectId)) ?? []
+    /// A bounded pretty-JSON snapshot for expanding an object. Uses
+    /// `callFunctionOn` (returns a string) rather than `getProperties`, whose
+    /// native converter crashes Hermes on some object graphs (e.g. a large
+    /// array). Returns a message string on failure so the row always resolves.
+    func expandedJSON(of objectId: String) async -> String {
+        await cdp.snapshotJSON(objectId: objectId) ?? "Couldn't read this value."
     }
 
     func clear() {
@@ -1116,7 +1120,7 @@ private struct JSValueView: View {
     let object: RemoteObject
     let session: JSConsoleSession
     @State private var expanded = false
-    @State private var children: [CDPProperty]?
+    @State private var expandedText: String?
     @State private var loading = false
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
@@ -1130,7 +1134,7 @@ private struct JSValueView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Button {
                     expanded.toggle()
-                    if expanded, children == nil, !loading { load() }
+                    if expanded, expandedText == nil, !loading { load() }
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -1177,26 +1181,15 @@ private struct JSValueView: View {
     @ViewBuilder private var expandedChildren: some View {
         if loading {
             ProgressView().controlSize(.small)
-        } else if let children {
-            VStack(alignment: .leading, spacing: 3) {
-                if children.isEmpty {
-                    Text("(no enumerable properties)").font(.caption).foregroundStyle(.tertiary)
-                }
-                ForEach(Array(children.enumerated()), id: \.offset) { _, property in
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        highlightedText("\(property.name):", query: query, base: jsColor(.key))
-                            .font(.system(.callout, design: .monospaced))
-                            .fixedSize(horizontal: false, vertical: true)
-                        if let value = property.value {
-                            JSValueView(object: value, session: session)
-                        } else {
-                            Text("—").foregroundStyle(.tertiary)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if let expandedText {
+            // A bounded pretty-JSON snapshot fetched via callFunctionOn (not
+            // getProperties, which crashes Hermes). Rendered read-only; the
+            // collapsed preview above stays the interactive summary.
+            highlightedText(expandedText, query: query, base: jsColor(.plain))
+                .font(.system(.callout, design: .monospaced))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -1204,8 +1197,8 @@ private struct JSValueView: View {
         guard let objectId = object.objectId else { return }
         loading = true
         Task {
-            let properties = await session.properties(of: objectId)
-            children = properties
+            let text = await session.expandedJSON(of: objectId)
+            expandedText = text
             loading = false
         }
     }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1189,7 +1189,13 @@ private struct JSValueView: View {
             // callFunctionOn (not getProperties, which crashes Hermes). All
             // further expansion is client-side over this snapshot — no more
             // device round-trips.
-            SnapChildrenView(node: snapshot, session: session)
+            //
+            // Height-bounded: a big object (up to 100 rendered rows) would
+            // otherwise reflow the whole feed on expand and — in the flipped
+            // newest-at-bottom layout — leave the viewport at the *end* of the
+            // object. Capping the height means the feed barely moves and the
+            // object's top shows first; it scrolls internally past the cap.
+            ExpandedTree(node: snapshot, session: session)
         } else if failed {
             Text("Couldn't read this value.").font(.caption).foregroundStyle(.tertiary)
         }
@@ -1209,33 +1215,82 @@ private struct JSValueView: View {
 
 // MARK: - Snapshot tree (client-side, no getProperties)
 
+/// An expanded object/array: an optional "search in object" field over a
+/// height-bounded, internally-scrolling tree. Bounding the height keeps a big
+/// object from reflowing the whole feed on expand (which, in the flipped
+/// newest-at-bottom layout, left the viewport at the object's end).
+private struct ExpandedTree: View {
+    let node: SnapNode
+    let session: JSConsoleSession
+    @State private var search = ""
+    @State private var height: CGFloat = 40
+
+    /// Max height before the object scrolls internally instead of growing the feed.
+    private static let maxHeight: CGFloat = 380
+
+    /// Only worth an in-object search box once there are enough children.
+    private var searchable: Bool {
+        (node.entries?.count ?? node.items?.count ?? 0) >= 8
+    }
+
+    var body: some View {
+        let query = search.trimmingCharacters(in: .whitespaces).lowercased()
+        VStack(alignment: .leading, spacing: 4) {
+            if searchable {
+                SearchField(prompt: "Search in object…", text: $search)
+                    .controlSize(.small)
+                    .frame(maxWidth: 260)
+            }
+            ScrollView(.vertical) {
+                SnapChildrenView(node: node, session: session, query: query)
+                    .background(GeometryReader { geo in
+                        Color.clear.preference(key: TreeHeightKey.self, value: geo.size.height)
+                    })
+            }
+            .frame(height: min(height, Self.maxHeight))
+            .onPreferenceChange(TreeHeightKey.self) { height = max(20, $0) }
+        }
+    }
+}
+
+private struct TreeHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 40
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
 /// The ordered child rows of a container `SnapNode` — array items with index
-/// labels, or object entries with key labels.
+/// labels, or object entries with key labels. `query` (lowercased) prunes to
+/// matching branches for the in-object search.
 private struct SnapChildrenView: View {
     let node: SnapNode
     let session: JSConsoleSession
+    var query: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             if node.type == "array", let items = node.items {
-                if items.isEmpty { emptyRow }
-                ForEach(Array(items.enumerated()), id: \.offset) { index, child in
-                    SnapValueView(label: String(index), node: child, session: session)
+                let shown = items.enumerated().filter { query.isEmpty || $0.element.matches(query) }
+                if shown.isEmpty { emptyRow }
+                ForEach(shown, id: \.offset) { index, child in
+                    SnapValueView(label: String(index), node: child, session: session, query: query)
                 }
-                if let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
+                if query.isEmpty, let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
             } else if let entries = node.entries {
-                if entries.isEmpty { emptyRow }
-                ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
-                    SnapValueView(label: entry.name, node: entry.node, session: session)
+                let shown = entries.enumerated().filter { query.isEmpty || $0.element.node.matches(query, key: $0.element.name) }
+                if shown.isEmpty { emptyRow }
+                ForEach(shown, id: \.offset) { _, entry in
+                    SnapValueView(label: entry.name, node: entry.node, session: session, query: query)
                 }
-                if node.truncated == true { moreRow("…(more)") }
+                if query.isEmpty, node.truncated == true { moreRow("…(more)") }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var emptyRow: some View {
-        Text(node.type == "array" ? "(empty array)" : "(no enumerable properties)")
+        Text(query.isEmpty
+            ? (node.type == "array" ? "(empty array)" : "(no enumerable properties)")
+            : "No matches")
             .font(.caption).foregroundStyle(.tertiary)
     }
 
@@ -1246,13 +1301,20 @@ private struct SnapChildrenView: View {
 
 /// One row in the snapshot tree: a primitive `key: value`, or a collapsible
 /// container header whose children (another `SnapChildrenView`) indent below.
+/// A non-empty `query` auto-expands containers so matches are revealed, and
+/// highlights the matched text.
 private struct SnapValueView: View {
     let label: String?
     let node: SnapNode
     let session: JSConsoleSession
+    var query: String = ""
     @State private var expanded = false
 
-    private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
+    /// Text highlighted in rows: the in-object search when active, else the ⌘F find.
+    private var highlight: String {
+        query.isEmpty ? session.findText.trimmingCharacters(in: .whitespaces) : query
+    }
+    private var isOpen: Bool { expanded || !query.isEmpty }
 
     var body: some View {
         if node.isContainer {
@@ -1261,26 +1323,27 @@ private struct SnapValueView: View {
                     expanded.toggle()
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        Image(systemName: isOpen ? "chevron.down" : "chevron.right")
                             .font(.system(size: 10, weight: .bold))
                             .foregroundStyle(.secondary)
                             .frame(width: 14)
                         labelText
-                        highlightedText(summary, query: query, base: jsColor(.className))
+                        highlightedText(summary, query: highlight, base: jsColor(.className))
                             .font(.system(.callout, design: .monospaced))
                     }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                if expanded {
-                    SnapChildrenView(node: node, session: session).padding(.leading, 18)
+                .disabled(!query.isEmpty)   // search drives expansion; manual toggle resumes when cleared
+                if isOpen {
+                    SnapChildrenView(node: node, session: session, query: query).padding(.leading, 18)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 labelText
-                highlightedText(primitiveText, query: query, base: jsColor(kind))
+                highlightedText(primitiveText, query: highlight, base: jsColor(kind))
                     .font(.system(.callout, design: .monospaced))
                     .textSelection(.enabled)
             }
@@ -1290,7 +1353,7 @@ private struct SnapValueView: View {
 
     @ViewBuilder private var labelText: some View {
         if let label {
-            highlightedText("\(label):", query: query, base: jsColor(.key))
+            highlightedText("\(label):", query: highlight, base: jsColor(.key))
                 .font(.system(.callout, design: .monospaced))
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -30,12 +30,15 @@ struct LogcatView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        // Filter once per render — the status count and the list share it,
+        // instead of each re-scanning the full buffer while searching.
+        let visible = visibleLines
+        return VStack(spacing: 0) {
             toolbar
             Divider()
-            statusBar
+            statusBar(visible: visible)
             Divider()
-            logList
+            logList(visible: visible)
         }
         .task(id: taskKey) { await streamLoop() }
         // Open pre-filtered to the bundle chosen in the device bar (changeable
@@ -114,7 +117,7 @@ struct LogcatView: View {
     }
 
     /// One line of truth about what the stream is actually doing.
-    private var statusBar: some View {
+    private func statusBar(visible: [LogLine]) -> some View {
         HStack(spacing: 6) {
             Circle()
                 .fill(statusColor)
@@ -140,7 +143,7 @@ struct LogcatView: View {
             }
             Spacer()
             if !search.isEmpty {
-                Text("\(visibleLines.count) of \(lines.count) lines match")
+                Text("\(visible.count) of \(lines.count) lines match")
                     .font(.caption)
                     .foregroundStyle(.textMuted)
             } else {
@@ -190,10 +193,10 @@ struct LogcatView: View {
         }
     }
 
-    private var logList: some View {
+    private func logList(visible: [LogLine]) -> some View {
         // Newest lines append at the bottom; LogTailView follows them while the
         // user is at the bottom and pauses the moment they scroll up.
-        LogTailView(entries: visibleLines, newestEdge: .bottom) { line in
+        LogTailView(entries: visible, newestEdge: .bottom) { line in
             Text(attributedDisplay(line))
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundStyle(color(for: line.level))

--- a/App/Sources/FeatureDetail/Views/MeminfoView.swift
+++ b/App/Sources/FeatureDetail/Views/MeminfoView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// Live memory usage for the selected bundle (2s polling) with a Total-PSS graph.
 struct MeminfoView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabIsActive) private var tabIsActive
     @State private var info: MemInfo?
     @State private var history: [MemSample] = []
     @State private var started: Date?
@@ -45,7 +46,9 @@ struct MeminfoView: View {
                 ProgressView("Reading memory…").frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .task(id: "\(state.selectedBundleId ?? "")|\(state.targetSerials.first ?? "")") {
+        // Keyed on visibility too, so polling pauses while the tab is hidden
+        // (tabs stay mounted) and resumes when it comes back to the foreground.
+        .task(id: "\(state.selectedBundleId ?? "")|\(state.targetSerials.first ?? "")|\(tabIsActive)") {
             await poll()
         }
     }
@@ -195,6 +198,9 @@ struct MeminfoView: View {
     }
 
     private func poll() async {
+        // Paused while the tab is hidden — keep the last reading on screen and
+        // spawn no adb until the tab is shown again.
+        guard tabIsActive else { return }
         info = nil
         history = []
         started = nil

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -336,12 +336,12 @@ struct NetworkView: View {
         baselineTx = nil
         sessionRx = 0
         sessionTx = 0
-        state.recordingActive = true
+        state.setRecording(true, owner: "network-speed")
     }
 
     private func stopRecording() {
         isRecording = false
-        state.recordingActive = false
+        state.setRecording(false, owner: "network-speed")
     }
 
     private func launchSampler() {

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -99,7 +99,7 @@ struct PerformanceView: View {
         }
         .onDisappear {
             sampler?.cancel()
-            state.recordingActive = false
+            state.setRecording(false, owner: "performance")
             state.clearExitGuard(exitGuardID)
         }
     }
@@ -521,7 +521,7 @@ struct PerformanceView: View {
             samples = []
             startDate = Date()
             phase = .recording
-            state.recordingActive = true
+            state.setRecording(true, owner: "performance")
             launchSampler()
         case .recording:
             phase = .paused
@@ -529,7 +529,7 @@ struct PerformanceView: View {
             sampler = nil
         case .paused:
             phase = .recording
-            state.recordingActive = true
+            state.setRecording(true, owner: "performance")
             launchSampler()
         }
     }
@@ -547,7 +547,7 @@ struct PerformanceView: View {
         phase = .idle
         sampler?.cancel()
         sampler = nil
-        state.recordingActive = false
+        state.setRecording(false, owner: "performance")
     }
 
     private func launchSampler() {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -436,6 +436,7 @@ final class ReactotronSession {
         guard flushTask == nil else { return }
         flushTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else { return }
             self?.flushPending()
         }
     }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -17,6 +17,12 @@ final class ReactotronSession {
     /// Cumulative wire bytes of `items`, maintained alongside it so the byte
     /// budget doesn't re-sum the buffer on every append.
     private var itemsBytes = 0
+    /// Timeline events received between flushes. Coalesced on a ~16ms timer so a
+    /// chatty client (tens of events/sec) triggers one `items` mutation — and
+    /// thus one SwiftUI invalidation — per frame, not one per event. Never
+    /// observed, so appending to it doesn't re-render.
+    @ObservationIgnored private var pendingItems: [RtItem] = []
+    @ObservationIgnored private var flushTask: Task<Void, Never>?
     // Anonymous usage stats (numbers only, no payload contents) reported per
     // session so the timeline caps can be sized against real workloads.
     private var peakItemsBytes = 0
@@ -119,6 +125,9 @@ final class ReactotronSession {
 
     private func reset() {
         flushUsageStats()
+        flushTask?.cancel()
+        flushTask = nil
+        pendingItems.removeAll()
         // The timeline/store graphs can be huge (gigabytes of nested JSON
         // payloads); hand them to a background task instead of freeing them
         // inline, which hangs the main thread for the whole release cascade.
@@ -270,6 +279,11 @@ final class ReactotronSession {
     }
 
     func clearTimeline() {
+        // Drop buffered-but-unflushed events too, or they'd reappear on the next
+        // flush right after the user cleared the timeline.
+        flushTask?.cancel()
+        flushTask = nil
+        pendingItems.removeAll()
         let cleared = items
         items = []
         itemsBytes = 0
@@ -314,7 +328,7 @@ final class ReactotronSession {
             clients.append(ClientInfo(id: connectionId, name: name, platform: platform))
             refreshConnectionState()
             if !subscriptionPaths.isEmpty { sendSubscriptions() }
-            append(RtItem(
+            enqueue(RtItem(
                 event: parsed, command: intro, connectionId: connectionId,
                 important: false, frameBytes: frameBytes
             ))
@@ -322,8 +336,10 @@ final class ReactotronSession {
             let parsed = ReactotronEvent(command: command)
             switch parsed {
             case .clear:
-                // Scope to the sending client so one app's clear doesn't wipe
-                // another connected app's timeline.
+                // Flush first so events still buffered for this client are
+                // included in the clear, then scope to the sending client so one
+                // app's clear doesn't wipe another connected app's timeline.
+                flushPending()
                 let previous = items
                 items = previous.filter { $0.connectionId != connectionId }
                 itemsBytes = items.reduce(0) { $0 + $1.frameBytes }
@@ -368,7 +384,7 @@ final class ReactotronSession {
             default:
                 break
             }
-            append(RtItem(
+            enqueue(RtItem(
                 event: parsed, command: command, connectionId: connectionId,
                 important: command.isImportant, frameBytes: frameBytes
             ))
@@ -413,13 +429,36 @@ final class ReactotronSession {
         }
     }
 
+    /// Buffer a timeline event and schedule a coalesced flush, so a burst of
+    /// events becomes one `items` mutation instead of one per event.
+    private func enqueue(_ item: RtItem) {
+        pendingItems.append(item)
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(16))
+            self?.flushPending()
+        }
+    }
+
+    /// Drain the pending buffer into the timeline in a single append. Called by
+    /// the flush timer, and eagerly before any read that must see every event
+    /// (a client `clear`, teardown).
+    private func flushPending() {
+        flushTask?.cancel()
+        flushTask = nil
+        guard !pendingItems.isEmpty else { return }
+        let batch = pendingItems
+        pendingItems.removeAll(keepingCapacity: true)
+        appendBatch(batch)
+    }
+
     /// Ring-buffer append bounded by count *and* cumulative frame bytes
     /// (`ReactotronTimeline`), so a client streaming huge payloads can't grow
     /// the retained timeline into gigabytes. Trims oldest-first in batches and
     /// frees the dropped items off the main actor.
-    private func append(_ item: RtItem) {
-        items.append(item)
-        itemsBytes += item.frameBytes
+    private func appendBatch(_ batch: [RtItem]) {
+        items.append(contentsOf: batch)
+        for item in batch { itemsBytes += item.frameBytes }
         peakItemsBytes = max(peakItemsBytes, itemsBytes)
         peakItemCount = max(peakItemCount, items.count)
         let drop = ReactotronTimeline.dropCount(
@@ -987,10 +1026,22 @@ private struct RtItem: Identifiable, Sendable {
     /// timeline's byte budget.
     let frameBytes: Int
     let receivedAt = Date()
+    /// Badge + primary text, lowercased once at creation, so search matching is
+    /// an allocation-free `contains` instead of rebuilding `event.presentation`
+    /// and re-lowercasing on every filter pass.
+    let searchText: String
 
-    var searchText: String {
+    init(event: ReactotronEvent, command: ReactotronCommand, connectionId: Int, important: Bool, frameBytes: Int) {
+        self.event = event
+        self.command = command
+        self.connectionId = connectionId
+        self.important = important
+        self.frameBytes = frameBytes
         let presentation = event.presentation
-        return "\(presentation.badge) \(presentation.primary)"
+        // Bounded so a giant log message (a console.log of a huge string) can't
+        // store a multi-megabyte lowercased copy per row — search matches the
+        // header text, and the full payload lives in the expandable row.
+        searchText = "\(presentation.badge) \(presentation.primary)".prefix(2000).lowercased()
     }
 }
 
@@ -1055,15 +1106,19 @@ private struct TimelinePane: View {
     @State private var newestFirst = true
 
     var body: some View {
-        VStack(spacing: 0) {
-            paneToolbar
+        // Filter once per render — the count badge, export button, and timeline
+        // all read the same result instead of each recomputing the filter.
+        let visible = filteredItems
+        let ordered = newestFirst ? Array(visible.reversed()) : visible
+        return VStack(spacing: 0) {
+            paneToolbar(visible: visible)
             Divider()
-            timeline
+            timeline(ordered: ordered)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var paneToolbar: some View {
+    private func paneToolbar(visible: [RtItem]) -> some View {
         HStack(spacing: 10) {
             Picker("Filter", selection: $filter) {
                 ForEach(RtFilter.allCases) { Text($0.label).tag($0) }
@@ -1077,19 +1132,19 @@ private struct TimelinePane: View {
             Spacer()
 
             if !search.isEmpty || filter != .all {
-                Text("\(visibleItems.count)")
+                Text("\(visible.count)")
                     .font(.caption)
                     .foregroundStyle(.textMuted)
             }
 
             Button {
-                onExport(visibleItems)
+                onExport(visible)
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
             .buttonStyle(IconButtonStyle())
             .help("Export this pane's filtered timeline to JSON")
-            .disabled(visibleItems.isEmpty)
+            .disabled(visible.isEmpty)
 
             Button {
                 newestFirst.toggle()
@@ -1105,22 +1160,21 @@ private struct TimelinePane: View {
         .padding(.vertical, 6)
     }
 
-    private var visibleItems: [RtItem] {
-        items.filter { item in
+    private var filteredItems: [RtItem] {
+        let query = search.trimmingCharacters(in: .whitespaces).lowercased()
+        return items.filter { item in
             if filter != .all, item.event.category != filter { return false }
-            if !search.isEmpty, !item.searchText.localizedCaseInsensitiveContains(search) { return false }
+            // item.searchText is lowercased at creation, so this is a plain,
+            // allocation-free substring check.
+            if !query.isEmpty, !item.searchText.contains(query) { return false }
             return true
         }
     }
 
-    private var orderedItems: [RtItem] {
-        newestFirst ? Array(visibleItems.reversed()) : visibleItems
-    }
-
-    private var timeline: some View {
+    private func timeline(ordered: [RtItem]) -> some View {
         // Newest events land at the top in newest-first, the bottom otherwise —
         // LogTailView follows whichever edge and pauses when the user scrolls off.
-        LogTailView(entries: orderedItems, newestEdge: newestFirst ? .top : .bottom) { item in
+        LogTailView(entries: ordered, newestEdge: newestFirst ? .top : .bottom) { item in
             RtRow(item: item)
             Divider()
         }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -833,11 +833,15 @@ struct ReactotronView: View {
                 Text(path)
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
                     .foregroundStyle(.rtKey)
-                Text(session.subscriptionValues[path]?.jsonString ?? "waiting for a change…")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(session.subscriptionValues[path] == nil ? Color.secondary : Color.textMuted)
-                    .textSelection(.enabled)
-                    .lineLimit(3)
+                if let value = session.subscriptionValues[path] {
+                    // A collapsible, colored tree instead of a raw JSON string —
+                    // the same reader the State browser uses.
+                    JSONTreeView(root: value, showSearch: false)
+                } else {
+                    Text("waiting for a change…")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer(minLength: 8)
             Button { session.removeSubscription(path) } label: {
@@ -892,36 +896,19 @@ struct ReactotronView: View {
                 EmptyHint(icon: "camera", message: "Take a snapshot to capture the store as it is right now.")
             } else {
                 VStack(spacing: 6) {
-                    ForEach(session.snapshots) { snapshot in snapshotRow(snapshot) }
+                    ForEach(session.snapshots) { snapshot in
+                        SnapshotRow(
+                            time: Self.timeFormatter.string(from: snapshot.takenAt),
+                            state: snapshot.state,
+                            onRestore: { session.restore(snapshot) },
+                            onDelete: { session.deleteSnapshot(snapshot) }
+                        )
+                    }
                 }
             }
         }
     }
 
-    private func snapshotRow(_ snapshot: Snapshot) -> some View {
-        HStack(alignment: .center, spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(Self.timeFormatter.string(from: snapshot.takenAt))
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(.rtNumber)
-                Text(snapshot.state.jsonString)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(.textMuted)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            Spacer(minLength: 8)
-            Button("Restore") { session.restore(snapshot) }
-                .controlSize(.small)
-            Button { session.deleteSnapshot(snapshot) } label: {
-                Image(systemName: "trash")
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.tertiary)
-            .help("Delete this snapshot")
-        }
-        .cardInset()
-    }
 
     // MARK: - REPL
 
@@ -1567,24 +1554,70 @@ private func rtRemoteURL(_ uri: String) -> URL? {
 /// Renders a `JSONValue` as a collapsible tree. Everything starts collapsed and
 /// only expanded/visible nodes are flattened into the `LazyVStack`, so even a
 /// very large object is cheap to display until the user drills in.
+/// A saved store snapshot: a compact header (time, Restore, Delete) that reveals
+/// the full state as a collapsible, searchable tree when expanded — instead of a
+/// one-line raw-JSON preview.
+private struct SnapshotRow: View {
+    let time: String
+    let state: JSONValue
+    let onRestore: () -> Void
+    let onDelete: () -> Void
+    @State private var expanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 10) {
+                Button { expanded.toggle() } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.secondary)
+                        Text(time)
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(.rtNumber)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(expanded ? "Hide the snapshot" : "Show the snapshot")
+                Spacer(minLength: 8)
+                Button("Restore", action: onRestore).controlSize(.small)
+                Button(action: onDelete) { Image(systemName: "trash") }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tertiary)
+                    .help("Delete this snapshot")
+            }
+            if expanded {
+                JSONTreeView(root: state)
+            }
+        }
+        .cardInset()
+    }
+}
+
 private struct JSONTreeView: View {
     let root: JSONValue
+    /// Show the built-in key/value search field (hidden when embedded in a list
+    /// where a search box per row would be clutter).
+    var showSearch: Bool = true
     @State private var expanded: Set<String> = []
     @State private var search = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 4) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
-                TextField("Search keys & values…", text: $search)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11, design: .monospaced))
-                if !search.isEmpty {
-                    Button { search = "" } label: { Image(systemName: "xmark.circle.fill") }
-                        .buttonStyle(.plain)
+            if showSearch {
+                HStack(spacing: 4) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 9))
                         .foregroundStyle(.tertiary)
+                    TextField("Search keys & values…", text: $search)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, design: .monospaced))
+                    if !search.isEmpty {
+                        Button { search = "" } label: { Image(systemName: "xmark.circle.fill") }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
             LazyVStack(alignment: .leading, spacing: 1) {

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -57,7 +57,7 @@ struct ScreenRecordView: View {
         }
         .onDisappear {
             limitTask?.cancel()
-            state.recordingActive = false
+            state.setRecording(false, owner: "screen-record")
             state.clearExitGuard(exitGuardID)
             if isRecording, let recorder { Task { await recorder.abort() } }
             if let url = recordedURL { try? FileManager.default.removeItem(at: url) }
@@ -249,7 +249,7 @@ struct ScreenRecordView: View {
             // performance/network recorders do. A recording targets one device;
             // switching it mid-capture would strand this recorder (the view stays
             // mounted on a device switch, so .onDisappear never fires to abort it).
-            state.recordingActive = true
+            state.setRecording(true, owner: "screen-record")
             state.setExitGuard(.init(
                 id: exitGuardID, featureID: tabFeatureID, style: .recording,
                 title: "Recording in progress",
@@ -310,7 +310,7 @@ struct ScreenRecordView: View {
         isStopping = false
         startedAt = nil
         self.recorder = nil
-        state.recordingActive = false
+        state.setRecording(false, owner: "screen-record")
         state.clearExitGuard(exitGuardID)
     }
 
@@ -322,7 +322,7 @@ struct ScreenRecordView: View {
         // Cleared here, not only in .onDisappear: a Stop & Save that resolves a
         // device switch keeps this view mounted, so onDisappear wouldn't fire to
         // unlock the device/bundle pickers.
-        state.recordingActive = false
+        state.setRecording(false, owner: "screen-record")
         guard let recorder else { state.finishExitSave(); return }
         self.recorder = nil
         isRecording = false

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -76,13 +76,13 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             }
             .coordinateSpace(name: "logtail")
             // Let a row scroll its own header into view (e.g. when an object is
-            // expanded). Scroll to the row's leading (newest-side) edge — `.top`
-            // in both layouts, since `.scrollPosition` already treats the newest
-            // side as the anchor and the per-row flip keeps the header there.
+            // expanded). In the flipped newest-at-bottom layout the per-row flip
+            // puts a row's header at its internal *bottom*, so `.bottom` lands it
+            // at the visible top; `.top` does that for the un-flipped layout.
+            // No animation — the caller may re-issue this as rows lay out, and
+            // snapping straight to the settled position avoids visible drift.
             .environment(\.logTailScrollToHeader) { id in
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    proxy.scrollTo(id, anchor: .top)
-                }
+                proxy.scrollTo(id, anchor: newestEdge == .bottom ? .bottom : .top)
             }
             .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest
             .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -75,6 +75,16 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
                     )
             }
             .coordinateSpace(name: "logtail")
+            // Let a row scroll its own header into view (e.g. when an object is
+            // expanded). The anchor matches the newest edge: in the flipped
+            // newest-at-bottom layout the row's header sits at its content-bottom,
+            // so `.bottom` brings it to the visible top — the inverse of `.top`
+            // for the un-flipped newest-at-top layout.
+            .environment(\.logTailScrollToHeader) { id in
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    proxy.scrollTo(id, anchor: newestEdge == .bottom ? .bottom : .top)
+                }
+            }
             .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest
             .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds
             .onAppear { leadingID = newestID }
@@ -153,4 +163,19 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
 private struct TailOffsetKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+/// A row can call this to scroll its own header into view (e.g. right after
+/// expanding a large object), so growth doesn't leave the viewport at the
+/// object's end. Injected by `LogTailView` with the correct anchor for its
+/// layout; a no-op outside one.
+private struct LogTailScrollKey: EnvironmentKey {
+    static let defaultValue: @MainActor (AnyHashable) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+    var logTailScrollToHeader: @MainActor (AnyHashable) -> Void {
+        get { self[LogTailScrollKey.self] }
+        set { self[LogTailScrollKey.self] = newValue }
+    }
 }

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -37,6 +37,15 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
     /// only from real position changes, so an append — which moves the "newest" id
     /// before the binding catches up — can't flip it falsely.
     @State private var isTailing = true
+    /// Distance the content has been scrolled from the newest edge. `leadingID`
+    /// alone only changes once a whole (possibly tall) row scrolls past the edge,
+    /// so scrolling *within* the newest row wouldn't register as "scrolled away";
+    /// this catches that so tailing pauses on any real scroll.
+    @State private var atNewestEdge = true
+
+    /// How far (points) the content may sit from the newest edge and still count
+    /// as "parked at the edge", covering sub-pixel rounding and a tail auto-scroll.
+    private static var edgeTolerance: CGFloat { 24 }
 
     /// The newest entry: `.bottom` feeds arrive at the end of `entries`, `.top`
     /// feeds at the front. Either way it becomes the first row laid out below.
@@ -52,15 +61,35 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) { orderedRows }
                     .scrollTargetLayout()
+                    .background(
+                        GeometryReader { geo in
+                            // Content top relative to the scroll view; ~0 at the
+                            // newest edge, growing in magnitude as the user scrolls
+                            // away. Sign flips with the layout flip, so compare the
+                            // magnitude.
+                            Color.clear.preference(
+                                key: TailOffsetKey.self,
+                                value: geo.frame(in: .named("logtail")).minY
+                            )
+                        }
+                    )
             }
+            .coordinateSpace(name: "logtail")
             .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest
             .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds
             .onAppear { leadingID = newestID }
-            .onChange(of: leadingID) { _, id in isTailing = (id == newestID) }
+            .onChange(of: leadingID) { recomputeTailing() }
+            .onPreferenceChange(TailOffsetKey.self) { minY in
+                let atEdge = abs(minY) <= Self.edgeTolerance
+                if atEdge != atNewestEdge {
+                    atNewestEdge = atEdge
+                    recomputeTailing()
+                }
+            }
             .onChange(of: newestID) { _, newest in
                 if isTailing, let newest { leadingID = newest }   // cheap: first row, offset 0
             }
-            .onChange(of: newestEdge) { isTailing = true; leadingID = newestID }
+            .onChange(of: newestEdge) { atNewestEdge = true; isTailing = true; leadingID = newestID }
             .onChange(of: focusID) { _, id in
                 guard let id else { return }
                 // `scrollTo` doesn't write back into `leadingID`, so stop tailing
@@ -80,6 +109,13 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
         }
     }
 
+    /// Tail only when the newest row is the leading row *and* the content is
+    /// parked at the newest edge — so scrolling within a tall newest row still
+    /// pauses following.
+    private func recomputeTailing() {
+        isTailing = (leadingID == newestID) && atNewestEdge
+    }
+
     /// Rows laid out newest-first. `.bottom` feeds reverse the display order and
     /// un-flip each row (the scroll view flip above mirrors the whole stack).
     @ViewBuilder private var orderedRows: some View {
@@ -96,6 +132,7 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
 
     private var jumpButton: some View {
         Button {
+            atNewestEdge = true
             withAnimation(.easeOut(duration: 0.25)) { leadingID = newestID }
         } label: {
             Image(systemName: newestEdge == .bottom ? "arrow.down" : "arrow.up")
@@ -109,4 +146,11 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
         .help("Jump to the newest logs")
         .accessibilityLabel("Jump to newest")
     }
+}
+
+/// Content-top offset of a `LogTailView` scroll, in its "logtail" coordinate
+/// space — used to detect scroll-away within a tall newest row.
+private struct TailOffsetKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -76,13 +76,12 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             }
             .coordinateSpace(name: "logtail")
             // Let a row scroll its own header into view (e.g. when an object is
-            // expanded). The anchor matches the newest edge: in the flipped
-            // newest-at-bottom layout the row's header sits at its content-bottom,
-            // so `.bottom` brings it to the visible top — the inverse of `.top`
-            // for the un-flipped newest-at-top layout.
+            // expanded). Scroll to the row's leading (newest-side) edge — `.top`
+            // in both layouts, since `.scrollPosition` already treats the newest
+            // side as the anchor and the per-row flip keeps the header there.
             .environment(\.logTailScrollToHeader) { id in
                 withAnimation(.easeInOut(duration: 0.15)) {
-                    proxy.scrollTo(id, anchor: newestEdge == .bottom ? .bottom : .top)
+                    proxy.scrollTo(id, anchor: .top)
                 }
             }
             .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest

--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -30,18 +30,18 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
     var focusID: Data.Element.ID? = nil
     @ViewBuilder var row: (Data.Element) -> Row
 
-    /// The row at the scroll's leading (offset-0) edge — the newest side. nil
-    /// before the first layout.
+    /// The row pinned at the scroll's leading (offset-0) edge. Drives
+    /// `.scrollPosition` for two things: keeping the viewport stable when rows are
+    /// inserted at the newest edge, and programmatically following the newest line
+    /// while tailing. It is *not* consulted to decide whether we're tailing — that
+    /// is the offset's job (below), because this binding lags and the follow
+    /// overwrites it, which used to race an append into snapping the view back.
     @State private var leadingID: Data.Element.ID?
-    /// True while the newest line sits at that edge (the user is tailing). Updated
-    /// only from real position changes, so an append — which moves the "newest" id
-    /// before the binding catches up — can't flip it falsely.
+    /// True while the content is parked at the newest edge (the user is tailing).
+    /// Derived solely from the measured scroll offset: content-top at the edge
+    /// (`minY ≈ 0`) *is* the newest row parked at the edge, in either flip mode, so
+    /// one signal decides it — no coupling with the laggy `leadingID` binding.
     @State private var isTailing = true
-    /// Distance the content has been scrolled from the newest edge. `leadingID`
-    /// alone only changes once a whole (possibly tall) row scrolls past the edge,
-    /// so scrolling *within* the newest row wouldn't register as "scrolled away";
-    /// this catches that so tailing pauses on any real scroll.
-    @State private var atNewestEdge = true
 
     /// How far (points) the content may sit from the newest edge and still count
     /// as "parked at the edge", covering sub-pixel rounding and a tail auto-scroll.
@@ -87,23 +87,24 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             .scrollPosition(id: $leadingID, anchor: .top)   // .top = first row = newest
             .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds
             .onAppear { leadingID = newestID }
-            .onChange(of: leadingID) { recomputeTailing() }
             .onPreferenceChange(TailOffsetKey.self) { minY in
+                // The offset is the single source of truth for tailing: at the
+                // newest edge the content top sits at ~0; any real scroll away
+                // grows its magnitude past the tolerance and pauses following.
                 let atEdge = abs(minY) <= Self.edgeTolerance
-                if atEdge != atNewestEdge {
-                    atNewestEdge = atEdge
-                    recomputeTailing()
-                }
+                if atEdge != isTailing { isTailing = atEdge }
             }
             .onChange(of: newestID) { _, newest in
                 if isTailing, let newest { leadingID = newest }   // cheap: first row, offset 0
             }
-            .onChange(of: newestEdge) { atNewestEdge = true; isTailing = true; leadingID = newestID }
+            .onChange(of: newestEdge) { isTailing = true; leadingID = newestID }
             .onChange(of: focusID) { _, id in
                 guard let id else { return }
                 // `scrollTo` doesn't write back into `leadingID`, so stop tailing
                 // here unless the target *is* the newest row — otherwise the next
-                // append would fire the follower and snap us off the match.
+                // append would fire the follower and snap us off the match. The
+                // offset settles this once the scroll lands, but set it eagerly so
+                // an append in the interim can't yank us off the match.
                 isTailing = (id == newestID)
                 withAnimation(.easeInOut(duration: 0.15)) { proxy.scrollTo(id, anchor: .center) }
             }
@@ -116,13 +117,6 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
             }
             .animation(.snappy(duration: 0.2), value: isTailing)
         }
-    }
-
-    /// Tail only when the newest row is the leading row *and* the content is
-    /// parked at the newest edge — so scrolling within a tall newest row still
-    /// pauses following.
-    private func recomputeTailing() {
-        isTailing = (leadingID == newestID) && atNewestEdge
     }
 
     /// Rows laid out newest-first. `.bottom` feeds reverse the display order and
@@ -141,7 +135,7 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
 
     private var jumpButton: some View {
         Button {
-            atNewestEdge = true
+            isTailing = true
             withAnimation(.easeOut(duration: 0.25)) { leadingID = newestID }
         } label: {
             Image(systemName: newestEdge == .bottom ? "arrow.down" : "arrow.up")

--- a/App/Sources/Root/BundleManagerView.swift
+++ b/App/Sources/Root/BundleManagerView.swift
@@ -10,6 +10,7 @@ struct BundleManagerView: View {
     @State private var nickname = ""
     @State private var packageId = ""
     @State private var editingBundle: AppBundle?
+    @State private var pendingDelete: AppBundle?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -39,12 +40,13 @@ struct BundleManagerView: View {
                         }
                         .buttonStyle(IconButtonStyle())
                         Button {
-                            state.removeBundle(id: bundle.id)
+                            pendingDelete = bundle
                         } label: {
                             Image(systemName: "trash")
                                 .foregroundStyle(.red)
                         }
                         .buttonStyle(IconButtonStyle())
+                        .accessibilityLabel("Delete \(bundle.nickname)")
                     }
                 }
                 .frame(minHeight: 120, maxHeight: 200)
@@ -78,6 +80,19 @@ struct BundleManagerView: View {
         }
         .padding(16)
         .frame(width: 440)
+        .confirmationDialog(
+            "Delete “\(pendingDelete?.nickname ?? "")”?",
+            isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let target = pendingDelete { state.removeBundle(id: target.id) }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: {
+            Text("This removes the saved bundle. This can't be undone.")
+        }
     }
 
     private func submit() {

--- a/App/Sources/Root/CommandLogView.swift
+++ b/App/Sources/Root/CommandLogView.swift
@@ -7,6 +7,7 @@ struct CommandLogView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var entries: [CommandLogEntry] = []
+    @State private var confirmClear = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -20,18 +21,32 @@ struct CommandLogView: View {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(IconButtonStyle())
+                .accessibilityLabel("Refresh")
                 Button(role: .destructive) {
-                    Task {
-                        await state.env.commandLog.clear()
-                        await refresh()
-                    }
+                    confirmClear = true
                 } label: {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(IconButtonStyle())
+                .accessibilityLabel("Clear command log")
                 Button("Close") { dismiss() }
             }
             .padding(12)
+            .confirmationDialog(
+                "Clear the command log?",
+                isPresented: $confirmClear,
+                titleVisibility: .visible
+            ) {
+                Button("Clear", role: .destructive) {
+                    Task {
+                        await state.env.commandLog.clear()
+                        await refresh()
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This removes all recorded commands.")
+            }
 
             Divider()
 

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -23,6 +23,7 @@ struct DeviceBarView: View {
             }
             .buttonStyle(IconButtonStyle())
             .help("Show or hide the sidebar (⌘B)")
+            .accessibilityLabel("Toggle sidebar")
 
             // Device and bundle are matching icon + pill pairs: identical inner
             // spacing, and both pills draw their own background (no hidden
@@ -83,6 +84,7 @@ struct DeviceBarView: View {
                 }
                 .buttonStyle(IconButtonStyle())
                 .help("Refresh devices")
+                .accessibilityLabel("Refresh devices")
 
                 NotificationBell()
             }

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -63,6 +63,10 @@ struct PaletteWindowView: View {
                     ForEach(Array(visibleMatches.enumerated()), id: \.element.id) { index, feature in
                         paletteRow(feature, index: index, isHighlighted: index == highlighted)
                             .onTapGesture { open(at: index) }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityAddTraits(index == highlighted ? [.isButton, .isSelected] : .isButton)
+                            .accessibilityLabel(feature.title)
+                            .accessibilityHint("Opens \(feature.title)")
                     }
                 }
                 .padding(6)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -86,6 +86,7 @@ struct RootView: View {
         // (the exitGuard alone is often unchanged), driving the leave dialog.
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
+            .overlay(alignment: .topLeading) { devMetricsOverlay }
             .environment(\.colorScheme, injectedColorScheme)
             .preferredColorScheme(preferredScheme)
             .background(WindowAccessor { window in
@@ -148,6 +149,15 @@ struct RootView: View {
                 Text(info.message)
             }
             .modifier(TerminalCloseConfirmation(state: state))
+    }
+
+    /// The debug-only self-metrics HUD (memory/CPU/network), pinned top-left over
+    /// the content. Empty in Release; visibility inside is driven by the
+    /// Settings ▸ Appearance toggle.
+    @ViewBuilder private var devMetricsOverlay: some View {
+        #if DEBUG
+        DevMetricsOverlay().padding(.top, 10).padding(.leading, 10)
+        #endif
     }
 
     /// Runs once when the root view appears: wires AppState callbacks, applies

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -86,7 +86,7 @@ struct RootView: View {
         // (the exitGuard alone is often unchanged), driving the leave dialog.
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
-            .overlay(alignment: .topLeading) { devMetricsOverlay }
+            .overlay(alignment: .topTrailing) { devMetricsOverlay }
             .environment(\.colorScheme, injectedColorScheme)
             .preferredColorScheme(preferredScheme)
             .background(WindowAccessor { window in
@@ -151,12 +151,12 @@ struct RootView: View {
             .modifier(TerminalCloseConfirmation(state: state))
     }
 
-    /// The debug-only self-metrics HUD (memory/CPU/network), pinned top-left over
+    /// The debug-only self-metrics HUD (memory/CPU/network), pinned top-right over
     /// the content. Empty in Release; visibility inside is driven by the
     /// Settings ▸ Appearance toggle.
     @ViewBuilder private var devMetricsOverlay: some View {
         #if DEBUG
-        DevMetricsOverlay().padding(.top, 10).padding(.leading, 10)
+        DevMetricsOverlay().padding(.top, 10).padding(.trailing, 10)
         #endif
     }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -92,11 +92,14 @@ struct RootView: View {
                 // Tag the main window so the ⌘W monitor can tell it apart from
                 // Settings / the palette panel.
                 window.identifier = NSUserInterfaceItemIdentifier(RootView.mainWindowID)
-                // Fill the screen's usable area on launch — a regular maximized
-                // window, not a native full-screen Space.
-                if let screen = window.screen ?? NSScreen.main {
+                // Restore the user's saved window frame; only fill the screen's
+                // usable area on the very first launch (nothing to restore), so
+                // a resized window survives relaunch instead of being maximized.
+                let autosaveName = NSWindow.FrameAutosaveName(RootView.mainWindowID)
+                if !window.setFrameUsingName(autosaveName), let screen = window.screen ?? NSScreen.main {
                     window.setFrame(screen.visibleFrame, display: true)
                 }
+                window.setFrameAutosaveName(autosaveName)
             })
             .overlay {
                 // Full-window takeover (macOS has no fullScreenCover), shown
@@ -316,8 +319,11 @@ struct RootView: View {
             }
             VStack(spacing: 0) {
                 // Device bar on top (shared across panes); each pane's own tab
-                // strip sits below it, inside the pane — VS Code-style.
-                if state.activeTabID != "catalog" {
+                // strip sits below it, inside the pane — VS Code-style. Shown
+                // whenever any visible pane needs a device, so focusing the
+                // catalog in one pane of a split doesn't pull the bar (and the
+                // progress strip) out from under a live feature in the other.
+                if state.workspace.groups.contains(where: { $0.activeTab != "catalog" }) {
                     DeviceBarView()
                     if let operation = state.runningOperation {
                         OperationProgressStrip(operation: operation)

--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -712,6 +712,9 @@ struct FeatureRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .onTapGesture { if !reordering { activate() } }
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+            .accessibilityHint("Opens \(feature.title)")
 
             pinControl
             trailingControl

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -243,6 +243,10 @@ private struct TabChip: View {
         .contentShape(Rectangle())
         .onTapGesture { onSelect() }
         .onHover { hovering = $0 }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+        .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)
+        .accessibilityHint("Opens this tab")
     }
 
     @ViewBuilder private var leading: some View {
@@ -270,7 +274,9 @@ private struct TabChip: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .help("Close tab (⌘W)")
+            // ⌘W closes the *active* tab, so only hint it on the active chip.
+            .help(isActive ? "Close tab (⌘W)" : "Close tab")
+            .accessibilityLabel("Close \(title)")
         } else {
             Color.clear.frame(width: 16, height: 16)
         }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -220,6 +220,7 @@ struct PrivacySettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage(ScreenCaptureService.captureFolderDefaultsKey) private var captureFolderPath = ""
     @State private var showCommandLog = false
+    @State private var confirmClearLog = false
 
     private var captureFolderDisplay: String {
         captureFolderPath.isEmpty
@@ -271,7 +272,7 @@ struct PrivacySettingsView: View {
                 LabeledContent("Command log") {
                     HStack {
                         Button("View…") { showCommandLog = true }
-                        Button("Clear") { Task { await state.env.commandLog.clear() } }
+                        Button("Clear") { confirmClearLog = true }
                     }
                 }
             }
@@ -279,6 +280,21 @@ struct PrivacySettingsView: View {
         .formStyle(.grouped)
         .sheet(isPresented: $showCommandLog) {
             CommandLogView()
+        }
+        .confirmationDialog(
+            "Clear the command log?",
+            isPresented: $confirmClearLog,
+            titleVisibility: .visible
+        ) {
+            Button("Clear", role: .destructive) {
+                Task {
+                    await state.env.commandLog.clear()
+                    state.showToast(Toast(message: "Command log cleared", ok: true))
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes all recorded commands.")
         }
     }
 }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -164,6 +164,9 @@ struct AppearanceSettingsView: View {
     @AppStorage("theme") private var theme = "dark"
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
+    #if DEBUG
+    @AppStorage(DevMetrics.overlayEnabledKey) private var showDevMetrics = true
+    #endif
 
     /// The accent ColorPicker reads/writes the stored hex; an empty value shows
     /// (and resets to) the bundled default.
@@ -210,6 +213,15 @@ struct AppearanceSettingsView: View {
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }
+
+            #if DEBUG
+            Section("Developer") {
+                Toggle("Show self-metrics overlay", isOn: $showDevMetrics)
+                Text("A floating panel (top-left) with Droidective's own memory, CPU, and network throughput. Debug builds only.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+            }
+            #endif
         }
         .formStyle(.grouped)
     }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -217,7 +217,7 @@ struct AppearanceSettingsView: View {
             #if DEBUG
             Section("Developer") {
                 Toggle("Show self-metrics overlay", isOn: $showDevMetrics)
-                Text("A floating panel (top-left) with Droidective's own memory, CPU, and network throughput. Debug builds only.")
+                Text("A floating panel (top-right) with Droidective's own memory, CPU, and network throughput. Debug builds only.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/State/AppState+Sidebar.swift
+++ b/App/Sources/State/AppState+Sidebar.swift
@@ -294,6 +294,9 @@ extension AppState {
     }
 
     func persistLayout() {
+        // Until bootstrap has loaded the persisted layout, `layout` is still the
+        // default — writing it would overwrite the user's saved data.
+        guard didLoadLayout else { return }
         let snapshot = layout
         Task {
             try? await env.stores.layout.save(snapshot)

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -288,6 +288,14 @@ final class AppState {
     /// async layout load can't overwrite the just-seeded curation.
     private var roleChosenThisSession = false
 
+    /// False until `bootstrap` has loaded the persisted layout. Until then the
+    /// in-memory `layout` is still the default, so persisting it would clobber
+    /// the user's saved layout — `persistLayout` no-ops while this is false.
+    private(set) var didLoadLayout = false
+    /// Feature opens that arrived before the layout finished loading (e.g. an
+    /// APK double-clicked in Finder on cold launch). Replayed after restore.
+    private var pendingFeatureOpens: [String] = []
+
     init(env: AppEnvironment) {
         self.env = env
         let savedStep = UserDefaults.standard.object(forKey: "fontScaleStep") as? Int ?? Self.defaultScaleIndex
@@ -313,19 +321,27 @@ final class AppState {
         let loadedLayout = await env.stores.layout.load()
         // A brand-new user can pick a role — which seeds `layout` — while these
         // async store loads are still in flight; don't clobber that seed.
+        var layoutChanged = false
         if !roleChosenThisSession {
             layout = loadedLayout
-            var layoutChanged = layout.adoptNewDefaults()
+            layoutChanged = layout.adoptNewDefaults()
             layoutChanged = layout.adoptAllEnabled() || layoutChanged
             layoutChanged = layout.adoptNewRoleFeatures() || layoutChanged
-            if layoutChanged {
-                persistLayout()
-            }
             // Reopen the tabs from the last session (idle — recordings/streams
             // don't resume). Falls back to a single Home tab for a new user or a
             // layout written before tabs existed.
             restoreTabs(from: layout)
         }
+        didLoadLayout = true
+        // Replay feature opens that raced the load (e.g. openAPKs from Finder),
+        // then persist for the first time now that `layout` is authoritative.
+        for id in pendingFeatureOpens {
+            workspace.open(id)
+        }
+        if layoutChanged || !pendingFeatureOpens.isEmpty {
+            persistTabs()
+        }
+        pendingFeatureOpens = []
         usageStats = await env.stores.usage.load()
         bundles = await env.stores.bundles.load()
         await refreshToolStatus()
@@ -571,7 +587,13 @@ final class AppState {
     /// stay mounted), so there's no leave guard.
     func requestFeature(_ id: String) {
         workspace.open(id)
-        persistTabs()
+        if didLoadLayout {
+            persistTabs()
+        } else {
+            // The layout hasn't finished loading; record the open so bootstrap
+            // can replay and persist it without a default layout clobbering disk.
+            pendingFeatureOpens.append(id)
+        }
     }
 
     /// What put the "close all terminals?" prompt on screen: closing the

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -123,9 +123,23 @@ final class AppState {
     /// Drives the first-launch role picker (a full-window takeover) and the
     /// "Change role" flow. Picking a role seeds a curated feature set.
     var presentRolePicker = false
-    /// True while a performance/network recording is in flight — locks the
-    /// device and bundle pickers so the captured series stays consistent.
-    var recordingActive = false
+    /// Owners of an in-flight performance/network/screen recording, keyed by
+    /// feature id. The device and bundle pickers lock while any recording runs,
+    /// so a second recorder in another tab can't have the device switched out
+    /// from under it when the first one stops.
+    private(set) var recordingOwners: Set<String> = []
+
+    /// True while any recording is in flight — locks the device/bundle pickers.
+    var recordingActive: Bool { !recordingOwners.isEmpty }
+
+    /// Mark a recording started/stopped for `owner` (its feature id).
+    func setRecording(_ active: Bool, owner: String) {
+        if active {
+            recordingOwners.insert(owner)
+        } else {
+            recordingOwners.remove(owner)
+        }
+    }
 
     /// Views holding losable work (an active recording, unsaved editor edits)
     /// register a guard here, keyed by the owning tab's feature id, so closing

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -759,6 +759,13 @@ final class AppState {
         FeatureRegistry.byID[id] != nil || ["home", "about", "catalog"].contains(id)
     }
 
+    /// Widen device polling while the app is backgrounded so an idle, hidden
+    /// window stops spawning `adb devices` every 2s; restore it on foreground.
+    func setForeground(_ active: Bool) {
+        let interval: Duration = active ? .seconds(2) : .seconds(10)
+        Task { [monitor = env.monitor] in await monitor.setPollInterval(interval) }
+    }
+
     /// Switch the active device, or hold it behind a confirmation when a guard
     /// is active.
     func requestDevice(_ serial: String) {

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -352,7 +352,9 @@ final class AppState {
         for id in pendingFeatureOpens {
             workspace.open(id)
         }
-        if layoutChanged || !pendingFeatureOpens.isEmpty {
+        // Persist if defaults were adopted, an open raced the load, or a role was
+        // seeded while loading (chooseRole's persistTabs no-op'd before load).
+        if layoutChanged || !pendingFeatureOpens.isEmpty || roleChosenThisSession {
             persistTabs()
         }
         pendingFeatureOpens = []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 541 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 544 tests, keep green
 make build         # xcodegen generate + xcodebuild Debug
 make run           # build + open the .app
 ```
@@ -327,7 +327,7 @@ and sign — with keystore creation) plus Frida setup, a custom accent color,
 launching emulators from the device bar, per-feature connect-a-device empty
 states, a live-preview hotkey recorder, and a Settings split into
 Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 541 tests green;
+Application Support and are sized/removable in Settings); 544 tests green;
 builds clean with zero warnings (enforced as errors in CI). Verified live against a
 physical device and an Android emulator. Release builds are Developer ID-signed +
 notarized and bundle scrcpy/ffmpeg (see `RELEASING.md`). Open gaps: the Apps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,14 @@ pane per feature. Swift 6 + SwiftUI, macOS 14+.
 
 ## Architecture (the load-bearing rule)
 
-Two layers, strictly separated so a future cross-platform port only re-does UI:
+Two layers, strictly separated so a second **Apple** UI (iPad/visionOS) could
+reuse ADBKit almost as-is. Note the honest scope: a Linux/Windows port re-does
+the UI **plus** the macOS-bound seams inside ADBKit — the Mirror media stack
+(CoreMedia/VideoToolbox/AVFoundation), the Network.framework socket servers,
+`ToolLocator`'s Homebrew/SDK paths + `zsh -lc`, and `.lzma`/`tar` extraction;
+an iOS companion can't run `Process` at all, so it would need a remote-host
+protocol, not just a UI swap. Keep the existing seams (`ProcessRunning`,
+injected directories) and don't pre-abstract the rest until a port is scheduled.
 
 - **`ADBKit/`** — a SwiftPM package holding *all* logic. Zero UI imports
   (feature icons are SF Symbol *name strings*). Actors for stateful services,
@@ -60,7 +67,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 350 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 539 tests, keep green
 make build         # xcodegen generate + xcodebuild Debug
 make run           # build + open the .app
 ```
@@ -320,7 +327,7 @@ and sign — with keystore creation) plus Frida setup, a custom accent color,
 launching emulators from the device bar, per-feature connect-a-device empty
 states, a live-preview hotkey recorder, and a Settings split into
 Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 513 tests green;
+Application Support and are sized/removable in Settings); 539 tests green;
 builds clean with zero warnings (enforced as errors in CI). Verified live against a
 physical device and an Android emulator. Release builds are Developer ID-signed +
 notarized and bundle scrcpy/ffmpeg (see `RELEASING.md`). Open gaps: the Apps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 539 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 541 tests, keep green
 make build         # xcodegen generate + xcodebuild Debug
 make run           # build + open the .app
 ```
@@ -327,7 +327,7 @@ and sign — with keystore creation) plus Frida setup, a custom accent color,
 launching emulators from the device bar, per-feature connect-a-device empty
 states, a live-preview hotkey recorder, and a Settings split into
 Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 539 tests green;
+Application Support and are sized/removable in Settings); 541 tests green;
 builds clean with zero warnings (enforced as errors in CI). Verified live against a
 physical device and an Android emulator. Release builds are Developer ID-signed +
 notarized and bundle scrcpy/ffmpeg (see `RELEASING.md`). Open gaps: the Apps

--- a/project.yml
+++ b/project.yml
@@ -9,19 +9,19 @@ packages:
     path: ADBKit
   KeyboardShortcuts:
     url: https://github.com/sindresorhus/KeyboardShortcuts
-    from: 1.10.0
+    exactVersion: 1.10.0
   SwiftTerm:
     url: https://github.com/migueldeicaza/SwiftTerm
-    from: 1.13.0
+    exactVersion: 1.13.0
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
-    from: 2.9.3
+    exactVersion: 2.9.3
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa
-    from: 9.18.0
+    exactVersion: 9.18.0
   PostHog:
     url: https://github.com/PostHog/posthog-ios
-    from: 3.61.0
+    exactVersion: 3.61.0
 targets:
   App:
     type: application

--- a/scripts/update-bundled-tools.sh
+++ b/scripts/update-bundled-tools.sh
@@ -20,14 +20,38 @@ RES="$ROOT/App/Resources"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-echo "==> scrcpy-server v$SCRCPY_VERSION"
-curl -fsSL -o "$RES/scrcpy-server" \
-  "https://github.com/Genymobile/scrcpy/releases/download/v${SCRCPY_VERSION}/scrcpy-server-v${SCRCPY_VERSION}"
+# Expected SHA-256 of each download. These pin the exact bytes shipped inside a
+# notarized, GPLv3-bundling app: a download whose hash doesn't match is rejected
+# rather than silently bundled. When intentionally updating a binary, run the
+# script, read the "got" hash from the mismatch error, and update the constant
+# here in the same commit that bumps the version.
+SCRCPY_SERVER_SHA256="84924bd564a1eb6089c872c7521f968058977f91f5ff02514a8c74aff3210f3a"
+FFMPEG_SHA256="ef4fe121377039053b0d7bed4a9aa46e7912918f5ba6424a1dd155f4eed625b0"
 
-echo "==> ffmpeg (latest static, macOS arm64)"
+verify_sha256() {
+  local file="$1" expected="$2" name="$3"
+  local got
+  got="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+  if [[ "$got" != "$expected" ]]; then
+    echo "ERROR: $name sha256 mismatch" >&2
+    echo "  expected $expected" >&2
+    echo "  got      $got" >&2
+    echo "  If this update is intentional, set the constant in this script to the got value." >&2
+    exit 1
+  fi
+}
+
+echo "==> scrcpy-server v$SCRCPY_VERSION"
+curl -fsSL -o "$TMP/scrcpy-server" \
+  "https://github.com/Genymobile/scrcpy/releases/download/v${SCRCPY_VERSION}/scrcpy-server-v${SCRCPY_VERSION}"
+verify_sha256 "$TMP/scrcpy-server" "$SCRCPY_SERVER_SHA256" "scrcpy-server"
+mv "$TMP/scrcpy-server" "$RES/scrcpy-server"
+
+echo "==> ffmpeg (static, macOS arm64)"
 curl -fsSL -o "$TMP/ffmpeg.zip" \
   "https://ffmpeg.martin-riedl.de/redirect/latest/macos/arm64/release/ffmpeg.zip"
 unzip -o -q "$TMP/ffmpeg.zip" -d "$TMP"
+verify_sha256 "$TMP/ffmpeg" "$FFMPEG_SHA256" "ffmpeg"
 mv "$TMP/ffmpeg" "$RES/ffmpeg"
 chmod +x "$RES/ffmpeg"
 


### PR DESCRIPTION
Addresses findings from a full project audit, then a round of React Native console fixes surfaced while testing against a live RN app.

## Security & correctness
- Wrap every user-controlled package/permission value that reaches `adb shell` in `shellQuote()` (AppControl, AppInspection, SystemApps, FeatureEngine `monkey`, PerformanceMonitor, LogcatStream, BugReport). adb subcommands that don't use the device shell (`uninstall`, `pull`, `pm list`) are left unquoted.
- `pm clear` reads its stdout (`Success`/`Failed`) instead of the exit code, which is 0 on failure.
- `CustomCommandService.buildArgs` tokenizes before substituting placeholders, so a `{bundleId}`/`{serial}` value with spaces stays one argv token.
- `JSONStore.save` caches the value only after the write succeeds.
- Guard layout persistence until bootstrap loads it, so an APK opened from Finder on cold launch can't overwrite the saved layout with defaults.
- Move the decompile tree walk and large-file reads off the main actor.

## JS Console
- Expanding an object no longer crashes the RN app. It used CDP `Runtime.getProperties`, which crashes Hermes's VM converting some object graphs (confirmed by a `libhermesvm.so` tombstone). Expansion now fetches a bounded, ordered JSON snapshot via `Runtime.callFunctionOn` (returns a string, so it never hits the native converter) parsed into a `SnapNode` tree and rendered client-side — depth/breadth/string/total-node caps keep big payloads bounded.
- Expanding scrolls the object's header to the top instead of landing on its end.
- Adds a "Search in object" field that prunes and highlights matching keys/values.

## Reactotron
- Coalesce incoming events into a 16 ms batch and filter the timeline once per render, so a chatty client stays smooth.
- Render subscriptions and snapshots as collapsible, syntax-colored trees instead of raw JSON strings.

## Logcat / shared log view
- Auto-follow pauses on any real scroll (offset-based), not only when a whole row scrolls past the edge.
- Hoist the logcat parser regex to a compiled static.

## Performance & polling
- Meminfo pauses polling while its tab is hidden; device polling widens while the app is backgrounded; the performance monitor derives app PSS from the full dump on process ticks.

## UX & platform
- Restore the main window's saved frame instead of maximizing every launch.
- Show the device bar whenever any split pane needs a device.
- Per-owner recording lock so stopping one recorder doesn't unlock the device picker while another is live.
- Confirm destructive deletes (custom commands, deep links, bundles, command-log clears).
- Button traits and accessibility labels on sidebar rows, palette rows, tab chips, and device-bar buttons.

## Supply chain & docs
- Pin the five App SPM dependencies to exact versions; verify bundled scrcpy/ffmpeg downloads against pinned SHA-256s.
- Correct the CLAUDE.md test count and the cross-platform framing.

## Tests / build
541 ADBKit tests pass; App builds clean with warnings-as-errors. New pure logic (`SnapNode` parse/match, the quoting arg-vectors, `pm clear` parsing) is covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)