### PR TITLE
Prepare v2.8.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ through Sparkle (and `brew upgrade` defers to that).
 ADBKit/   Swift package — all logic, zero UI dependencies (swift test)
   Exec/         adb process execution, tool location, scoped command log
   Devices/      discovery (2s polling), getprop, hardware/usage overview
-  Features/     declarative 55-feature registry + runners + how-to notes
+  Features/     declarative 56-feature registry + runners + how-to notes
   Services/     logcat streaming, overrides, file/apps explorers, capture,
                 screen record, crash, bug report, wireless, emulators,
                 performance + network monitors, APK inspect/sign/decompile,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,41 @@
+## Droidective v2.8.3
+
+Adds iOS Simulator support, per-feature product analytics, and a redesigned
+role picker, and ships a rebuilt marketing site.
+
+### New features
+
+- **iOS Simulators in the device bar** — booted iOS Simulators now sit alongside
+  Android devices, and features adapt to the selected platform. Screenshot, dark
+  mode, demo mode, fake battery, and deep links run against a simulator through
+  `xcrun simctl`; push notifications are a new Simulator-only tool. The
+  Emulators & Simulators screen lists and boots or shuts down simulators, and a
+  new iOS Developer role leads with them. A feature that only applies to Android
+  shows a platform-mismatch state with a one-click switch to a connected device.
+  The registry grows from 55 to 56 tools.
+
+### Improvements
+
+- **Role picker redesign** — each role card carries a tool-count pill and
+  feature-preview chips, with hover, press, and keyboard-focus states, a
+  staggered entrance, and Reduce Motion respected.
+- **Product analytics** — anonymous usage is now attributed per feature (which
+  tool was open when an event, hang, or crash occurred), with install-level
+  retention and the target-device landscape. It stays on by default with opt-out
+  in Settings → Privacy; no serials, paths, package ids, SSIDs, or command text
+  are ever sent, and the first-run consent prompt has been removed.
+- **Reactotron & logs** — Reactotron subscriptions and snapshots render as
+  readable trees, expanded console objects are bounded and searchable in place,
+  and log auto-follow is steadier while scrolling.
+
+### Fixes
+
+- Security hardening from an audit pass — device-shell values are consistently
+  shell-quoted — plus a JS Console crash fix and React Native console UX
+  follow-ups.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.8.2
 
 A patch release that fixes the JS Console's reconnect behavior against Metro

--- a/project.yml
+++ b/project.yml
@@ -86,7 +86,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.8.2"
+        MARKETING_VERSION: "2.8.3"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/website/index.html
+++ b/website/index.html
@@ -44,7 +44,7 @@
     "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 56 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "2.8.2",
+    "softwareVersion": "2.8.3",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },

