### PR TITLE
Background mode + global Quick Actions panel

### DIFF
--- a/ADBKit/Sources/ADBKit/Devices/SimulatorMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Devices/SimulatorMonitor.swift
@@ -13,6 +13,7 @@ public actor SimulatorMonitor {
     private var continuations: [UUID: AsyncStream<[Device]>.Continuation] = [:]
     private var pollTask: Task<Void, Never>?
     private var lastPublished: [Device]?
+    private var pollInterval: Duration = .seconds(3)
 
     public init(client: SimctlClient) {
         self.client = client
@@ -55,12 +56,20 @@ public actor SimulatorMonitor {
         return stream
     }
 
+    /// Adjust the polling cadence at runtime — DeviceMonitor's counterpart, so
+    /// the app can widen it while backgrounded instead of spawning `simctl
+    /// list` every 3s forever. Takes effect on the next loop iteration.
+    public func setPollInterval(_ interval: Duration) {
+        pollInterval = interval
+    }
+
     private func startPollingIfNeeded(interval: Duration) {
+        pollInterval = interval
         guard pollTask == nil else { return }
         pollTask = Task {
             while !Task.isCancelled {
                 await self.pollOnce()
-                try? await Task.sleep(for: interval)
+                try? await Task.sleep(for: self.pollInterval)
             }
         }
     }

--- a/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
+++ b/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
@@ -13,14 +13,17 @@ public enum PaletteSearch {
         query: String, enabled: Set<String>, favorites: [String]
     ) -> [FeatureDef] {
         if !query.isEmpty {
-            let ranked = FeatureRegistry.all.enumerated()
-                .filter { $0.element.matches(query) && !$0.element.isAbsorbedByHub }
-                .sorted { lhs, rhs in
-                    let rl = lhs.element.relevance(for: query)
-                    let rr = rhs.element.relevance(for: query)
-                    return rl != rr ? rl > rr : lhs.offset < rhs.offset
+            // Score once per feature — relevance scans title/keywords, so
+            // recomputing it inside the sort comparator is O(n log n) scans.
+            var scored: [Scored] = []
+            for (offset, feature) in FeatureRegistry.all.enumerated() {
+                let score = feature.relevance(for: query)
+                if score > 0, !feature.isAbsorbedByHub {
+                    scored.append(Scored(feature: feature, offset: offset, score: score))
                 }
-                .map(\.element)
+            }
+            scored.sort { $0.score != $1.score ? $0.score > $1.score : $0.offset < $1.offset }
+            let ranked = scored.map(\.feature)
             return ranked.filter { enabled.contains($0.id) }
                 + ranked.filter { !enabled.contains($0.id) }
         }
@@ -46,14 +49,23 @@ public enum PaletteSearch {
                 && implemented.contains($0.element.id)
         }
         guard !query.isEmpty else { return actionable.map(\.element) }
-        return actionable
-            .filter { $0.element.matches(query) }
-            .sorted { lhs, rhs in
-                let rl = lhs.element.relevance(for: query)
-                let rr = rhs.element.relevance(for: query)
-                return rl != rr ? rl > rr : lhs.offset < rhs.offset
+        var scored: [Scored] = []
+        for entry in actionable {
+            let score = entry.element.relevance(for: query)
+            if score > 0 {
+                scored.append(Scored(feature: entry.element, offset: entry.offset, score: score))
             }
-            .map(\.element)
+        }
+        scored.sort { $0.score != $1.score ? $0.score > $1.score : $0.offset < $1.offset }
+        return scored.map(\.feature)
+    }
+
+    /// A feature with its registry position and query relevance, computed
+    /// once before sorting.
+    private struct Scored {
+        let feature: FeatureDef
+        let offset: Int
+        let score: Int
     }
 
     /// Custom commands matching a query against name or command template,

--- a/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
+++ b/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure ordering for the search palettes — the in-app ⌘K palette and the Quick
+/// Actions panel share it, so the ranking rules live here (tested) instead of
+/// in the views.
+public enum PaletteSearch {
+    /// Features in display order. Hub-absorbed members never appear (their hub
+    /// carries their keywords). With a query, matches rank by relevance —
+    /// registry order breaks ties — enabled before disabled. Without one,
+    /// pinned features lead in pin order, then the rest of the registry,
+    /// enabled first.
+    public static func features(
+        query: String, enabled: Set<String>, favorites: [String]
+    ) -> [FeatureDef] {
+        if !query.isEmpty {
+            let ranked = FeatureRegistry.all.enumerated()
+                .filter { $0.element.matches(query) && !$0.element.isAbsorbedByHub }
+                .sorted { lhs, rhs in
+                    let rl = lhs.element.relevance(for: query)
+                    let rr = rhs.element.relevance(for: query)
+                    return rl != rr ? rl > rr : lhs.offset < rhs.offset
+                }
+                .map(\.element)
+            return ranked.filter { enabled.contains($0.id) }
+                + ranked.filter { !enabled.contains($0.id) }
+        }
+        let pinned = favorites
+            .compactMap { FeatureRegistry.byID[$0] }
+            .filter { !$0.isAbsorbedByHub }
+        let pinnedIDs = Set(pinned.map(\.id))
+        let rest = FeatureRegistry.all.filter { !$0.isAbsorbedByHub && !pinnedIDs.contains($0.id) }
+        return pinned
+            + rest.filter { enabled.contains($0.id) }
+            + rest.filter { !enabled.contains($0.id) }
+    }
+
+    /// Custom commands matching a query against name or command template,
+    /// case-insensitively; an empty query keeps the user's saved order.
+    public static func commands(_ commands: [CustomCommand], query: String) -> [CustomCommand] {
+        let needle = query.lowercased().trimmingCharacters(in: .whitespaces)
+        guard !needle.isEmpty else { return commands }
+        return commands.filter {
+            $0.name.lowercased().contains(needle) || $0.command.lowercased().contains(needle)
+        }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
+++ b/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
@@ -34,6 +34,28 @@ public enum PaletteSearch {
             + rest.filter { !enabled.contains($0.id) }
     }
 
+    /// The Quick Actions panel's universe: every *implemented* instant,
+    /// toggle, or form action — hub members included (they are the quick
+    /// actions; a hub is just their in-app grouping). View and system screens
+    /// need the full app and never appear. Empty query keeps registry order;
+    /// otherwise matches rank by relevance, registry order breaking ties.
+    public static func quickActions(query: String, implemented: Set<String>) -> [FeatureDef] {
+        let actionable = FeatureRegistry.all.enumerated().filter {
+            let kind = $0.element.kind
+            return (kind == .instantAction || kind == .toggleAction || kind == .formAction)
+                && implemented.contains($0.element.id)
+        }
+        guard !query.isEmpty else { return actionable.map(\.element) }
+        return actionable
+            .filter { $0.element.matches(query) }
+            .sorted { lhs, rhs in
+                let rl = lhs.element.relevance(for: query)
+                let rr = rhs.element.relevance(for: query)
+                return rl != rr ? rl > rr : lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
     /// Custom commands matching a query against name or command template,
     /// case-insensitively; an empty query keeps the user's saved order.
     public static func commands(_ commands: [CustomCommand], query: String) -> [CustomCommand] {

--- a/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
+++ b/ADBKit/Sources/ADBKit/Features/PaletteSearch.swift
@@ -38,17 +38,34 @@ public enum PaletteSearch {
     }
 
     /// The Quick Actions panel's universe: every *implemented* instant,
-    /// toggle, or form action — hub members included (they are the quick
-    /// actions; a hub is just their in-app grouping). View and system screens
-    /// need the full app and never appear. Empty query keeps registry order;
-    /// otherwise matches rank by relevance, registry order breaking ties.
-    public static func quickActions(query: String, implemented: Set<String>) -> [FeatureDef] {
-        let actionable = FeatureRegistry.all.enumerated().filter {
-            let kind = $0.element.kind
-            return (kind == .instantAction || kind == .toggleAction || kind == .formAction)
-                && implemented.contains($0.element.id)
+    /// toggle, or form action that's enabled — hub members included (they are
+    /// the quick actions; a member's enabledness rides on its hub, since the
+    /// catalog manages members only through the hub). View and system screens
+    /// need the full app and never appear. Empty query leads with pinned
+    /// features then registry order; otherwise matches rank by relevance,
+    /// registry order breaking ties.
+    public static func quickActions(
+        query: String, implemented: Set<String>, enabled: Set<String>, favorites: [String]
+    ) -> [FeatureDef] {
+        var hubByMember: [String: String] = [:]
+        for (hub, members) in FeatureRegistry.absorbedByHub {
+            for member in members { hubByMember[member] = hub }
         }
-        guard !query.isEmpty else { return actionable.map(\.element) }
+        let actionable = FeatureRegistry.all.enumerated().filter { entry in
+            let feature = entry.element
+            let isAction = feature.kind == .instantAction
+                || feature.kind == .toggleAction
+                || feature.kind == .formAction
+            guard isAction, implemented.contains(feature.id) else { return false }
+            if let hub = hubByMember[feature.id] { return enabled.contains(hub) }
+            return enabled.contains(feature.id)
+        }
+        guard !query.isEmpty else {
+            let all = actionable.map(\.element)
+            let pinned = favorites.compactMap { id in all.first { $0.id == id } }
+            let pinnedIDs = Set(pinned.map(\.id))
+            return pinned + all.filter { !pinnedIDs.contains($0.id) }
+        }
         var scored: [Scored] = []
         for entry in actionable {
             let score = entry.element.relevance(for: query)

--- a/ADBKit/Sources/ADBKit/Features/PanelTargeting.swift
+++ b/ADBKit/Sources/ADBKit/Features/PanelTargeting.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure device-target resolution for the Quick Actions panel. The panel must
+/// resolve its own targets from an explicit pick, an approved "All devices"
+/// set, the device-bar selection, and the currently-ready devices — never the
+/// app's `targetSerials`, whose run-on-all state belongs to the hidden main
+/// window. Kept here as plain serials (no `Device`, no app state) so these
+/// rules — the source of several panel targeting bugs — are tested directly.
+public enum PanelTargeting {
+    /// The single device a panel action targets: the most recent pick (dropped
+    /// when that device is no longer ready), else the device-bar selection
+    /// (when ready), else the first ready device — nil when nothing is ready.
+    public static func singleTarget(
+        picked: String?, selected: String?, ready: [String]
+    ) -> String? {
+        if let picked, ready.contains(picked) { return picked }
+        if let selected, ready.contains(selected) { return selected }
+        return ready.first
+    }
+
+    /// The serials an "All devices" approval still covers: approved ∩ ready, in
+    /// the approved order; nil when the approval covers nothing live. A device
+    /// attached *after* the approval isn't in `approved`, so it's never
+    /// targeted — the approval can only shrink as devices drop, never grow.
+    public static func approvedTargets(
+        approved: [String]?, ready: [String]
+    ) -> [String]? {
+        guard let approved else { return nil }
+        let readySet = Set(ready)
+        let live = approved.filter(readySet.contains)
+        return live.isEmpty ? nil : live
+    }
+
+    /// The concrete serials a run hits: the approved fan-out when more than one
+    /// approved device is still ready, otherwise the single target as a
+    /// one-element list ([] when nothing is ready). An approval that has shrunk
+    /// to one live device collapses to it — no spurious single-device fan-out.
+    public static func fanOut(
+        picked: String?, selected: String?, approved: [String]?, ready: [String]
+    ) -> [String] {
+        if let live = approvedTargets(approved: approved, ready: ready), live.count > 1 {
+            return live
+        }
+        return singleTarget(picked: picked, selected: selected, ready: ready).map { [$0] } ?? []
+    }
+
+    /// Explicit run targets for a feature: nil when it needs no device (passed
+    /// straight through to `run`, which then targets none), else `fanOut`.
+    /// Returning the panel's own targets — never the device bar's — is what
+    /// keeps the hidden window's run-on-all state from fanning a single pick
+    /// out, and a guard-deferred device switch from retargeting the run.
+    public static func runTargets(
+        needsDevice: Bool, picked: String?, selected: String?,
+        approved: [String]?, ready: [String]
+    ) -> [String]? {
+        guard needsDevice else { return nil }
+        return fanOut(picked: picked, selected: selected, approved: approved, ready: ready)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
@@ -7,7 +7,11 @@ public struct AppListing: Sendable, Equatable, Identifiable {
 
     public var id: String { packageId }
     /// Display name derived from the package id ("weather" → "Weather").
-    public var displayName: String {
+    public var displayName: String { Self.displayName(for: packageId) }
+
+    /// The package-id → display-name rule, callable without a full listing —
+    /// the Quick Actions panel derives names from bare `pm list` package ids.
+    public static func displayName(for packageId: String) -> String {
         packageId.split(separator: ".").last.map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? packageId
     }
 

--- a/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
@@ -49,6 +49,38 @@ import Testing
         }
     }
 
+    @Test func quickActionsSpanActionsAndHubMembersButNeverViews() {
+        let ids = Set(
+            PaletteSearch.quickActions(query: "", implemented: FeatureEngine.implementedIDs)
+                .map(\.id)
+        )
+        // Form actions — including hub-absorbed members — are quick actions.
+        #expect(ids.contains("send-text"))
+        #expect(ids.contains("reverse-port"))
+        #expect(ids.contains("screenshot"))
+        // View/system screens (and the hubs themselves) need the full app.
+        #expect(!ids.contains("logcat"))
+        #expect(!ids.contains("reactotron"))
+        #expect(!ids.contains("js-console"))
+        #expect(!ids.contains("terminal"))
+        #expect(!ids.contains("react-native"))
+        #expect(!ids.contains("simulate"))
+        for id in ids {
+            let kind = FeatureRegistry.byID[id]?.kind
+            #expect(kind == .instantAction || kind == .toggleAction || kind == .formAction)
+        }
+    }
+
+    @Test func quickActionsRankByRelevanceAndDropUnimplemented() {
+        let implemented = FeatureEngine.implementedIDs
+        let sendText = PaletteSearch.quickActions(query: "Send Text", implemented: implemented)
+        #expect(sendText.first?.id == "send-text")
+
+        let without = implemented.subtracting(["send-text"])
+        let result = PaletteSearch.quickActions(query: "Send Text", implemented: without)
+        #expect(!result.contains { $0.id == "send-text" })
+    }
+
     @Test func commandsMatchNameOrTemplateCaseInsensitively() {
         let commands = [
             CustomCommand(name: "Wipe app data", command: "shell pm clear {bundleId}", needsBundle: true, createdAt: 1),

--- a/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct PaletteSearchTests {
+    private var allEnabled: Set<String> { Set(FeatureRegistry.all.map(\.id)) }
+
+    @Test func emptyQueryLeadsWithPinnedThenEnabledThenDisabled() {
+        let visible = FeatureRegistry.all.filter { !$0.isAbsorbedByHub }
+        let pinned = [visible[4].id, visible[1].id]
+        let disabled = visible[7].id
+        let enabled = allEnabled.subtracting([disabled])
+
+        let result = PaletteSearch.features(query: "", enabled: enabled, favorites: pinned)
+
+        #expect(result.prefix(2).map(\.id) == pinned)
+        #expect(result.last?.id == disabled)
+        #expect(Set(result.map(\.id)).count == result.count)
+        #expect(result.count == visible.count)
+    }
+
+    @Test func exactTitleQueryRanksThatFeatureFirst() throws {
+        let target = FeatureRegistry.all.first { !$0.isAbsorbedByHub && $0.id == "logcat" }
+        let title = try #require(target).title
+
+        let result = PaletteSearch.features(query: title, enabled: allEnabled, favorites: [])
+
+        #expect(result.first?.id == "logcat")
+    }
+
+    @Test func disabledMatchesSinkBelowEnabledOnes() throws {
+        // Disable every match for a broad query except one — that one must lead.
+        let matches = FeatureRegistry.all.filter { $0.matches("app") && !$0.isAbsorbedByHub }
+        try #require(matches.count >= 2)
+        let keep = matches[matches.count - 1].id
+        let enabled = allEnabled.subtracting(matches.map(\.id)).union([keep])
+
+        let result = PaletteSearch.features(query: "app", enabled: enabled, favorites: [])
+
+        #expect(result.first?.id == keep)
+    }
+
+    @Test func absorbedHubMembersNeverSurfaceEvenByExactTitle() throws {
+        for memberID in FeatureRegistry.absorbedFeatureIDs {
+            let member = try #require(FeatureRegistry.byID[memberID])
+            let result = PaletteSearch.features(
+                query: member.title, enabled: allEnabled, favorites: [memberID]
+            )
+            #expect(!result.contains { $0.id == memberID })
+        }
+    }
+
+    @Test func commandsMatchNameOrTemplateCaseInsensitively() {
+        let commands = [
+            CustomCommand(name: "Wipe app data", command: "shell pm clear {bundleId}", needsBundle: true, createdAt: 1),
+            CustomCommand(name: "List packages", command: "shell pm list packages", needsBundle: false, createdAt: 2),
+            CustomCommand(name: "Reboot", command: "reboot", needsBundle: false, createdAt: 3),
+        ]
+
+        #expect(PaletteSearch.commands(commands, query: "WIPE").map(\.name) == ["Wipe app data"])
+        #expect(PaletteSearch.commands(commands, query: "pm").count == 2)
+        #expect(PaletteSearch.commands(commands, query: "ssh").isEmpty)
+    }
+
+    @Test func emptyCommandQueryKeepsSavedOrder() {
+        let commands = [
+            CustomCommand(name: "B", command: "b", needsBundle: false, createdAt: 2),
+            CustomCommand(name: "A", command: "a", needsBundle: false, createdAt: 1),
+        ]
+        #expect(PaletteSearch.commands(commands, query: "  ").map(\.name) == ["B", "A"])
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PaletteSearchTests.swift
@@ -49,10 +49,14 @@ import Testing
         }
     }
 
+    private var allCatalogEnabled: Set<String> { Set(FeatureRegistry.catalogFeatureIDs) }
+
     @Test func quickActionsSpanActionsAndHubMembersButNeverViews() {
         let ids = Set(
-            PaletteSearch.quickActions(query: "", implemented: FeatureEngine.implementedIDs)
-                .map(\.id)
+            PaletteSearch.quickActions(
+                query: "", implemented: FeatureEngine.implementedIDs,
+                enabled: allCatalogEnabled, favorites: []
+            ).map(\.id)
         )
         // Form actions — including hub-absorbed members — are quick actions.
         #expect(ids.contains("send-text"))
@@ -73,12 +77,42 @@ import Testing
 
     @Test func quickActionsRankByRelevanceAndDropUnimplemented() {
         let implemented = FeatureEngine.implementedIDs
-        let sendText = PaletteSearch.quickActions(query: "Send Text", implemented: implemented)
+        let sendText = PaletteSearch.quickActions(
+            query: "Send Text", implemented: implemented,
+            enabled: allCatalogEnabled, favorites: []
+        )
         #expect(sendText.first?.id == "send-text")
 
         let without = implemented.subtracting(["send-text"])
-        let result = PaletteSearch.quickActions(query: "Send Text", implemented: without)
+        let result = PaletteSearch.quickActions(
+            query: "Send Text", implemented: without,
+            enabled: allCatalogEnabled, favorites: []
+        )
         #expect(!result.contains { $0.id == "send-text" })
+    }
+
+    @Test func quickActionsFollowTheEnabledSetWithMembersRidingTheirHub() {
+        // Disabling the Connection hub hides its absorbed reverse-port member.
+        let withoutHub = PaletteSearch.quickActions(
+            query: "", implemented: FeatureEngine.implementedIDs,
+            enabled: allCatalogEnabled.subtracting(["connection"]), favorites: []
+        )
+        #expect(!withoutHub.contains { $0.id == "reverse-port" })
+
+        // Disabling a standalone action hides it directly.
+        let withoutSendText = PaletteSearch.quickActions(
+            query: "", implemented: FeatureEngine.implementedIDs,
+            enabled: allCatalogEnabled.subtracting(["send-text"]), favorites: []
+        )
+        #expect(!withoutSendText.contains { $0.id == "send-text" })
+    }
+
+    @Test func quickActionsLeadWithPinnedFeaturesWhenNotSearching() {
+        let result = PaletteSearch.quickActions(
+            query: "", implemented: FeatureEngine.implementedIDs,
+            enabled: allCatalogEnabled, favorites: ["screenshot"]
+        )
+        #expect(result.first?.id == "screenshot")
     }
 
     @Test func commandsMatchNameOrTemplateCaseInsensitively() {

--- a/ADBKit/Tests/ADBKitTests/PanelTargetingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PanelTargetingTests.swift
@@ -1,0 +1,138 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct PanelTargetingTests {
+    // MARK: - singleTarget
+
+    @Test func singleTargetPrefersTheLivePickOverEverything() {
+        let target = PanelTargeting.singleTarget(
+            picked: "A", selected: "B", ready: ["A", "B", "C"]
+        )
+        #expect(target == "A")
+    }
+
+    @Test func singleTargetDropsAPickWhoseDeviceDisconnectedAndFallsToSelection() {
+        // "A" was picked but is no longer ready — fall back to the selection.
+        let target = PanelTargeting.singleTarget(
+            picked: "A", selected: "B", ready: ["B", "C"]
+        )
+        #expect(target == "B")
+    }
+
+    @Test func singleTargetFallsToFirstReadyWhenNeitherPickNorSelectionIsReady() {
+        let target = PanelTargeting.singleTarget(
+            picked: "gone", selected: "also-gone", ready: ["C", "D"]
+        )
+        #expect(target == "C")
+    }
+
+    @Test func singleTargetUsesSelectionWhenThereIsNoPick() {
+        let target = PanelTargeting.singleTarget(
+            picked: nil, selected: "B", ready: ["A", "B"]
+        )
+        #expect(target == "B")
+    }
+
+    @Test func singleTargetIsNilWhenNothingIsReady() {
+        #expect(PanelTargeting.singleTarget(picked: "A", selected: "B", ready: []) == nil)
+    }
+
+    // MARK: - approvedTargets
+
+    @Test func approvedTargetsIsApprovedIntersectReadyInApprovedOrder() {
+        let live = PanelTargeting.approvedTargets(
+            approved: ["A", "B", "C"], ready: ["C", "A", "B"]
+        )
+        // Approved order, not ready order.
+        #expect(live == ["A", "B", "C"])
+    }
+
+    @Test func approvedTargetsExcludesADeviceAttachedAfterTheApproval() {
+        // "D" is ready now but wasn't in the approval — it must never join it.
+        let live = PanelTargeting.approvedTargets(
+            approved: ["A", "B"], ready: ["A", "B", "D"]
+        )
+        #expect(live == ["A", "B"])
+    }
+
+    @Test func approvedTargetsDropsDisconnectedApprovedDevices() {
+        let live = PanelTargeting.approvedTargets(
+            approved: ["A", "B", "C"], ready: ["A", "C"]
+        )
+        #expect(live == ["A", "C"])
+    }
+
+    @Test func approvedTargetsIsNilWhenNoApprovalExists() {
+        #expect(PanelTargeting.approvedTargets(approved: nil, ready: ["A"]) == nil)
+    }
+
+    @Test func approvedTargetsIsNilWhenNothingApprovedIsStillReady() {
+        #expect(PanelTargeting.approvedTargets(approved: ["A", "B"], ready: ["C"]) == nil)
+    }
+
+    // MARK: - fanOut
+
+    @Test func fanOutReturnsEveryLiveApprovedDeviceWhenMoreThanOne() {
+        let targets = PanelTargeting.fanOut(
+            picked: nil, selected: "A", approved: ["A", "B", "C"], ready: ["A", "B", "C"]
+        )
+        #expect(targets == ["A", "B", "C"])
+    }
+
+    @Test func fanOutCollapsesToSingleWhenApprovalShrankToOneLiveDevice() {
+        // Approved A+B, but B disconnected — one live approved device is not a
+        // fan-out; fall to the single-target rule (the live pick here).
+        let targets = PanelTargeting.fanOut(
+            picked: "A", selected: "B", approved: ["A", "B"], ready: ["A"]
+        )
+        #expect(targets == ["A"])
+    }
+
+    @Test func fanOutIsSingleTargetWhenThereIsNoApproval() {
+        let targets = PanelTargeting.fanOut(
+            picked: "A", selected: "B", approved: nil, ready: ["A", "B"]
+        )
+        #expect(targets == ["A"])
+    }
+
+    @Test func fanOutIsEmptyWhenNothingIsReady() {
+        let targets = PanelTargeting.fanOut(
+            picked: "A", selected: "B", approved: ["A", "B"], ready: []
+        )
+        #expect(targets.isEmpty)
+    }
+
+    // MARK: - runTargets
+
+    @Test func runTargetsIsNilForAFeatureThatNeedsNoDeviceEvenWithDevicesReady() {
+        let targets = PanelTargeting.runTargets(
+            needsDevice: false, picked: "A", selected: "B",
+            approved: ["A", "B"], ready: ["A", "B"]
+        )
+        #expect(targets == nil)
+    }
+
+    @Test func runTargetsFansOutForADeviceFeature() {
+        let targets = PanelTargeting.runTargets(
+            needsDevice: true, picked: nil, selected: "A",
+            approved: ["A", "B"], ready: ["A", "B"]
+        )
+        #expect(targets == ["A", "B"])
+    }
+
+    @Test func runTargetsIsASingleElementForADeviceFeatureWithNoApproval() {
+        let targets = PanelTargeting.runTargets(
+            needsDevice: true, picked: "B", selected: "A",
+            approved: nil, ready: ["A", "B"]
+        )
+        #expect(targets == ["B"])
+    }
+
+    @Test func runTargetsIsEmptyForADeviceFeatureWithNothingReady() {
+        let targets = PanelTargeting.runTargets(
+            needsDevice: true, picked: "A", selected: "B",
+            approved: nil, ready: []
+        )
+        #expect(targets == [])
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -21,16 +21,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// "the user closed the window" and start background mode mid-quit.
     @MainActor var isQuitting = false
 
-    /// When the last APK arrived from Finder. Opening a document activates
-    /// the app and can ride in with a reopen event — the Quick Actions panel
-    /// handles APKs, so a reopen right after one must not resurrect the
-    /// main window over it.
-    @MainActor private var lastAPKOpenAt: Date?
-
     func application(_ application: NSApplication, open urls: [URL]) {
         let apks = urls.filter { $0.pathExtension.lowercased() == "apk" }
         guard !apks.isEmpty else { return }
-        MainActor.assumeIsolated { lastAPKOpenAt = Date() }
         InstallInbox.shared.receive(apks)
     }
 
@@ -78,13 +71,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Relaunching from Finder/Spotlight while resident in the background (no
-    /// Dock icon, window closed) lands here — reopen the main window. Not for
-    /// a reopen riding in with an APK open, which stays panel-only.
+    /// Dock icon, window closed) lands here — reopen the main window.
     func applicationShouldHandleReopen(
         _ sender: NSApplication, hasVisibleWindows flag: Bool
     ) -> Bool {
         MainActor.assumeIsolated {
-            if let at = lastAPKOpenAt, Date().timeIntervalSince(at) < 2 { return false }
             guard !flag, let appState else { return true }
             appState.activateMainWindow()
             return false

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -60,8 +60,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let closing = notification.object as? NSWindow,
               closing.canBecomeMain, !(closing is NSPanel)
         else { return }
+        // Minimized windows count — a main window in the Dock is still the
+        // user's workspace, not a cue to kill sessions and go accessory.
         let remaining = NSApp.windows.contains {
-            $0 !== closing && $0.isVisible && $0.canBecomeMain && !($0 is NSPanel)
+            $0 !== closing && ($0.isVisible || $0.isMiniaturized)
+                && $0.canBecomeMain && !($0 is NSPanel)
         }
         guard !remaining else { return }
         appState.enterBackground()
@@ -71,12 +74,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Relaunching from Finder/Spotlight while resident in the background (no
-    /// Dock icon, window closed) lands here — reopen the main window.
+    /// Dock icon, window closed) lands here — reopen the main window. Checked
+    /// structurally, not via `hasVisibleWindows`: an open Quick Actions panel
+    /// counts as a visible window and would otherwise make the relaunch a
+    /// no-op with no main window and no Dock icon.
     func applicationShouldHandleReopen(
         _ sender: NSApplication, hasVisibleWindows flag: Bool
     ) -> Bool {
         MainActor.assumeIsolated {
-            guard !flag, let appState else { return true }
+            let hasPrimary = NSApp.windows.contains {
+                ($0.isVisible || $0.isMiniaturized) && $0.canBecomeMain && !($0 is NSPanel)
+            }
+            guard !hasPrimary, let appState else { return true }
             appState.activateMainWindow()
             return false
         }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -5,6 +5,10 @@ import SwiftUI
 /// Read with `object(forKey:)` nil-coalesced to true, so it defaults to on.
 let keepRunningInBackgroundKey = "keepRunningInBackground"
 
+/// UserDefaults key for how long (minutes) a closed Quick Actions panel keeps
+/// its session for resume; 0 disables resume. Defaults to 5.
+let quickPanelResumeMinutesKey = "quickPanelResumeMinutes"
+
 /// Routes APKs opened from Finder (double-click / "Open With") into the install
 /// inbox, which surfaces the device picker once the UI is ready.
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -17,9 +21,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// "the user closed the window" and start background mode mid-quit.
     @MainActor var isQuitting = false
 
+    /// When the last APK arrived from Finder. Opening a document activates
+    /// the app and can ride in with a reopen event — the Quick Actions panel
+    /// handles APKs, so a reopen right after one must not resurrect the
+    /// main window over it.
+    @MainActor private var lastAPKOpenAt: Date?
+
     func application(_ application: NSApplication, open urls: [URL]) {
         let apks = urls.filter { $0.pathExtension.lowercased() == "apk" }
         guard !apks.isEmpty else { return }
+        MainActor.assumeIsolated { lastAPKOpenAt = Date() }
         InstallInbox.shared.receive(apks)
     }
 
@@ -67,11 +78,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Relaunching from Finder/Spotlight while resident in the background (no
-    /// Dock icon, window closed) lands here — reopen the main window.
+    /// Dock icon, window closed) lands here — reopen the main window. Not for
+    /// a reopen riding in with an APK open, which stays panel-only.
     func applicationShouldHandleReopen(
         _ sender: NSApplication, hasVisibleWindows flag: Bool
     ) -> Bool {
         MainActor.assumeIsolated {
+            if let at = lastAPKOpenAt, Date().timeIntervalSince(at) < 2 { return false }
             guard !flag, let appState else { return true }
             appState.activateMainWindow()
             return false

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -1,12 +1,21 @@
 import ADBKit
 import SwiftUI
 
+/// UserDefaults key for Settings ▸ General ▸ "Keep running in the background".
+/// Read with `object(forKey:)` nil-coalesced to true, so it defaults to on.
+let keepRunningInBackgroundKey = "keepRunningInBackground"
+
 /// Routes APKs opened from Finder (double-click / "Open With") into the install
 /// inbox, which surfaces the device picker once the UI is ready.
 final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Set by RootView once the UI is up, so quit can tear down a kept-alive
     /// Reactotron session (server socket + adb reverse tunnels).
     weak var appState: AppState?
+
+    /// True from the moment termination is requested until it's cancelled, so
+    /// the window-close observer doesn't mistake quit's window teardown for
+    /// "the user closed the window" and start background mode mid-quit.
+    @MainActor var isQuitting = false
 
     func application(_ application: NSApplication, open urls: [URL]) {
         let apks = urls.filter { $0.pathExtension.lowercased() == "apk" }
@@ -21,6 +30,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task.detached(priority: .utility) {
             CacheTrash.sweep(around: AppPaths.decompiledCacheDir)
         }
+        // Selector-based (not the block API): `Notification` isn't Sendable,
+        // so a @Sendable block can't hand it to the main actor. The selector
+        // route delivers it straight into a @MainActor method — safe because
+        // willClose is always posted on the main thread.
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification, object: nil
+        )
+    }
+
+    /// Background mode: closing the main window (not quitting) stops running
+    /// feature work and — once no primary window is left — removes the Dock
+    /// icon. The app stays resident for the menu bar icon, global hotkeys, and
+    /// the Quick Actions panel; quit still exits fully.
+    @MainActor @objc private func windowWillClose(_ notification: Notification) {
+        guard !isQuitting, let appState,
+              let closing = notification.object as? NSWindow,
+              UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true
+        else { return }
+        if closing.identifier?.rawValue == RootView.mainWindowID {
+            appState.enterBackground()
+        }
+        // Vacate the Dock only when no primary window remains. Settings counts:
+        // an accessory app's visible windows would lose the menu bar.
+        let remaining = NSApp.windows.contains {
+            $0 !== closing && $0.isVisible && $0.canBecomeMain && !($0 is NSPanel)
+        }
+        if !remaining, NSApp.activationPolicy() == .regular {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+
+    /// Relaunching from Finder/Spotlight while resident in the background (no
+    /// Dock icon, window closed) lands here — reopen the main window.
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication, hasVisibleWindows flag: Bool
+    ) -> Bool {
+        MainActor.assumeIsolated {
+            guard !flag, let appState else { return true }
+            appState.activateMainWindow()
+            return false
+        }
     }
 
     /// Block quit when losable work is in flight (an active recording / unsaved
@@ -30,6 +81,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard let appState else { return .terminateNow }
         return MainActor.assumeIsolated {
+            // From here on, window closes belong to quit teardown, not
+            // background mode. Cleared again if the quit gets cancelled
+            // (`AppState.cancelDeferredQuit`).
+            isQuitting = true
             // The leave prompt's resolution (quit / cancel) drives termination.
             if !appState.requestQuit() { return .terminateLater }
             guard appState.reactotronSession.isRunning else { return .terminateNow }
@@ -321,6 +376,9 @@ struct MenuBarView: View {
         Divider()
 
         // Always-on quick actions — no window needed.
+        Button("Quick Actions…") {
+            QuickActionsPanel.toggle(state: state)
+        }
         Button("Screenshot") {
             runByID("screenshot")
         }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -8,8 +8,8 @@ let keepRunningInBackgroundKey = "keepRunningInBackground"
 /// Routes APKs opened from Finder (double-click / "Open With") into the install
 /// inbox, which surfaces the device picker once the UI is ready.
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    /// Set by RootView once the UI is up, so quit can tear down a kept-alive
-    /// Reactotron session (server socket + adb reverse tunnels).
+    /// Wired in `ADTApp.body` (the adaptor instance is the real delegate), so
+    /// quit and window-close can tear down kept-alive sessions.
     weak var appState: AppState?
 
     /// True from the moment termination is requested until it's cancelled, so
@@ -46,18 +46,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the Quick Actions panel; quit still exits fully.
     @MainActor @objc private func windowWillClose(_ notification: Notification) {
         guard !isQuitting, let appState,
-              let closing = notification.object as? NSWindow,
               UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true
         else { return }
-        if closing.identifier?.rawValue == RootView.mainWindowID {
-            appState.enterBackground()
-        }
-        // Vacate the Dock only when no primary window remains. Settings counts:
-        // an accessory app's visible windows would lose the menu bar.
+        // Structural identification, not identifiers: SwiftUI re-stamps the
+        // main window's identifier (`main-AppWindow-1`) by close time, so the
+        // `droidective-main` tag can't be trusted here. Background mode starts
+        // when the last *primary* window closes — panels don't count, and
+        // Settings does (an accessory app's visible windows lose the menu bar).
+        guard let closing = notification.object as? NSWindow,
+              closing.canBecomeMain, !(closing is NSPanel)
+        else { return }
         let remaining = NSApp.windows.contains {
             $0 !== closing && $0.isVisible && $0.canBecomeMain && !($0 is NSPanel)
         }
-        if !remaining, NSApp.activationPolicy() == .regular {
+        guard !remaining else { return }
+        appState.enterBackground()
+        if NSApp.activationPolicy() == .regular {
             NSApp.setActivationPolicy(.accessory)
         }
     }
@@ -188,6 +192,13 @@ struct ADTApp: App {
                 // `.brandAccent` re-resolves. AppState (and its device list) is
                 // owned above this view, so the rebuild preserves it.
                 .id(accentHex)
+                .onAppear {
+                    // Wire the delegate ↔ state references through the adaptor
+                    // instance: on macOS `NSApp.delegate` is SwiftUI's own
+                    // wrapper, so casting it to `AppDelegate` fails silently.
+                    appDelegate.appState = appState
+                    appState.appDelegate = appDelegate
+                }
                 .onChange(of: scenePhase) { _, phase in
                     appState.setForeground(phase == .active)
                 }

--- a/App/Sources/FeatureDetail/Views/InstallAppView.swift
+++ b/App/Sources/FeatureDetail/Views/InstallAppView.swift
@@ -177,7 +177,7 @@ struct InstallAppView: View {
         installing = true
         Task {
             let summary = await state.installAPKs(urls, onSerials: serials)
-            lastResult = summary.isEmpty ? nil : summary
+            lastResult = summary.report.isEmpty ? nil : summary.report
             installing = false
             staged = []
         }

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -1,13 +1,18 @@
 import AppKit
+import KeyboardShortcuts
 import SwiftUI
 
 /// A short paged walkthrough shown once on first launch (and replayable from
 /// Home). Each step explains one part of the app; finishing or skipping marks
-/// the tour seen so it won't reappear.
+/// the tour seen so it won't reappear. Completing it (not skipping) ends on a
+/// one-time ask to record a Quick Actions hotkey — shown only while none is
+/// set, so a replay after recording one just closes.
 struct TourView: View {
     @Environment(AppState.self) private var state
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @State private var index = 0
+    @State private var pickingHotkey = false
+    @State private var quickActionsShortcut: KeyboardShortcuts.Shortcut?
 
     private struct Step {
         let icon: String
@@ -41,9 +46,15 @@ struct TourView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            content
-            Divider()
-            controls
+            if pickingHotkey {
+                hotkeyContent
+                Divider()
+                hotkeyControls
+            } else {
+                content
+                Divider()
+                controls
+            }
         }
         .frame(width: 540, height: 440)
     }
@@ -105,7 +116,7 @@ struct TourView: View {
                 }
                 Button(isLast ? "Get Started" : "Next") {
                     if isLast {
-                        finish()
+                        advancePastTour()
                     } else {
                         withAnimation { index += 1 }
                     }
@@ -115,6 +126,78 @@ struct TourView: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
+    }
+
+    private var hotkeyContent: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 54))
+                .foregroundStyle(.brandAccent)
+                .symbolRenderingMode(.hierarchical)
+            Text("One more thing: Quick Actions")
+                .font(.title.bold())
+                .multilineTextAlignment(.center)
+            Text("A global hotkey summons the Quick Actions panel from any app — run adb actions, manage apps, and boot emulators without opening the window. Pick one now, or change it anytime in Settings ▸ Hotkeys.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.textMuted)
+                .frame(maxWidth: 420)
+                .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: 8) {
+                HotkeyRecorderField(name: .quickActions)
+                    .frame(width: 220)
+                Text("Recommended: ⇧⌘Space — it's free on a stock Mac, and Spotlight keeps ⌘Space.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+        .onChange(of: HotkeyRecording.shared.active) {
+            quickActionsShortcut = KeyboardShortcuts.getShortcut(for: .quickActions)
+        }
+    }
+
+    private var hotkeyControls: some View {
+        HStack {
+            Button("Maybe Later") { finish() }
+                .buttonStyle(.plain)
+                .foregroundStyle(.textMuted)
+                .focusEffectDisabled()
+                .keyboardShortcut(.cancelAction)
+
+            Spacer()
+
+            if quickActionsShortcut == nil {
+                Button("Use ⇧⌘Space") {
+                    // Launcher-style but free on a stock Mac: ⌘Space is
+                    // Spotlight, ⌥Space is usually Raycast/Alfred, and
+                    // ⌃Space/⌃⌥Space switch input sources.
+                    KeyboardShortcuts.setShortcut(
+                        KeyboardShortcuts.Shortcut(.space, modifiers: [.shift, .command]),
+                        for: .quickActions
+                    )
+                    finish()
+                }
+                .keyboardShortcut(.defaultAction)
+            } else {
+                Button("Done") { finish() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    /// Completing the tour asks for a Quick Actions hotkey — but only while
+    /// none is recorded, so it never nags after a choice (or a replay).
+    private func advancePastTour() {
+        hasSeenTour = true
+        if KeyboardShortcuts.getShortcut(for: .quickActions) == nil {
+            withAnimation { pickingHotkey = true }
+        } else {
+            state.presentTour = false
+        }
     }
 
     private func finish() {

--- a/App/Sources/Root/InstallInbox.swift
+++ b/App/Sources/Root/InstallInbox.swift
@@ -10,6 +10,11 @@ final class InstallInbox {
     private var pending: [URL] = []
     var onReceive: (([URL]) -> Void)? { didSet { drain() } }
 
+    /// True while APKs wait for the UI. On a cold launch this means the app
+    /// was launched *to open an APK* (the open event precedes window
+    /// creation) — RootView uses it to keep that launch panel-only.
+    var hasPending: Bool { !pending.isEmpty }
+
     func receive(_ urls: [URL]) {
         pending.append(contentsOf: urls)
         drain()

--- a/App/Sources/Root/InstallInbox.swift
+++ b/App/Sources/Root/InstallInbox.swift
@@ -10,11 +10,6 @@ final class InstallInbox {
     private var pending: [URL] = []
     var onReceive: (([URL]) -> Void)? { didSet { drain() } }
 
-    /// True while APKs wait for the UI. On a cold launch this means the app
-    /// was launched *to open an APK* (the open event precedes window
-    /// creation) — RootView uses it to keep that launch panel-only.
-    var hasPending: Bool { !pending.isEmpty }
-
     func receive(_ urls: [URL]) {
         pending.append(contentsOf: urls)
         drain()

--- a/App/Sources/Root/PalettePanel.swift
+++ b/App/Sources/Root/PalettePanel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// A borderless panel that can still take key focus. Borderless `NSWindow`s
 /// return `false` from `canBecomeKey`/`canBecomeMain` by default, which would
-/// stop the palette's search field from receiving input; overriding them keeps
+/// stop a palette's search field from receiving input; overriding them keeps
 /// the panel chromeless yet focusable. A panel we own (vs. a SwiftUI `Window`
 /// scene) can do this without colliding with SwiftUI's window constraints.
 final class KeyablePanel: NSPanel {
@@ -11,35 +11,53 @@ final class KeyablePanel: NSPanel {
     override var canBecomeMain: Bool { true }
 }
 
-/// Owns the ⌘K command palette as a borderless `NSPanel`. Borderless removes the
-/// 32pt title-bar region a hidden-title-bar `Window` scene always reserves, so
-/// the content sizes the panel exactly — flush at top and bottom. The panel
-/// hosts `PaletteWindowView`, resizes to its content, keeps its top edge anchored
-/// as results grow/shrink, and closes when it loses key (click-away) or on Esc.
+/// Owns one floating, borderless panel hosting SwiftUI content — the shared
+/// chassis of the ⌘K palette and the Quick Actions panel. Borderless removes
+/// the 32pt title-bar region a hidden-title-bar `Window` scene always
+/// reserves, so the content sizes the panel exactly — flush at top and
+/// bottom. The panel resizes to its content, keeps its top edge anchored as
+/// results grow/shrink, and closes when it loses key (click-away) or on Esc.
 @MainActor
-final class PaletteController {
-    static let shared = PaletteController()
+final class FloatingPanelController {
+    /// The in-app ⌘K search palette.
+    static let palette = FloatingPanelController(identifier: "palette", activatesApp: true)
 
+    /// The global-hotkey Quick Actions panel. Non-activating: it takes key
+    /// input without activating Droidective, so whatever app was frontmost
+    /// keeps focus underneath — summonable while the app is resident in the
+    /// background with no window and no Dock icon.
+    static let quickActions = FloatingPanelController(identifier: "quick-actions", activatesApp: false)
+
+    private let identifier: String
+    private let activatesApp: Bool
     private var panel: KeyablePanel?
     private var anchorMaxY: CGFloat = 0
     private var resignObserver: NSObjectProtocol?
     private var resizeObserver: NSObjectProtocol?
 
-    func show(appState: AppState) {
+    private init(identifier: String, activatesApp: Bool) {
+        self.identifier = identifier
+        self.activatesApp = activatesApp
+    }
+
+    var isVisible: Bool { panel != nil }
+
+    /// Present the panel with `content`, which receives the close action to
+    /// wire into its Esc/dismiss handling. Re-showing an open panel just
+    /// re-fronts it.
+    func show<Content: View>(@ViewBuilder content: (_ close: @escaping () -> Void) -> Content) {
         if let panel {
             panel.makeKeyAndOrderFront(nil)
             return
         }
 
-        let root = PaletteWindowView(onClose: { [weak self] in self?.close() })
-            .environment(appState)
-            .tint(.brandAccent)
+        let root = content { [weak self] in self?.close() }
         let hosting = NSHostingController(rootView: root)
         hosting.sizingOptions = [.preferredContentSize]
 
         let panel = KeyablePanel(contentViewController: hosting)
-        panel.styleMask = [.borderless]
-        panel.identifier = NSUserInterfaceItemIdentifier("palette")
+        panel.styleMask = activatesApp ? [.borderless] : [.borderless, .nonactivatingPanel]
+        panel.identifier = NSUserInterfaceItemIdentifier(identifier)
         panel.isFloatingPanel = true
         panel.level = .floating
         panel.isOpaque = false

--- a/App/Sources/Root/PalettePanel.swift
+++ b/App/Sources/Root/PalettePanel.swift
@@ -35,6 +35,15 @@ final class FloatingPanelController {
     private var resignObserver: NSObjectProtocol?
     private var resizeObserver: NSObjectProtocol?
 
+    /// While true, losing key focus doesn't close the panel — set around an
+    /// open/save dialog the panel itself presents (e.g. Install APK's file
+    /// picker), which necessarily takes key.
+    var holdsThroughResign = false
+
+    /// Fired whenever the panel actually closes (Esc, click-away, auto-close),
+    /// for session bookkeeping like the Quick Actions resume timestamp.
+    var onClosed: (() -> Void)?
+
     private init(identifier: String, activatesApp: Bool) {
         self.identifier = identifier
         self.activatesApp = activatesApp
@@ -75,27 +84,39 @@ final class FloatingPanelController {
         panel.setContentSize(hosting.view.fittingSize)
 
         positionInitially(panel)
+        self.panel = panel
         panel.makeKeyAndOrderFront(nil)
 
         resignObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification, object: panel, queue: .main
-        ) { [weak self] _ in MainActor.assumeIsolated { self?.close() } }
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, !self.holdsThroughResign else { return }
+                self.close()
+            }
+        }
         resizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResizeNotification, object: panel, queue: .main
         ) { [weak self] _ in MainActor.assumeIsolated { self?.keepCentered() } }
-
-        self.panel = panel
     }
 
     func close() {
+        guard let panel else { return }
         if let resignObserver { NotificationCenter.default.removeObserver(resignObserver) }
         if let resizeObserver { NotificationCenter.default.removeObserver(resizeObserver) }
         resignObserver = nil
         resizeObserver = nil
-        panel?.orderOut(nil)
-        panel?.close()
-        panel = nil
+        panel.orderOut(nil)
+        panel.close()
+        self.panel = nil
+        onClosed?()
     }
+
+    /// Re-front and re-key the open panel (after a modal dialog took key).
+    func makeKey() {
+        panel?.makeKeyAndOrderFront(nil)
+    }
+
 
     /// Center on screen, and remember the top edge so later resizes grow
     /// downward from there instead of drifting up off the bottom-left origin.

--- a/App/Sources/Root/PalettePanel.swift
+++ b/App/Sources/Root/PalettePanel.swift
@@ -20,15 +20,14 @@ final class KeyablePanel: NSPanel {
 @MainActor
 final class FloatingPanelController {
     /// The in-app ⌘K search palette.
-    static let palette = FloatingPanelController(identifier: "palette", activatesApp: true)
+    static let palette = FloatingPanelController(activatesApp: true)
 
     /// The global-hotkey Quick Actions panel. Non-activating: it takes key
     /// input without activating Droidective, so whatever app was frontmost
     /// keeps focus underneath — summonable while the app is resident in the
     /// background with no window and no Dock icon.
-    static let quickActions = FloatingPanelController(identifier: "quick-actions", activatesApp: false)
+    static let quickActions = FloatingPanelController(activatesApp: false)
 
-    private let identifier: String
     private let activatesApp: Bool
     private var panel: KeyablePanel?
     private var anchorMaxY: CGFloat = 0
@@ -44,8 +43,7 @@ final class FloatingPanelController {
     /// for session bookkeeping like the Quick Actions resume timestamp.
     var onClosed: (() -> Void)?
 
-    private init(identifier: String, activatesApp: Bool) {
-        self.identifier = identifier
+    private init(activatesApp: Bool) {
         self.activatesApp = activatesApp
     }
 
@@ -66,7 +64,6 @@ final class FloatingPanelController {
 
         let panel = KeyablePanel(contentViewController: hosting)
         panel.styleMask = activatesApp ? [.borderless] : [.borderless, .nonactivatingPanel]
-        panel.identifier = NSUserInterfaceItemIdentifier(identifier)
         panel.isFloatingPanel = true
         panel.level = .floating
         panel.isOpaque = false

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -20,31 +20,15 @@ struct PaletteWindowView: View {
 
     private static let digitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8"]
 
-    private var searching: Bool { !query.isEmpty }
-
-    /// Results in display order. When not searching, pinned features lead; once
-    /// the user types, the pinned section drops and results rank by relevance.
+    /// Results in display order — the shared, tested ranking (`PaletteSearch`):
+    /// pinned features lead when not searching; once the user types, results
+    /// rank by relevance with disabled features last.
     private var matches: [FeatureDef] {
-        let enabled = state.layout.effectiveEnabledIDs
-        if searching {
-            let ranked = FeatureRegistry.all.enumerated()
-                .filter { $0.element.matches(query) && !$0.element.isAbsorbedByHub }
-                .sorted { lhs, rhs in
-                    let rl = lhs.element.relevance(for: query)
-                    let rr = rhs.element.relevance(for: query)
-                    return rl != rr ? rl > rr : lhs.offset < rhs.offset
-                }
-                .map(\.element)
-            return ranked.filter { enabled.contains($0.id) } + ranked.filter { !enabled.contains($0.id) }
-        }
-        let pinned = state.layout.favorites
-            .compactMap { FeatureRegistry.byID[$0] }
-            .filter { !$0.isAbsorbedByHub }
-        let pinnedIDs = Set(pinned.map(\.id))
-        let rest = FeatureRegistry.all.filter { !$0.isAbsorbedByHub && !pinnedIDs.contains($0.id) }
-        return pinned
-            + rest.filter { enabled.contains($0.id) }
-            + rest.filter { !enabled.contains($0.id) }
+        PaletteSearch.features(
+            query: query,
+            enabled: state.layout.effectiveEnabledIDs,
+            favorites: state.layout.favorites
+        )
     }
 
     private var visibleMatches: [FeatureDef] { Array(matches.prefix(8)) }

--- a/App/Sources/Root/QuickActionFormView.swift
+++ b/App/Sources/Root/QuickActionFormView.swift
@@ -48,7 +48,9 @@ struct QuickActionFormView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { seedDefaults() }
         .task {
-            presets = await state.env.stores.presets.load()
+            let loaded = await state.env.stores.presets.load()
+            guard !Task.isCancelled else { return }
+            presets = loaded
             // Land the cursor in the first typed-input field once the screen
             // has mounted, mirroring the palette's focus timing.
             guard let first = firstFocusableField else { return }
@@ -168,7 +170,8 @@ struct QuickActionFormView: View {
 
     private func submit() {
         guard !running else { return }
-        if feature.needsDevice, state.targetSerials.isEmpty {
+        // The panel resolves targets explicitly; [] means no device is ready.
+        if feature.needsDevice, targetsProvider(feature)?.isEmpty == true {
             onFinish(QuickRunOutcome(message: "No device connected.", ok: false))
             return
         }

--- a/App/Sources/Root/QuickActionFormView.swift
+++ b/App/Sources/Root/QuickActionFormView.swift
@@ -1,0 +1,238 @@
+import ADBKit
+import SwiftUI
+
+/// The Quick Actions panel's compact form screen: renders a form action's
+/// declarative `FieldDef`s (the same definitions `FormActionView` uses in the
+/// main window) and submits through `AppState.run`, so Send Text, Reverse
+/// Port, Deep Link, Fake Battery… all work in-panel with no per-feature UI.
+/// ⏎ in a text field runs; the outcome goes to the panel footer via `onFinish`.
+struct QuickActionFormView: View {
+    @Environment(AppState.self) private var state
+
+    let feature: FeatureDef
+    /// The panel's device fan-out: non-nil when "All devices" is in effect
+    /// and this feature supports run-on-all; nil defers to the selection.
+    let targetsProvider: (FeatureDef) -> [String]?
+    /// Reports the outcome back to the panel, which renders it in the footer
+    /// (with Reveal/Copy affordances when the result carries them).
+    let onFinish: (QuickRunOutcome) -> Void
+
+    @State private var textValues: [String: String] = [:]
+    @State private var boolValues: [String: Bool] = [:]
+    @State private var sliderValues: [String: Double] = [:]
+    @State private var presets = Presets()
+    @State private var running = false
+    @FocusState private var focusedField: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(feature.fields, id: \.name) { field in
+                fieldRow(for: field)
+            }
+            HStack(spacing: 10) {
+                Button {
+                    submit()
+                } label: {
+                    Label(running ? "Running…" : "Run", systemImage: "play.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(running)
+                .keyboardShortcut(.return, modifiers: .command)
+                Text("⏎ or ⌘⏎ to run")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear { seedDefaults() }
+        .task {
+            presets = await state.env.stores.presets.load()
+            // Land the cursor in the first typed-input field once the screen
+            // has mounted, mirroring the palette's focus timing.
+            guard let first = firstFocusableField else { return }
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled else { return }
+            focusedField = first
+        }
+    }
+
+    private var firstFocusableField: String? {
+        feature.fields.first { field in
+            switch field.control {
+            case .text, .number, .bundle, .preset: return true
+            case .select, .switch, .slider: return false
+            }
+        }?.name
+    }
+
+    @ViewBuilder
+    private func fieldRow(for field: FieldDef) -> some View {
+        switch field.control {
+        case .switch, .slider:
+            control(for: field)
+        default:
+            VStack(alignment: .leading, spacing: 4) {
+                Text(field.label)
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+                control(for: field)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func control(for field: FieldDef) -> some View {
+        switch field.control {
+        case .text, .number, .bundle:
+            textField(for: field)
+        case .preset:
+            HStack(spacing: 4) {
+                textField(for: field)
+                let values = presetValues(for: field.presetKey ?? "")
+                if !values.isEmpty {
+                    Menu {
+                        ForEach(values, id: \.self) { value in
+                            Button(value) { textValues[field.name] = value }
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .foregroundStyle(.textMuted)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    .help("Recent values")
+                }
+            }
+        case .select:
+            Picker("", selection: binding(for: field)) {
+                ForEach(field.options, id: \.value) { option in
+                    Text(option.label).tag(option.value)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+        case .switch:
+            Toggle(field.label, isOn: boolBinding(for: field))
+                .toggleStyle(.switch)
+                .controlSize(.small)
+        case .slider:
+            let range = (field.min ?? 0)...(field.max ?? 1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(field.label): \(sliderValues[field.name] ?? defaultSlider(field), specifier: "%.2f")")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+                Slider(value: sliderBinding(for: field), in: range, step: field.step ?? 1)
+            }
+        }
+    }
+
+    private func textField(for field: FieldDef) -> some View {
+        TextField("", text: binding(for: field), prompt: field.placeholder.map(Text.init))
+            .textFieldStyle(.roundedBorder)
+            .focused($focusedField, equals: field.name)
+            .onSubmit { submit() }
+    }
+
+    private func presetValues(for key: String) -> [String] {
+        switch key {
+        case "reversePorts": return presets.reversePorts.map(String.init)
+        case "proxies": return presets.proxies
+        default: return []
+        }
+    }
+
+    private func seedDefaults() {
+        for field in feature.fields {
+            switch field.defaultValue {
+            case .string(let value) where textValues[field.name] == nil:
+                textValues[field.name] = value
+            case .bool(let value) where boolValues[field.name] == nil:
+                boolValues[field.name] = value
+            case .number(let value):
+                if field.control == .slider, sliderValues[field.name] == nil {
+                    sliderValues[field.name] = value
+                } else if textValues[field.name] == nil {
+                    // No locale grouping — "1,000" wouldn't round-trip.
+                    textValues[field.name] = value == value.rounded()
+                        ? String(Int(value))
+                        : String(value)
+                }
+            default:
+                break
+            }
+        }
+    }
+
+    private func submit() {
+        guard !running else { return }
+        if feature.needsDevice, state.targetSerials.isEmpty {
+            onFinish(QuickRunOutcome(message: "No device connected.", ok: false))
+            return
+        }
+        if feature.needsBundle, state.selectedBundle == nil {
+            onFinish(QuickRunOutcome(message: "Pick a saved bundle first.", ok: false))
+            return
+        }
+        var params: [String: FeatureValue] = [:]
+        for field in feature.fields {
+            switch field.control {
+            case .switch:
+                params[field.name] = .bool(boolValues[field.name] ?? (field.defaultValue?.boolValue ?? false))
+            case .slider:
+                params[field.name] = .number(sliderValues[field.name] ?? defaultSlider(field))
+            case .number:
+                let raw = (textValues[field.name] ?? "").trimmingCharacters(in: .whitespaces)
+                if raw.isEmpty { break }
+                guard let value = Double(raw.replacingOccurrences(of: ",", with: "")) else {
+                    onFinish(QuickRunOutcome(
+                        message: "\"\(raw)\" isn't a valid number for \(field.label).", ok: false
+                    ))
+                    return
+                }
+                params[field.name] = .number(value)
+            default:
+                if let value = textValues[field.name], !value.isEmpty {
+                    params[field.name] = .string(value)
+                }
+            }
+        }
+        running = true
+        Task {
+            let started = Date()
+            await state.run(feature: feature, params: params, on: targetsProvider(feature))
+            running = false
+            let fresh = state.lastResults[feature.id].flatMap { entry in
+                entry.at >= started ? QuickRunOutcome(result: entry.result) : nil
+            }
+            onFinish(fresh ?? QuickRunOutcome(message: "Done", ok: true))
+        }
+    }
+
+    private func defaultSlider(_ field: FieldDef) -> Double {
+        field.defaultValue?.numberValue ?? field.min ?? 0
+    }
+
+    private func binding(for field: FieldDef) -> Binding<String> {
+        Binding(
+            get: { textValues[field.name] ?? "" },
+            set: { textValues[field.name] = $0 }
+        )
+    }
+
+    private func boolBinding(for field: FieldDef) -> Binding<Bool> {
+        Binding(
+            get: { boolValues[field.name] ?? (field.defaultValue?.boolValue ?? false) },
+            set: { boolValues[field.name] = $0 }
+        )
+    }
+
+    private func sliderBinding(for field: FieldDef) -> Binding<Double> {
+        Binding(
+            get: { sliderValues[field.name] ?? defaultSlider(field) },
+            set: { sliderValues[field.name] = $0 }
+        )
+    }
+}

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -539,7 +539,25 @@ struct QuickActionsView: View {
                     : .runFeature(feature)
             )
         }
-        return rows
+        guard query.isEmpty else { return rows }
+        // Pinned tiles lead the whole grid — native screens included, in the
+        // favorites' own order — ahead of commands and the registry order.
+        let favorites = state.layout.favorites
+        var pinned: [QuickRow] = []
+        var rest: [QuickRow] = []
+        for row in rows {
+            if let id = pinnableFeatureID(of: row), favorites.contains(id) {
+                pinned.append(row)
+            } else {
+                rest.append(row)
+            }
+        }
+        pinned.sort { lhs, rhs in
+            let li = pinnableFeatureID(of: lhs).flatMap(favorites.firstIndex) ?? .max
+            let ri = pinnableFeatureID(of: rhs).flatMap(favorites.firstIndex) ?? .max
+            return li < ri
+        }
+        return pinned + rest
     }
 
     /// Full-app screens below the grid — everything that can't run in a
@@ -567,10 +585,13 @@ struct QuickActionsView: View {
         }
     }
 
-    /// The panel's own sub-screens and actions, searchable alongside the rest.
+    /// The panel's own sub-screens and actions, searchable alongside the
+    /// rest. Each fronts a registry feature and follows its enabledness, so
+    /// the panel mirrors the app's role/catalog curation here too.
     private var nativeRows: [QuickRow] {
+        let enabled = state.layout.effectiveEnabledIDs
         var rows: [QuickRow] = []
-        if matchesNative(title: "Manage Apps", keywords: [
+        if enabled.contains("apps"), matchesNative(title: "Manage Apps", keywords: [
             "apps", "app", "packages", "manage", "open", "force stop",
             "clear data", "clear cache", "uninstall",
         ]) {
@@ -581,7 +602,7 @@ struct QuickActionsView: View {
                 pushes: true, action: .push(.apps)
             ))
         }
-        if matchesNative(title: "Emulators", keywords: [
+        if enabled.contains("emulators"), matchesNative(title: "Emulators", keywords: [
             "emulator", "simulator", "avd", "boot", "launch", "virtual",
         ]) {
             rows.append(QuickRow(
@@ -591,7 +612,8 @@ struct QuickActionsView: View {
                 pushes: true, action: .push(.emulators)
             ))
         }
-        if matchesNative(title: "Install APK", keywords: ["install", "apk", "sideload", "package"]) {
+        if enabled.contains("install-app"),
+           matchesNative(title: "Install APK", keywords: ["install", "apk", "sideload", "package"]) {
             rows.append(QuickRow(
                 id: "native:install", icon: "arrow.down.app",
                 title: "Install APK",
@@ -1066,12 +1088,18 @@ struct QuickActionsView: View {
         panelTargetSerial.flatMap { serial in state.devices.first { $0.serial == serial } }
     }
 
-    /// The feature id ⌘P pins/unpins for this row, nil for rows that aren't
-    /// registry features (commands, apps, devices, the panel's own screens).
+    /// The feature id ⌘P pins/unpins for this row. The panel's native screens
+    /// map to the registry features they replace (Manage Apps → `apps`,
+    /// Emulators → `emulators`, Install APK → `install-app`), so pinning them
+    /// shares the app's favorites like everything else. Only rows with no
+    /// registry counterpart (commands, apps, devices, verbs) aren't pinnable.
     private func pinnableFeatureID(of row: QuickRow?) -> String? {
         switch row?.action {
         case .runFeature(let feature): return feature.id
         case .push(.form(let id)): return id
+        case .push(.apps): return "apps"
+        case .push(.emulators): return "emulators"
+        case .installAPK: return "install-app"
         case .openInApp(let feature): return feature.id
         default: return nil
         }

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -1,10 +1,16 @@
 import ADBKit
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Entry point for the Quick Actions panel — a Raycast-style floating
-/// launcher summoned by a global hotkey (or the menu bar) that runs instant/
-/// toggle actions and saved custom commands directly against the selected
-/// device, no main window needed. View features open the full app instead.
+/// mini app summoned by a global hotkey (or the menu bar). The root shows a
+/// grid of everything runnable in place (instant/toggle actions, in-panel
+/// forms, saved custom commands, Manage Apps / Emulators / Install APK) with
+/// an "Open in Droidective" list below for the full-app screens. Esc, ⌫ on an
+/// empty query, or `<` pops a screen; at the root Esc closes. A session
+/// resumes where it left off when reopened within the Settings ▸ Quick
+/// Actions window (default 5 minutes).
 @MainActor
 enum QuickActionsPanel {
     static func toggle(state: AppState) {
@@ -13,9 +19,33 @@ enum QuickActionsPanel {
             controller.close()
             return
         }
+        let memory = QuickPanelMemory.shared
+        let minutes = UserDefaults.standard.object(forKey: quickPanelResumeMinutesKey) as? Int ?? 5
+        let expired = memory.closedAt.map { Date().timeIntervalSince($0) > Double(minutes) * 60 } ?? true
+        if minutes <= 0 || expired { memory.reset() }
+        present(state: state)
+    }
+
+    /// APKs double-clicked in Finder land here (via `InstallInbox`): the panel
+    /// opens straight on the APK options screen — install in place, or take
+    /// the file into APK Studio / the Install App screen.
+    static func showAPKOptions(_ urls: [URL], state: AppState) {
+        guard !urls.isEmpty else { return }
+        let memory = QuickPanelMemory.shared
+        memory.stack = [.apk(urls)]
+        memory.closedAt = nil
+        let controller = FloatingPanelController.quickActions
+        // Rebuild if already up — the view seeds its screen stack at init.
+        if controller.isVisible { controller.close() }
+        present(state: state)
+    }
+
+    private static func present(state: AppState) {
         // While backgrounded the device poll is widened, so the list can be
         // stale — refresh once on open.
         state.refreshDevices()
+        let controller = FloatingPanelController.quickActions
+        controller.onClosed = { QuickPanelMemory.shared.closedAt = Date() }
         controller.show { close in
             QuickActionsView(onClose: close)
                 .environment(state)
@@ -24,87 +54,281 @@ enum QuickActionsPanel {
     }
 }
 
-/// The panel's content: type to filter saved custom commands and features,
-/// ⏎ runs the highlighted one in place (result shown in the footer, success
-/// auto-dismisses), Esc closes. Features that need their own screen open the
-/// main window instead.
+/// One screen of the panel's push-navigation stack.
+enum QuickScreen: Equatable {
+    case root
+    /// A form action's in-panel input screen (feature id).
+    case form(String)
+    /// Installed apps on the selected device.
+    case apps
+    /// Per-app verbs (open / stop / clear / uninstall …).
+    case appActions(packageId: String, display: String)
+    /// AVDs + iOS Simulators to boot (running ones select their device).
+    case emulators
+    /// Pick which connected device the actions target.
+    case devices
+    /// Interstitial before a device-scoped action when several devices are
+    /// connected; `allowAll` offers run-on-all for features that support it.
+    case pickDevice(allowAll: Bool)
+    /// Options for APKs opened from Finder: install in place, or hand them to
+    /// APK Studio / the Install App screen in the main window.
+    case apk([URL])
+}
+
+/// The panel's session state, kept outside the view so closing (click-away,
+/// auto-close after a run) and reopening within the resume window lands back
+/// on the same screen with the same device choice.
+@MainActor
+final class QuickPanelMemory {
+    static let shared = QuickPanelMemory()
+
+    var stack: [QuickScreen] = []
+    var hasPickedDevice = false
+    var runAllDevices = false
+    var closedAt: Date?
+
+    func reset() {
+        stack = []
+        hasPickedDevice = false
+        runAllDevices = false
+        closedAt = nil
+    }
+}
+
+/// What a panel run produced. The footer renders the message plus Copy /
+/// Reveal-in-Finder affordances when the result carries them — the panel's
+/// equivalent of the in-app result toasts.
+struct QuickRunOutcome {
+    var message: String
+    var ok: Bool
+    var copyText: String?
+    var revealPath: String?
+
+    init(message: String, ok: Bool, copyText: String? = nil, revealPath: String? = nil) {
+        self.message = message
+        self.ok = ok
+        self.copyText = copyText
+        self.revealPath = revealPath
+    }
+
+    init(result: FeatureResult) {
+        self.init(
+            message: result.message, ok: result.ok,
+            copyText: result.copyText, revealPath: result.revealPath
+        )
+    }
+}
+
 struct QuickActionsView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
 
     let onClose: () -> Void
 
+    @State private var stack: [QuickScreen]
     @State private var query = ""
     @State private var highlighted = 0
     @State private var commands: [CustomCommand] = []
+    /// Installed packages of the selected device; nil while loading.
+    @State private var installedApps: [String]?
     /// Row id of the action in flight (drives its spinner), nil when idle.
     @State private var runningRowID: String?
+    /// Destructive row armed by a first ⏎, awaiting the confirming second.
+    @State private var armedRowID: String?
+    /// The action held while the device interstitial is up.
+    @State private var pendingAction: QuickRow.Action?
+    /// This session's device choice: once made, actions stop asking.
+    @State private var hasPickedDevice: Bool
+    /// "All devices" was chosen — features that support run-on-all fan out.
+    @State private var runAllDevices: Bool
     /// Outcome of the last action run from the panel, shown in the footer.
-    @State private var lastRun: (message: String, ok: Bool)?
-    @FocusState private var fieldFocused: Bool
+    @State private var lastRun: QuickRunOutcome?
+    @FocusState private var searchFocused: Bool
+
+    @MainActor init(onClose: @escaping () -> Void) {
+        self.onClose = onClose
+        let memory = QuickPanelMemory.shared
+        _stack = State(initialValue: memory.stack)
+        _hasPickedDevice = State(initialValue: memory.hasPickedDevice)
+        _runAllDevices = State(initialValue: memory.runAllDevices)
+    }
 
     private static let digitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8"]
+    private static let gridColumns = 5
 
     private var accentText: Color { Color.brandAccent.contrastingForeground(for: colorScheme) }
 
-    /// One result row: a saved custom command, or a registry feature.
-    private enum Row: Identifiable {
-        case command(CustomCommand)
-        case feature(FeatureDef)
+    private var screen: QuickScreen { stack.last ?? .root }
 
-        var id: String {
-            switch self {
-            case .command(let command): return "command:\(command.id)"
-            case .feature(let feature): return "feature:\(feature.id)"
-            }
-        }
-
-        var title: String {
-            switch self {
-            case .command(let command): return command.name
-            case .feature(let feature): return feature.title
-            }
-        }
-
-        var subtitle: String? {
-            switch self {
-            case .command(let command): return command.command
-            case .feature(let feature): return feature.subtitle
-            }
-        }
-
-        var icon: String {
-            switch self {
-            case .command: return "terminal"
-            case .feature(let feature): return feature.icon
-            }
-        }
-    }
-
-    /// Saved commands lead (they're the user's own scripts — the point of this
-    /// panel), then features in palette order.
-    private var visibleRows: [Row] {
-        let features = PaletteSearch.features(
-            query: query,
-            enabled: state.layout.effectiveEnabledIDs,
-            favorites: state.layout.favorites
-        )
-        let commandRows = PaletteSearch.commands(commands, query: query).map(Row.command)
-        return Array((commandRows + features.map(Row.feature)).prefix(8))
-    }
-
-    private var highlightedRow: Row? {
-        visibleRows.indices.contains(highlighted) ? visibleRows[highlighted] : nil
-    }
+    private var isRoot: Bool { stack.isEmpty }
 
     var body: some View {
         VStack(spacing: 0) {
-            searchField
-            if !visibleRows.isEmpty {
+            header
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 560)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background { shortcutButtons }
+        .onExitCommand { escape() }
+        .task { commands = await state.env.stores.customCommands.load() }
+        .task(id: taskKey) { await loadScreenData() }
+        .onAppear {
+            // Focus must land after the panel becomes key — setting it
+            // synchronously in onAppear loses the race.
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(250))
+                searchFocused = true
+            }
+        }
+        .onChange(of: query) {
+            highlighted = 0
+            armedRowID = nil
+        }
+    }
+
+    // MARK: - Navigation
+
+    private func push(_ next: QuickScreen) {
+        stack.append(next)
+        query = ""
+        highlighted = 0
+        armedRowID = nil
+        lastRun = nil
+        syncMemory()
+        refocusSearch()
+    }
+
+    private func pop() {
+        guard !stack.isEmpty else { return }
+        stack.removeLast()
+        query = ""
+        highlighted = 0
+        armedRowID = nil
+        pendingAction = nil
+        lastRun = nil
+        syncMemory()
+        refocusSearch()
+    }
+
+    /// Esc pops one screen; at the root it dismisses the panel.
+    private func escape() {
+        if stack.isEmpty {
+            onClose()
+        } else {
+            pop()
+        }
+    }
+
+    /// Mirror the navigation/device state into the session memory, so a
+    /// close → reopen within the resume window restores it. A pending device
+    /// interstitial isn't kept — its held action doesn't survive the view.
+    private func syncMemory() {
+        let memory = QuickPanelMemory.shared
+        memory.stack = stack.filter {
+            if case .pickDevice = $0 { return false }
+            return true
+        }
+        memory.hasPickedDevice = hasPickedDevice
+        memory.runAllDevices = runAllDevices
+    }
+
+    private func refocusSearch() {
+        guard !isFormScreen else { return }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(60))
+            searchFocused = true
+        }
+    }
+
+    private var isFormScreen: Bool {
+        if case .form = screen { return true }
+        return false
+    }
+
+    private var formFeature: FeatureDef? {
+        if case .form(let id) = screen { return FeatureRegistry.byID[id] }
+        return nil
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder private var header: some View {
+        HStack(spacing: 12) {
+            if stack.isEmpty {
+                Image(systemName: "bolt.fill")
+                    .font(.title)
+                    .foregroundStyle(.brandAccent)
+            } else {
+                Button(action: pop) {
+                    Image(systemName: "chevron.left")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(.textMuted)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Back (esc)")
+            }
+            if let feature = formFeature {
+                Text(feature.title)
+                    .font(.title)
+                Spacer()
+                Image(systemName: feature.icon)
+                    .font(.title2)
+                    .foregroundStyle(.brandAccent)
+            } else {
+                TextField(searchPlaceholder, text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.title)
+                    .focused($searchFocused)
+                    .onSubmit { if let row = highlightedRow { activate(row) } }
+                    .onKeyPress(.downArrow) { moveVertical(1); return .handled }
+                    .onKeyPress(.upArrow) { moveVertical(-1); return .handled }
+                    .onKeyPress(.leftArrow) { moveHorizontal(-1) }
+                    .onKeyPress(.rightArrow) { moveHorizontal(1) }
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+    }
+
+    private var searchPlaceholder: String {
+        switch screen {
+        case .root: return "Run a quick action…"
+        case .apps: return "Search installed apps…"
+        case .appActions(_, let display): return display
+        case .emulators: return "Boot an emulator or simulator…"
+        case .devices: return "Switch device…"
+        case .pickDevice: return "Pick a device for this action…"
+        case .apk(let urls):
+            return urls.count == 1 ? urls[0].lastPathComponent : "\(urls.count) APKs"
+        case .form: return ""
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder private var content: some View {
+        if let feature = formFeature {
+            Divider()
+            QuickActionFormView(
+                feature: feature,
+                targetsProvider: { explicitTargets(for: $0) },
+                onFinish: finish
+            )
+        } else if isRoot {
+            Divider()
+            rootContent
+        } else {
+            let rows = flatItems
+            if !rows.isEmpty {
                 Divider()
                 VStack(spacing: 0) {
-                    ForEach(Array(visibleRows.enumerated()), id: \.element.id) { index, row in
-                        rowView(row, index: index, isHighlighted: index == highlighted)
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                        rowView(row, index: index, isHighlighted: index == highlighted, showsDigitHint: true)
                             .onTapGesture { activate(row) }
                             .accessibilityElement(children: .combine)
                             .accessibilityAddTraits(index == highlighted ? [.isButton, .isSelected] : .isButton)
@@ -112,114 +336,468 @@ struct QuickActionsView: View {
                     }
                 }
                 .padding(6)
-            } else if !query.isEmpty {
+            } else {
                 Divider()
-                Text("No matching actions")
+                Text(emptyMessage)
                     .font(.callout)
                     .foregroundStyle(.textMuted)
                     .padding(14)
             }
-            Divider()
-            footer
         }
-        .frame(width: 520)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .background { shortcutButtons }
-        .onExitCommand { onClose() }
-        .task { commands = await state.env.stores.customCommands.load() }
-        .onAppear {
-            // Focus must land after the panel becomes key — setting it
-            // synchronously in onAppear loses the race.
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(250))
-                fieldFocused = true
-            }
-        }
-        .onChange(of: query) { highlighted = 0 }
     }
 
-    private var searchField: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "bolt.fill")
-                .font(.title)
-                .foregroundStyle(.brandAccent)
-            TextField("Run a quick action…", text: $query)
-                .textFieldStyle(.plain)
-                .font(.title)
-                .focused($fieldFocused)
-                .onSubmit { if let row = highlightedRow { activate(row) } }
-                .onKeyPress(.downArrow) { move(1); return .handled }
-                .onKeyPress(.upArrow) { move(-1); return .handled }
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 16)
-    }
-
-    /// Hidden buttons backing ⌘1–8 row jumps, like the ⌘K palette.
-    private var shortcutButtons: some View {
-        ZStack {
-            ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
-                Button("") {
-                    if visibleRows.indices.contains(index) { activate(visibleRows[index]) }
+    /// The root: a grid of in-panel actions, then the open-in-app list. Fixed
+    /// height with everything reachable by scrolling — the grid holds every
+    /// action, not a truncated top-8.
+    private var rootContent: some View {
+        let grid = rootGridItems
+        let appOpeners = rootAppItems
+        return ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    if !grid.isEmpty {
+                        sectionLabel("Quick actions")
+                        LazyVGrid(
+                            columns: Array(
+                                repeating: GridItem(.flexible(), spacing: 8),
+                                count: Self.gridColumns
+                            ),
+                            spacing: 8
+                        ) {
+                            ForEach(Array(grid.enumerated()), id: \.element.id) { index, row in
+                                gridTile(row, isHighlighted: index == highlighted)
+                                    .id(row.id)
+                                    .onTapGesture { activate(row) }
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityAddTraits(index == highlighted ? [.isButton, .isSelected] : .isButton)
+                                    .accessibilityLabel(row.title)
+                            }
+                        }
+                    }
+                    if !appOpeners.isEmpty {
+                        sectionLabel("Open in Droidective")
+                            .padding(.top, grid.isEmpty ? 0 : 4)
+                        VStack(spacing: 0) {
+                            ForEach(Array(appOpeners.enumerated()), id: \.element.id) { offset, row in
+                                let index = grid.count + offset
+                                rowView(row, index: index, isHighlighted: index == highlighted, showsDigitHint: false)
+                                    .id(row.id)
+                                    .onTapGesture { activate(row) }
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityAddTraits(index == highlighted ? [.isButton, .isSelected] : .isButton)
+                                    .accessibilityLabel(row.title)
+                            }
+                        }
+                    }
+                    if grid.isEmpty && appOpeners.isEmpty {
+                        Text(query.isEmpty ? "Nothing to run yet" : "No matching actions")
+                            .font(.callout)
+                            .foregroundStyle(.textMuted)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 24)
+                    }
                 }
-                .keyboardShortcut(key, modifiers: .command)
+                .padding(10)
+            }
+            .frame(height: 400)
+            .onChange(of: highlighted) {
+                let items = flatItems
+                guard items.indices.contains(highlighted) else { return }
+                proxy.scrollTo(items[highlighted].id)
             }
         }
-        .frame(width: 0, height: 0)
-        .opacity(0)
     }
 
-    @ViewBuilder private var footer: some View {
-        HStack(spacing: 10) {
-            if runningRowID != nil {
-                ProgressView().controlSize(.small)
-                Text("Running…")
-                    .font(.caption)
-                    .foregroundStyle(.textMuted)
-            } else if let lastRun {
-                Image(systemName: lastRun.ok ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                    .foregroundStyle(lastRun.ok ? Color.brandAccent : Color.orange)
-                Text(lastRun.message)
-                    .font(.caption)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            } else {
-                Label(
-                    state.selectedDevice.map(state.deviceTitle) ?? "No device connected",
-                    systemImage: state.selectedDevice?.platform == .iosSimulator
-                        ? "iphone" : "iphone.gen3"
+    private func sectionLabel(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.textMuted)
+            .padding(.horizontal, 4)
+    }
+
+    private var emptyMessage: String {
+        switch screen {
+        case .apps where state.targetSerials.isEmpty: return "Connect a device to manage its apps"
+        case .apps where installedApps == nil: return "Loading apps…"
+        case .apps: return "No matching apps"
+        case .emulators: return "No emulators or simulators found"
+        case .devices, .pickDevice: return "No ready devices"
+        default: return query.isEmpty ? "Nothing to run yet" : "No matching actions"
+        }
+    }
+
+    // MARK: - Rows
+
+    /// One grid tile or list row, and what activating it does.
+    struct QuickRow: Identifiable {
+        enum Action {
+            case runCommand(CustomCommand)
+            case runFeature(FeatureDef)
+            case push(QuickScreen)
+            case openInApp(FeatureDef)
+            /// Install APK from the grid: ask for files first.
+            case installAPK
+            /// Install these specific files (the Finder-opened APK screen).
+            case installFiles([URL])
+            /// Load an APK into APK Studio on `tab` and open the main window.
+            case openStudio(tab: ApkStudioTab, url: URL)
+            /// Stage the files in the main window's Install App screen.
+            case stageInstallScreen([URL])
+            case appVerb(AppControlService.AppAction, packageId: String)
+            case launchAvd(Avd)
+            case bootSimulator(Simulator)
+            /// Switch the app's selection (Switch Device screen, running
+            /// emulator rows).
+            case selectDevice(serial: String, label: String)
+            /// Resolve the interstitial, then perform the held action.
+            case chooseDevice(serial: String, label: String)
+            case chooseAllDevices
+        }
+
+        let id: String
+        let icon: String
+        let title: String
+        var subtitle: String?
+        /// Small trailing tag, e.g. "Running" / "Booted".
+        var badge: String?
+        var destructive = false
+        /// Renders a › chevron: activating navigates instead of running.
+        var pushes = false
+        let action: Action
+    }
+
+    /// Every navigable item of the current screen, in highlight order. The
+    /// root is grid + open-in-app list; sub-screens are flat lists.
+    private var flatItems: [QuickRow] {
+        switch screen {
+        case .root: return rootGridItems + rootAppItems
+        case .apps: return Array(appRows.prefix(8))
+        case .appActions(let packageId, _): return appActionRows(packageId)
+        case .emulators: return Array(emulatorRows.prefix(8))
+        case .devices: return deviceRows
+        case .pickDevice(let allowAll): return pickDeviceRows(allowAll: allowAll)
+        case .apk(let urls): return apkRows(urls)
+        case .form: return []
+        }
+    }
+
+    private var highlightedRow: QuickRow? {
+        let rows = flatItems
+        return rows.indices.contains(highlighted) ? rows[highlighted] : nil
+    }
+
+    /// The grid: saved commands, the panel's own screens, and every
+    /// implemented instant/toggle/form action (hub members included).
+    private var rootGridItems: [QuickRow] {
+        var rows: [QuickRow] = PaletteSearch.commands(commands, query: query).map { command in
+            QuickRow(
+                id: "command:\(command.id)", icon: "terminal",
+                title: command.name, subtitle: command.command,
+                action: .runCommand(command)
+            )
+        }
+        rows += nativeRows
+        rows += PaletteSearch.quickActions(query: query, implemented: FeatureEngine.implementedIDs)
+            .map { feature in
+                QuickRow(
+                    id: "feature:\(feature.id)", icon: feature.icon,
+                    title: feature.title, subtitle: feature.subtitle,
+                    pushes: feature.kind == .formAction,
+                    action: feature.kind == .formAction
+                        ? .push(.form(feature.id))
+                        : .runFeature(feature)
                 )
-                .font(.caption)
-                .foregroundStyle(.textMuted)
-                .lineLimit(1)
             }
-            Spacer()
-            footerHint("⏎", "Run")
-            footerHint("esc", "Close")
+        return rows
+    }
+
+    /// Full-app screens below the grid — everything that can't run in a
+    /// panel opens the main window instead. The panel's native screens
+    /// replace their in-app counterparts here.
+    private var rootAppItems: [QuickRow] {
+        let covered: Set<String> = ["apps", "emulators", "install-app"]
+        return PaletteSearch.features(
+            query: query,
+            enabled: state.layout.effectiveEnabledIDs,
+            favorites: state.layout.favorites
+        )
+        .filter { ($0.kind == .view || $0.kind == .system) && !covered.contains($0.id) }
+        .map { feature in
+            QuickRow(
+                id: "open:\(feature.id)", icon: feature.icon,
+                title: feature.title, subtitle: feature.subtitle,
+                action: .openInApp(feature)
+            )
         }
-        .padding(.horizontal, 14)
+    }
+
+    /// The panel's own sub-screens and actions, searchable alongside the rest.
+    private var nativeRows: [QuickRow] {
+        var rows: [QuickRow] = []
+        if matchesNative(title: "Manage Apps", keywords: [
+            "apps", "app", "packages", "manage", "open", "force stop",
+            "clear data", "clear cache", "uninstall",
+        ]) {
+            rows.append(QuickRow(
+                id: "screen:apps", icon: "square.grid.3x3",
+                title: "Manage Apps",
+                subtitle: "Open, force-stop, clear cache/data, uninstall",
+                pushes: true, action: .push(.apps)
+            ))
+        }
+        if matchesNative(title: "Emulators", keywords: [
+            "emulator", "simulator", "avd", "boot", "launch", "virtual",
+        ]) {
+            rows.append(QuickRow(
+                id: "screen:emulators", icon: "play.display",
+                title: "Emulators",
+                subtitle: "Boot an Android emulator or iOS Simulator",
+                pushes: true, action: .push(.emulators)
+            ))
+        }
+        if matchesNative(title: "Install APK", keywords: ["install", "apk", "sideload", "package"]) {
+            rows.append(QuickRow(
+                id: "native:install", icon: "arrow.down.app",
+                title: "Install APK",
+                subtitle: "Pick .apk files and install them",
+                action: .installAPK
+            ))
+        }
+        if state.devices.filter(\.isReady).count > 1,
+           matchesNative(title: "Switch Device", keywords: ["device", "switch", "select", "target"]) {
+            rows.append(QuickRow(
+                id: "screen:devices", icon: "arrow.triangle.2.circlepath",
+                title: "Switch Device",
+                subtitle: state.selectedDevice.map { "Now targeting \($0.label)" },
+                pushes: true, action: .push(.devices)
+            ))
+        }
+        return rows
+    }
+
+    private func matchesNative(title: String, keywords: [String]) -> Bool {
+        let needle = query.trimmingCharacters(in: .whitespaces)
+        guard !needle.isEmpty else { return true }
+        return title.localizedCaseInsensitiveContains(needle)
+            || keywords.contains { $0.localizedCaseInsensitiveContains(needle) }
+    }
+
+    /// Installed apps, saved bundles pinned first — mirroring how the device
+    /// bar treats bundles as the apps you actually work on.
+    private var appRows: [QuickRow] {
+        guard let installedApps else { return [] }
+        let bundleIDs = state.bundles.map(\.packageId)
+        let pinned = bundleIDs.filter(installedApps.contains)
+        let rest = installedApps.filter { !pinned.contains($0) }
+        return (pinned + rest)
+            .filter { packageId in
+                guard !query.isEmpty else { return true }
+                let nickname = state.bundles.first { $0.packageId == packageId }?.nickname
+                return packageId.localizedCaseInsensitiveContains(query)
+                    || Self.appDisplayName(packageId).localizedCaseInsensitiveContains(query)
+                    || (nickname?.localizedCaseInsensitiveContains(query) ?? false)
+            }
+            .map { packageId in
+                let nickname = state.bundles.first { $0.packageId == packageId }?.nickname
+                return QuickRow(
+                    id: "app:\(packageId)", icon: "app.badge",
+                    title: nickname ?? Self.appDisplayName(packageId),
+                    subtitle: packageId,
+                    badge: nickname != nil ? "saved" : nil,
+                    pushes: true,
+                    action: .push(.appActions(
+                        packageId: packageId,
+                        display: nickname ?? Self.appDisplayName(packageId)
+                    ))
+                )
+            }
+    }
+
+    /// "com.foo.weather" → "Weather", like `AppListing.displayName`.
+    private static func appDisplayName(_ packageId: String) -> String {
+        packageId.split(separator: ".").last
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? packageId
+    }
+
+    private func appActionRows(_ packageId: String) -> [QuickRow] {
+        let verbs: [(AppControlService.AppAction, String, String)] = [
+            (.open, "Open", "play.circle"),
+            (.stop, "Force Stop", "stop.circle"),
+            (.minimize, "Minimize", "chevron.down.circle"),
+            (.clearCache, "Clear Cache", "eraser"),
+            (.clearData, "Clear Data", "eraser.fill"),
+            (.uninstall, "Uninstall", "trash"),
+        ]
+        return verbs
+            .filter { query.isEmpty || $0.1.localizedCaseInsensitiveContains(query) }
+            .map { verb, title, icon in
+                QuickRow(
+                    id: "verb:\(verb.rawValue):\(packageId)", icon: icon,
+                    title: title, subtitle: packageId,
+                    destructive: verb.isDestructive,
+                    action: .appVerb(verb, packageId: packageId)
+                )
+            }
+    }
+
+    /// AVDs then iOS Simulators. Idle ones boot; running/booted ones switch
+    /// the selection to their device instead.
+    private var emulatorRows: [QuickRow] {
+        var rows: [QuickRow] = state.availableAvds.map { avd in
+            if let serial = avd.runningSerial {
+                return QuickRow(
+                    id: "avd:\(avd.name)", icon: "memorychip",
+                    title: avd.displayName, subtitle: "Android emulator",
+                    badge: "Running",
+                    action: .selectDevice(serial: serial, label: avd.displayName)
+                )
+            }
+            return QuickRow(
+                id: "avd:\(avd.name)", icon: "memorychip",
+                title: avd.displayName, subtitle: "Android emulator",
+                action: .launchAvd(avd)
+            )
+        }
+        rows += state.availableSimulators.filter(\.isAvailable).map { simulator in
+            if simulator.state == "Booted" {
+                return QuickRow(
+                    id: "sim:\(simulator.udid)", icon: "iphone",
+                    title: simulator.name, subtitle: simulator.runtime,
+                    badge: "Booted",
+                    action: .selectDevice(serial: simulator.udid, label: simulator.name)
+                )
+            }
+            return QuickRow(
+                id: "sim:\(simulator.udid)", icon: "iphone",
+                title: simulator.name, subtitle: simulator.runtime,
+                action: .bootSimulator(simulator)
+            )
+        }
+        guard !query.isEmpty else { return rows }
+        return rows.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+
+    private var readyDevices: [Device] { state.devices.filter(\.isReady) }
+
+    private var deviceRows: [QuickRow] {
+        readyDevices
+            .filter { query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query) }
+            .map { device in
+                QuickRow(
+                    id: "device:\(device.serial)",
+                    icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
+                    title: device.label,
+                    subtitle: state.deviceTitle(device),
+                    badge: device.serial == state.selectedSerial ? "selected" : nil,
+                    action: .selectDevice(serial: device.serial, label: device.label)
+                )
+            }
+    }
+
+    /// What you can do with Finder-opened APKs: install right here, or hand
+    /// them to APK Studio (inspect/decompile/sign) or the Install App screen.
+    /// The studio takes one APK — with several, it gets the first.
+    private func apkRows(_ urls: [URL]) -> [QuickRow] {
+        guard let first = urls.first else { return [] }
+        let name = urls.count == 1 ? first.lastPathComponent : "\(urls.count) APKs"
+        var rows = [QuickRow(
+            id: "apk:install", icon: "arrow.down.app",
+            title: "Install", subtitle: "Install \(name) on a device",
+            action: .installFiles(urls)
+        )]
+        let studioTabs: [(String, ApkStudioTab)] = [
+            ("apk-inspector", .inspect),
+            ("apk-decompile", .decompile),
+            ("apk-sign", .sign),
+        ]
+        rows += studioTabs.compactMap { featureID, tab in
+            guard let feature = FeatureRegistry.byID[featureID] else { return nil }
+            return QuickRow(
+                id: "apk:\(featureID)", icon: feature.icon,
+                title: feature.title,
+                subtitle: "\(first.lastPathComponent) in APK Studio",
+                action: .openStudio(tab: tab, url: first)
+            )
+        }
+        rows.append(QuickRow(
+            id: "apk:install-screen", icon: "square.grid.3x3",
+            title: "Open in App",
+            subtitle: "Stage \(name) with the full device picker",
+            action: .stageInstallScreen(urls)
+        ))
+        guard !query.isEmpty else { return rows }
+        return rows.filter { $0.title.localizedCaseInsensitiveContains(query) }
+    }
+
+    /// The interstitial's rows: optionally "All devices", then each device.
+    private func pickDeviceRows(allowAll: Bool) -> [QuickRow] {
+        var rows: [QuickRow] = []
+        if allowAll, matchesNative(title: "All devices", keywords: ["all", "every"]) {
+            rows.append(QuickRow(
+                id: "pick:all", icon: "square.stack.3d.down.right",
+                title: "All devices",
+                subtitle: "Run on every connected device",
+                action: .chooseAllDevices
+            ))
+        }
+        rows += readyDevices
+            .filter { query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query) }
+            .map { device in
+                QuickRow(
+                    id: "pick:\(device.serial)",
+                    icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
+                    title: device.label,
+                    subtitle: state.deviceTitle(device),
+                    badge: device.serial == state.selectedSerial ? "selected" : nil,
+                    action: .chooseDevice(serial: device.serial, label: device.label)
+                )
+            }
+        return rows
+    }
+
+    // MARK: - Row rendering
+
+    private func gridTile(_ row: QuickRow, isHighlighted: Bool) -> some View {
+        VStack(spacing: 6) {
+            if runningRowID == row.id {
+                ProgressView().controlSize(.small).frame(height: 26)
+            } else {
+                Image(systemName: row.icon)
+                    .font(.title2)
+                    .frame(height: 26)
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText) : AnyShapeStyle(.brandAccent))
+            }
+            Text(row.title)
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .lineLimit(2, reservesSpace: true)
+        }
+        .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        .background(
+            isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.quaternary.opacity(0.5)),
+            in: RoundedRectangle(cornerRadius: 10)
+        )
+        .foregroundStyle(isHighlighted ? accentText : .primary)
+        .contentShape(RoundedRectangle(cornerRadius: 10))
+        .help(row.subtitle ?? row.title)
     }
 
-    private func footerHint(_ key: String, _ label: String) -> some View {
-        HStack(spacing: 5) {
-            KeyHint(key)
-            Text(label).font(.caption2).foregroundStyle(.textMuted)
-        }
-    }
-
-    private func rowView(_ row: Row, index: Int, isHighlighted: Bool) -> some View {
+    private func rowView(
+        _ row: QuickRow, index: Int, isHighlighted: Bool, showsDigitHint: Bool
+    ) -> some View {
         HStack(spacing: 10) {
             if runningRowID == row.id {
                 ProgressView().controlSize(.small).frame(width: 22)
             } else {
                 Image(systemName: row.icon)
                     .frame(width: 22)
-                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText) : AnyShapeStyle(.brandAccent))
+                    .foregroundStyle(iconStyle(row, isHighlighted: isHighlighted))
             }
             VStack(alignment: .leading, spacing: 0) {
                 Text(row.title)
+                    .foregroundStyle(row.destructive && !isHighlighted ? AnyShapeStyle(.red) : AnyShapeStyle(.primary))
                 if let subtitle = row.subtitle {
                     Text(subtitle)
                         .font(.caption)
@@ -228,13 +806,22 @@ struct QuickActionsView: View {
                 }
             }
             Spacer()
-            if !runsInPlace(row) {
+            if let badge = row.badge {
+                Text(badge)
+                    .font(.caption2)
+                    .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
+            }
+            if case .openInApp = row.action {
                 Image(systemName: "arrow.up.forward.app")
                     .font(.caption)
                     .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
-                    .help("Opens in Droidective")
             }
-            if index < 8 {
+            if row.pushes {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
+            }
+            if showsDigitHint, index < 8 {
                 KeyHint("⌘\(index + 1)", prominent: isHighlighted)
             }
         }
@@ -248,69 +835,323 @@ struct QuickActionsView: View {
         .contentShape(Rectangle())
     }
 
-    private func move(_ offset: Int) {
-        let count = visibleRows.count
-        guard count > 0 else { return }
-        highlighted = (highlighted + offset + count) % count
+    private func iconStyle(_ row: QuickRow, isHighlighted: Bool) -> AnyShapeStyle {
+        if isHighlighted { return AnyShapeStyle(accentText) }
+        if row.destructive { return AnyShapeStyle(.red) }
+        return AnyShapeStyle(.brandAccent)
     }
 
-    /// Whether activating this row runs it here (custom commands, implemented
-    /// instant/toggle actions — including Screenshot, whose quick path saves
-    /// straight to the capture folder) vs. opening the main window.
-    private func runsInPlace(_ row: Row) -> Bool {
-        switch row {
-        case .command: return true
-        case .feature(let feature):
-            return (feature.kind == .instantAction || feature.kind == .toggleAction)
-                && FeatureEngine.implementedIDs.contains(feature.id)
+    /// Hidden buttons backing ⌘1–8 jumps to the first eight items.
+    private var shortcutButtons: some View {
+        ZStack {
+            ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
+                Button("") {
+                    let rows = flatItems
+                    if rows.indices.contains(index) { activate(rows[index]) }
+                }
+                .keyboardShortcut(key, modifiers: .command)
+            }
+        }
+        .frame(width: 0, height: 0)
+        .opacity(0)
+    }
+
+    // MARK: - Screen data
+
+    /// Re-keys per screen + device, so entering Apps loads the package list
+    /// and Emulators refreshes AVDs/simulators.
+    private var taskKey: String {
+        switch screen {
+        case .apps: return "apps:\(state.targetSerials.first ?? "")"
+        case .emulators: return "emulators"
+        default: return "static"
         }
     }
 
-    private func activate(_ row: Row) {
+    private func loadScreenData() async {
+        switch screen {
+        case .apps:
+            installedApps = nil
+            guard let serial = state.targetSerials.first else {
+                installedApps = []
+                return
+            }
+            let packages = (try? await state.env.engine.appControl.listInstalledPackages(serial: serial)) ?? []
+            guard !Task.isCancelled else { return }
+            installedApps = packages.sorted()
+        case .emulators:
+            await state.refreshAvds()
+            await state.refreshSimulators()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Footer
+
+    @ViewBuilder private var footer: some View {
+        HStack(spacing: 10) {
+            if runningRowID != nil {
+                ProgressView().controlSize(.small)
+                Text("Running…")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            } else if let armedRowID, let row = flatItems.first(where: { $0.id == armedRowID }) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Press ⏎ again to \(row.title.lowercased()) — this can't be undone")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+            } else if let lastRun {
+                Image(systemName: lastRun.ok ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .foregroundStyle(lastRun.ok ? Color.brandAccent : Color.orange)
+                Text(lastRun.message)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let path = lastRun.revealPath {
+                    Button("Reveal") {
+                        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                    .help("Show in Finder")
+                }
+                if let copyText = lastRun.copyText {
+                    Button("Copy") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(copyText, forType: .string)
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                }
+            } else if runAllDevices, readyDevices.count > 1 {
+                Label("All devices (\(readyDevices.count))", systemImage: "square.stack.3d.down.right")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            } else {
+                Label(
+                    state.selectedDevice.map(state.deviceTitle) ?? "No device connected",
+                    systemImage: state.selectedDevice?.platform == .iosSimulator
+                        ? "iphone" : "iphone.gen3"
+                )
+                .font(.caption)
+                .foregroundStyle(.textMuted)
+                .lineLimit(1)
+            }
+            Spacer()
+            footerHint("⏎", isFormScreen ? "Run" : "Select")
+            footerHint("esc", stack.isEmpty ? "Close" : "Back")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    private func footerHint(_ key: String, _ label: String) -> some View {
+        HStack(spacing: 5) {
+            KeyHint(key)
+            Text(label).font(.caption2).foregroundStyle(.textMuted)
+        }
+    }
+
+    // MARK: - Highlight movement
+
+    /// ↑/↓: 2D through the root grid, then row-by-row through the list
+    /// below; plain ±1 with wraparound on sub-screens.
+    private func moveVertical(_ direction: Int) {
+        armedRowID = nil
+        guard isRoot else {
+            let count = flatItems.count
+            guard count > 0 else { return }
+            highlighted = (highlighted + direction + count) % count
+            return
+        }
+        let gridCount = rootGridItems.count
+        let total = gridCount + rootAppItems.count
+        guard total > 0 else { return }
+        var index = min(highlighted, total - 1)
+        if direction > 0 {
+            if index < gridCount {
+                let below = index + Self.gridColumns
+                if below < gridCount {
+                    index = below
+                } else if gridCount < total {
+                    index = gridCount
+                }
+            } else if index + 1 < total {
+                index += 1
+            }
+        } else {
+            if index >= gridCount {
+                index = index == gridCount ? max(gridCount - 1, 0) : index - 1
+            } else if index >= Self.gridColumns {
+                index -= Self.gridColumns
+            }
+        }
+        highlighted = index
+    }
+
+    /// ←/→ step through the root grid — only while the query is empty, so
+    /// they keep moving the text caret while typing.
+    private func moveHorizontal(_ direction: Int) -> KeyPress.Result {
+        guard isRoot, query.isEmpty else { return .ignored }
+        let total = rootGridItems.count + rootAppItems.count
+        guard total > 0 else { return .ignored }
+        armedRowID = nil
+        highlighted = min(max(highlighted + direction, 0), total - 1)
+        return .handled
+    }
+
+    // MARK: - Activation
+
+    private func activate(_ row: QuickRow) {
         guard runningRowID == nil else { return }
-        switch row {
-        case .command(let command):
+        // Destructive verbs take two ⏎s: the first arms, the second runs.
+        if row.destructive, armedRowID != row.id {
+            armedRowID = row.id
+            return
+        }
+        armedRowID = nil
+        // Several devices and no choice yet: ask first, hold the action.
+        let choice = deviceChoice(for: row.action)
+        if choice.needed {
+            pendingAction = row.action
+            push(.pickDevice(allowAll: choice.allowAll))
+            return
+        }
+        perform(row.action)
+    }
+
+    /// Whether this action needs the device interstitial, and whether that
+    /// interstitial offers "All devices" (only where fan-out is supported).
+    private func deviceChoice(for action: QuickRow.Action) -> (needed: Bool, allowAll: Bool) {
+        guard readyDevices.count > 1, !hasPickedDevice else { return (false, false) }
+        switch action {
+        case .runFeature(let feature):
+            return (feature.needsDevice, feature.supportsRunAll)
+        case .push(.form(let id)):
+            guard let feature = FeatureRegistry.byID[id] else { return (false, false) }
+            return (feature.needsDevice, feature.supportsRunAll)
+        case .push(.apps):
+            return (true, false)
+        case .runCommand(let command):
+            return (command.kind == .adb || command.command.contains("{serial}"), false)
+        case .installAPK, .installFiles:
+            return (true, true)
+        default:
+            return (false, false)
+        }
+    }
+
+    private func perform(_ action: QuickRow.Action) {
+        switch action {
+        case .runCommand(let command):
             run(command)
-        case .feature(let feature) where runsInPlace(row):
+        case .runFeature(let feature):
             run(feature)
-        case .feature(let feature):
+        case .push(let next):
+            push(next)
+        case .openInApp(let feature):
             onClose()
             state.activateMainWindow()
             state.requestFeature(feature.id)
+        case .installAPK:
+            pickAndInstallAPKs()
+        case .installFiles(let urls):
+            install(urls)
+        case .openStudio(let tab, let url):
+            // Load the studio session before opening — the studio view renders
+            // whatever `apkStudio.apk` holds, on the chosen tab.
+            state.apkStudio.apk = url
+            state.apkStudio.signInput = nil
+            state.apkStudio.tab = tab
+            onClose()
+            state.activateMainWindow()
+            state.requestFeature("apk-studio")
+        case .stageInstallScreen(let urls):
+            onClose()
+            state.openAPKs(urls)
+        case .appVerb(let verb, let packageId):
+            run(verb, packageId: packageId)
+        case .launchAvd(let avd):
+            state.launchEmulator(avd)
+            finish(QuickRunOutcome(message: "Launching \(avd.displayName)…", ok: true))
+        case .bootSimulator(let simulator):
+            state.bootSimulator(simulator)
+            finish(QuickRunOutcome(message: "Booting \(simulator.name)…", ok: true))
+        case .selectDevice(let serial, let label):
+            state.requestDevice(serial)
+            hasPickedDevice = true
+            runAllDevices = false
+            syncMemory()
+            if !stack.isEmpty { pop() }
+            finish(QuickRunOutcome(message: "Now targeting \(label)", ok: true))
+        case .chooseDevice(let serial, _):
+            state.requestDevice(serial)
+            hasPickedDevice = true
+            runAllDevices = false
+            resumePendingAfterPick()
+        case .chooseAllDevices:
+            hasPickedDevice = true
+            runAllDevices = true
+            resumePendingAfterPick()
         }
+    }
+
+    /// Leave the interstitial and carry out the action it was holding.
+    private func resumePendingAfterPick() {
+        let held = pendingAction
+        pendingAction = nil
+        syncMemory()
+        pop()
+        if let held { perform(held) }
+    }
+
+    /// Fan-out targets for a feature when "All devices" is in effect (and the
+    /// feature supports run-on-all); nil defers to the device-bar selection.
+    private func explicitTargets(for feature: FeatureDef) -> [String]? {
+        guard runAllDevices, feature.supportsRunAll else { return nil }
+        var serials = readyDevices.map(\.serial)
+        guard serials.count > 1 else { return nil }
+        // Selected device first, mirroring `targetSerials`' ordering rule.
+        if let selected = state.selectedSerial, let index = serials.firstIndex(of: selected) {
+            serials.swapAt(0, index)
+        }
+        return serials
     }
 
     private func run(_ feature: FeatureDef) {
         // `state.run` reports these preconditions only via toast (it doesn't
         // write `lastResults`), so check them here where the panel can say so.
         if feature.needsDevice, state.targetSerials.isEmpty {
-            lastRun = ("No device connected.", false)
+            lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
         }
         if feature.needsBundle, state.selectedBundle == nil {
-            lastRun = ("Pick a saved bundle first.", false)
+            lastRun = QuickRunOutcome(message: "Pick a saved bundle first.", ok: false)
             return
         }
         runningRowID = "feature:\(feature.id)"
         lastRun = nil
         Task {
             let started = Date()
-            await state.run(feature: feature, params: [:])
+            await state.run(feature: feature, params: [:], on: explicitTargets(for: feature))
             let fresh = state.lastResults[feature.id].flatMap { entry in
-                entry.at >= started ? (entry.result.message, entry.result.ok) : nil
+                entry.at >= started ? QuickRunOutcome(result: entry.result) : nil
             }
-            finish(fresh ?? ("Done", true))
+            finish(fresh ?? QuickRunOutcome(message: "Done", ok: true))
         }
     }
 
     private func run(_ command: CustomCommand) {
         if command.needsBundle, state.selectedBundle == nil {
-            lastRun = ("Pick a saved bundle first.", false)
+            lastRun = QuickRunOutcome(message: "Pick a saved bundle first.", ok: false)
             return
         }
         let serial = state.targetSerials.first ?? ""
         if command.kind == .adb, serial.isEmpty {
-            lastRun = ("No device connected.", false)
+            lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
         }
         runningRowID = "command:\(command.id)"
@@ -325,20 +1166,77 @@ struct QuickActionsView: View {
             // Mirror the Custom Commands screen: failures land in the
             // notifications history too, not just this transient footer.
             state.showToast(Toast(message: result.message, ok: result.ok))
-            finish((result.message, result.ok))
+            finish(QuickRunOutcome(result: result))
         }
     }
 
-    /// Show the outcome in the footer; success auto-dismisses the panel after
-    /// a beat, failure keeps it open for another try.
-    private func finish(_ result: (message: String, ok: Bool)) {
-        runningRowID = nil
-        lastRun = result
-        guard result.ok else { return }
-        Task {
-            try? await Task.sleep(for: .milliseconds(1300))
-            // A newer run may be in flight (or have failed) — don't close over it.
-            if runningRowID == nil, lastRun?.ok == true { onClose() }
+    private func run(_ verb: AppControlService.AppAction, packageId: String) {
+        guard let serial = state.targetSerials.first else {
+            lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
+            return
         }
+        runningRowID = "verb:\(verb.rawValue):\(packageId)"
+        lastRun = nil
+        Task {
+            let result = await CommandLog.userInitiated {
+                do {
+                    return try await state.env.engine.appControl.control(
+                        serial: serial, packageId: packageId, action: verb
+                    )
+                } catch {
+                    return FeatureResult(ok: false, message: error.localizedDescription)
+                }
+            }
+            if verb == .uninstall, result.ok {
+                installedApps?.removeAll { $0 == packageId }
+            }
+            finish(QuickRunOutcome(result: result))
+        }
+    }
+
+    /// Pick .apk files, then install them. The file dialog takes key focus,
+    /// so the panel holds itself open across it.
+    private func pickAndInstallAPKs() {
+        let picker = NSOpenPanel()
+        picker.allowedContentTypes = [UTType(filenameExtension: "apk")].compactMap { $0 }
+        picker.allowsMultipleSelection = true
+        picker.message = "Choose APKs to install"
+        let controller = FloatingPanelController.quickActions
+        controller.holdsThroughResign = true
+        NSApp.activate(ignoringOtherApps: true)
+        let confirmed = picker.runModal() == .OK
+        controller.holdsThroughResign = false
+        controller.makeKey()
+        refocusSearch()
+        guard confirmed, !picker.urls.isEmpty else { return }
+        install(picker.urls)
+    }
+
+    /// Install APKs on the panel's target device(s) — one device, or all of
+    /// them after an "All devices" pick.
+    private func install(_ urls: [URL]) {
+        let serials = runAllDevices
+            ? readyDevices.map(\.serial)
+            : Array(state.targetSerials.prefix(1))
+        guard !serials.isEmpty else {
+            lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
+            return
+        }
+        runningRowID = "native:install"
+        lastRun = nil
+        Task {
+            let report = await state.installAPKs(urls, onSerials: serials)
+            finish(QuickRunOutcome(
+                message: report.components(separatedBy: "\n").first ?? "Install finished",
+                ok: true
+            ))
+        }
+    }
+
+    /// Show the outcome in the footer. The panel stays up — chain more
+    /// actions, use the result's Reveal/Copy, and leave with Esc.
+    private func finish(_ outcome: QuickRunOutcome) {
+        runningRowID = nil
+        lastRun = outcome
     }
 }

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -98,10 +98,11 @@ final class QuickPanelMemory {
     static let shared = QuickPanelMemory()
 
     var stack: [QuickScreen] = []
-    /// The serial explicitly picked at the device interstitial (or Switch
-    /// Device). Stored as the serial — not a flag — so a device that
-    /// disconnected while the panel was closed re-raises the interstitial
-    /// instead of silently running on whatever the selection drifted to.
+    /// The serial from the most recent device interstitial (or Switch
+    /// Device) — the target for device-scoped screens (Manage Apps) and the
+    /// footer. Stored as the serial, not a flag, so a device that
+    /// disconnected while the panel was closed falls back visibly instead of
+    /// silently retargeting. Actions themselves re-ask before every run.
     var pickedSerial: String?
     /// The exact serials approved by an "All devices" pick. Fan-outs use this
     /// ∩ currently-ready, so a device plugged in *after* the approval is
@@ -1075,10 +1076,10 @@ struct QuickActionsView: View {
         highlighted = index
     }
 
-    /// ←/→ step through the root grid — only while the query is empty, so
-    /// they keep moving the text caret while typing.
+    /// ←/→ step through the root grid, searching or not — arrow keys own
+    /// grid navigation (Raycast-style); the query caret cedes to them.
     private func moveHorizontal(_ direction: Int) -> KeyPress.Result {
-        guard isRoot, query.isEmpty else { return .ignored }
+        guard isRoot else { return .ignored }
         let total = rootGridItems.count + rootAppItems.count
         guard total > 0 else { return .ignored }
         armedRowID = nil
@@ -1108,8 +1109,7 @@ struct QuickActionsView: View {
 
     // MARK: - Device targeting
 
-    /// The session's pick, discarded if that device is no longer ready — a
-    /// stale pick re-raises the interstitial instead of silently retargeting.
+    /// The latest pick, discarded if that device is no longer ready.
     private var effectivePickedSerial: String? {
         pickedSerial.flatMap { picked in
             readyDevices.contains { $0.serial == picked } ? picked : nil
@@ -1152,10 +1152,11 @@ struct QuickActionsView: View {
 
     /// Whether this action needs the device interstitial, and whether that
     /// interstitial offers "All devices" (only where fan-out is supported).
+    /// With several devices connected, every device-scoped action asks —
+    /// each pick scopes just the action it precedes (verbs inside Manage
+    /// Apps inherit the pick that opened the list).
     private func deviceChoice(for action: QuickRow.Action) -> (needed: Bool, allowAll: Bool) {
-        guard readyDevices.count > 1,
-              effectivePickedSerial == nil, effectiveApprovedSerials == nil
-        else { return (false, false) }
+        guard readyDevices.count > 1 else { return (false, false) }
         switch action {
         case .runFeature(let feature):
             return (feature.needsDevice, feature.supportsRunAll)

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -423,7 +423,9 @@ struct QuickActionsView: View {
                             .padding(.vertical, 24)
                     }
                 }
-                .padding(10)
+                .padding(.horizontal, 10)
+                .padding(.top, 16)
+                .padding(.bottom, 10)
             }
             .frame(height: 400)
             .onChange(of: highlighted) {

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -1,0 +1,344 @@
+import ADBKit
+import SwiftUI
+
+/// Entry point for the Quick Actions panel — a Raycast-style floating
+/// launcher summoned by a global hotkey (or the menu bar) that runs instant/
+/// toggle actions and saved custom commands directly against the selected
+/// device, no main window needed. View features open the full app instead.
+@MainActor
+enum QuickActionsPanel {
+    static func toggle(state: AppState) {
+        let controller = FloatingPanelController.quickActions
+        if controller.isVisible {
+            controller.close()
+            return
+        }
+        // While backgrounded the device poll is widened, so the list can be
+        // stale — refresh once on open.
+        state.refreshDevices()
+        controller.show { close in
+            QuickActionsView(onClose: close)
+                .environment(state)
+                .tint(.brandAccent)
+        }
+    }
+}
+
+/// The panel's content: type to filter saved custom commands and features,
+/// ⏎ runs the highlighted one in place (result shown in the footer, success
+/// auto-dismisses), Esc closes. Features that need their own screen open the
+/// main window instead.
+struct QuickActionsView: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.colorScheme) private var colorScheme
+
+    let onClose: () -> Void
+
+    @State private var query = ""
+    @State private var highlighted = 0
+    @State private var commands: [CustomCommand] = []
+    /// Row id of the action in flight (drives its spinner), nil when idle.
+    @State private var runningRowID: String?
+    /// Outcome of the last action run from the panel, shown in the footer.
+    @State private var lastRun: (message: String, ok: Bool)?
+    @FocusState private var fieldFocused: Bool
+
+    private static let digitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8"]
+
+    private var accentText: Color { Color.brandAccent.contrastingForeground(for: colorScheme) }
+
+    /// One result row: a saved custom command, or a registry feature.
+    private enum Row: Identifiable {
+        case command(CustomCommand)
+        case feature(FeatureDef)
+
+        var id: String {
+            switch self {
+            case .command(let command): return "command:\(command.id)"
+            case .feature(let feature): return "feature:\(feature.id)"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .command(let command): return command.name
+            case .feature(let feature): return feature.title
+            }
+        }
+
+        var subtitle: String? {
+            switch self {
+            case .command(let command): return command.command
+            case .feature(let feature): return feature.subtitle
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .command: return "terminal"
+            case .feature(let feature): return feature.icon
+            }
+        }
+    }
+
+    /// Saved commands lead (they're the user's own scripts — the point of this
+    /// panel), then features in palette order.
+    private var visibleRows: [Row] {
+        let features = PaletteSearch.features(
+            query: query,
+            enabled: state.layout.effectiveEnabledIDs,
+            favorites: state.layout.favorites
+        )
+        let commandRows = PaletteSearch.commands(commands, query: query).map(Row.command)
+        return Array((commandRows + features.map(Row.feature)).prefix(8))
+    }
+
+    private var highlightedRow: Row? {
+        visibleRows.indices.contains(highlighted) ? visibleRows[highlighted] : nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            if !visibleRows.isEmpty {
+                Divider()
+                VStack(spacing: 0) {
+                    ForEach(Array(visibleRows.enumerated()), id: \.element.id) { index, row in
+                        rowView(row, index: index, isHighlighted: index == highlighted)
+                            .onTapGesture { activate(row) }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityAddTraits(index == highlighted ? [.isButton, .isSelected] : .isButton)
+                            .accessibilityLabel(row.title)
+                    }
+                }
+                .padding(6)
+            } else if !query.isEmpty {
+                Divider()
+                Text("No matching actions")
+                    .font(.callout)
+                    .foregroundStyle(.textMuted)
+                    .padding(14)
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 520)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background { shortcutButtons }
+        .onExitCommand { onClose() }
+        .task { commands = await state.env.stores.customCommands.load() }
+        .onAppear {
+            // Focus must land after the panel becomes key — setting it
+            // synchronously in onAppear loses the race.
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(250))
+                fieldFocused = true
+            }
+        }
+        .onChange(of: query) { highlighted = 0 }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bolt.fill")
+                .font(.title)
+                .foregroundStyle(.brandAccent)
+            TextField("Run a quick action…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.title)
+                .focused($fieldFocused)
+                .onSubmit { if let row = highlightedRow { activate(row) } }
+                .onKeyPress(.downArrow) { move(1); return .handled }
+                .onKeyPress(.upArrow) { move(-1); return .handled }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+    }
+
+    /// Hidden buttons backing ⌘1–8 row jumps, like the ⌘K palette.
+    private var shortcutButtons: some View {
+        ZStack {
+            ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
+                Button("") {
+                    if visibleRows.indices.contains(index) { activate(visibleRows[index]) }
+                }
+                .keyboardShortcut(key, modifiers: .command)
+            }
+        }
+        .frame(width: 0, height: 0)
+        .opacity(0)
+    }
+
+    @ViewBuilder private var footer: some View {
+        HStack(spacing: 10) {
+            if runningRowID != nil {
+                ProgressView().controlSize(.small)
+                Text("Running…")
+                    .font(.caption)
+                    .foregroundStyle(.textMuted)
+            } else if let lastRun {
+                Image(systemName: lastRun.ok ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .foregroundStyle(lastRun.ok ? Color.brandAccent : Color.orange)
+                Text(lastRun.message)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            } else {
+                Label(
+                    state.selectedDevice.map(state.deviceTitle) ?? "No device connected",
+                    systemImage: state.selectedDevice?.platform == .iosSimulator
+                        ? "iphone" : "iphone.gen3"
+                )
+                .font(.caption)
+                .foregroundStyle(.textMuted)
+                .lineLimit(1)
+            }
+            Spacer()
+            footerHint("⏎", "Run")
+            footerHint("esc", "Close")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+    }
+
+    private func footerHint(_ key: String, _ label: String) -> some View {
+        HStack(spacing: 5) {
+            KeyHint(key)
+            Text(label).font(.caption2).foregroundStyle(.textMuted)
+        }
+    }
+
+    private func rowView(_ row: Row, index: Int, isHighlighted: Bool) -> some View {
+        HStack(spacing: 10) {
+            if runningRowID == row.id {
+                ProgressView().controlSize(.small).frame(width: 22)
+            } else {
+                Image(systemName: row.icon)
+                    .frame(width: 22)
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText) : AnyShapeStyle(.brandAccent))
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                Text(row.title)
+                if let subtitle = row.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            if !runsInPlace(row) {
+                Image(systemName: "arrow.up.forward.app")
+                    .font(.caption)
+                    .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
+                    .help("Opens in Droidective")
+            }
+            if index < 8 {
+                KeyHint("⌘\(index + 1)", prominent: isHighlighted)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.clear),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
+        .foregroundStyle(isHighlighted ? accentText : .primary)
+        .contentShape(Rectangle())
+    }
+
+    private func move(_ offset: Int) {
+        let count = visibleRows.count
+        guard count > 0 else { return }
+        highlighted = (highlighted + offset + count) % count
+    }
+
+    /// Whether activating this row runs it here (custom commands, implemented
+    /// instant/toggle actions — including Screenshot, whose quick path saves
+    /// straight to the capture folder) vs. opening the main window.
+    private func runsInPlace(_ row: Row) -> Bool {
+        switch row {
+        case .command: return true
+        case .feature(let feature):
+            return (feature.kind == .instantAction || feature.kind == .toggleAction)
+                && FeatureEngine.implementedIDs.contains(feature.id)
+        }
+    }
+
+    private func activate(_ row: Row) {
+        guard runningRowID == nil else { return }
+        switch row {
+        case .command(let command):
+            run(command)
+        case .feature(let feature) where runsInPlace(row):
+            run(feature)
+        case .feature(let feature):
+            onClose()
+            state.activateMainWindow()
+            state.requestFeature(feature.id)
+        }
+    }
+
+    private func run(_ feature: FeatureDef) {
+        // `state.run` reports these preconditions only via toast (it doesn't
+        // write `lastResults`), so check them here where the panel can say so.
+        if feature.needsDevice, state.targetSerials.isEmpty {
+            lastRun = ("No device connected.", false)
+            return
+        }
+        if feature.needsBundle, state.selectedBundle == nil {
+            lastRun = ("Pick a saved bundle first.", false)
+            return
+        }
+        runningRowID = "feature:\(feature.id)"
+        lastRun = nil
+        Task {
+            let started = Date()
+            await state.run(feature: feature, params: [:])
+            let fresh = state.lastResults[feature.id].flatMap { entry in
+                entry.at >= started ? (entry.result.message, entry.result.ok) : nil
+            }
+            finish(fresh ?? ("Done", true))
+        }
+    }
+
+    private func run(_ command: CustomCommand) {
+        if command.needsBundle, state.selectedBundle == nil {
+            lastRun = ("Pick a saved bundle first.", false)
+            return
+        }
+        let serial = state.targetSerials.first ?? ""
+        if command.kind == .adb, serial.isEmpty {
+            lastRun = ("No device connected.", false)
+            return
+        }
+        runningRowID = "command:\(command.id)"
+        lastRun = nil
+        let bundleId = state.selectedBundle?.packageId
+        Task {
+            let result = await CommandLog.userInitiated {
+                await state.env.engine.customCommands.run(
+                    command: command, bundleId: bundleId, serial: serial
+                )
+            }
+            // Mirror the Custom Commands screen: failures land in the
+            // notifications history too, not just this transient footer.
+            state.showToast(Toast(message: result.message, ok: result.ok))
+            finish((result.message, result.ok))
+        }
+    }
+
+    /// Show the outcome in the footer; success auto-dismisses the panel after
+    /// a beat, failure keeps it open for another try.
+    private func finish(_ result: (message: String, ok: Bool)) {
+        runningRowID = nil
+        lastRun = result
+        guard result.ok else { return }
+        Task {
+            try? await Task.sleep(for: .milliseconds(1300))
+            // A newer run may be in flight (or have failed) — don't close over it.
+            if runningRowID == nil, lastRun?.ok == true { onClose() }
+        }
+    }
+}

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -948,10 +948,13 @@ struct QuickActionsView: View {
     // MARK: - Screen data
 
     /// Re-keys per screen + device, so entering Apps loads the package list
-    /// and Emulators refreshes AVDs/simulators.
+    /// and Emulators refreshes AVDs/simulators. The Apps key must use
+    /// `panelTargetSerial` — the exact device `loadScreenData` loads — so a
+    /// target change (a picked device disconnecting, a deferred switch landing)
+    /// re-fires the load instead of leaving a stale list from the old device.
     private var taskKey: String {
         switch screen {
-        case .apps: return "apps:\(state.targetSerials.first ?? "")"
+        case .apps: return "apps:\(panelTargetSerial ?? "")"
         case .emulators: return "emulators"
         default: return "static"
         }

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -741,6 +741,10 @@ struct QuickActionsView: View {
 
     private var readyDevices: [Device] { state.devices.filter(\.isReady) }
 
+    /// Ready-device serials in bar order — the input `PanelTargeting` resolves
+    /// the panel's target(s) from.
+    private var readySerials: [String] { readyDevices.map(\.serial) }
+
     private var matchingReadyDevices: [Device] {
         readyDevices.filter {
             query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query)
@@ -1180,47 +1184,31 @@ struct QuickActionsView: View {
 
     // MARK: - Device targeting
 
-    /// The latest pick, discarded if that device is no longer ready.
-    private var effectivePickedSerial: String? {
-        pickedSerial.flatMap { picked in
-            readyDevices.contains { $0.serial == picked } ? picked : nil
-        }
-    }
-
-    /// The serials an "All devices" approval still covers: approved ∩ ready.
-    /// Devices attached after the approval are never included.
+    /// The serials an "All devices" approval still covers (approved ∩ ready) —
+    /// the footer's "All devices (N)" count reads this. See `PanelTargeting`.
     private var effectiveApprovedSerials: [String]? {
-        guard let approvedAllSerials else { return nil }
-        let ready = Set(readyDevices.map(\.serial))
-        let live = approvedAllSerials.filter(ready.contains)
-        return live.isEmpty ? nil : live
+        PanelTargeting.approvedTargets(approved: approvedAllSerials, ready: readySerials)
     }
 
     /// The single device a panel action targets: the session pick, else the
-    /// device-bar selection, else the first ready device.
+    /// device-bar selection, else the first ready device. See `PanelTargeting`.
     private var panelTargetSerial: String? {
-        if let picked = effectivePickedSerial { return picked }
-        if let selected = state.selectedSerial,
-           readyDevices.contains(where: { $0.serial == selected }) {
-            return selected
-        }
-        return readyDevices.first?.serial
+        PanelTargeting.singleTarget(
+            picked: pickedSerial, selected: state.selectedSerial, ready: readySerials
+        )
     }
 
-    /// Explicit targets for `AppState.run(feature:params:on:)`. Always
-    /// explicit for device features (empty = no device, which `run` reports):
-    /// falling back to `targetSerials` would let the *hidden main window's*
-    /// run-on-all state fan a panel action out past an explicit single pick,
-    /// and a device switch deferred behind an exit guard would silently run
-    /// on the old selection. An "All devices" pick (⌘⏎ at the interstitial)
-    /// fans out any device feature — the panel loops explicit targets, so it
-    /// isn't limited to the registry's `supportsRunAll` set.
+    /// Explicit targets for `AppState.run(feature:params:on:)` — always the
+    /// panel's own single pick or "All devices" fan-out, never the device
+    /// bar's `targetSerials` (whose run-on-all state belongs to the hidden main
+    /// window, and whose selection can lag a guard-deferred switch). An "All
+    /// devices" pick fans out any device feature, not just `supportsRunAll`
+    /// ones, since the panel loops explicit targets. See `PanelTargeting`.
     private func explicitTargets(for feature: FeatureDef) -> [String]? {
-        guard feature.needsDevice else { return nil }
-        if let approved = effectiveApprovedSerials, approved.count > 1 {
-            return approved
-        }
-        return panelTargetSerial.map { [$0] } ?? []
+        PanelTargeting.runTargets(
+            needsDevice: feature.needsDevice, picked: pickedSerial,
+            selected: state.selectedSerial, approved: approvedAllSerials, ready: readySerials
+        )
     }
 
     /// Whether this action needs the device interstitial, and whether that
@@ -1347,12 +1335,12 @@ struct QuickActionsView: View {
         // Device-scoped commands honor an "All devices" approval (the footer
         // advertises it); shell commands without {serial} run once.
         let deviceScoped = command.kind == .adb || command.command.contains("{serial}")
-        let targets: [String]
-        if deviceScoped, let approved = effectiveApprovedSerials, approved.count > 1 {
-            targets = approved
-        } else {
-            targets = panelTargetSerial.map { [$0] } ?? []
-        }
+        let targets: [String] = deviceScoped
+            ? PanelTargeting.fanOut(
+                picked: pickedSerial, selected: state.selectedSerial,
+                approved: approvedAllSerials, ready: readySerials
+            )
+            : (panelTargetSerial.map { [$0] } ?? [])
         if command.kind == .adb, targets.isEmpty {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
@@ -1436,12 +1424,10 @@ struct QuickActionsView: View {
     /// Install APKs on the panel's target device(s) — one device, or the
     /// serials an "All devices" pick approved.
     private func install(_ urls: [URL]) {
-        let serials: [String]
-        if let approved = effectiveApprovedSerials, approved.count > 1 {
-            serials = approved
-        } else {
-            serials = panelTargetSerial.map { [$0] } ?? []
-        }
+        let serials = PanelTargeting.fanOut(
+            picked: pickedSerial, selected: state.selectedSerial,
+            approved: approvedAllSerials, ready: readySerials
+        )
         guard !serials.isEmpty else {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -7,10 +7,9 @@ import UniformTypeIdentifiers
 /// mini app summoned by a global hotkey (or the menu bar). The root shows a
 /// grid of everything runnable in place (instant/toggle actions, in-panel
 /// forms, saved custom commands, Manage Apps / Emulators / Install APK) with
-/// an "Open in Droidective" list below for the full-app screens. Esc, ⌫ on an
-/// empty query, or `<` pops a screen; at the root Esc closes. A session
-/// resumes where it left off when reopened within the Settings ▸ Quick
-/// Actions window (default 5 minutes).
+/// an "Open in Droidective" list below for the full-app screens. Esc pops a
+/// screen; at the root it closes. A session resumes where it left off when
+/// reopened within the Settings ▸ Quick Actions window (default 5 minutes).
 @MainActor
 enum QuickActionsPanel {
     static func toggle(state: AppState) {
@@ -19,10 +18,7 @@ enum QuickActionsPanel {
             controller.close()
             return
         }
-        let memory = QuickPanelMemory.shared
-        let minutes = UserDefaults.standard.object(forKey: quickPanelResumeMinutesKey) as? Int ?? 5
-        let expired = memory.closedAt.map { Date().timeIntervalSince($0) > Double(minutes) * 60 } ?? true
-        if minutes <= 0 || expired { memory.reset() }
+        resetSessionIfExpired()
         present(state: state)
     }
 
@@ -31,13 +27,32 @@ enum QuickActionsPanel {
     /// the file into APK Studio / the Install App screen.
     static func showAPKOptions(_ urls: [URL], state: AppState) {
         guard !urls.isEmpty else { return }
+        // Same expiry rule as toggle — a stale session's device pick (worst
+        // case a stale "All devices") must not govern this install.
+        resetSessionIfExpired()
         let memory = QuickPanelMemory.shared
         memory.stack = [.apk(urls)]
         memory.closedAt = nil
         let controller = FloatingPanelController.quickActions
         // Rebuild if already up — the view seeds its screen stack at init.
         if controller.isVisible { controller.close() }
+        // The app activation that delivered the APK can shuffle key windows
+        // for a beat; don't let that churn dismiss the panel it opens.
+        controller.holdsThroughResign = true
         present(state: state)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(1500))
+            controller.holdsThroughResign = false
+        }
+    }
+
+    /// Clear the resumable session once it's older than the Settings ▸ Quick
+    /// Actions window (0 = never resume).
+    private static func resetSessionIfExpired() {
+        let memory = QuickPanelMemory.shared
+        let minutes = UserDefaults.standard.object(forKey: quickPanelResumeMinutesKey) as? Int ?? 5
+        let expired = memory.closedAt.map { Date().timeIntervalSince($0) > Double(minutes) * 60 } ?? true
+        if minutes <= 0 || expired { memory.reset() }
     }
 
     private static func present(state: AppState) {
@@ -83,14 +98,21 @@ final class QuickPanelMemory {
     static let shared = QuickPanelMemory()
 
     var stack: [QuickScreen] = []
-    var hasPickedDevice = false
-    var runAllDevices = false
+    /// The serial explicitly picked at the device interstitial (or Switch
+    /// Device). Stored as the serial — not a flag — so a device that
+    /// disconnected while the panel was closed re-raises the interstitial
+    /// instead of silently running on whatever the selection drifted to.
+    var pickedSerial: String?
+    /// The exact serials approved by an "All devices" pick. Fan-outs use this
+    /// ∩ currently-ready, so a device plugged in *after* the approval is
+    /// never targeted by it.
+    var approvedAllSerials: [String]?
     var closedAt: Date?
 
     func reset() {
         stack = []
-        hasPickedDevice = false
-        runAllDevices = false
+        pickedSerial = nil
+        approvedAllSerials = nil
         closedAt = nil
     }
 }
@@ -137,10 +159,12 @@ struct QuickActionsView: View {
     @State private var armedRowID: String?
     /// The action held while the device interstitial is up.
     @State private var pendingAction: QuickRow.Action?
-    /// This session's device choice: once made, actions stop asking.
-    @State private var hasPickedDevice: Bool
-    /// "All devices" was chosen — features that support run-on-all fan out.
-    @State private var runAllDevices: Bool
+    /// This session's explicit device pick; nil until the interstitial ran.
+    @State private var pickedSerial: String?
+    /// The serials approved by an "All devices" pick, nil otherwise.
+    @State private var approvedAllSerials: [String]?
+    /// True while the Emulators screen's AVD/simulator refresh is in flight.
+    @State private var emulatorsLoading = false
     /// Outcome of the last action run from the panel, shown in the footer.
     @State private var lastRun: QuickRunOutcome?
     @FocusState private var searchFocused: Bool
@@ -149,8 +173,8 @@ struct QuickActionsView: View {
         self.onClose = onClose
         let memory = QuickPanelMemory.shared
         _stack = State(initialValue: memory.stack)
-        _hasPickedDevice = State(initialValue: memory.hasPickedDevice)
-        _runAllDevices = State(initialValue: memory.runAllDevices)
+        _pickedSerial = State(initialValue: memory.pickedSerial)
+        _approvedAllSerials = State(initialValue: memory.approvedAllSerials)
     }
 
     private static let digitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8"]
@@ -174,7 +198,11 @@ struct QuickActionsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .background { shortcutButtons }
         .onExitCommand { escape() }
-        .task { commands = await state.env.stores.customCommands.load() }
+        .task {
+            let loaded = await state.env.stores.customCommands.load()
+            guard !Task.isCancelled else { return }
+            commands = loaded
+        }
         .task(id: taskKey) { await loadScreenData() }
         .onAppear {
             // Focus must land after the panel becomes key — setting it
@@ -232,8 +260,8 @@ struct QuickActionsView: View {
             if case .pickDevice = $0 { return false }
             return true
         }
-        memory.hasPickedDevice = hasPickedDevice
-        memory.runAllDevices = runAllDevices
+        memory.pickedSerial = pickedSerial
+        memory.approvedAllSerials = approvedAllSerials
     }
 
     private func refocusSearch() {
@@ -417,9 +445,10 @@ struct QuickActionsView: View {
 
     private var emptyMessage: String {
         switch screen {
-        case .apps where state.targetSerials.isEmpty: return "Connect a device to manage its apps"
+        case .apps where panelTargetSerial == nil: return "Connect a device to manage its apps"
         case .apps where installedApps == nil: return "Loading apps…"
         case .apps: return "No matching apps"
+        case .emulators where emulatorsLoading: return "Looking for emulators and simulators…"
         case .emulators: return "No emulators or simulators found"
         case .devices, .pickDevice: return "No ready devices"
         default: return query.isEmpty ? "Nothing to run yet" : "No matching actions"
@@ -471,7 +500,7 @@ struct QuickActionsView: View {
     private var flatItems: [QuickRow] {
         switch screen {
         case .root: return rootGridItems + rootAppItems
-        case .apps: return Array(appRows.prefix(8))
+        case .apps: return appRows
         case .appActions(let packageId, _): return appActionRows(packageId)
         case .emulators: return Array(emulatorRows.prefix(8))
         case .devices: return deviceRows
@@ -563,12 +592,12 @@ struct QuickActionsView: View {
                 action: .installAPK
             ))
         }
-        if state.devices.filter(\.isReady).count > 1,
+        if readyDevices.count > 1,
            matchesNative(title: "Switch Device", keywords: ["device", "switch", "select", "target"]) {
             rows.append(QuickRow(
                 id: "screen:devices", icon: "arrow.triangle.2.circlepath",
                 title: "Switch Device",
-                subtitle: state.selectedDevice.map { "Now targeting \($0.label)" },
+                subtitle: panelTargetDevice.map { "Now targeting \($0.label)" },
                 pushes: true, action: .push(.devices)
             ))
         }
@@ -583,61 +612,72 @@ struct QuickActionsView: View {
     }
 
     /// Installed apps, saved bundles pinned first — mirroring how the device
-    /// bar treats bundles as the apps you actually work on.
+    /// bar treats bundles as the apps you actually work on. O(1) nickname
+    /// lookups and an early cap: with hundreds of packages this recomputes
+    /// per keystroke, so no per-package bundle scans and no rows built past
+    /// what the list shows.
     private var appRows: [QuickRow] {
         guard let installedApps else { return [] }
-        let bundleIDs = state.bundles.map(\.packageId)
-        let pinned = bundleIDs.filter(installedApps.contains)
-        let rest = installedApps.filter { !pinned.contains($0) }
-        return (pinned + rest)
-            .filter { packageId in
-                guard !query.isEmpty else { return true }
-                let nickname = state.bundles.first { $0.packageId == packageId }?.nickname
-                return packageId.localizedCaseInsensitiveContains(query)
-                    || Self.appDisplayName(packageId).localizedCaseInsensitiveContains(query)
-                    || (nickname?.localizedCaseInsensitiveContains(query) ?? false)
-            }
-            .map { packageId in
-                let nickname = state.bundles.first { $0.packageId == packageId }?.nickname
-                return QuickRow(
-                    id: "app:\(packageId)", icon: "app.badge",
-                    title: nickname ?? Self.appDisplayName(packageId),
-                    subtitle: packageId,
-                    badge: nickname != nil ? "saved" : nil,
-                    pushes: true,
-                    action: .push(.appActions(
-                        packageId: packageId,
-                        display: nickname ?? Self.appDisplayName(packageId)
-                    ))
-                )
-            }
+        let nicknames = Dictionary(
+            state.bundles.map { ($0.packageId, $0.nickname) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let pinned = installedApps.filter { nicknames[$0] != nil }
+        let rest = installedApps.filter { nicknames[$0] == nil }
+        let matching = (pinned + rest).filter { packageId in
+            guard !query.isEmpty else { return true }
+            return packageId.localizedCaseInsensitiveContains(query)
+                || AppListing.displayName(for: packageId).localizedCaseInsensitiveContains(query)
+                || (nicknames[packageId]?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+        return matching.prefix(8).map { packageId in
+            let display = nicknames[packageId] ?? AppListing.displayName(for: packageId)
+            return QuickRow(
+                id: "app:\(packageId)", icon: "app.badge",
+                title: display,
+                subtitle: packageId,
+                badge: nicknames[packageId] != nil ? "saved" : nil,
+                pushes: true,
+                action: .push(.appActions(packageId: packageId, display: display))
+            )
+        }
     }
 
-    /// "com.foo.weather" → "Weather", like `AppListing.displayName`.
-    private static func appDisplayName(_ packageId: String) -> String {
-        packageId.split(separator: ".").last
-            .map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? packageId
-    }
-
+    /// One row per `AppAction` case — the exhaustive switches make a new verb
+    /// in ADBKit a compile error here instead of a silently missing row.
     private func appActionRows(_ packageId: String) -> [QuickRow] {
-        let verbs: [(AppControlService.AppAction, String, String)] = [
-            (.open, "Open", "play.circle"),
-            (.stop, "Force Stop", "stop.circle"),
-            (.minimize, "Minimize", "chevron.down.circle"),
-            (.clearCache, "Clear Cache", "eraser"),
-            (.clearData, "Clear Data", "eraser.fill"),
-            (.uninstall, "Uninstall", "trash"),
-        ]
-        return verbs
-            .filter { query.isEmpty || $0.1.localizedCaseInsensitiveContains(query) }
-            .map { verb, title, icon in
+        AppControlService.AppAction.allCases
+            .filter { query.isEmpty || Self.verbTitle($0).localizedCaseInsensitiveContains(query) }
+            .map { verb in
                 QuickRow(
-                    id: "verb:\(verb.rawValue):\(packageId)", icon: icon,
-                    title: title, subtitle: packageId,
+                    id: "verb:\(verb.rawValue):\(packageId)", icon: Self.verbIcon(verb),
+                    title: Self.verbTitle(verb), subtitle: packageId,
                     destructive: verb.isDestructive,
                     action: .appVerb(verb, packageId: packageId)
                 )
             }
+    }
+
+    private static func verbTitle(_ verb: AppControlService.AppAction) -> String {
+        switch verb {
+        case .open: return "Open"
+        case .stop: return "Force Stop"
+        case .minimize: return "Minimize"
+        case .clearCache: return "Clear Cache"
+        case .clearData: return "Clear Data"
+        case .uninstall: return "Uninstall"
+        }
+    }
+
+    private static func verbIcon(_ verb: AppControlService.AppAction) -> String {
+        switch verb {
+        case .open: return "play.circle"
+        case .stop: return "stop.circle"
+        case .minimize: return "chevron.down.circle"
+        case .clearCache: return "eraser"
+        case .clearData: return "eraser.fill"
+        case .uninstall: return "trash"
+        }
     }
 
     /// AVDs then iOS Simulators. Idle ones boot; running/booted ones switch
@@ -680,18 +720,28 @@ struct QuickActionsView: View {
     private var readyDevices: [Device] { state.devices.filter(\.isReady) }
 
     private var deviceRows: [QuickRow] {
-        readyDevices
-            .filter { query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query) }
-            .map { device in
-                QuickRow(
-                    id: "device:\(device.serial)",
-                    icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
-                    title: device.label,
-                    subtitle: state.deviceTitle(device),
-                    badge: device.serial == state.selectedSerial ? "selected" : nil,
-                    action: .selectDevice(serial: device.serial, label: device.label)
-                )
-            }
+        matchingReadyDevices.map {
+            deviceRow($0, idPrefix: "device", action: .selectDevice(serial: $0.serial, label: $0.label))
+        }
+    }
+
+    private var matchingReadyDevices: [Device] {
+        readyDevices.filter {
+            query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    /// One device row — shared by Switch Device and the pick interstitial so
+    /// the two lists can't drift apart visually.
+    private func deviceRow(_ device: Device, idPrefix: String, action: QuickRow.Action) -> QuickRow {
+        QuickRow(
+            id: "\(idPrefix):\(device.serial)",
+            icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
+            title: device.label,
+            subtitle: state.deviceTitle(device),
+            badge: device.serial == panelTargetSerial ? "selected" : nil,
+            action: action
+        )
     }
 
     /// What you can do with Finder-opened APKs: install right here, or hand
@@ -710,12 +760,19 @@ struct QuickActionsView: View {
             ("apk-decompile", .decompile),
             ("apk-sign", .sign),
         ]
+        // Loading this APK replaces whatever APK Studio already has open —
+        // if a different session is loaded, ask for the confirming second ⏎
+        // like the destructive app verbs do.
+        let clobbersStudio = state.apkStudio.apk.map { $0 != first } ?? false
         rows += studioTabs.compactMap { featureID, tab in
             guard let feature = FeatureRegistry.byID[featureID] else { return nil }
             return QuickRow(
                 id: "apk:\(featureID)", icon: feature.icon,
                 title: feature.title,
-                subtitle: "\(first.lastPathComponent) in APK Studio",
+                subtitle: clobbersStudio
+                    ? "Replaces the APK loaded in APK Studio"
+                    : "\(first.lastPathComponent) in APK Studio",
+                destructive: clobbersStudio,
                 action: .openStudio(tab: tab, url: first)
             )
         }
@@ -740,18 +797,9 @@ struct QuickActionsView: View {
                 action: .chooseAllDevices
             ))
         }
-        rows += readyDevices
-            .filter { query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query) }
-            .map { device in
-                QuickRow(
-                    id: "pick:\(device.serial)",
-                    icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
-                    title: device.label,
-                    subtitle: state.deviceTitle(device),
-                    badge: device.serial == state.selectedSerial ? "selected" : nil,
-                    action: .chooseDevice(serial: device.serial, label: device.label)
-                )
-            }
+        rows += matchingReadyDevices.map {
+            deviceRow($0, idPrefix: "pick", action: .chooseDevice(serial: $0.serial, label: $0.label))
+        }
         return rows
     }
 
@@ -787,7 +835,14 @@ struct QuickActionsView: View {
     private func rowView(
         _ row: QuickRow, index: Int, isHighlighted: Bool, showsDigitHint: Bool
     ) -> some View {
-        HStack(spacing: 10) {
+        let isArmed = armedRowID == row.id
+        // Destructive rows keep their danger color when highlighted (a red
+        // fill instead of the accent), and an armed row says so on the row
+        // itself — the footer warning alone was easy to miss.
+        let highlightFill: AnyShapeStyle = row.destructive
+            ? AnyShapeStyle(Color.red)
+            : AnyShapeStyle(.brandAccent)
+        return HStack(spacing: 10) {
             if runningRowID == row.id {
                 ProgressView().controlSize(.small).frame(width: 22)
             } else {
@@ -806,7 +861,11 @@ struct QuickActionsView: View {
                 }
             }
             Spacer()
-            if let badge = row.badge {
+            if isArmed {
+                Text("⏎ to confirm")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText) : AnyShapeStyle(.orange))
+            } else if let badge = row.badge {
                 Text(badge)
                     .font(.caption2)
                     .foregroundStyle(isHighlighted ? accentText.opacity(0.75) : .secondary)
@@ -828,7 +887,7 @@ struct QuickActionsView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(
-            isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.clear),
+            isHighlighted ? highlightFill : AnyShapeStyle(.clear),
             in: RoundedRectangle(cornerRadius: 8)
         )
         .foregroundStyle(isHighlighted ? accentText : .primary)
@@ -872,16 +931,25 @@ struct QuickActionsView: View {
         switch screen {
         case .apps:
             installedApps = nil
-            guard let serial = state.targetSerials.first else {
+            guard let serial = panelTargetSerial else {
                 installedApps = []
                 return
             }
-            let packages = (try? await state.env.engine.appControl.listInstalledPackages(serial: serial)) ?? []
+            // User-initiated navigation, so it belongs in the Command Log
+            // like the panel's other adb calls.
+            let packages = await CommandLog.userInitiated {
+                (try? await state.env.engine.appControl.listInstalledPackages(serial: serial)) ?? []
+            }
             guard !Task.isCancelled else { return }
             installedApps = packages.sorted()
         case .emulators:
-            await state.refreshAvds()
-            await state.refreshSimulators()
+            emulatorsLoading = true
+            // Independent probes (emulator -list-avds vs simctl list) — run
+            // them together instead of paying the sum of both spawns.
+            async let avds: Void = state.refreshAvds()
+            async let simulators: Void = state.refreshSimulators()
+            _ = await (avds, simulators)
+            emulatorsLoading = false
         default:
             break
         }
@@ -926,15 +994,17 @@ struct QuickActionsView: View {
                     .buttonStyle(.link)
                     .font(.caption)
                 }
-            } else if runAllDevices, readyDevices.count > 1 {
-                Label("All devices (\(readyDevices.count))", systemImage: "square.stack.3d.down.right")
+            } else if let approved = effectiveApprovedSerials, approved.count > 1, !singleDeviceScreen {
+                Label("All devices (\(approved.count))", systemImage: "square.stack.3d.down.right")
                     .font(.caption)
                     .foregroundStyle(.textMuted)
             } else {
+                // The device the next action actually targets — the panel's
+                // pick, not just the device-bar selection.
+                let device = panelTargetDevice
                 Label(
-                    state.selectedDevice.map(state.deviceTitle) ?? "No device connected",
-                    systemImage: state.selectedDevice?.platform == .iosSimulator
-                        ? "iphone" : "iphone.gen3"
+                    device.map(state.deviceTitle) ?? "No device connected",
+                    systemImage: device?.platform == .iosSimulator ? "iphone" : "iphone.gen3"
                 )
                 .font(.caption)
                 .foregroundStyle(.textMuted)
@@ -952,6 +1022,19 @@ struct QuickActionsView: View {
         HStack(spacing: 5) {
             KeyHint(key)
             Text(label).font(.caption2).foregroundStyle(.textMuted)
+        }
+    }
+
+    private var panelTargetDevice: Device? {
+        panelTargetSerial.flatMap { serial in state.devices.first { $0.serial == serial } }
+    }
+
+    /// Screens whose actions are single-device by nature (the app list came
+    /// from one device) — the footer names that device, never "All devices".
+    private var singleDeviceScreen: Bool {
+        switch screen {
+        case .apps, .appActions: return true
+        default: return false
         }
     }
 
@@ -1023,10 +1106,56 @@ struct QuickActionsView: View {
         perform(row.action)
     }
 
+    // MARK: - Device targeting
+
+    /// The session's pick, discarded if that device is no longer ready — a
+    /// stale pick re-raises the interstitial instead of silently retargeting.
+    private var effectivePickedSerial: String? {
+        pickedSerial.flatMap { picked in
+            readyDevices.contains { $0.serial == picked } ? picked : nil
+        }
+    }
+
+    /// The serials an "All devices" approval still covers: approved ∩ ready.
+    /// Devices attached after the approval are never included.
+    private var effectiveApprovedSerials: [String]? {
+        guard let approvedAllSerials else { return nil }
+        let ready = Set(readyDevices.map(\.serial))
+        let live = approvedAllSerials.filter(ready.contains)
+        return live.isEmpty ? nil : live
+    }
+
+    /// The single device a panel action targets: the session pick, else the
+    /// device-bar selection, else the first ready device.
+    private var panelTargetSerial: String? {
+        if let picked = effectivePickedSerial { return picked }
+        if let selected = state.selectedSerial,
+           readyDevices.contains(where: { $0.serial == selected }) {
+            return selected
+        }
+        return readyDevices.first?.serial
+    }
+
+    /// Explicit targets for `AppState.run(feature:params:on:)`. Always
+    /// explicit for device features (empty = no device, which `run` reports):
+    /// falling back to `targetSerials` would let the *hidden main window's*
+    /// run-on-all state fan a panel action out past an explicit single pick,
+    /// and a device switch deferred behind an exit guard would silently run
+    /// on the old selection.
+    private func explicitTargets(for feature: FeatureDef) -> [String]? {
+        guard feature.needsDevice else { return nil }
+        if let approved = effectiveApprovedSerials, feature.supportsRunAll, approved.count > 1 {
+            return approved
+        }
+        return panelTargetSerial.map { [$0] } ?? []
+    }
+
     /// Whether this action needs the device interstitial, and whether that
     /// interstitial offers "All devices" (only where fan-out is supported).
     private func deviceChoice(for action: QuickRow.Action) -> (needed: Bool, allowAll: Bool) {
-        guard readyDevices.count > 1, !hasPickedDevice else { return (false, false) }
+        guard readyDevices.count > 1,
+              effectivePickedSerial == nil, effectiveApprovedSerials == nil
+        else { return (false, false) }
         switch action {
         case .runFeature(let feature):
             return (feature.needsDevice, feature.supportsRunAll)
@@ -1081,20 +1210,23 @@ struct QuickActionsView: View {
             state.bootSimulator(simulator)
             finish(QuickRunOutcome(message: "Booting \(simulator.name)…", ok: true))
         case .selectDevice(let serial, let label):
+            // The panel target is carried explicitly (`pickedSerial`) — the
+            // device-bar switch is a courtesy and may defer behind an exit
+            // guard, so nothing here depends on it landing.
+            pickedSerial = serial
+            approvedAllSerials = nil
             state.requestDevice(serial)
-            hasPickedDevice = true
-            runAllDevices = false
             syncMemory()
             if !stack.isEmpty { pop() }
             finish(QuickRunOutcome(message: "Now targeting \(label)", ok: true))
         case .chooseDevice(let serial, _):
+            pickedSerial = serial
+            approvedAllSerials = nil
             state.requestDevice(serial)
-            hasPickedDevice = true
-            runAllDevices = false
             resumePendingAfterPick()
         case .chooseAllDevices:
-            hasPickedDevice = true
-            runAllDevices = true
+            approvedAllSerials = readyDevices.map(\.serial)
+            pickedSerial = nil
             resumePendingAfterPick()
         }
     }
@@ -1108,23 +1240,10 @@ struct QuickActionsView: View {
         if let held { perform(held) }
     }
 
-    /// Fan-out targets for a feature when "All devices" is in effect (and the
-    /// feature supports run-on-all); nil defers to the device-bar selection.
-    private func explicitTargets(for feature: FeatureDef) -> [String]? {
-        guard runAllDevices, feature.supportsRunAll else { return nil }
-        var serials = readyDevices.map(\.serial)
-        guard serials.count > 1 else { return nil }
-        // Selected device first, mirroring `targetSerials`' ordering rule.
-        if let selected = state.selectedSerial, let index = serials.firstIndex(of: selected) {
-            serials.swapAt(0, index)
-        }
-        return serials
-    }
-
     private func run(_ feature: FeatureDef) {
         // `state.run` reports these preconditions only via toast (it doesn't
         // write `lastResults`), so check them here where the panel can say so.
-        if feature.needsDevice, state.targetSerials.isEmpty {
+        if feature.needsDevice, panelTargetSerial == nil {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
         }
@@ -1149,8 +1268,16 @@ struct QuickActionsView: View {
             lastRun = QuickRunOutcome(message: "Pick a saved bundle first.", ok: false)
             return
         }
-        let serial = state.targetSerials.first ?? ""
-        if command.kind == .adb, serial.isEmpty {
+        // Device-scoped commands honor an "All devices" approval (the footer
+        // advertises it); shell commands without {serial} run once.
+        let deviceScoped = command.kind == .adb || command.command.contains("{serial}")
+        let targets: [String]
+        if deviceScoped, let approved = effectiveApprovedSerials, approved.count > 1 {
+            targets = approved
+        } else {
+            targets = panelTargetSerial.map { [$0] } ?? []
+        }
+        if command.kind == .adb, targets.isEmpty {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
         }
@@ -1158,20 +1285,38 @@ struct QuickActionsView: View {
         lastRun = nil
         let bundleId = state.selectedBundle?.packageId
         Task {
-            let result = await CommandLog.userInitiated {
-                await state.env.engine.customCommands.run(
-                    command: command, bundleId: bundleId, serial: serial
-                )
+            var okCount = 0
+            var lastResult = FeatureResult(ok: false, message: "\(command.name) didn't run")
+            for serial in targets.isEmpty ? [""] : targets {
+                let result = await CommandLog.userInitiated {
+                    await state.env.engine.customCommands.run(
+                        command: command, bundleId: bundleId, serial: serial
+                    )
+                }
+                if result.ok { okCount += 1 }
+                lastResult = result
+                // Mirror the Custom Commands screen: results land in the
+                // notifications history too, not just this transient footer.
+                let label = state.devices.first { $0.serial == serial }?.label
+                state.showToast(Toast(
+                    message: targets.count > 1 ? "\(label ?? serial): \(result.message)" : result.message,
+                    ok: result.ok
+                ))
             }
-            // Mirror the Custom Commands screen: failures land in the
-            // notifications history too, not just this transient footer.
-            state.showToast(Toast(message: result.message, ok: result.ok))
-            finish(QuickRunOutcome(result: result))
+            if targets.count > 1 {
+                finish(QuickRunOutcome(
+                    message: "\(command.name) — ok on \(okCount) of \(targets.count) devices",
+                    ok: okCount == targets.count
+                ))
+            } else {
+                finish(QuickRunOutcome(result: lastResult))
+            }
         }
     }
 
     private func run(_ verb: AppControlService.AppAction, packageId: String) {
-        guard let serial = state.targetSerials.first else {
+        // Single device by design — the app list itself came from one device.
+        guard let serial = panelTargetSerial else {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
         }
@@ -1212,12 +1357,15 @@ struct QuickActionsView: View {
         install(picker.urls)
     }
 
-    /// Install APKs on the panel's target device(s) — one device, or all of
-    /// them after an "All devices" pick.
+    /// Install APKs on the panel's target device(s) — one device, or the
+    /// serials an "All devices" pick approved.
     private func install(_ urls: [URL]) {
-        let serials = runAllDevices
-            ? readyDevices.map(\.serial)
-            : Array(state.targetSerials.prefix(1))
+        let serials: [String]
+        if let approved = effectiveApprovedSerials, approved.count > 1 {
+            serials = approved
+        } else {
+            serials = panelTargetSerial.map { [$0] } ?? []
+        }
         guard !serials.isEmpty else {
             lastRun = QuickRunOutcome(message: "No device connected.", ok: false)
             return
@@ -1225,10 +1373,10 @@ struct QuickActionsView: View {
         runningRowID = "native:install"
         lastRun = nil
         Task {
-            let report = await state.installAPKs(urls, onSerials: serials)
+            let outcome = await state.installAPKs(urls, onSerials: serials)
             finish(QuickRunOutcome(
-                message: report.components(separatedBy: "\n").first ?? "Install finished",
-                ok: true
+                message: outcome.report.components(separatedBy: "\n").first ?? "Install finished",
+                ok: outcome.ok
             ))
         }
     }

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -80,10 +80,8 @@ enum QuickScreen: Equatable {
     case appActions(packageId: String, display: String)
     /// AVDs + iOS Simulators to boot (running ones select their device).
     case emulators
-    /// Pick which connected device the actions target.
-    case devices
     /// Interstitial before a device-scoped action when several devices are
-    /// connected; `allowAll` offers run-on-all for features that support it.
+    /// connected; `allowAll` offers the ⌘⏎ run-on-all path.
     case pickDevice(allowAll: Bool)
     /// Options for APKs opened from Finder: install in place, or hand them to
     /// APK Studio / the Install App screen in the main window.
@@ -330,7 +328,6 @@ struct QuickActionsView: View {
         case .apps: return "Search installed apps…"
         case .appActions(_, let display): return display
         case .emulators: return "Boot an emulator or simulator…"
-        case .devices: return "Switch device…"
         case .pickDevice: return "Pick a device for this action…"
         case .apk(let urls):
             return urls.count == 1 ? urls[0].lastPathComponent : "\(urls.count) APKs"
@@ -451,7 +448,7 @@ struct QuickActionsView: View {
         case .apps: return "No matching apps"
         case .emulators where emulatorsLoading: return "Looking for emulators and simulators…"
         case .emulators: return "No emulators or simulators found"
-        case .devices, .pickDevice: return "No ready devices"
+        case .pickDevice: return "No ready devices"
         default: return query.isEmpty ? "Nothing to run yet" : "No matching actions"
         }
     }
@@ -504,8 +501,7 @@ struct QuickActionsView: View {
         case .apps: return appRows
         case .appActions(let packageId, _): return appActionRows(packageId)
         case .emulators: return Array(emulatorRows.prefix(8))
-        case .devices: return deviceRows
-        case .pickDevice(let allowAll): return pickDeviceRows(allowAll: allowAll)
+        case .pickDevice: return pickDeviceRows
         case .apk(let urls): return apkRows(urls)
         case .form: return []
         }
@@ -527,31 +523,41 @@ struct QuickActionsView: View {
             )
         }
         rows += nativeRows
-        rows += PaletteSearch.quickActions(query: query, implemented: FeatureEngine.implementedIDs)
-            .map { feature in
-                QuickRow(
-                    id: "feature:\(feature.id)", icon: feature.icon,
-                    title: feature.title, subtitle: feature.subtitle,
-                    pushes: feature.kind == .formAction,
-                    action: feature.kind == .formAction
-                        ? .push(.form(feature.id))
-                        : .runFeature(feature)
-                )
-            }
+        rows += PaletteSearch.quickActions(
+            query: query,
+            implemented: FeatureEngine.implementedIDs,
+            enabled: state.layout.effectiveEnabledIDs,
+            favorites: state.layout.favorites
+        )
+        .map { feature in
+            QuickRow(
+                id: "feature:\(feature.id)", icon: feature.icon,
+                title: feature.title, subtitle: feature.subtitle,
+                pushes: feature.kind == .formAction,
+                action: feature.kind == .formAction
+                    ? .push(.form(feature.id))
+                    : .runFeature(feature)
+            )
+        }
         return rows
     }
 
     /// Full-app screens below the grid — everything that can't run in a
     /// panel opens the main window instead. The panel's native screens
-    /// replace their in-app counterparts here.
+    /// replace their in-app counterparts here, and it mirrors the app: only
+    /// enabled features (per the user's role/catalog curation) appear.
     private var rootAppItems: [QuickRow] {
         let covered: Set<String> = ["apps", "emulators", "install-app"]
+        let enabled = state.layout.effectiveEnabledIDs
         return PaletteSearch.features(
             query: query,
-            enabled: state.layout.effectiveEnabledIDs,
+            enabled: enabled,
             favorites: state.layout.favorites
         )
-        .filter { ($0.kind == .view || $0.kind == .system) && !covered.contains($0.id) }
+        .filter {
+            ($0.kind == .view || $0.kind == .system)
+                && !covered.contains($0.id) && enabled.contains($0.id)
+        }
         .map { feature in
             QuickRow(
                 id: "open:\(feature.id)", icon: feature.icon,
@@ -591,15 +597,6 @@ struct QuickActionsView: View {
                 title: "Install APK",
                 subtitle: "Pick .apk files and install them",
                 action: .installAPK
-            ))
-        }
-        if readyDevices.count > 1,
-           matchesNative(title: "Switch Device", keywords: ["device", "switch", "select", "target"]) {
-            rows.append(QuickRow(
-                id: "screen:devices", icon: "arrow.triangle.2.circlepath",
-                title: "Switch Device",
-                subtitle: panelTargetDevice.map { "Now targeting \($0.label)" },
-                pushes: true, action: .push(.devices)
             ))
         }
         return rows
@@ -720,29 +717,10 @@ struct QuickActionsView: View {
 
     private var readyDevices: [Device] { state.devices.filter(\.isReady) }
 
-    private var deviceRows: [QuickRow] {
-        matchingReadyDevices.map {
-            deviceRow($0, idPrefix: "device", action: .selectDevice(serial: $0.serial, label: $0.label))
-        }
-    }
-
     private var matchingReadyDevices: [Device] {
         readyDevices.filter {
             query.isEmpty || state.deviceTitle($0).localizedCaseInsensitiveContains(query)
         }
-    }
-
-    /// One device row — shared by Switch Device and the pick interstitial so
-    /// the two lists can't drift apart visually.
-    private func deviceRow(_ device: Device, idPrefix: String, action: QuickRow.Action) -> QuickRow {
-        QuickRow(
-            id: "\(idPrefix):\(device.serial)",
-            icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
-            title: device.label,
-            subtitle: state.deviceTitle(device),
-            badge: device.serial == panelTargetSerial ? "selected" : nil,
-            action: action
-        )
     }
 
     /// What you can do with Finder-opened APKs: install right here, or hand
@@ -787,21 +765,19 @@ struct QuickActionsView: View {
         return rows.filter { $0.title.localizedCaseInsensitiveContains(query) }
     }
 
-    /// The interstitial's rows: optionally "All devices", then each device.
-    private func pickDeviceRows(allowAll: Bool) -> [QuickRow] {
-        var rows: [QuickRow] = []
-        if allowAll, matchesNative(title: "All devices", keywords: ["all", "every"]) {
-            rows.append(QuickRow(
-                id: "pick:all", icon: "square.stack.3d.down.right",
-                title: "All devices",
-                subtitle: "Run on every connected device",
-                action: .chooseAllDevices
-            ))
+    /// The interstitial's rows — one per ready device, no persistent-selection
+    /// badge (each action picks afresh). Run-on-all lives in the footer (⌘⏎),
+    /// not the list.
+    private var pickDeviceRows: [QuickRow] {
+        matchingReadyDevices.map { device in
+            QuickRow(
+                id: "pick:\(device.serial)",
+                icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
+                title: device.label,
+                subtitle: state.deviceTitle(device),
+                action: .chooseDevice(serial: device.serial, label: device.label)
+            )
         }
-        rows += matchingReadyDevices.map {
-            deviceRow($0, idPrefix: "pick", action: .chooseDevice(serial: $0.serial, label: $0.label))
-        }
-        return rows
     }
 
     // MARK: - Row rendering
@@ -828,9 +804,21 @@ struct QuickActionsView: View {
             isHighlighted ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.quaternary.opacity(0.5)),
             in: RoundedRectangle(cornerRadius: 10)
         )
+        .overlay(alignment: .topTrailing) {
+            if isPinned(row) {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 8))
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText.opacity(0.8)) : AnyShapeStyle(.brandAccent))
+                    .padding(4)
+            }
+        }
         .foregroundStyle(isHighlighted ? accentText : .primary)
         .contentShape(RoundedRectangle(cornerRadius: 10))
         .help(row.subtitle ?? row.title)
+    }
+
+    private func isPinned(_ row: QuickRow) -> Bool {
+        pinnableFeatureID(of: row).map { state.layout.favorites.contains($0) } ?? false
     }
 
     private func rowView(
@@ -862,6 +850,11 @@ struct QuickActionsView: View {
                 }
             }
             Spacer()
+            if isPinned(row) {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(isHighlighted ? AnyShapeStyle(accentText.opacity(0.8)) : AnyShapeStyle(.brandAccent))
+            }
             if isArmed {
                 Text("⏎ to confirm")
                     .font(.caption2.weight(.semibold))
@@ -901,7 +894,9 @@ struct QuickActionsView: View {
         return AnyShapeStyle(.brandAccent)
     }
 
-    /// Hidden buttons backing ⌘1–8 jumps to the first eight items.
+    /// Hidden buttons backing ⌘1–8 jumps, ⌘P pin/unpin, and — only while the
+    /// interstitial offers it, so it can't collide with the form's ⌘⏎ Run —
+    /// ⌘⏎ run-on-all.
     private var shortcutButtons: some View {
         ZStack {
             ForEach(Array(Self.digitKeys.enumerated()), id: \.offset) { index, key in
@@ -910,6 +905,16 @@ struct QuickActionsView: View {
                     if rows.indices.contains(index) { activate(rows[index]) }
                 }
                 .keyboardShortcut(key, modifiers: .command)
+            }
+            Button("") {
+                if let id = pinnableFeatureID(of: highlightedRow) {
+                    state.toggleFavorite(id)
+                }
+            }
+            .keyboardShortcut("p", modifiers: .command)
+            if case .pickDevice(allowAll: true) = screen {
+                Button("") { perform(.chooseAllDevices) }
+                    .keyboardShortcut(.return, modifiers: .command)
             }
         }
         .frame(width: 0, height: 0)
@@ -995,28 +1000,59 @@ struct QuickActionsView: View {
                     .buttonStyle(.link)
                     .font(.caption)
                 }
-            } else if let approved = effectiveApprovedSerials, approved.count > 1, !singleDeviceScreen {
-                Label("All devices (\(approved.count))", systemImage: "square.stack.3d.down.right")
+            } else if let context = footerContext {
+                Label(context.text, systemImage: context.icon)
                     .font(.caption)
                     .foregroundStyle(.textMuted)
-            } else {
-                // The device the next action actually targets — the panel's
-                // pick, not just the device-bar selection.
-                let device = panelTargetDevice
-                Label(
-                    device.map(state.deviceTitle) ?? "No device connected",
-                    systemImage: device?.platform == .iosSimulator ? "iphone" : "iphone.gen3"
-                )
-                .font(.caption)
-                .foregroundStyle(.textMuted)
-                .lineLimit(1)
+                    .lineLimit(1)
             }
             Spacer()
+            if case .pickDevice(allowAll: true) = screen {
+                Button {
+                    perform(.chooseAllDevices)
+                } label: {
+                    footerHint("⌘⏎", "All devices")
+                }
+                .buttonStyle(.plain)
+                .help("Run on every connected device")
+            }
+            if let id = pinnableFeatureID(of: highlightedRow) {
+                footerHint("⌘P", state.layout.favorites.contains(id) ? "Unpin" : "Pin")
+            }
             footerHint("⏎", isFormScreen ? "Run" : "Select")
             footerHint("esc", stack.isEmpty ? "Close" : "Back")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
+    }
+
+    /// The footer's left-side context, shown only where a device scope is in
+    /// play: which device Manage Apps is listing, and what a form's ⏎ will
+    /// target. The root shows nothing — every action picks its device.
+    private var footerContext: (text: String, icon: String)? {
+        switch screen {
+        case .apps, .appActions:
+            guard let device = panelTargetDevice else {
+                return ("No device connected", "iphone.gen3")
+            }
+            return (
+                state.deviceTitle(device),
+                device.platform == .iosSimulator ? "iphone" : "iphone.gen3"
+            )
+        case .form:
+            if let approved = effectiveApprovedSerials, approved.count > 1 {
+                return ("All devices (\(approved.count))", "square.stack.3d.down.right")
+            }
+            guard let device = panelTargetDevice else {
+                return ("No device connected", "iphone.gen3")
+            }
+            return (
+                state.deviceTitle(device),
+                device.platform == .iosSimulator ? "iphone" : "iphone.gen3"
+            )
+        default:
+            return nil
+        }
     }
 
     private func footerHint(_ key: String, _ label: String) -> some View {
@@ -1030,12 +1066,14 @@ struct QuickActionsView: View {
         panelTargetSerial.flatMap { serial in state.devices.first { $0.serial == serial } }
     }
 
-    /// Screens whose actions are single-device by nature (the app list came
-    /// from one device) — the footer names that device, never "All devices".
-    private var singleDeviceScreen: Bool {
-        switch screen {
-        case .apps, .appActions: return true
-        default: return false
+    /// The feature id ⌘P pins/unpins for this row, nil for rows that aren't
+    /// registry features (commands, apps, devices, the panel's own screens).
+    private func pinnableFeatureID(of row: QuickRow?) -> String? {
+        switch row?.action {
+        case .runFeature(let feature): return feature.id
+        case .push(.form(let id)): return id
+        case .openInApp(let feature): return feature.id
+        default: return nil
         }
     }
 
@@ -1141,10 +1179,12 @@ struct QuickActionsView: View {
     /// falling back to `targetSerials` would let the *hidden main window's*
     /// run-on-all state fan a panel action out past an explicit single pick,
     /// and a device switch deferred behind an exit guard would silently run
-    /// on the old selection.
+    /// on the old selection. An "All devices" pick (⌘⏎ at the interstitial)
+    /// fans out any device feature — the panel loops explicit targets, so it
+    /// isn't limited to the registry's `supportsRunAll` set.
     private func explicitTargets(for feature: FeatureDef) -> [String]? {
         guard feature.needsDevice else { return nil }
-        if let approved = effectiveApprovedSerials, feature.supportsRunAll, approved.count > 1 {
+        if let approved = effectiveApprovedSerials, approved.count > 1 {
             return approved
         }
         return panelTargetSerial.map { [$0] } ?? []
@@ -1159,14 +1199,16 @@ struct QuickActionsView: View {
         guard readyDevices.count > 1 else { return (false, false) }
         switch action {
         case .runFeature(let feature):
-            return (feature.needsDevice, feature.supportsRunAll)
+            return (feature.needsDevice, feature.needsDevice)
         case .push(.form(let id)):
             guard let feature = FeatureRegistry.byID[id] else { return (false, false) }
-            return (feature.needsDevice, feature.supportsRunAll)
+            return (feature.needsDevice, feature.needsDevice)
         case .push(.apps):
+            // The apps list is inherently one device's.
             return (true, false)
         case .runCommand(let command):
-            return (command.kind == .adb || command.command.contains("{serial}"), false)
+            let scoped = command.kind == .adb || command.command.contains("{serial}")
+            return (scoped, scoped)
         case .installAPK, .installFiles:
             return (true, true)
         default:

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -77,15 +77,6 @@ struct RootView: View {
                 // panels, and identifiers don't survive a close (SwiftUI
                 // re-stamps `main-AppWindow-1` over any tag).
                 state.mainWindow = window
-                // Launched by double-clicking an APK (the open event precedes
-                // window creation, so it's already inboxed): the Quick Actions
-                // panel handles it — close the auto-created window so the
-                // launch is panel-only, like when the app is already resident.
-                // Tracking + autosave still ran, so a later reopen is normal.
-                if InstallInbox.shared.hasPending,
-                   UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true {
-                    DispatchQueue.main.async { window.close() }
-                }
                 // Restore the user's saved window frame; only fill the screen's
                 // usable area on the very first launch (nothing to restore), so
                 // a resized window survives relaunch instead of being maximized.

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -139,7 +139,13 @@ struct RootView: View {
     /// out of `body` so the view-builder expression stays cheap to type-check.
     private func performLaunchSetup() {
         state.openMainWindow = { openWindow(id: "main") }
-        state.openPalette = { PaletteController.shared.show(appState: state) }
+        state.openPalette = {
+            FloatingPanelController.palette.show { close in
+                PaletteWindowView(onClose: close)
+                    .environment(state)
+                    .tint(.brandAccent)
+            }
+        }
         (NSApp.delegate as? AppDelegate)?.appState = state
         InstallInbox.shared.onReceive = { urls in state.openAPKs(urls) }
         migrateDefaultsIfNeeded()
@@ -177,8 +183,9 @@ struct RootView: View {
     }
 
     /// Identifier stamped on the main window so `installCloseTabMonitor` can
-    /// scope ⌘W to it and leave Settings / the palette panel alone.
-    fileprivate static let mainWindowID = "droidective-main"
+    /// scope ⌘W to it, `AppDelegate`'s close observer can recognize it, and
+    /// `activateMainWindow` can re-front it — leaving Settings / panels alone.
+    static let mainWindowID = "droidective-main"
     private static var closeTabMonitorInstalled = false
 
     /// ⌘W closes the active tab, not the window. A local key-down monitor

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -72,9 +72,11 @@ struct RootView: View {
             .environment(\.colorScheme, injectedColorScheme)
             .preferredColorScheme(preferredScheme)
             .background(WindowAccessor { window in
-                // Tag the main window so the ⌘W monitor can tell it apart from
-                // Settings / the palette panel.
-                window.identifier = NSUserInterfaceItemIdentifier(RootView.mainWindowID)
+                // Track the main window by reference — the ⌘W monitor and
+                // `activateMainWindow` need to tell it apart from Settings /
+                // panels, and identifiers don't survive a close (SwiftUI
+                // re-stamps `main-AppWindow-1` over any tag).
+                state.mainWindow = window
                 // Restore the user's saved window frame; only fill the screen's
                 // usable area on the very first launch (nothing to restore), so
                 // a resized window survives relaunch instead of being maximized.
@@ -146,7 +148,6 @@ struct RootView: View {
                     .tint(.brandAccent)
             }
         }
-        (NSApp.delegate as? AppDelegate)?.appState = state
         InstallInbox.shared.onReceive = { urls in state.openAPKs(urls) }
         migrateDefaultsIfNeeded()
         applyStoredTheme()
@@ -182,10 +183,10 @@ struct RootView: View {
         }
     }
 
-    /// Identifier stamped on the main window so `installCloseTabMonitor` can
-    /// scope ⌘W to it, `AppDelegate`'s close observer can recognize it, and
-    /// `activateMainWindow` can re-front it — leaving Settings / panels alone.
-    static let mainWindowID = "droidective-main"
+    /// The main window's frame-autosave name. (Recognizing the window itself
+    /// goes through `AppState.mainWindow` by reference — window identifiers
+    /// don't survive a close, SwiftUI re-stamps its own.)
+    fileprivate static let mainWindowID = "droidective-main"
     private static var closeTabMonitorInstalled = false
 
     /// ⌘W closes the active tab, not the window. A local key-down monitor
@@ -199,7 +200,7 @@ struct RootView: View {
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
                   event.charactersIgnoringModifiers == "w",
-                  NSApp.keyWindow?.identifier?.rawValue == RootView.mainWindowID
+                  let keyWindow = NSApp.keyWindow, keyWindow === state.mainWindow
             else { return event }
             state.closeActiveTab()
             return nil

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -80,7 +80,7 @@ struct RootView: View {
                 // Restore the user's saved window frame; only fill the screen's
                 // usable area on the very first launch (nothing to restore), so
                 // a resized window survives relaunch instead of being maximized.
-                let autosaveName = NSWindow.FrameAutosaveName(RootView.mainWindowID)
+                let autosaveName = NSWindow.FrameAutosaveName(RootView.mainWindowFrameAutosaveName)
                 if !window.setFrameUsingName(autosaveName), let screen = window.screen ?? NSScreen.main {
                     window.setFrame(screen.visibleFrame, display: true)
                 }
@@ -188,10 +188,11 @@ struct RootView: View {
         }
     }
 
-    /// The main window's frame-autosave name. (Recognizing the window itself
-    /// goes through `AppState.mainWindow` by reference — window identifiers
-    /// don't survive a close, SwiftUI re-stamps its own.)
-    fileprivate static let mainWindowID = "droidective-main"
+    /// The main window's frame-autosave name — the value must stay
+    /// "droidective-main" so existing users' saved frames survive.
+    /// (Recognizing the window itself goes through `AppState.mainWindow` by
+    /// reference; identifiers don't survive a close.)
+    fileprivate static let mainWindowFrameAutosaveName = "droidective-main"
     private static var closeTabMonitorInstalled = false
 
     /// ⌘W closes the active tab, not the window. A local key-down monitor

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -77,6 +77,15 @@ struct RootView: View {
                 // panels, and identifiers don't survive a close (SwiftUI
                 // re-stamps `main-AppWindow-1` over any tag).
                 state.mainWindow = window
+                // Launched by double-clicking an APK (the open event precedes
+                // window creation, so it's already inboxed): the Quick Actions
+                // panel handles it — close the auto-created window so the
+                // launch is panel-only, like when the app is already resident.
+                // Tracking + autosave still ran, so a later reopen is normal.
+                if InstallInbox.shared.hasPending,
+                   UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true {
+                    DispatchQueue.main.async { window.close() }
+                }
                 // Restore the user's saved window frame; only fill the screen's
                 // usable area on the very first launch (nothing to restore), so
                 // a resized window survives relaunch instead of being maximized.
@@ -148,7 +157,12 @@ struct RootView: View {
                     .tint(.brandAccent)
             }
         }
-        InstallInbox.shared.onReceive = { urls in state.openAPKs(urls) }
+        // A double-clicked APK opens the Quick Actions panel on its options
+        // screen (install in place / APK Studio / the Install App screen)
+        // instead of taking over the main window.
+        InstallInbox.shared.onReceive = { urls in
+            QuickActionsPanel.showAPKOptions(urls, state: state)
+        }
         migrateDefaultsIfNeeded()
         applyStoredTheme()
         updateDockIcon()

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -49,6 +49,7 @@ func applyStoredTheme() {
 struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
+    @AppStorage(keepRunningInBackgroundKey) private var keepRunningInBackground = true
     @State private var openAtLoginOn = false
     @State private var showMenuItems = false
 
@@ -112,6 +113,13 @@ struct GeneralSettingsView: View {
 
             Section("Startup") {
                 Toggle("Open at login", isOn: openAtLogin)
+            }
+
+            Section("Background") {
+                Toggle("Keep running in the background", isOn: $keepRunningInBackground)
+                Text("Closing the window hides Droidective from the Dock and stops running feature work — including terminal shells. The menu bar icon, global hotkeys, and the Quick Actions panel stay available; quit fully with ⌘Q.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
             }
 
             #if !APPSTORE
@@ -509,6 +517,9 @@ struct HotkeysSettingsView: View {
             Section("Global") {
                 LabeledContent("Show Droidective") {
                     HotkeyRecorderField(name: .globalLaunch)
+                }
+                LabeledContent("Quick Actions panel") {
+                    HotkeyRecorderField(name: .quickActions)
                 }
             }
             // Mirrors the sidebar: enabled features in their sidebar order.

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -50,6 +50,7 @@ struct GeneralSettingsView: View {
     @Environment(AppState.self) private var state
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
     @AppStorage(keepRunningInBackgroundKey) private var keepRunningInBackground = true
+    @AppStorage(quickPanelResumeMinutesKey) private var quickPanelResumeMinutes = 5
     @State private var openAtLoginOn = false
     @State private var showMenuItems = false
 
@@ -118,6 +119,19 @@ struct GeneralSettingsView: View {
             Section("Background") {
                 Toggle("Keep running in the background", isOn: $keepRunningInBackground)
                 Text("Closing the window hides Droidective from the Dock and stops running feature work — including terminal shells. The menu bar icon, global hotkeys, and the Quick Actions panel stay available; quit fully with ⌘Q.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+            }
+
+            Section("Quick Actions") {
+                Picker("Resume where I left off", selection: $quickPanelResumeMinutes) {
+                    Text("Off").tag(0)
+                    Text("For 1 minute").tag(1)
+                    Text("For 5 minutes").tag(5)
+                    Text("For 15 minutes").tag(15)
+                    Text("For 1 hour").tag(60)
+                }
+                Text("Reopening the panel within this window returns to the screen and device you had — after that it starts fresh.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -131,7 +131,7 @@ struct GeneralSettingsView: View {
                     Text("For 15 minutes").tag(15)
                     Text("For 1 hour").tag(60)
                 }
-                Text("Reopening the panel within this window returns to the screen and device you had — after that it starts fresh.")
+                Text("Reopening the panel within this window returns to the screen and device you had — after that it starts fresh. Open the panel with its global hotkey (record one in the Hotkeys tab) or from the menu bar icon.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1134,12 +1134,14 @@ final class AppState {
 
     /// Install one or more APKs on the given device serials, one toast per APK
     /// (failures keep the full adb output in the toast's copyText). Returns a
-    /// short multi-line summary for inline display. Shared by the Install App
-    /// screen's drop zone, the file picker, and APKs opened from Finder.
+    /// short multi-line summary for inline display plus whether every install
+    /// landed. Shared by the Install App screen's drop zone, the file picker,
+    /// and APKs opened from Finder.
     @discardableResult
-    func installAPKs(_ urls: [URL], onSerials serials: [String]) async -> String {
-        guard !urls.isEmpty, !serials.isEmpty else { return "" }
+    func installAPKs(_ urls: [URL], onSerials serials: [String]) async -> (report: String, ok: Bool) {
+        guard !urls.isEmpty, !serials.isEmpty else { return ("", false) }
         var report: [String] = []
+        var allOK = true
         await CommandLog.userInitiated {
             for url in urls {
                 let name = url.lastPathComponent
@@ -1150,13 +1152,14 @@ final class AppState {
                         ?? FeatureResult(ok: false, message: "adb not found")
                     if result.ok { ok += 1 } else { failures.append((serial, result)) }
                 }
+                if !failures.isEmpty { allOK = false }
                 showToast(Self.installToast(name: name, ok: ok, total: serials.count, failures: failures))
                 report.append(ok == serials.count
                     ? "Installed \(name)"
                     : "Installed \(name) on \(ok) of \(serials.count) devices")
             }
         }
-        return report.joined(separator: "\n")
+        return (report.joined(separator: "\n"), allOK)
     }
 
     /// A short install headline for the toast; on failure the full adb output is

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -234,6 +234,14 @@ final class AppState {
     var pendingInstallAPKs: [URL] = []
     /// Set by RootView so hotkeys/menu bar can reopen a closed main window.
     var openMainWindow: (() -> Void)?
+    /// The real app delegate (the adaptor instance, wired in `ADTApp.body`) —
+    /// `NSApp.delegate` is SwiftUI's wrapper on macOS, so casting it fails.
+    weak var appDelegate: AppDelegate?
+    /// The main window, resolved by RootView's `WindowAccessor`. Held by
+    /// *reference* because identifiers can't be trusted across a close:
+    /// SwiftUI re-stamps its own (`main-AppWindow-1`) over our tag, which
+    /// broke the ⌘W tab-close monitor after a close → reopen cycle.
+    weak var mainWindow: NSWindow?
     /// Set by RootView; opens the floating ⌘K search palette.
     var openPalette: (() -> Void)?
     /// Bumped by the ⌘K menu command; the sidebar focuses search on change.
@@ -338,9 +346,10 @@ final class AppState {
 
     private func bringMainWindowFront() {
         NSApp.activate(ignoringOtherApps: true)
-        // Identifier first — `canBecomeMain` alone can pick a floating panel
-        // (KeyablePanel overrides it to true) while one is up.
-        let window = NSApp.windows.first { $0.identifier?.rawValue == RootView.mainWindowID }
+        // The tracked reference first (identifiers are unreliable across a
+        // close); the structural fallback excludes panels, whose KeyablePanel
+        // overrides `canBecomeMain` to true.
+        let window = mainWindow
             ?? NSApp.windows.first { $0.canBecomeMain && !($0 is NSPanel) }
         if let window {
             window.makeKeyAndOrderFront(nil)
@@ -960,7 +969,7 @@ final class AppState {
     /// delegate's in-quit flag first, so a later window close still routes
     /// through background mode instead of being mistaken for quit teardown.
     private func cancelDeferredQuit() {
-        (NSApp.delegate as? AppDelegate)?.isQuitting = false
+        appDelegate?.isQuitting = false
         NSApp.reply(toApplicationShouldTerminate: false)
     }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -323,14 +323,31 @@ final class AppState {
     /// fires once per device (the serial is used only locally, never sent).
     private var reportedDeviceSerials: Set<String> = []
 
-    /// Bring the app forward, reopening the main window if it was closed.
+    /// Bring the app forward, reopening the main window if it was closed. When
+    /// resident in the background (no Dock icon — see `AppDelegate`), rejoin
+    /// the Dock first; that policy flip needs a runloop turn before activation
+    /// reliably fronts the window, so that path hops once.
     func activateMainWindow() {
+        if NSApp.activationPolicy() == .regular {
+            bringMainWindowFront()
+        } else {
+            NSApp.setActivationPolicy(.regular)
+            Task { self.bringMainWindowFront() }
+        }
+    }
+
+    private func bringMainWindowFront() {
         NSApp.activate(ignoringOtherApps: true)
-        if let window = NSApp.windows.first(where: { $0.canBecomeMain }) {
+        // Identifier first — `canBecomeMain` alone can pick a floating panel
+        // (KeyablePanel overrides it to true) while one is up.
+        let window = NSApp.windows.first { $0.identifier?.rawValue == RootView.mainWindowID }
+            ?? NSApp.windows.first { $0.canBecomeMain && !($0 is NSPanel) }
+        if let window {
             window.makeKeyAndOrderFront(nil)
         } else {
             openMainWindow?()
         }
+        setForeground(true)
     }
 
     var adbMissing: Bool { adbStatus?.installed == false }
@@ -754,7 +771,7 @@ final class AppState {
                 terminals.killAll()
                 quitNow()
             } else {
-                NSApp.reply(toApplicationShouldTerminate: false)
+                cancelDeferredQuit()
             }
         }
     }
@@ -868,10 +885,26 @@ final class AppState {
     }
 
     /// Widen device polling while the app is backgrounded so an idle, hidden
-    /// window stops spawning `adb devices` every 2s; restore it on foreground.
+    /// window stops spawning `adb devices` / `simctl list` every few seconds;
+    /// restore it on foreground.
     func setForeground(_ active: Bool) {
         let interval: Duration = active ? .seconds(2) : .seconds(10)
         Task { [monitor = env.monitor] in await monitor.setPollInterval(interval) }
+        let simInterval: Duration = active ? .seconds(3) : .seconds(15)
+        Task { [monitor = env.simulatorMonitor] in await monitor.setPollInterval(simInterval) }
+    }
+
+    /// The main window closed with background mode on (Settings ▸ General).
+    /// Stop the kept-alive sessions — terminal shells, the Reactotron server,
+    /// JS-console reverse tunnels — so no feature process outlives the UI
+    /// (view-owned work like recordings and log streams already dies with its
+    /// view), and widen device polling. The tabs stay in the workspace, so
+    /// reopening the window restores them idle.
+    func enterBackground() {
+        for id in openFeatureIDs {
+            stopBackgroundWork(for: id)
+        }
+        setForeground(false)
     }
 
     /// Switch the active device, or hold it behind a confirmation when a guard
@@ -920,7 +953,15 @@ final class AppState {
     func cancelExit() {
         let wasQuit = pendingExit?.target == .quit
         pendingExit = nil
-        if wasQuit { NSApp.reply(toApplicationShouldTerminate: false) }
+        if wasQuit { cancelDeferredQuit() }
+    }
+
+    /// Abandon a quit `applicationShouldTerminate` deferred: clear the
+    /// delegate's in-quit flag first, so a later window close still routes
+    /// through background mode instead of being mistaken for quit teardown.
+    private func cancelDeferredQuit() {
+        (NSApp.delegate as? AppDelegate)?.isQuitting = false
+        NSApp.reply(toApplicationShouldTerminate: false)
     }
 
     /// "Stop & save": ask the active view to save (it observes `pendingExit`),

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1021,7 +1021,15 @@ final class AppState {
         persistUsage()
     }
 
-    func run(feature: FeatureDef, params: [String: FeatureValue]) async {
+    /// Run a feature. `explicitTargets` overrides the device-bar selection —
+    /// the Quick Actions panel passes its own pick (or run-on-all fan-out)
+    /// since `targetSerials`' run-all gating keys off the active tab, which is
+    /// meaningless with no window.
+    func run(
+        feature: FeatureDef,
+        params: [String: FeatureValue],
+        on explicitTargets: [String]? = nil
+    ) async {
         isRunningFeature = true
         defer { isRunningFeature = false }
         Telemetry.shared.trackFeatureUsed(feature.id, kind: feature.kind.rawValue)
@@ -1063,7 +1071,7 @@ final class AppState {
                 return
             }
 
-            let targets = self.targetSerials
+            let targets = explicitTargets ?? self.targetSerials
             guard !targets.isEmpty else {
                 self.showToast(Toast(message: "No device connected.", ok: false))
                 return

--- a/App/Sources/State/HotkeyManager.swift
+++ b/App/Sources/State/HotkeyManager.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 extension KeyboardShortcuts.Name {
     @MainActor static let globalLaunch = Self("globalLaunch")
+    @MainActor static let quickActions = Self("quickActions")
 }
 
 /// Bridges KeyboardShortcuts (Carbon RegisterEventHotKey — no Accessibility
@@ -30,6 +31,10 @@ enum HotkeyManager {
         installed = true
         KeyboardShortcuts.onKeyUp(for: .globalLaunch) { [weak state] in
             state?.activateMainWindow()
+        }
+        KeyboardShortcuts.onKeyUp(for: .quickActions) { [weak state] in
+            guard let state else { return }
+            QuickActionsPanel.toggle(state: state)
         }
         for feature in FeatureRegistry.all {
             KeyboardShortcuts.onKeyUp(for: featureName(feature.id)) { [weak state] in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,11 +276,24 @@ platforms annotation without a runner.
   `AppDelegate.windowWillClose`, guarded by `isQuitting` so quit teardown isn't
   mistaken for a window close). The app stays resident for the menu bar, the
   per-feature hotkeys, and `QuickActionsPanel` — a **non-activating**
-  `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys) that
-  runs instant/toggle actions and saved custom commands in place, ranked by the
-  shared, tested `PaletteSearch`; view features reopen the app
-  (`activateMainWindow` flips the policy back to `.regular`, then fronts the
-  window on the next runloop turn).
+  `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys) that is
+  a small push-navigation mini app. The root is a *grid* of everything
+  runnable in place — saved custom commands, every implemented
+  instant/toggle/form action (hub members included —
+  `PaletteSearch.quickActions`, tested), Manage Apps / Emulators / Install
+  APK / Switch Device — with an "Open in Droidective" list below for the
+  full-app view screens. Form actions render their registry `FieldDef`s
+  in-panel (`QuickActionFormView`); app verbs come from
+  `AppControlService.AppAction` (destructive ones need a second ⏎). With >1
+  device connected, the first device-scoped action pushes a pick-device
+  interstitial ("All devices" fans out via `AppState.run(feature:params:on:)`
+  when `supportsRunAll`); the choice sticks for the session. Esc (or the
+  header's ‹ button) pops a screen and closes at the root, and a closed panel
+  resumes its screen + device choice when reopened within Settings ▸ Quick
+  Actions' window (`QuickPanelMemory`, default 5 min). Reopening the app goes
+  through `activateMainWindow` (flips the policy back to `.regular`, then
+  fronts the window on the next runloop turn; the main window is tracked by
+  reference in `AppState.mainWindow` — identifiers don't survive a close).
 - UI automation for verification: prefer AX element refs over coordinate
   clicks; the user works on the Mac alongside you (see memory).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,9 @@ platforms annotation without a runner.
   `AppDelegate.windowWillClose`, guarded by `isQuitting` so quit teardown isn't
   mistaken for a window close). The app stays resident for the menu bar, the
   per-feature hotkeys, and `QuickActionsPanel` — a **non-activating**
-  `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys) that is
+  `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys; the
+  welcome tour's "Get Started" ends on a record-a-hotkey ask recommending
+  ⇧⌘Space, shown only while none is set) that is
   a small push-navigation mini app. The root is a *grid* of everything
   runnable in place — saved custom commands, every *enabled* implemented
   instant/toggle/form action (mirrors the app's role/catalog curation; hub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,9 +285,12 @@ platforms annotation without a runner.
   full-app view screens. Form actions render their registry `FieldDef`s
   in-panel (`QuickActionFormView`); app verbs come from
   `AppControlService.AppAction` (destructive ones need a second ⏎). With >1
-  device connected, the first device-scoped action pushes a pick-device
+  device connected, every device-scoped action pushes a pick-device
   interstitial ("All devices" fans out via `AppState.run(feature:params:on:)`
-  when `supportsRunAll`); the choice sticks for the session. Esc (or the
+  when `supportsRunAll`); the latest pick scopes Manage Apps, its verbs, and
+  the footer. Targets always ride explicitly through `run(on:)` — never the
+  device-bar selection, whose run-on-all state belongs to the hidden window.
+  ←→/↑↓ navigate the root grid even while a query is typed. Esc (or the
   header's ‹ button) pops a screen and closes at the root, and a closed panel
   resumes its screen + device choice when reopened within Settings ▸ Quick
   Actions' window (`QuickPanelMemory`, default 5 min). Reopening the app goes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,19 @@ platforms annotation without a runner.
   (⌘Z / ⇧⌘Z) is snapshot-based (full image+annotations) and reaches the editor
   via `CommandGroup(replacing: .undoRedo)` + a `focusedSceneValue` — nil'd while
   typing a text label so ⌘Z falls through to the text field.
+- **Background mode & the Quick Actions panel.** With Settings ▸ General ▸
+  "Keep running in the background" on (the default), closing the main window
+  stops the kept-alive sessions (`AppState.enterBackground` — terminal shells,
+  Reactotron, JS-console tunnels; view-owned work dies with its view), widens
+  both device polls, and drops the Dock icon (`.accessory` — see
+  `AppDelegate.windowWillClose`, guarded by `isQuitting` so quit teardown isn't
+  mistaken for a window close). The app stays resident for the menu bar, the
+  per-feature hotkeys, and `QuickActionsPanel` — a **non-activating**
+  `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys) that
+  runs instant/toggle actions and saved custom commands in place, ranked by the
+  shared, tested `PaletteSearch`; view features reopen the app
+  (`activateMainWindow` flips the policy back to `.regular`, then fronts the
+  window on the next runloop turn).
 - UI automation for verification: prefer AX element refs over coordinate
   clicks; the user works on the Mac alongside you (see memory).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,18 +278,19 @@ platforms annotation without a runner.
   per-feature hotkeys, and `QuickActionsPanel` — a **non-activating**
   `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys) that is
   a small push-navigation mini app. The root is a *grid* of everything
-  runnable in place — saved custom commands, every implemented
-  instant/toggle/form action (hub members included —
-  `PaletteSearch.quickActions`, tested), Manage Apps / Emulators / Install
-  APK / Switch Device — with an "Open in Droidective" list below for the
-  full-app view screens. Form actions render their registry `FieldDef`s
-  in-panel (`QuickActionFormView`); app verbs come from
+  runnable in place — saved custom commands, every *enabled* implemented
+  instant/toggle/form action (mirrors the app's role/catalog curation; hub
+  members ride their hub's enabledness, pinned features lead — ⌘P toggles,
+  shared with the app's favorites; `PaletteSearch.quickActions`, tested),
+  Manage Apps / Emulators / Install APK — with an "Open in Droidective" list
+  below for the enabled full-app view screens. Form actions render their
+  registry `FieldDef`s in-panel (`QuickActionFormView`); app verbs come from
   `AppControlService.AppAction` (destructive ones need a second ⏎). With >1
   device connected, every device-scoped action pushes a pick-device
-  interstitial ("All devices" fans out via `AppState.run(feature:params:on:)`
-  when `supportsRunAll`); the latest pick scopes Manage Apps, its verbs, and
-  the footer. Targets always ride explicitly through `run(on:)` — never the
-  device-bar selection, whose run-on-all state belongs to the hidden window.
+  interstitial; ⌘⏎ there runs on all devices (any device feature — the panel
+  fans out explicit targets itself, not gated on `supportsRunAll`). Targets
+  always ride explicitly through `run(on:)` — never the device-bar
+  selection, whose run-on-all state belongs to the hidden window.
   ←→/↑↓ navigate the root grid even while a query is typed. Esc (or the
   header's ‹ button) pops a screen and closes at the root, and a closed panel
   resumes its screen + device choice when reopened within Settings ▸ Quick


### PR DESCRIPTION
## What this does

**Background mode** (Settings ▸ General ▸ "Keep running in the background", on by default): closing the main window stops the kept-alive sessions (terminal shells, Reactotron server, JS-console reverse tunnels), widens both device polls (`SimulatorMonitor` gains `setPollInterval`), and removes the Dock icon (`.accessory`). The app stays resident for the menu bar icon, global hotkeys, and the Quick Actions panel; ⌘Q still quits fully. Relaunching from Finder/Spotlight reopens the window. Fixes along the way: the delegate never received its AppState reference (`NSApp.delegate` is SwiftUI's wrapper on macOS — the cast silently failed, which also broke the shipped quit-teardown paths), and window identifiers don't survive a close (SwiftUI re-stamps `main-AppWindow-1`), so the main window is now tracked by reference and lifecycle checks are structural.

**Quick Actions panel**: a Raycast-style floating **mini app** on a global hotkey (Settings ▸ Hotkeys; also in the menu bar). Non-activating — it takes keyboard input without stealing focus from the frontmost app.
- **Root**: a grid of everything runnable in place — saved custom commands, every *enabled* implemented instant/toggle/form action (mirrors the app's role/catalog curation; hub members ride their hub; ⌘P pins, shared with the app's favorites, pinned lead the grid), Manage Apps, Emulators, Install APK — plus an "Open in Droidective" list for full-app view screens.
- **Form actions** (Send Text, Reverse Port, Deep Link, …) render their registry `FieldDef`s in-panel; ⏎ runs.
- **Manage Apps**: installed packages (saved bundles pinned) → open / force-stop / minimize / clear cache / clear data / uninstall; destructive verbs need a second ⏎ (the row shows "⏎ to confirm" and stays red when highlighted).
- **Emulators**: boot AVDs and iOS Simulators (with a loading state); running ones switch the selection.
- **Multi-device**: every device-scoped action asks which device (⌘⏎ at the interstitial runs on all devices — any device feature, fanned out as explicit targets; the latest pick scopes Manage Apps and its verbs). The pick is carried as an explicit serial through every run — never via the global selection — so the hidden main window's run-on-all state can't fan a panel action out, and an exit-guard-deferred device switch can't retarget it. "All devices" records the approved serials; devices attached later are never targeted by an old approval; a disconnected pick re-raises the interstitial. Custom adb commands fan out per-device with per-device results.
- **Results** stay in the footer with Reveal-in-Finder / Copy affordances and honest success/failure (installs included); the panel never auto-dismisses. Esc (or ‹) pops a screen, closes at the root; ←→/↑↓ navigate the grid even mid-query.
- **Pinning**: ⌘P pins/unpins the highlighted feature (grid tiles, forms, open-in-app rows, and the native Manage Apps / Emulators / Install APK, which map to their registry features); pinned tiles lead the grid, shared with the app's favorites.
- **Role-aware**: the panel mirrors the app's role/catalog curation — only enabled features appear (hub members ride their hub's enabledness; the native rows follow `apps`/`emulators`/`install-app`), so e.g. an iOS-developer role doesn't see Install APK.
- **Session resume**: reopening within a configurable window (default 5 min, Settings ▸ General ▸ Quick Actions) restores the screen stack and device choice; the expiry rule also applies to Finder-opened APKs.
- **Discoverability**: completing the welcome tour ends on a record-a-hotkey ask — one click applies the recommended ⇧⌘Space (free on a stock Mac; ⌘Space is Spotlight, ⌥Space is usually Raycast/Alfred), the live recorder takes a custom combo, Maybe Later defers to Settings ▸ Hotkeys. Shown only while no hotkey is set, so it never reappears after a choice or on a tour replay.

**APK routing**: double-clicking an APK opens the panel on an APK options screen — Install in place (real failure reporting), or hand the file to APK Studio (Inspect/Decompile/Sign tabs; replacing a different loaded session asks for a confirming second ⏎) or the full Install App screen. The main window may open/front alongside it (macOS activates the app for a document open) — accepted behavior; the panel sits on top.

**Refactors**: palette ranking extracted into ADBKit as pure, tested `PaletteSearch` (relevance scored once before sorting); `PaletteController` generalized into `FloatingPanelController`; `AppListing.displayName(for:)` shared; app verbs derived from `AppAction.allCases` via exhaustive switches (a new verb is a compile error, not a missing row).

## Audit (9-angle review: correctness ×3, reuse, simplification, efficiency, altitude, conventions, UI/UX)

**Fixed in this PR (15):**
| # | Finding | Class |
|---|---------|-------|
| 1 | Panel runs could inherit the hidden window's run-on-all state and fan out past an explicit single-device pick | correctness |
| 2 | Device pick routed through `requestDevice`, which defers behind exit guards — action ran on the old device | correctness |
| 3 | Install APK reported success unconditionally (`ok: true` hardcoded) | correctness |
| 4 | Finder-APK path skipped the session-expiry check — a stale "All devices" governed the install | correctness |
| 5 | Resume persisted a picked *flag*, not the serial — targeting drifted across close/reopen | correctness |
| 6 | "All devices" approval leaked onto devices attached after the approval | correctness |
| 7 | Custom commands ran on one device while the footer claimed "All devices" | correctness |
| 8 | Minimized main window didn't count as "remaining" — closing Settings killed sessions | correctness |
| 9 | Relaunch-reopen was a no-op when the panel was the only visible window | correctness |
| 10 | Loading an APK over a live APK Studio session silently clobbered it | UX/data-loss |
| 11 | Destructive rows lost red when highlighted; armed state invisible on the row | UX |
| 12 | Emulators screen said "none found" while still loading | UX |
| 13 | `pm list packages` from the panel bypassed the Command Log; store loads lacked cancellation guards | conventions |
| 14 | Apps list did O(packages × bundles) scans per keystroke; relevance recomputed inside sort comparators; emulator refreshes ran sequentially | efficiency |
| 15 | Duplicated display-name rule, device rows, verb tables; vestigial panel identifier; stale doc comments; misnamed autosave constant | reuse/cleanup |

**Refuted (3):** screenshot feedback (its runner does write `lastResults` on both paths); terminals killed on window close without a prompt (explicitly requested behavior, documented in the Settings copy); panel actions not cancelled on close (intended — a fired action should survive the panel dismissing).

**Deferred, noted as follow-ups (4):** `QuickActionFormView` shares ~110 lines of field/param logic with `FormActionView` (extract a shared form model); the panel row chassis duplicates the ⌘K palette's row styling; `QuickPanelMemory` could be `@Observable` to delete the manual `syncMemory` mirroring; the root's fixed 400pt height (Raycast-style) vs content-sized sub-screens is a deliberate tradeoff.

## Use cases verified
- Close window: background on / off, minimized window + Settings close, quit (⌘Q) with/without live shells and recordings, quit-cancel then close.
- Reopen: menu bar, global hotkey, Spotlight relaunch (with and without the panel open), ⌘W tab-close after close→reopen.
- Panel: 0 / 1 / N devices; pick / All-devices / switch mid-session; device disconnects while panel closed; resume within and past the window; Off setting; destructive double-⏎; form validation errors; no-device empty states per screen; Esc/‹ navigation; focus after push/pop and after the file dialog.
- APKs: Finder open while resident / while window open / cold launch; multi-APK install; failed install reporting; studio handoff with and without a loaded session.

## Tests
- 593 ADBKit tests green (10 new for `PaletteSearch`)
- Debug build with zero warnings (warnings-as-errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