--- a/website/src/components/site/Changelog.tsx
+++ b/website/src/components/site/Changelog.tsx
@@ -8,7 +8,7 @@ export function Changelog() {
   return (
     <section id="changelog" className="mx-auto max-w-[1120px] px-6 py-26 max-[620px]:py-18">
       <SectionHead center eyebrow="changelog" title="Shipped, and still moving.">
-        Fifteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized
+        Sixteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized
         builds since v2.4.0.
       </SectionHead>
       <Reveal className="relative mx-auto max-w-190 pl-7.5 before:absolute before:top-2 before:bottom-2 before:left-1.25 before:w-px before:bg-border-2">

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -16,7 +16,7 @@ export const GITHUB_URL = "https://github.com/Droidective/Droidective"
 export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const LATEST_RELEASE_URL = `${GITHUB_URL}/releases/latest`
-export const APP_VERSION = "v2.8.2"
+export const APP_VERSION = "v2.8.3"
 
 export interface PaletteCommand {
   icon: LucideIcon
@@ -163,7 +163,8 @@ export const galleryShots = [
 ]
 
 export const releases: { version: string; date: string; latest?: boolean; html: string }[] = [
-  { version: "v2.8.2", date: "Jul 2026", latest: true, html: "<b>JS Console reconnect fix</b> — a race killed each fresh Metro connection and leaked the old socket, so the console reconnected in a loop and spammed the dev server; connections are now generation-guarded with a bounded handshake, so it connects once and stays connected. Plus <b>anonymous performance self-monitoring</b> — sustained high CPU or memory in the app is reported with the features open at the time (opt-out in Settings → Privacy)." },
+  { version: "v2.8.3", date: "Jul 2026", latest: true, html: "<b>iOS Simulator support</b> — booted iOS Simulators sit in the same device bar as Android devices, and features adapt to the selection: screenshot, dark mode, demo mode, fake battery, and deep links run through <code>xcrun simctl</code>, with push notifications as a Simulator-only tool and a new iOS Developer role. Plus a <b>redesigned role picker</b>, <b>per-feature product analytics</b> (anonymous, opt-out), and Reactotron/log readability fixes." },
+  { version: "v2.8.2", date: "Jul 2026", html: "<b>JS Console reconnect fix</b> — a race killed each fresh Metro connection and leaked the old socket, so the console reconnected in a loop and spammed the dev server; connections are now generation-guarded with a bounded handshake, so it connects once and stays connected. Plus <b>anonymous performance self-monitoring</b> — sustained high CPU or memory in the app is reported with the features open at the time (opt-out in Settings → Privacy)." },
   { version: "v2.8.1", date: "Jul 2026", html: "<b>Built-in Terminal</b> — multi-tab PTY login shells with the selected device exported as ANDROID_SERIAL — plus <b>shell custom commands</b> through zsh, a <b>Security / Pentest role</b> with reworked per-role sidebars, a <b>Device Info</b> rework, and a round of performance fixes (launch hang, Reactotron memory, JS console search)." },
   { version: "v2.8.0", date: "Jul 2026", html: "<b>Tabbed workspace with split panes</b> — open features in tabs, keep them running while hidden, and split the window in two — plus a <b>React Native JS Console</b> over the Hermes CDP, a curated <b>Run on all devices</b> toggle, and a round of <b>light-mode fixes</b>." },
   { version: "v2.7.1", date: "Jun 2026", html: "<b>Screen mirroring on emulators</b> — scrcpy aborted the whole mirror (video included) when a device couldn't capture audio, which is most emulators; the in-app mirror now detects that and reconnects video-only, so it keeps working." },


### PR DESCRIPTION
Release-prep for v2.8.3. Bundles the version bump, release notes, and the doc/site version updates for the app work that has merged to `main` since v2.8.2 (iOS Simulator support #103, product analytics #102, audit remediation #101) plus the marketing-site rebuild #104.

## Changes
- `project.yml`: `MARKETING_VERSION` 2.8.2 → 2.8.3.
- `RELEASE_NOTES.md`: v2.8.3 section — iOS Simulators in the device bar (screenshot / dark mode / demo mode / fake battery / deep links via `xcrun simctl`, push notifications as a Simulator-only tool, iOS Developer role, registry 55→56), role-picker redesign, per-feature product analytics (anonymous, opt-out; first-run consent prompt removed), and Reactotron/log readability + audit fixes.
- `README.md`: registry count 55 → 56 (matches `hasAll56Features`).
- Marketing site: version string, JSON-LD `softwareVersion`, and changelog updated to 2.8.3.

## Verification
- `cd ADBKit && swift test` — 583 tests pass.
- `make build` — succeeds, zero warnings.
- `npm run build` (website) + lint — clean.

## Release checklist
- [x] `swift test` green
- [x] `make build` clean (zero warnings)
- [x] `MARKETING_VERSION` bumped to 2.8.3
- [x] `RELEASE_NOTES.md` v2.8.3 section added (factual)
- [x] Feature count corrected (README 55→56)
- [x] Screenshots refreshed (shipped in #104)
- [ ] PR reviewed and merged to `main`
- [ ] Tag from `main`: `git tag v2.8.3 && git push origin v2.8.3`

Note: iOS Simulator support is a headline feature — consider tagging this **v2.9.0** instead of a patch. If so, this is a one-line change to `MARKETING_VERSION` and the notes heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)