### PR TITLE
Terminal selection, tab rail with groups, sidebar auto-hide, selectable logcat

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/TerminalTabs.swift
+++ b/ADBKit/Sources/ADBKit/Features/TerminalTabs.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Pure grouping + ordering model for the Terminal feature's tab rail: named
+/// groups of tab ids, each collapsible, with tabs reorderable within and
+/// across groups and groups reorderable among themselves. Kept out of the
+/// SwiftUI layer (the `SidebarOrdering` pattern) so every move is unit-tested
+/// without a UI. The sessions behind the ids live in the App layer; this type
+/// only owns *where* each tab sits.
+public struct TerminalTabs: Equatable, Sendable {
+    public struct Group: Identifiable, Equatable, Sendable {
+        public let id: UUID
+        public var name: String
+        public var isCollapsed: Bool
+        public internal(set) var tabIDs: [UUID]
+
+        init(name: String) {
+            id = UUID()
+            self.name = name
+            isCollapsed = false
+            tabIDs = []
+        }
+    }
+
+    public static let defaultGroupName = "Terminals"
+
+    public private(set) var groups: [Group] = []
+
+    public init() {}
+
+    // MARK: - Queries
+
+    /// Every tab id in display order — groups top to bottom, tabs within them.
+    public var allTabIDs: [UUID] { groups.flatMap(\.tabIDs) }
+
+    public var tabCount: Int { groups.reduce(0) { $0 + $1.tabIDs.count } }
+
+    public func group(_ id: UUID) -> Group? {
+        groups.first { $0.id == id }
+    }
+
+    public func groupID(ofTab id: UUID) -> UUID? {
+        groups.first { $0.tabIDs.contains(id) }?.id
+    }
+
+    // MARK: - Group operations
+
+    /// Adds an empty group at the end. An empty/whitespace name falls back to
+    /// the default so the rail never shows a blank header.
+    @discardableResult
+    public mutating func addGroup(named name: String) -> UUID {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        let group = Group(name: trimmed.isEmpty ? Self.defaultGroupName : trimmed)
+        groups.append(group)
+        return group.id
+    }
+
+    /// Renames a group; empty/whitespace names are ignored.
+    public mutating func renameGroup(_ id: UUID, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        groups[index].name = trimmed
+    }
+
+    public mutating func setCollapsed(_ id: UUID, _ collapsed: Bool) {
+        guard let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        groups[index].isCollapsed = collapsed
+    }
+
+    /// Removes the group and returns the tab ids it held, in order — the
+    /// caller owns the sessions behind them and must tear those down.
+    @discardableResult
+    public mutating func removeGroup(_ id: UUID) -> [UUID] {
+        guard let index = groups.firstIndex(where: { $0.id == id }) else { return [] }
+        return groups.remove(at: index).tabIDs
+    }
+
+    /// Moves a whole group so it sits immediately before `target`. No-op when
+    /// either id is unknown or they're the same group.
+    public mutating func moveGroup(_ id: UUID, before target: UUID) {
+        guard id != target,
+              let from = groups.firstIndex(where: { $0.id == id }) else { return }
+        let moving = groups.remove(at: from)
+        if let to = groups.firstIndex(where: { $0.id == target }) {
+            groups.insert(moving, at: to)
+        } else {
+            groups.insert(moving, at: from)
+        }
+    }
+
+    public mutating func moveGroupToEnd(_ id: UUID) {
+        guard let from = groups.firstIndex(where: { $0.id == id }) else { return }
+        let moving = groups.remove(at: from)
+        groups.append(moving)
+    }
+
+    // MARK: - Tab operations
+
+    /// Appends a tab to `groupID`, or to the last group when nil — creating
+    /// the default group first if none exist (so `add` can never lose a tab).
+    public mutating func add(tab: UUID, toGroup groupID: UUID? = nil) {
+        if groups.isEmpty {
+            addGroup(named: Self.defaultGroupName)
+        }
+        let index = groupID.flatMap { id in groups.firstIndex { $0.id == id } } ?? groups.count - 1
+        groups[index].tabIDs.append(tab)
+    }
+
+    /// Removes a tab from whichever group holds it. Empty groups stay — the
+    /// user shaped them and may be about to refill them.
+    @discardableResult
+    public mutating func remove(tab: UUID) -> Bool {
+        for index in groups.indices {
+            if let at = groups[index].tabIDs.firstIndex(of: tab) {
+                groups[index].tabIDs.remove(at: at)
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Moves a tab so it sits immediately before `target`, crossing groups
+    /// when the target lives elsewhere. No-op when either id is unknown.
+    public mutating func move(tab: UUID, before target: UUID) {
+        guard tab != target,
+              let fromGroup = groups.firstIndex(where: { $0.tabIDs.contains(tab) }),
+              let toGroup = groups.firstIndex(where: { $0.tabIDs.contains(target) }),
+              let from = groups[fromGroup].tabIDs.firstIndex(of: tab) else { return }
+        groups[fromGroup].tabIDs.remove(at: from)
+        // Look the target up *after* the removal — same-group moves shift it.
+        guard let to = groups[toGroup].tabIDs.firstIndex(of: target) else { return }
+        groups[toGroup].tabIDs.insert(tab, at: to)
+    }
+
+    /// Moves a tab to the end of `groupID`. No-op when either id is unknown.
+    public mutating func move(tab: UUID, toEndOfGroup groupID: UUID) {
+        guard let toGroup = groups.firstIndex(where: { $0.id == groupID }),
+              let fromGroup = groups.firstIndex(where: { $0.tabIDs.contains(tab) }),
+              let from = groups[fromGroup].tabIDs.firstIndex(of: tab) else { return }
+        // A same-group "to end" of the last tab is already a no-op shape.
+        groups[fromGroup].tabIDs.remove(at: from)
+        groups[toGroup].tabIDs.append(tab)
+    }
+
+    // MARK: - Focus math
+
+    /// The tab focus should land on after `id` closes: the tab that slides
+    /// into its slot in the flattened order, or the previous one when it was
+    /// last — mirroring the app's own tab-close behavior across groups.
+    public func neighbor(of id: UUID) -> UUID? {
+        let flat = allTabIDs
+        guard let index = flat.firstIndex(of: id) else { return nil }
+        let remaining = flat.filter { $0 != id }
+        guard !remaining.isEmpty else { return nil }
+        return remaining[min(index, remaining.count - 1)]
+    }
+
+    /// The tab `offset` steps away in the flattened order, wrapping — feeds
+    /// the Next/Previous Terminal commands across group boundaries.
+    public func tab(offset: Int, from id: UUID) -> UUID? {
+        let flat = allTabIDs
+        guard !flat.isEmpty else { return nil }
+        guard let index = flat.firstIndex(of: id) else { return flat.first }
+        let count = flat.count
+        return flat[((index + offset) % count + count) % count]
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/TerminalTabs.swift
+++ b/ADBKit/Sources/ADBKit/Features/TerminalTabs.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-/// Pure grouping + ordering model for the Terminal feature's tab rail: named
-/// groups of tab ids, each collapsible, with tabs reorderable within and
-/// across groups and groups reorderable among themselves. Kept out of the
-/// SwiftUI layer (the `SidebarOrdering` pattern) so every move is unit-tested
-/// without a UI. The sessions behind the ids live in the App layer; this type
-/// only owns *where* each tab sits.
+/// Pure layout model for the Terminal feature's tab rail. Tabs are *loose*
+/// (ungrouped) by default; a group is created only by wrapping a tab, and a
+/// group deletes itself the moment its last tab leaves. Loose tabs and groups
+/// share one ordered list so they interleave the way browser/VS-Code tab
+/// groups do — a tab dragged out of a group lands where it's dropped. Kept out
+/// of the SwiftUI layer (the `SidebarOrdering` pattern) so every move is
+/// unit-tested without a UI; the sessions behind the ids live in the App layer.
 public struct TerminalTabs: Equatable, Sendable {
     public struct Group: Identifiable, Equatable, Sendable {
         public let id: UUID
@@ -13,132 +14,201 @@ public struct TerminalTabs: Equatable, Sendable {
         public var isCollapsed: Bool
         public internal(set) var tabIDs: [UUID]
 
-        init(name: String) {
-            id = UUID()
+        init(id: UUID = UUID(), name: String, tabIDs: [UUID]) {
+            self.id = id
             self.name = name
             isCollapsed = false
-            tabIDs = []
+            self.tabIDs = tabIDs
         }
     }
 
-    public static let defaultGroupName = "Terminals"
+    /// A top-level row of the rail: a loose tab, or a group of tabs.
+    public enum Entry: Identifiable, Equatable, Sendable {
+        case tab(UUID)
+        case group(Group)
 
-    public private(set) var groups: [Group] = []
+        public var id: UUID {
+            switch self {
+            case .tab(let id): return id
+            case .group(let group): return group.id
+            }
+        }
+    }
+
+    public static let defaultGroupName = "Group"
+
+    public private(set) var entries: [Entry] = []
 
     public init() {}
 
     // MARK: - Queries
 
-    /// Every tab id in display order — groups top to bottom, tabs within them.
-    public var allTabIDs: [UUID] { groups.flatMap(\.tabIDs) }
+    /// Every tab id in display order — loose tabs and each group's tabs, top
+    /// to bottom.
+    public var allTabIDs: [UUID] {
+        entries.flatMap { entry -> [UUID] in
+            switch entry {
+            case .tab(let id): return [id]
+            case .group(let group): return group.tabIDs
+            }
+        }
+    }
 
-    public var tabCount: Int { groups.reduce(0) { $0 + $1.tabIDs.count } }
+    public var tabCount: Int { allTabIDs.count }
+
+    /// The groups in display order (loose tabs omitted).
+    public var groups: [Group] {
+        entries.compactMap { if case .group(let group) = $0 { return group } else { return nil } }
+    }
 
     public func group(_ id: UUID) -> Group? {
-        groups.first { $0.id == id }
+        for entry in entries {
+            if case .group(let group) = entry, group.id == id { return group }
+        }
+        return nil
     }
 
+    /// The group holding `id`, or nil when the tab is loose.
     public func groupID(ofTab id: UUID) -> UUID? {
-        groups.first { $0.tabIDs.contains(id) }?.id
+        for entry in entries {
+            if case .group(let group) = entry, group.tabIDs.contains(id) { return group.id }
+        }
+        return nil
     }
 
-    // MARK: - Group operations
+    // MARK: - Adding
 
-    /// Adds an empty group at the end. An empty/whitespace name falls back to
-    /// the default so the rail never shows a blank header.
+    /// Append a tab — loose, or to `groupID` when given. Default is loose, so
+    /// a fresh rail has no groups at all.
+    public mutating func add(tab: UUID, toGroup groupID: UUID? = nil) {
+        if let groupID, let index = groupIndex(groupID) {
+            mutateGroup(at: index) { $0.tabIDs.append(tab) }
+        } else {
+            entries.append(.tab(tab))
+        }
+    }
+
+    // MARK: - Grouping
+
+    /// Wrap `tab` in a new group, created at the tab's current position. An
+    /// empty/whitespace name falls back to the default. Returns the group id,
+    /// or nil when the tab isn't present.
     @discardableResult
-    public mutating func addGroup(named name: String) -> UUID {
+    public mutating func newGroup(named name: String, containing tab: UUID) -> UUID? {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
-        let group = Group(name: trimmed.isEmpty ? Self.defaultGroupName : trimmed)
-        groups.append(group)
+        let groupName = trimmed.isEmpty ? Self.defaultGroupName : trimmed
+
+        // A loose tab becomes a group in place; a grouped tab detaches (its old
+        // group may vanish) and the new group lands at the end.
+        if let index = looseIndex(ofTab: tab) {
+            let group = Group(name: groupName, tabIDs: [tab])
+            entries[index] = .group(group)
+            return group.id
+        }
+        guard groupID(ofTab: tab) != nil else { return nil }
+        remove(tab: tab)
+        let group = Group(name: groupName, tabIDs: [tab])
+        entries.append(.group(group))
         return group.id
     }
 
     /// Renames a group; empty/whitespace names are ignored.
     public mutating func renameGroup(_ id: UUID, to name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty, let index = groups.firstIndex(where: { $0.id == id }) else { return }
-        groups[index].name = trimmed
+        guard !trimmed.isEmpty, let index = groupIndex(id) else { return }
+        mutateGroup(at: index) { $0.name = trimmed }
     }
 
     public mutating func setCollapsed(_ id: UUID, _ collapsed: Bool) {
-        guard let index = groups.firstIndex(where: { $0.id == id }) else { return }
-        groups[index].isCollapsed = collapsed
+        guard let index = groupIndex(id) else { return }
+        mutateGroup(at: index) { $0.isCollapsed = collapsed }
     }
 
-    /// Removes the group and returns the tab ids it held, in order — the
-    /// caller owns the sessions behind them and must tear those down.
+    /// Remove a group and return the tab ids it held, in order — the caller
+    /// owns the sessions and must tear them down.
     @discardableResult
     public mutating func removeGroup(_ id: UUID) -> [UUID] {
-        guard let index = groups.firstIndex(where: { $0.id == id }) else { return [] }
-        return groups.remove(at: index).tabIDs
+        guard let index = groupIndex(id), case .group(let group) = entries[index] else { return [] }
+        entries.remove(at: index)
+        return group.tabIDs
     }
 
-    /// Moves a whole group so it sits immediately before `target`. No-op when
-    /// either id is unknown or they're the same group.
-    public mutating func moveGroup(_ id: UUID, before target: UUID) {
-        guard id != target,
-              let from = groups.firstIndex(where: { $0.id == id }) else { return }
-        let moving = groups.remove(at: from)
-        if let to = groups.firstIndex(where: { $0.id == target }) {
-            groups.insert(moving, at: to)
-        } else {
-            groups.insert(moving, at: from)
-        }
-    }
+    // MARK: - Removing
 
-    public mutating func moveGroupToEnd(_ id: UUID) {
-        guard let from = groups.firstIndex(where: { $0.id == id }) else { return }
-        let moving = groups.remove(at: from)
-        groups.append(moving)
-    }
-
-    // MARK: - Tab operations
-
-    /// Appends a tab to `groupID`, or to the last group when nil — creating
-    /// the default group first if none exist (so `add` can never lose a tab).
-    public mutating func add(tab: UUID, toGroup groupID: UUID? = nil) {
-        if groups.isEmpty {
-            addGroup(named: Self.defaultGroupName)
-        }
-        let index = groupID.flatMap { id in groups.firstIndex { $0.id == id } } ?? groups.count - 1
-        groups[index].tabIDs.append(tab)
-    }
-
-    /// Removes a tab from whichever group holds it. Empty groups stay — the
-    /// user shaped them and may be about to refill them.
+    /// Remove a tab from wherever it sits. A group left empty by the removal
+    /// deletes itself.
     @discardableResult
     public mutating func remove(tab: UUID) -> Bool {
-        for index in groups.indices {
-            if let at = groups[index].tabIDs.firstIndex(of: tab) {
-                groups[index].tabIDs.remove(at: at)
+        for index in entries.indices {
+            switch entries[index] {
+            case .tab(let id) where id == tab:
+                entries.remove(at: index)
                 return true
+            case .group(var group):
+                guard let at = group.tabIDs.firstIndex(of: tab) else { continue }
+                group.tabIDs.remove(at: at)
+                if group.tabIDs.isEmpty {
+                    entries.remove(at: index)
+                } else {
+                    entries[index] = .group(group)
+                }
+                return true
+            default:
+                continue
             }
         }
         return false
     }
 
-    /// Moves a tab so it sits immediately before `target`, crossing groups
-    /// when the target lives elsewhere. No-op when either id is unknown.
+    // MARK: - Moving tabs
+
+    /// Move `tab` so it sits immediately before `target`. The destination
+    /// follows the target: before a loose tab it becomes loose; before a
+    /// grouped tab it joins that group. No-op when either id is unknown or
+    /// they're the same.
     public mutating func move(tab: UUID, before target: UUID) {
-        guard tab != target,
-              let fromGroup = groups.firstIndex(where: { $0.tabIDs.contains(tab) }),
-              let toGroup = groups.firstIndex(where: { $0.tabIDs.contains(target) }),
-              let from = groups[fromGroup].tabIDs.firstIndex(of: tab) else { return }
-        groups[fromGroup].tabIDs.remove(at: from)
-        // Look the target up *after* the removal — same-group moves shift it.
-        guard let to = groups[toGroup].tabIDs.firstIndex(of: target) else { return }
-        groups[toGroup].tabIDs.insert(tab, at: to)
+        guard tab != target, tabExists(tab), tabExists(target) else { return }
+        remove(tab: tab)
+        insert(tab: tab, before: target)
     }
 
-    /// Moves a tab to the end of `groupID`. No-op when either id is unknown.
+    /// Move `tab` to the end of `groupID`. No-op when it's already that group's
+    /// sole tab, or when either id is unknown.
     public mutating func move(tab: UUID, toEndOfGroup groupID: UUID) {
-        guard let toGroup = groups.firstIndex(where: { $0.id == groupID }),
-              let fromGroup = groups.firstIndex(where: { $0.tabIDs.contains(tab) }),
-              let from = groups[fromGroup].tabIDs.firstIndex(of: tab) else { return }
-        // A same-group "to end" of the last tab is already a no-op shape.
-        groups[fromGroup].tabIDs.remove(at: from)
-        groups[toGroup].tabIDs.append(tab)
+        guard tabExists(tab), let group = group(groupID) else { return }
+        if group.tabIDs == [tab] { return }
+        remove(tab: tab)
+        guard let index = groupIndex(groupID) else { return }
+        mutateGroup(at: index) { $0.tabIDs.append(tab) }
+    }
+
+    /// Move `tab` out to the end of the rail as a loose tab.
+    public mutating func moveToLooseEnd(tab: UUID) {
+        guard tabExists(tab) else { return }
+        // Already the last loose entry → nothing to do.
+        if case .tab(let id)? = entries.last, id == tab { return }
+        remove(tab: tab)
+        entries.append(.tab(tab))
+    }
+
+    // MARK: - Moving groups
+
+    /// Move a group so it sits immediately before `target` (another top-level
+    /// entry — a group or a loose tab). No-op when the ids match or are unknown.
+    public mutating func moveGroup(_ id: UUID, before target: UUID) {
+        guard id != target, let from = entryIndex(id) else { return }
+        let moving = entries.remove(at: from)
+        if let to = entryIndex(target) {
+            entries.insert(moving, at: to)
+        } else {
+            entries.insert(moving, at: from)
+        }
+    }
+
+    public mutating func moveGroupToEnd(_ id: UUID) {
+        guard let from = entryIndex(id) else { return }
+        let moving = entries.remove(at: from)
+        entries.append(moving)
     }
 
     // MARK: - Focus math
@@ -162,5 +232,51 @@ public struct TerminalTabs: Equatable, Sendable {
         guard let index = flat.firstIndex(of: id) else { return flat.first }
         let count = flat.count
         return flat[((index + offset) % count + count) % count]
+    }
+
+    // MARK: - Internal helpers
+
+    private func tabExists(_ id: UUID) -> Bool {
+        allTabIDs.contains(id)
+    }
+
+    /// The top-level index of a loose tab entry (not a tab inside a group).
+    private func looseIndex(ofTab id: UUID) -> Int? {
+        entries.firstIndex { if case .tab(let tab) = $0 { return tab == id } else { return false } }
+    }
+
+    private func groupIndex(_ id: UUID) -> Int? {
+        entries.firstIndex { if case .group(let group) = $0 { return group.id == id } else { return false } }
+    }
+
+    /// The top-level index of any entry (loose tab or group) by its id.
+    private func entryIndex(_ id: UUID) -> Int? {
+        entries.firstIndex { $0.id == id }
+    }
+
+    private mutating func mutateGroup(at index: Int, _ body: (inout Group) -> Void) {
+        guard case .group(var group) = entries[index] else { return }
+        body(&group)
+        entries[index] = .group(group)
+    }
+
+    /// Insert `tab` immediately before `target`, matching the target's context:
+    /// a loose target inserts a loose entry, a grouped target inserts into that
+    /// group. Assumes `tab` has already been detached.
+    private mutating func insert(tab: UUID, before target: UUID) {
+        for index in entries.indices {
+            switch entries[index] {
+            case .tab(let id) where id == target:
+                entries.insert(.tab(tab), at: index)
+                return
+            case .group(var group):
+                guard let at = group.tabIDs.firstIndex(of: target) else { continue }
+                group.tabIDs.insert(tab, at: at)
+                entries[index] = .group(group)
+                return
+            default:
+                continue
+            }
+        }
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/LogStreamDiff.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogStreamDiff.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// How a rendered log pane catches up with the ring buffer behind it. The
+/// stream only ever drops lines at the head (ring trim) and appends at the
+/// tail, so those become surgical edits; anything else (filter change, clear)
+/// rebuilds. Pure so the plan — the off-by-one-prone part — is unit-tested
+/// without AppKit.
+public enum LogStreamDiff: Equatable, Sendable {
+    /// The buffer already matches what's rendered.
+    case unchanged
+    /// The shapes don't line up as a trim + append — start over.
+    case rebuild
+    /// Drop the first `dropHead` rendered lines, then append the incoming
+    /// lines from index `appendFrom` on.
+    case edit(dropHead: Int, appendFrom: Int)
+
+    public static func plan(rendered: [UUID], incoming: [UUID]) -> LogStreamDiff {
+        if incoming.count == rendered.count,
+           incoming.first == rendered.first, incoming.last == rendered.last {
+            return .unchanged
+        }
+        guard let first = incoming.first,
+              let overlapStart = rendered.firstIndex(of: first) else { return .rebuild }
+        // The rendered lines from `overlapStart` down must reappear verbatim
+        // at the head of `incoming` — checking the count and the last id is
+        // enough because ids are unique and both sides preserve stream order.
+        let overlap = rendered.count - overlapStart
+        guard incoming.count >= overlap, incoming[overlap - 1] == rendered.last else { return .rebuild }
+        return .edit(dropHead: overlapStart, appendFrom: overlap)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/LogStreamDiffTests.swift
+++ b/ADBKit/Tests/ADBKitTests/LogStreamDiffTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite("LogStreamDiff")
+struct LogStreamDiffTests {
+    private func ids(_ count: Int) -> [UUID] {
+        (0..<count).map { _ in UUID() }
+    }
+
+    @Test func identicalBuffersAreUnchanged() {
+        let lines = ids(3)
+        #expect(LogStreamDiff.plan(rendered: lines, incoming: lines) == .unchanged)
+    }
+
+    @Test func bothEmptyIsUnchanged() {
+        #expect(LogStreamDiff.plan(rendered: [], incoming: []) == .unchanged)
+    }
+
+    @Test func pureAppendKeepsTheHead() {
+        let rendered = ids(3)
+        let incoming = rendered + ids(2)
+        #expect(
+            LogStreamDiff.plan(rendered: rendered, incoming: incoming)
+                == .edit(dropHead: 0, appendFrom: 3)
+        )
+    }
+
+    @Test func ringTrimDropsTheHead() {
+        let rendered = ids(5)
+        let incoming = Array(rendered.dropFirst(2))
+        #expect(
+            LogStreamDiff.plan(rendered: rendered, incoming: incoming)
+                == .edit(dropHead: 2, appendFrom: 3)
+        )
+    }
+
+    @Test func trimAndAppendCombine() {
+        let rendered = ids(5)
+        let incoming = Array(rendered.dropFirst(2)) + ids(4)
+        #expect(
+            LogStreamDiff.plan(rendered: rendered, incoming: incoming)
+                == .edit(dropHead: 2, appendFrom: 3)
+        )
+    }
+
+    @Test func clearedBufferRebuilds() {
+        #expect(LogStreamDiff.plan(rendered: ids(3), incoming: []) == .rebuild)
+    }
+
+    @Test func firstContentRebuilds() {
+        #expect(LogStreamDiff.plan(rendered: [], incoming: ids(3)) == .rebuild)
+    }
+
+    @Test func disjointBuffersRebuild() {
+        #expect(LogStreamDiff.plan(rendered: ids(3), incoming: ids(3)) == .rebuild)
+    }
+
+    @Test func interiorGapRebuilds() {
+        // A filter change that keeps the head but drops interior lines isn't
+        // a trim + append shape — the overlap-count check catches it.
+        let rendered = ids(4)
+        let incoming = [rendered[0], rendered[1], rendered[3]]
+        #expect(LogStreamDiff.plan(rendered: rendered, incoming: incoming) == .rebuild)
+    }
+
+    @Test func changedTailRebuilds() {
+        // Same head, but the rendered tail was replaced instead of extended.
+        let rendered = ids(3)
+        let incoming = [rendered[0], rendered[1], UUID(), rendered[2]]
+        #expect(LogStreamDiff.plan(rendered: rendered, incoming: incoming) == .rebuild)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
@@ -137,6 +137,16 @@ struct TerminalTabsTests {
         #expect(tabs.group(group)?.tabIDs == [b, a, c])
     }
 
+    @Test func moveToEndOfGroupWithUnknownIDsIsANoOp() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "G")
+        tabs.add(tab: UUID(), toGroup: group)
+        let before = tabs
+        tabs.move(tab: before.allTabIDs[0], toEndOfGroup: UUID())
+        tabs.move(tab: UUID(), toEndOfGroup: group)
+        #expect(tabs == before)
+    }
+
     @Test func moveToEndOfGroupAppends() {
         var tabs = TerminalTabs()
         let build = tabs.addGroup(named: "Build")
@@ -161,6 +171,15 @@ struct TerminalTabsTests {
         #expect(tabs.groups.map(\.id) == [c, a, b])
         tabs.moveGroupToEnd(c)
         #expect(tabs.groups.map(\.id) == [a, b, c])
+    }
+
+    @Test func moveGroupForwardAccountsForTheRemovalShift() {
+        var tabs = TerminalTabs()
+        let a = tabs.addGroup(named: "A")
+        let b = tabs.addGroup(named: "B")
+        let c = tabs.addGroup(named: "C")
+        tabs.moveGroup(a, before: c)
+        #expect(tabs.groups.map(\.id) == [b, a, c])
     }
 
     @Test func moveGroupBeforeUnknownTargetKeepsItsPlace() {

--- a/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite("TerminalTabs")
+struct TerminalTabsTests {
+    // MARK: - Adding
+
+    @Test func addingATabWithNoGroupsCreatesTheDefaultGroup() {
+        var tabs = TerminalTabs()
+        let tab = UUID()
+        tabs.add(tab: tab)
+        #expect(tabs.groups.count == 1)
+        #expect(tabs.groups[0].name == TerminalTabs.defaultGroupName)
+        #expect(tabs.allTabIDs == [tab])
+    }
+
+    @Test func addingWithoutAGroupAppendsToTheLastGroup() {
+        var tabs = TerminalTabs()
+        tabs.addGroup(named: "Build")
+        let device = tabs.addGroup(named: "Device")
+        let tab = UUID()
+        tabs.add(tab: tab)
+        #expect(tabs.group(device)?.tabIDs == [tab])
+    }
+
+    @Test func addingToASpecificGroupLandsThere() {
+        var tabs = TerminalTabs()
+        let build = tabs.addGroup(named: "Build")
+        tabs.addGroup(named: "Device")
+        let tab = UUID()
+        tabs.add(tab: tab, toGroup: build)
+        #expect(tabs.group(build)?.tabIDs == [tab])
+        #expect(tabs.groupID(ofTab: tab) == build)
+    }
+
+    @Test func addGroupFallsBackToDefaultNameWhenBlank() {
+        var tabs = TerminalTabs()
+        let id = tabs.addGroup(named: "   ")
+        #expect(tabs.group(id)?.name == TerminalTabs.defaultGroupName)
+    }
+
+    // MARK: - Removing
+
+    @Test func removingATabLeavesItsEmptyGroupInPlace() {
+        var tabs = TerminalTabs()
+        let tab = UUID()
+        tabs.add(tab: tab)
+        let removed = tabs.remove(tab: tab)
+        #expect(removed)
+        #expect(tabs.groups.count == 1)
+        #expect(tabs.tabCount == 0)
+    }
+
+    @Test func removingAnUnknownTabReportsFalse() {
+        var tabs = TerminalTabs()
+        tabs.add(tab: UUID())
+        let removed = tabs.remove(tab: UUID())
+        #expect(!removed)
+        #expect(tabs.tabCount == 1)
+    }
+
+    @Test func removingAGroupReturnsItsTabsInOrder() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "Build")
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a, toGroup: group)
+        tabs.add(tab: b, toGroup: group)
+        let evicted = tabs.removeGroup(group)
+        #expect(evicted == [a, b])
+        #expect(tabs.groups.isEmpty)
+    }
+
+    // MARK: - Renaming / collapsing
+
+    @Test func renameTrimsAndIgnoresEmpty() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "Build")
+        tabs.renameGroup(group, to: "  Deploy  ")
+        #expect(tabs.group(group)?.name == "Deploy")
+        tabs.renameGroup(group, to: "   ")
+        #expect(tabs.group(group)?.name == "Deploy")
+    }
+
+    @Test func collapseIsPerGroup() {
+        var tabs = TerminalTabs()
+        let a = tabs.addGroup(named: "A")
+        let b = tabs.addGroup(named: "B")
+        tabs.setCollapsed(a, true)
+        #expect(tabs.group(a)?.isCollapsed == true)
+        #expect(tabs.group(b)?.isCollapsed == false)
+    }
+
+    // MARK: - Moving tabs
+
+    @Test func moveBeforeReordersWithinAGroup() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "G")
+        let a = UUID(), b = UUID(), c = UUID()
+        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
+        tabs.move(tab: c, before: a)
+        #expect(tabs.group(group)?.tabIDs == [c, a, b])
+    }
+
+    @Test func moveBeforeCrossesGroups() {
+        var tabs = TerminalTabs()
+        let build = tabs.addGroup(named: "Build")
+        let device = tabs.addGroup(named: "Device")
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a, toGroup: build)
+        tabs.add(tab: b, toGroup: device)
+        tabs.move(tab: a, before: b)
+        #expect(tabs.group(build)?.tabIDs == [])
+        #expect(tabs.group(device)?.tabIDs == [a, b])
+        #expect(tabs.groupID(ofTab: a) == device)
+    }
+
+    @Test func moveBeforeItselfOrUnknownIsANoOp() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "G")
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a, toGroup: group)
+        tabs.add(tab: b, toGroup: group)
+        let before = tabs
+        tabs.move(tab: a, before: a)
+        tabs.move(tab: UUID(), before: a)
+        tabs.move(tab: a, before: UUID())
+        #expect(tabs == before)
+    }
+
+    @Test func moveDownWithinAGroupAccountsForTheRemovalShift() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "G")
+        let a = UUID(), b = UUID(), c = UUID()
+        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
+        tabs.move(tab: a, before: c)
+        #expect(tabs.group(group)?.tabIDs == [b, a, c])
+    }
+
+    @Test func moveToEndOfGroupAppends() {
+        var tabs = TerminalTabs()
+        let build = tabs.addGroup(named: "Build")
+        let device = tabs.addGroup(named: "Device")
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a, toGroup: build)
+        tabs.add(tab: b, toGroup: device)
+        tabs.move(tab: a, toEndOfGroup: device)
+        #expect(tabs.group(device)?.tabIDs == [b, a])
+        tabs.move(tab: b, toEndOfGroup: device)
+        #expect(tabs.group(device)?.tabIDs == [a, b])
+    }
+
+    // MARK: - Moving groups
+
+    @Test func moveGroupBeforeAndToEnd() {
+        var tabs = TerminalTabs()
+        let a = tabs.addGroup(named: "A")
+        let b = tabs.addGroup(named: "B")
+        let c = tabs.addGroup(named: "C")
+        tabs.moveGroup(c, before: a)
+        #expect(tabs.groups.map(\.id) == [c, a, b])
+        tabs.moveGroupToEnd(c)
+        #expect(tabs.groups.map(\.id) == [a, b, c])
+    }
+
+    @Test func moveGroupBeforeUnknownTargetKeepsItsPlace() {
+        var tabs = TerminalTabs()
+        let a = tabs.addGroup(named: "A")
+        let b = tabs.addGroup(named: "B")
+        tabs.moveGroup(a, before: UUID())
+        #expect(tabs.groups.map(\.id) == [a, b])
+    }
+
+    // MARK: - Focus math
+
+    @Test func neighborIsTheTabSlidingIntoTheSlot() {
+        var tabs = TerminalTabs()
+        let group = tabs.addGroup(named: "G")
+        let a = UUID(), b = UUID(), c = UUID()
+        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
+        #expect(tabs.neighbor(of: b) == c)
+        #expect(tabs.neighbor(of: c) == b)   // last: falls back to previous
+    }
+
+    @Test func neighborCrossesGroupBoundaries() {
+        var tabs = TerminalTabs()
+        let build = tabs.addGroup(named: "Build")
+        let device = tabs.addGroup(named: "Device")
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a, toGroup: build)
+        tabs.add(tab: b, toGroup: device)
+        #expect(tabs.neighbor(of: a) == b)
+        #expect(tabs.neighbor(of: b) == a)
+    }
+
+    @Test func neighborOfTheOnlyTabIsNil() {
+        var tabs = TerminalTabs()
+        let tab = UUID()
+        tabs.add(tab: tab)
+        #expect(tabs.neighbor(of: tab) == nil)
+    }
+
+    @Test func cycleWrapsAcrossGroupsInBothDirections() {
+        var tabs = TerminalTabs()
+        let build = tabs.addGroup(named: "Build")
+        let device = tabs.addGroup(named: "Device")
+        let a = UUID(), b = UUID(), c = UUID()
+        tabs.add(tab: a, toGroup: build)
+        tabs.add(tab: b, toGroup: build)
+        tabs.add(tab: c, toGroup: device)
+        #expect(tabs.tab(offset: 1, from: c) == a)    // wraps forward
+        #expect(tabs.tab(offset: -1, from: a) == c)   // wraps backward
+        #expect(tabs.tab(offset: 1, from: b) == c)    // crosses the boundary
+    }
+
+    @Test func cycleFromAnUnknownTabFallsToTheFirst() {
+        var tabs = TerminalTabs()
+        let a = UUID()
+        tabs.add(tab: a)
+        #expect(tabs.tab(offset: 1, from: UUID()) == a)
+    }
+
+    @Test func cycleWithNoTabsIsNil() {
+        let tabs = TerminalTabs()
+        #expect(tabs.tab(offset: 1, from: UUID()) == nil)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TerminalTabsTests.swift
@@ -4,53 +4,110 @@ import Testing
 
 @Suite("TerminalTabs")
 struct TerminalTabsTests {
-    // MARK: - Adding
+    // MARK: - Loose tabs by default
 
-    @Test func addingATabWithNoGroupsCreatesTheDefaultGroup() {
+    @Test func tabsAreLooseByDefault() {
         var tabs = TerminalTabs()
-        let tab = UUID()
-        tabs.add(tab: tab)
-        #expect(tabs.groups.count == 1)
-        #expect(tabs.groups[0].name == TerminalTabs.defaultGroupName)
-        #expect(tabs.allTabIDs == [tab])
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        #expect(tabs.groups.isEmpty)
+        #expect(tabs.allTabIDs == [a, b])
+        #expect(tabs.groupID(ofTab: a) == nil)
     }
 
-    @Test func addingWithoutAGroupAppendsToTheLastGroup() {
+    @Test func addingToAGroupLandsThere() {
         var tabs = TerminalTabs()
-        tabs.addGroup(named: "Build")
-        let device = tabs.addGroup(named: "Device")
-        let tab = UUID()
-        tabs.add(tab: tab)
-        #expect(tabs.group(device)?.tabIDs == [tab])
+        let a = UUID()
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "Build", containing: a)!
+        let b = UUID()
+        tabs.add(tab: b, toGroup: group)
+        #expect(tabs.group(group)?.tabIDs == [a, b])
+        #expect(tabs.groupID(ofTab: b) == group)
     }
 
-    @Test func addingToASpecificGroupLandsThere() {
+    // MARK: - Creating groups
+
+    @Test func newGroupWrapsALooseTabInPlace() {
         var tabs = TerminalTabs()
-        let build = tabs.addGroup(named: "Build")
-        tabs.addGroup(named: "Device")
-        let tab = UUID()
-        tabs.add(tab: tab, toGroup: build)
-        #expect(tabs.group(build)?.tabIDs == [tab])
-        #expect(tabs.groupID(ofTab: tab) == build)
+        let a = UUID(), b = UUID(), c = UUID()
+        for tab in [a, b, c] { tabs.add(tab: tab) }
+        let group = tabs.newGroup(named: "Mid", containing: b)!
+        // b's slot is now a group; a and c stay loose around it.
+        #expect(tabs.allTabIDs == [a, b, c])
+        #expect(tabs.groupID(ofTab: b) == group)
+        #expect(tabs.groupID(ofTab: a) == nil)
+        #expect(tabs.groupID(ofTab: c) == nil)
     }
 
-    @Test func addGroupFallsBackToDefaultNameWhenBlank() {
+    @Test func newGroupNameFallsBackWhenBlank() {
         var tabs = TerminalTabs()
-        let id = tabs.addGroup(named: "   ")
-        #expect(tabs.group(id)?.name == TerminalTabs.defaultGroupName)
+        let a = UUID()
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "   ", containing: a)!
+        #expect(tabs.group(group)?.name == TerminalTabs.defaultGroupName)
+    }
+
+    @Test func newGroupOnAnUnknownTabIsNil() {
+        var tabs = TerminalTabs()
+        #expect(tabs.newGroup(named: "X", containing: UUID()) == nil)
+    }
+
+    @Test func newGroupFromAGroupedTabMovesItOut() {
+        var tabs = TerminalTabs()
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let first = tabs.newGroup(named: "First", containing: a)!
+        tabs.move(tab: b, toEndOfGroup: first)
+        // Now re-group b into its own group; First keeps a and survives.
+        let second = tabs.newGroup(named: "Second", containing: b)!
+        #expect(tabs.group(first)?.tabIDs == [a])
+        #expect(tabs.group(second)?.tabIDs == [b])
+    }
+
+    // MARK: - Auto-deleting empty groups
+
+    @Test func removingTheLastTabDeletesItsGroup() {
+        var tabs = TerminalTabs()
+        let a = UUID()
+        tabs.add(tab: a)
+        tabs.newGroup(named: "Solo", containing: a)
+        let removed = tabs.remove(tab: a)
+        #expect(removed)
+        #expect(tabs.groups.isEmpty)
+        #expect(tabs.tabCount == 0)
+    }
+
+    @Test func removingANonLastTabKeepsTheGroup() {
+        var tabs = TerminalTabs()
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "Pair", containing: a)!
+        tabs.move(tab: b, toEndOfGroup: group)   // b is loose after add? add first
+        tabs.add(tab: b)
+        tabs.move(tab: b, toEndOfGroup: group)
+        let removed = tabs.remove(tab: a)
+        #expect(removed)
+        #expect(tabs.group(group)?.tabIDs == [b])
+    }
+
+    @Test func draggingTheLastTabOutDeletesTheGroup() {
+        var tabs = TerminalTabs()
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let group = tabs.newGroup(named: "G", containing: b)!
+        // Drag b out to become loose — its group empties and vanishes.
+        tabs.moveToLooseEnd(tab: b)
+        #expect(tabs.group(group) == nil)
+        #expect(tabs.groups.isEmpty)
+        #expect(tabs.allTabIDs == [a, b])
+        #expect(tabs.groupID(ofTab: b) == nil)
     }
 
     // MARK: - Removing
-
-    @Test func removingATabLeavesItsEmptyGroupInPlace() {
-        var tabs = TerminalTabs()
-        let tab = UUID()
-        tabs.add(tab: tab)
-        let removed = tabs.remove(tab: tab)
-        #expect(removed)
-        #expect(tabs.groups.count == 1)
-        #expect(tabs.tabCount == 0)
-    }
 
     @Test func removingAnUnknownTabReportsFalse() {
         var tabs = TerminalTabs()
@@ -60,11 +117,11 @@ struct TerminalTabsTests {
         #expect(tabs.tabCount == 1)
     }
 
-    @Test func removingAGroupReturnsItsTabsInOrder() {
+    @Test func removeGroupReturnsItsTabsInOrder() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "Build")
         let a = UUID(), b = UUID()
-        tabs.add(tab: a, toGroup: group)
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "G", containing: a)!
         tabs.add(tab: b, toGroup: group)
         let evicted = tabs.removeGroup(group)
         #expect(evicted == [a, b])
@@ -75,7 +132,9 @@ struct TerminalTabsTests {
 
     @Test func renameTrimsAndIgnoresEmpty() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "Build")
+        let a = UUID()
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "Build", containing: a)!
         tabs.renameGroup(group, to: "  Deploy  ")
         #expect(tabs.group(group)?.name == "Deploy")
         tabs.renameGroup(group, to: "   ")
@@ -84,43 +143,57 @@ struct TerminalTabsTests {
 
     @Test func collapseIsPerGroup() {
         var tabs = TerminalTabs()
-        let a = tabs.addGroup(named: "A")
-        let b = tabs.addGroup(named: "B")
-        tabs.setCollapsed(a, true)
-        #expect(tabs.group(a)?.isCollapsed == true)
-        #expect(tabs.group(b)?.isCollapsed == false)
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let first = tabs.newGroup(named: "A", containing: a)!
+        let second = tabs.newGroup(named: "B", containing: b)!
+        tabs.setCollapsed(first, true)
+        #expect(tabs.group(first)?.isCollapsed == true)
+        #expect(tabs.group(second)?.isCollapsed == false)
     }
 
     // MARK: - Moving tabs
 
-    @Test func moveBeforeReordersWithinAGroup() {
+    @Test func moveBeforeReordersLooseTabs() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "G")
         let a = UUID(), b = UUID(), c = UUID()
-        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
+        for tab in [a, b, c] { tabs.add(tab: tab) }
         tabs.move(tab: c, before: a)
-        #expect(tabs.group(group)?.tabIDs == [c, a, b])
+        #expect(tabs.allTabIDs == [c, a, b])
+        #expect(tabs.groups.isEmpty)
     }
 
-    @Test func moveBeforeCrossesGroups() {
+    @Test func moveBeforeAGroupedTabJoinsThatGroup() {
         var tabs = TerminalTabs()
-        let build = tabs.addGroup(named: "Build")
-        let device = tabs.addGroup(named: "Device")
         let a = UUID(), b = UUID()
-        tabs.add(tab: a, toGroup: build)
-        tabs.add(tab: b, toGroup: device)
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let group = tabs.newGroup(named: "G", containing: b)!
         tabs.move(tab: a, before: b)
-        #expect(tabs.group(build)?.tabIDs == [])
-        #expect(tabs.group(device)?.tabIDs == [a, b])
-        #expect(tabs.groupID(ofTab: a) == device)
+        #expect(tabs.group(group)?.tabIDs == [a, b])
+        #expect(tabs.groupID(ofTab: a) == group)
+    }
+
+    @Test func moveBeforeALooseTabLeavesTheGroup() {
+        var tabs = TerminalTabs()
+        let a = UUID(), b = UUID(), c = UUID()
+        tabs.add(tab: a)   // loose
+        tabs.add(tab: b)
+        tabs.add(tab: c)
+        let group = tabs.newGroup(named: "G", containing: b)!
+        tabs.move(tab: c, toEndOfGroup: group)   // group holds b, c
+        tabs.move(tab: c, before: a)             // pull c out, before loose a
+        #expect(tabs.groupID(ofTab: c) == nil)
+        #expect(tabs.group(group)?.tabIDs == [b])
+        #expect(tabs.allTabIDs == [c, a, b])
     }
 
     @Test func moveBeforeItselfOrUnknownIsANoOp() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "G")
         let a = UUID(), b = UUID()
-        tabs.add(tab: a, toGroup: group)
-        tabs.add(tab: b, toGroup: group)
+        tabs.add(tab: a)
+        tabs.add(tab: b)
         let before = tabs
         tabs.move(tab: a, before: a)
         tabs.move(tab: UUID(), before: a)
@@ -128,88 +201,101 @@ struct TerminalTabsTests {
         #expect(tabs == before)
     }
 
-    @Test func moveDownWithinAGroupAccountsForTheRemovalShift() {
+    @Test func moveToEndOfGroupCrossesFromLoose() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "G")
-        let a = UUID(), b = UUID(), c = UUID()
-        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
-        tabs.move(tab: a, before: c)
-        #expect(tabs.group(group)?.tabIDs == [b, a, c])
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let group = tabs.newGroup(named: "G", containing: a)!
+        tabs.move(tab: b, toEndOfGroup: group)
+        #expect(tabs.group(group)?.tabIDs == [a, b])
+    }
+
+    @Test func moveToEndOfGroupOfTheSoleTabIsANoOp() {
+        var tabs = TerminalTabs()
+        let a = UUID()
+        tabs.add(tab: a)
+        let group = tabs.newGroup(named: "G", containing: a)!
+        let before = tabs
+        tabs.move(tab: a, toEndOfGroup: group)
+        #expect(tabs == before)
     }
 
     @Test func moveToEndOfGroupWithUnknownIDsIsANoOp() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "G")
-        tabs.add(tab: UUID(), toGroup: group)
-        let before = tabs
-        tabs.move(tab: before.allTabIDs[0], toEndOfGroup: UUID())
-        tabs.move(tab: UUID(), toEndOfGroup: group)
-        #expect(tabs == before)
-    }
-
-    @Test func moveToEndOfGroupAppends() {
-        var tabs = TerminalTabs()
-        let build = tabs.addGroup(named: "Build")
-        let device = tabs.addGroup(named: "Device")
         let a = UUID(), b = UUID()
-        tabs.add(tab: a, toGroup: build)
-        tabs.add(tab: b, toGroup: device)
-        tabs.move(tab: a, toEndOfGroup: device)
-        #expect(tabs.group(device)?.tabIDs == [b, a])
-        tabs.move(tab: b, toEndOfGroup: device)
-        #expect(tabs.group(device)?.tabIDs == [a, b])
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let group = tabs.newGroup(named: "G", containing: a)!
+        let before = tabs
+        tabs.move(tab: b, toEndOfGroup: UUID())       // unknown group
+        tabs.move(tab: UUID(), toEndOfGroup: group)   // unknown tab
+        #expect(tabs == before)
     }
 
     // MARK: - Moving groups
 
     @Test func moveGroupBeforeAndToEnd() {
         var tabs = TerminalTabs()
-        let a = tabs.addGroup(named: "A")
-        let b = tabs.addGroup(named: "B")
-        let c = tabs.addGroup(named: "C")
-        tabs.moveGroup(c, before: a)
-        #expect(tabs.groups.map(\.id) == [c, a, b])
-        tabs.moveGroupToEnd(c)
-        #expect(tabs.groups.map(\.id) == [a, b, c])
+        let a = UUID(), b = UUID(), c = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        tabs.add(tab: c)
+        let first = tabs.newGroup(named: "A", containing: a)!
+        let second = tabs.newGroup(named: "B", containing: b)!
+        let third = tabs.newGroup(named: "C", containing: c)!
+        tabs.moveGroup(third, before: first)
+        #expect(tabs.groups.map(\.id) == [third, first, second])
+        tabs.moveGroupToEnd(third)
+        #expect(tabs.groups.map(\.id) == [first, second, third])
+    }
+
+    @Test func moveGroupBeforeALooseTabInterleaves() {
+        var tabs = TerminalTabs()
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)   // loose, first
+        tabs.add(tab: b)
+        let group = tabs.newGroup(named: "G", containing: b)!   // group, second
+        tabs.moveGroup(group, before: a)
+        #expect(tabs.allTabIDs == [b, a])
     }
 
     @Test func moveGroupForwardAccountsForTheRemovalShift() {
         var tabs = TerminalTabs()
-        let a = tabs.addGroup(named: "A")
-        let b = tabs.addGroup(named: "B")
-        let c = tabs.addGroup(named: "C")
-        tabs.moveGroup(a, before: c)
-        #expect(tabs.groups.map(\.id) == [b, a, c])
+        let a = UUID(), b = UUID(), c = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        tabs.add(tab: c)
+        let first = tabs.newGroup(named: "A", containing: a)!
+        let second = tabs.newGroup(named: "B", containing: b)!
+        let third = tabs.newGroup(named: "C", containing: c)!
+        // Forward move: the target is re-found after the group is removed.
+        tabs.moveGroup(first, before: third)
+        #expect(tabs.groups.map(\.id) == [second, first, third])
     }
 
     @Test func moveGroupBeforeUnknownTargetKeepsItsPlace() {
         var tabs = TerminalTabs()
-        let a = tabs.addGroup(named: "A")
-        let b = tabs.addGroup(named: "B")
-        tabs.moveGroup(a, before: UUID())
-        #expect(tabs.groups.map(\.id) == [a, b])
+        let a = UUID(), b = UUID()
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        let first = tabs.newGroup(named: "A", containing: a)!
+        let second = tabs.newGroup(named: "B", containing: b)!
+        tabs.moveGroup(first, before: UUID())
+        #expect(tabs.groups.map(\.id) == [first, second])
     }
 
     // MARK: - Focus math
 
-    @Test func neighborIsTheTabSlidingIntoTheSlot() {
+    @Test func neighborCrossesLooseAndGroupedTabs() {
         var tabs = TerminalTabs()
-        let group = tabs.addGroup(named: "G")
         let a = UUID(), b = UUID(), c = UUID()
-        for tab in [a, b, c] { tabs.add(tab: tab, toGroup: group) }
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        tabs.add(tab: c)
+        tabs.newGroup(named: "G", containing: b)
         #expect(tabs.neighbor(of: b) == c)
-        #expect(tabs.neighbor(of: c) == b)   // last: falls back to previous
-    }
-
-    @Test func neighborCrossesGroupBoundaries() {
-        var tabs = TerminalTabs()
-        let build = tabs.addGroup(named: "Build")
-        let device = tabs.addGroup(named: "Device")
-        let a = UUID(), b = UUID()
-        tabs.add(tab: a, toGroup: build)
-        tabs.add(tab: b, toGroup: device)
-        #expect(tabs.neighbor(of: a) == b)
-        #expect(tabs.neighbor(of: b) == a)
+        #expect(tabs.neighbor(of: c) == b)
     }
 
     @Test func neighborOfTheOnlyTabIsNil() {
@@ -221,15 +307,15 @@ struct TerminalTabsTests {
 
     @Test func cycleWrapsAcrossGroupsInBothDirections() {
         var tabs = TerminalTabs()
-        let build = tabs.addGroup(named: "Build")
-        let device = tabs.addGroup(named: "Device")
         let a = UUID(), b = UUID(), c = UUID()
-        tabs.add(tab: a, toGroup: build)
-        tabs.add(tab: b, toGroup: build)
-        tabs.add(tab: c, toGroup: device)
-        #expect(tabs.tab(offset: 1, from: c) == a)    // wraps forward
-        #expect(tabs.tab(offset: -1, from: a) == c)   // wraps backward
-        #expect(tabs.tab(offset: 1, from: b) == c)    // crosses the boundary
+        tabs.add(tab: a)
+        tabs.add(tab: b)
+        tabs.add(tab: c)
+        let group = tabs.newGroup(named: "G", containing: a)!
+        tabs.move(tab: b, toEndOfGroup: group)   // group: a, b ; loose: c
+        #expect(tabs.tab(offset: 1, from: c) == a)
+        #expect(tabs.tab(offset: -1, from: a) == c)
+        #expect(tabs.tab(offset: 1, from: b) == c)
     }
 
     @Test func cycleFromAnUnknownTabFallsToTheFirst() {

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -61,6 +61,7 @@ struct ADTApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
+    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
     /// The user-chosen accent. Read here so changing it re-renders the scene and
     /// re-keys RootView (`.id`), forcing every `.brandAccent` to re-resolve.
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
@@ -82,7 +83,8 @@ struct ADTApp: App {
         // the window is small.
         let detailMinWidth: CGFloat = appState.isSplit ? 648 : 360
         let notifications: CGFloat = appState.showNotifications ? 321 : 0
-        let sidebar: CGFloat = appState.sidebarVisible
+        // An auto-hidden sidebar overlays the content, so it costs no width.
+        let sidebar: CGFloat = appState.sidebarVisible && !sidebarAutoHide
             ? CGFloat(min(max(sidebarWidth, 300), 460))
             : 0
         // The content is laid out at window ÷ fontScale then scaled up, so the

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -242,6 +242,30 @@ struct ADTApp: App {
                     appState.requestFeature("catalog")
                 }
                 .keyboardShortcut(".", modifiers: .command)
+
+                Divider()
+
+                // SwiftTerm ships a find bar but SwiftUI's stock Edit menu has
+                // no Find items to reach it — wire them for the focused shell.
+                // Disabled outside the Terminal so ⌘F falls through to views
+                // with their own find (e.g. the JS console's filter).
+                Button("Find in Terminal…") {
+                    appState.terminals.activeTab?.session.showFindBar()
+                }
+                .keyboardShortcut("f", modifiers: .command)
+                .disabled(!terminalCommandsEnabled)
+
+                Button("Find Next") {
+                    appState.terminals.activeTab?.session.findNext()
+                }
+                .keyboardShortcut("g", modifiers: .command)
+                .disabled(!terminalCommandsEnabled)
+
+                Button("Find Previous") {
+                    appState.terminals.activeTab?.session.findPrevious()
+                }
+                .keyboardShortcut("g", modifiers: [.command, .shift])
+                .disabled(!terminalCommandsEnabled)
             }
 
             CommandGroup(after: .sidebar) {

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -61,7 +61,7 @@ struct ADTApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
-    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
+    @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
     /// The user-chosen accent. Read here so changing it re-renders the scene and
     /// re-keys RootView (`.id`), forcing every `.brandAccent` to re-resolve.
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""

--- a/App/Sources/FeatureDetail/NativeTerminalView.swift
+++ b/App/Sources/FeatureDetail/NativeTerminalView.swift
@@ -2,13 +2,121 @@ import AppKit
 import SwiftTerm
 import SwiftUI
 
+/// SwiftTerm's Mac view computes an auto-scroll velocity while drag-selecting
+/// past the viewport edge but never schedules the timer that would consume it,
+/// so a selection stops dead at the visible edge. This subclass drives the
+/// scroll itself, and adds the other desktop-terminal table stakes SwiftTerm
+/// leaves to the host: a right-click Copy/Paste menu and find-bar entry points.
+final class DroidTerminalView: LocalProcessTerminalView {
+    private var dragWatchTimer: Timer?
+
+    /// SwiftTerm seals `mouseDragged` as `public` (not `open`), so the drag
+    /// can't be observed by override. But every drag-selection announces
+    /// itself here (`startSelection` notifies the moment the drag begins) —
+    /// a selection change while the left button is down means a drag-select
+    /// is in flight, so start watching the pointer.
+    override func selectionChanged(source: SwiftTerm.Terminal) {
+        super.selectionChanged(source: source)
+        guard NSEvent.pressedMouseButtons & 1 == 1 else { return }
+        // When the program owns the mouse (vim, htop), drags go to it and no
+        // selection is being made — nothing to scroll.
+        guard !(allowMouseReporting && getTerminal().mouseMode != .off) else { return }
+        startDragWatch()
+    }
+
+    // A tab closing mid-drag unparents the view before the button lifts; the
+    // repeating timer retains its target, so it must die here too.
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil { stopDragWatch() }
+    }
+
+    private func startDragWatch() {
+        guard dragWatchTimer == nil else { return }
+        let timer = Timer(
+            timeInterval: 0.05, target: self, selector: #selector(dragWatchTick),
+            userInfo: nil, repeats: true
+        )
+        // .common so it keeps firing during the mouse-drag event stream.
+        RunLoop.main.add(timer, forMode: .common)
+        dragWatchTimer = timer
+    }
+
+    private func stopDragWatch() {
+        dragWatchTimer?.invalidate()
+        dragWatchTimer = nil
+    }
+
+    @objc private func dragWatchTick() {
+        guard NSEvent.pressedMouseButtons & 1 == 1, let window, selectionActive else {
+            stopDragWatch()
+            return
+        }
+        // Scroll when the pointer is within a small band at either edge, not
+        // only past it — the terminal's bottom edge usually sits at the screen
+        // edge, where macOS clamps the cursor, so "past the edge" can be
+        // unreachable (Terminal.app uses the same edge-zone trick). The view
+        // is y-up: the top edge reveals scrollback (up), the bottom edge
+        // advances toward the newest output (down). Between the zones there's
+        // nothing to do — keep watching until the button lifts.
+        let zone: CGFloat = 8
+        let location = window.mouseLocationOutsideOfEventStream
+        let point = convert(location, from: nil)
+        if point.y > bounds.height - zone {
+            scrollUp(lines: dragScrollStep(overshoot: point.y - (bounds.height - zone)))
+        } else if point.y < zone {
+            scrollDown(lines: dragScrollStep(overshoot: zone - point.y))
+        } else {
+            return
+        }
+        // Replay the drag at the (unmoved) pointer so the selection extends
+        // into the rows the scroll just revealed.
+        let synthesized = NSEvent.mouseEvent(
+            with: .leftMouseDragged, location: location, modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber, context: nil,
+            eventNumber: 0, clickCount: 1, pressure: 1
+        )
+        if let synthesized { mouseDragged(with: synthesized) }
+    }
+
+    /// Farther past the edge scrolls faster, like every native text view.
+    private func dragScrollStep(overshoot: CGFloat) -> Int {
+        max(1, min(6, Int(overshoot / 12)))
+    }
+
+    /// Right-click menu. Items target self so validation runs through
+    /// SwiftTerm's `validateUserInterfaceItem` (Copy needs a selection).
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        addItem(to: menu, title: "Copy", action: #selector(SwiftTerm.TerminalView.copy(_:)), key: "c")
+        addItem(to: menu, title: "Paste", action: #selector(SwiftTerm.TerminalView.paste(_:)), key: "v")
+        addItem(to: menu, title: "Select All", action: #selector(NSResponder.selectAll(_:)), key: "a")
+        menu.addItem(.separator())
+        let find = addItem(
+            to: menu, title: "Find…",
+            action: #selector(SwiftTerm.TerminalView.performFindPanelAction(_:)), key: "f"
+        )
+        find.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
+        return menu
+    }
+
+    @discardableResult
+    private func addItem(to menu: NSMenu, title: String, action: Selector, key: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: key)
+        item.target = self
+        menu.addItem(item)
+        return item
+    }
+}
+
 /// One real embedded shell (PTY-backed, via SwiftTerm). The Terminal feature's
 /// manager owns one session per tab, all held on `AppState` so every shell and
 /// its scrollback survive switching features. The login shell is started
 /// lazily the first time the tab is shown.
 @MainActor
 final class TerminalSession {
-    private var terminalView: LocalProcessTerminalView?
+    private var terminalView: DroidTerminalView?
     /// Latched by `kill()`. SwiftUI's teardown pass can call `view(serial:)`
     /// once more on the dying representable — without the latch that silently
     /// respawned an orphan shell for every closed tab.
@@ -23,7 +131,7 @@ final class TerminalSession {
     /// it without `-s`.
     func view(serial: String?) -> LocalProcessTerminalView {
         if let terminalView { return terminalView }
-        let view = LocalProcessTerminalView(frame: .zero)
+        let view = DroidTerminalView(frame: .zero)
         view.font = Self.terminalFont(size: 12)
         view.processDelegate = self
         terminalView = view
@@ -56,6 +164,20 @@ final class TerminalSession {
             }
         }
         terminalView = nil
+    }
+
+    /// Open SwiftTerm's built-in find bar over this shell's scrollback.
+    func showFindBar() { sendFindPanelAction(.showFindPanel) }
+    func findNext() { sendFindPanelAction(.next) }
+    func findPrevious() { sendFindPanelAction(.previous) }
+
+    /// SwiftTerm's find entry point is menu-shaped — it reads the action off
+    /// an `NSMenuItem` tag — so the menu-bar commands feed it a synthetic item.
+    private func sendFindPanelAction(_ action: NSFindPanelAction) {
+        guard let terminalView else { return }
+        let item = NSMenuItem()
+        item.tag = Int(action.rawValue)
+        terminalView.performFindPanelAction(item)
     }
 
     /// A fixed-width Nerd Font so prompt-theme glyphs (powerline separators,
@@ -101,28 +223,48 @@ extension TerminalSession: LocalProcessTerminalViewDelegate {
 struct NativeTerminalView: NSViewRepresentable {
     let session: TerminalSession
     let serial: String?
+    /// Whether this session's tab is the focused one in the terminal strip.
+    let isActive: Bool
+
+    /// Remembers the last activation state so focus is grabbed only on the
+    /// inactive→active edge — not on every SwiftUI update, which would steal
+    /// the first responder from the sidebar search field mid-typing.
+    final class Coordinator {
+        var wasActive = false
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> NSView {
         let container = NSView()
-        mount(in: container)
+        mount(in: container, coordinator: context.coordinator)
         return container
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        mount(in: nsView)
+        mount(in: nsView, coordinator: context.coordinator)
     }
 
-    private func mount(in container: NSView) {
+    private func mount(in container: NSView, coordinator: Coordinator) {
         let terminal = session.view(serial: serial)
-        guard terminal.superview !== container else { return }
-        terminal.removeFromSuperview()
-        terminal.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(terminal)
-        NSLayoutConstraint.activate([
-            terminal.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            terminal.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            terminal.topAnchor.constraint(equalTo: container.topAnchor),
-            terminal.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-        ])
+        if terminal.superview !== container {
+            terminal.removeFromSuperview()
+            terminal.translatesAutoresizingMaskIntoConstraints = false
+            container.addSubview(terminal)
+            NSLayoutConstraint.activate([
+                terminal.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+                terminal.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+                terminal.topAnchor.constraint(equalTo: container.topAnchor),
+                terminal.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            ])
+        }
+        // Focus the shell when its tab becomes active (or on first show) so
+        // typing works right away, like Terminal.app — no click required.
+        if isActive && !coordinator.wasActive {
+            Task { @MainActor in
+                terminal.window?.makeFirstResponder(terminal)
+            }
+        }
+        coordinator.wasActive = isActive
     }
 }

--- a/App/Sources/FeatureDetail/SelectableLogView.swift
+++ b/App/Sources/FeatureDetail/SelectableLogView.swift
@@ -1,0 +1,299 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// An NSTextView-backed log pane. Unlike the SwiftUI row list (whose
+/// `.textSelection` is trapped inside each row), this gives real cross-line
+/// selection with native drag autoscroll, ⌘C, and Select All over the whole
+/// buffer. Appends are incremental and the ring buffer's head-trim deletes
+/// characters instead of rebuilding, so a full 5000-line buffer streams
+/// smoothly.
+struct SelectableLogView: NSViewRepresentable {
+    let lines: [LogLine]
+    let search: String
+    /// True while the view is parked at the bottom following new lines; the
+    /// caller shows its "jump to newest" button when this goes false.
+    @Binding var isTailing: Bool
+    /// Increment to ask the view to scroll back to the newest line.
+    let jumpToken: Int
+    let onFilterTag: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isTailing: $isTailing)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = LogTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 8, height: 4)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = true
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.documentView = textView
+
+        context.coordinator.install(textView: textView, scrollView: scrollView)
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.onFilterTag = onFilterTag
+        context.coordinator.update(lines: lines, search: search)
+        context.coordinator.handleJump(token: jumpToken)
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private let isTailing: Binding<Bool>
+        var onFilterTag: ((String) -> Void)?
+
+        private weak var textView: LogTextView?
+        private weak var scrollView: NSScrollView?
+
+        /// What the text storage currently shows, line by line. `lineLengths`
+        /// holds each line's UTF-16 length (newline included) so a head-trim
+        /// knows exactly how many characters to delete.
+        private var renderedLines: [LogLine] = []
+        private var lineLengths: [Int] = []
+        private var renderedSearch = ""
+        private var lastJumpToken: Int?
+
+        init(isTailing: Binding<Bool>) {
+            self.isTailing = isTailing
+        }
+
+        func install(textView: LogTextView, scrollView: NSScrollView) {
+            self.textView = textView
+            self.scrollView = scrollView
+            textView.lineAt = { [weak self] characterIndex in
+                self?.line(atCharacter: characterIndex)
+            }
+            textView.filterTag = { [weak self] tag in
+                self?.onFilterTag?(tag)
+            }
+            scrollView.contentView.postsBoundsChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(scrolled),
+                name: NSView.boundsDidChangeNotification, object: scrollView.contentView
+            )
+        }
+
+        @objc private func scrolled() {
+            syncTailing()
+        }
+
+        private func syncTailing() {
+            let atBottom = isAtBottom
+            guard atBottom != isTailing.wrappedValue else { return }
+            // This can run inside a SwiftUI update pass (scroll notifications,
+            // updateNSView) — defer the state write out of it.
+            Task { @MainActor in
+                self.isTailing.wrappedValue = atBottom
+            }
+        }
+
+        /// Within this many points of the bottom still counts as tailing,
+        /// covering sub-pixel rounding and the follow scroll itself.
+        private var isAtBottom: Bool {
+            guard let scrollView, let document = scrollView.documentView else { return true }
+            let visible = scrollView.contentView.bounds
+            return visible.maxY >= document.frame.height - 30
+        }
+
+        func handleJump(token: Int) {
+            guard lastJumpToken != nil, token != lastJumpToken else {
+                lastJumpToken = token
+                return
+            }
+            lastJumpToken = token
+            scrollToBottom()
+        }
+
+        // MARK: Content diffing
+
+        /// The stream only ever drops lines at the head (ring trim) and
+        /// appends at the tail, so those paths are surgical edits; anything
+        /// else (filter change, clear, search change) rebuilds.
+        func update(lines: [LogLine], search: String) {
+            guard let storage = textView?.textStorage else { return }
+            let wasTailing = renderedLines.isEmpty || isAtBottom
+
+            defer {
+                if wasTailing { scrollToBottom() }
+                // Appends below the viewport don't fire a scroll notification,
+                // so the follow state must also sync here or the jump button
+                // never appears while parked in scrollback.
+                syncTailing()
+            }
+
+            if search != renderedSearch {
+                renderedSearch = search
+                rebuild(lines, in: storage)
+                return
+            }
+            // Fast path: nothing changed.
+            if lines.count == renderedLines.count,
+               lines.first?.id == renderedLines.first?.id,
+               lines.last?.id == renderedLines.last?.id {
+                return
+            }
+            guard let first = lines.first else {
+                rebuild(lines, in: storage)
+                return
+            }
+            guard let overlapStart = renderedLines.firstIndex(where: { $0.id == first.id }) else {
+                rebuild(lines, in: storage)
+                return
+            }
+            let overlap = renderedLines.count - overlapStart
+            guard lines.count >= overlap, lines[overlap - 1].id == renderedLines.last?.id else {
+                rebuild(lines, in: storage)
+                return
+            }
+            if overlapStart > 0 {
+                let headLength = lineLengths.prefix(overlapStart).reduce(0, +)
+                storage.deleteCharacters(in: NSRange(location: 0, length: headLength))
+                renderedLines.removeFirst(overlapStart)
+                lineLengths.removeFirst(overlapStart)
+            }
+            if lines.count > overlap {
+                append(Array(lines[overlap...]), to: storage)
+            }
+        }
+
+        private func rebuild(_ lines: [LogLine], in storage: NSTextStorage) {
+            renderedLines = []
+            lineLengths = []
+            storage.setAttributedString(NSAttributedString())
+            append(lines, to: storage)
+        }
+
+        private func append(_ lines: [LogLine], to storage: NSTextStorage) {
+            guard !lines.isEmpty else { return }
+            let batch = NSMutableAttributedString()
+            for line in lines {
+                let attributed = Self.attributedLine(line, search: renderedSearch)
+                lineLengths.append(attributed.length)
+                batch.append(attributed)
+            }
+            renderedLines.append(contentsOf: lines)
+            storage.append(batch)
+        }
+
+        private func scrollToBottom() {
+            guard let textView, let storage = textView.textStorage else { return }
+            textView.scrollRangeToVisible(NSRange(location: storage.length, length: 0))
+        }
+
+        /// The line under a character index — prefix-sums `lineLengths` (the
+        /// context menu's one lookup; not worth a cached table).
+        private func line(atCharacter index: Int) -> LogLine? {
+            var remaining = index
+            for (offset, length) in lineLengths.enumerated() {
+                if remaining < length { return renderedLines[offset] }
+                remaining -= length
+            }
+            return renderedLines.last
+        }
+
+        // MARK: Rendering
+
+        private static let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+
+        private static func color(for level: String) -> NSColor {
+            switch level {
+            case "E", "F": return .systemRed
+            case "W": return .systemOrange
+            case "I": return .labelColor
+            default: return .secondaryLabelColor
+            }
+        }
+
+        static func display(_ line: LogLine) -> String {
+            line.level.isEmpty
+                ? line.raw
+                : "\(line.time)  \(line.pid)  \(line.level)/\(line.tag): \(line.message)"
+        }
+
+        /// One rendered line (newline included), with the search matches
+        /// highlighted the way the old row list did.
+        static func attributedLine(_ line: LogLine, search: String) -> NSAttributedString {
+            let text = display(line) + "\n"
+            let attributed = NSMutableAttributedString(string: text, attributes: [
+                .font: font,
+                .foregroundColor: color(for: line.level),
+            ])
+            guard !search.isEmpty else { return attributed }
+            let haystack = text as NSString
+            var location = 0
+            while location < haystack.length {
+                let range = haystack.range(
+                    of: search, options: .caseInsensitive,
+                    range: NSRange(location: location, length: haystack.length - location)
+                )
+                guard range.location != NSNotFound else { break }
+                attributed.addAttribute(
+                    .backgroundColor, value: NSColor.systemYellow.withAlphaComponent(0.35),
+                    range: range
+                )
+                location = range.location + range.length
+            }
+            return attributed
+        }
+    }
+}
+
+/// Adds the per-line context menu (filter by tag, copy line) on top of the
+/// text view's native Copy/Select All.
+final class LogTextView: NSTextView {
+    var lineAt: ((Int) -> LogLine?)?
+    var filterTag: ((String) -> Void)?
+    private var menuLine: LogLine?
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        menuLine = lineAt?(characterIndexForInsertion(at: point))
+        let menu = NSMenu()
+        if let line = menuLine {
+            if !line.tag.isEmpty {
+                let item = NSMenuItem(
+                    title: "Filter by tag \u{201C}\(line.tag)\u{201D}",
+                    action: #selector(filterByTag(_:)), keyEquivalent: ""
+                )
+                item.target = self
+                menu.addItem(item)
+            }
+            let copyLine = NSMenuItem(title: "Copy Line", action: #selector(copyLine(_:)), keyEquivalent: "")
+            copyLine.target = self
+            menu.addItem(copyLine)
+            menu.addItem(.separator())
+        }
+        menu.addItem(NSMenuItem(title: "Copy", action: #selector(copy(_:)), keyEquivalent: "c"))
+        menu.addItem(NSMenuItem(title: "Select All", action: #selector(selectAll(_:)), keyEquivalent: "a"))
+        return menu
+    }
+
+    @objc private func filterByTag(_ sender: Any?) {
+        if let tag = menuLine?.tag, !tag.isEmpty {
+            filterTag?(tag)
+        }
+    }
+
+    @objc private func copyLine(_ sender: Any?) {
+        guard let line = menuLine else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(line.raw, forType: .string)
+    }
+}

--- a/App/Sources/FeatureDetail/SelectableLogView.swift
+++ b/App/Sources/FeatureDetail/SelectableLogView.swift
@@ -24,6 +24,10 @@ struct SelectableLogView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = LogTextView()
+        // Head-trims measure the deleted height through the TextKit 1 layout
+        // manager; touch it before any content lands so the view starts in
+        // TextKit 1 instead of downgrading mid-stream.
+        _ = textView.layoutManager
         textView.isEditable = false
         textView.isSelectable = true
         textView.drawsBackground = false
@@ -143,34 +147,50 @@ struct SelectableLogView: NSViewRepresentable {
                 rebuild(lines, in: storage)
                 return
             }
-            // Fast path: nothing changed.
-            if lines.count == renderedLines.count,
-               lines.first?.id == renderedLines.first?.id,
-               lines.last?.id == renderedLines.last?.id {
+            switch LogStreamDiff.plan(rendered: renderedLines.map(\.id), incoming: lines.map(\.id)) {
+            case .unchanged:
                 return
-            }
-            guard let first = lines.first else {
+            case .rebuild:
                 rebuild(lines, in: storage)
-                return
+            case .edit(let dropHead, let appendFrom):
+                if dropHead > 0 {
+                    trimHead(dropHead, in: storage, keepScrollPlace: !wasTailing)
+                }
+                if lines.count > appendFrom {
+                    append(Array(lines[appendFrom...]), to: storage)
+                }
             }
-            guard let overlapStart = renderedLines.firstIndex(where: { $0.id == first.id }) else {
-                rebuild(lines, in: storage)
-                return
+        }
+
+        /// Deletes the first `count` rendered lines. While the user is parked
+        /// in scrollback, the deleted height is subtracted from the scroll
+        /// offset so the lines being read hold still — without this every
+        /// ring trim yanked the scrollback up by the trimmed amount.
+        private func trimHead(_ count: Int, in storage: NSTextStorage, keepScrollPlace: Bool) {
+            let headLength = lineLengths.prefix(count).reduce(0, +)
+            let trimmedHeight = keepScrollPlace ? height(ofFirstCharacters: headLength) : 0
+            storage.deleteCharacters(in: NSRange(location: 0, length: headLength))
+            renderedLines.removeFirst(count)
+            lineLengths.removeFirst(count)
+            if trimmedHeight > 0, let scrollView {
+                let clip = scrollView.contentView
+                var origin = clip.bounds.origin
+                origin.y = max(0, origin.y - trimmedHeight)
+                clip.scroll(to: origin)
+                scrollView.reflectScrolledClipView(clip)
             }
-            let overlap = renderedLines.count - overlapStart
-            guard lines.count >= overlap, lines[overlap - 1].id == renderedLines.last?.id else {
-                rebuild(lines, in: storage)
-                return
-            }
-            if overlapStart > 0 {
-                let headLength = lineLengths.prefix(overlapStart).reduce(0, +)
-                storage.deleteCharacters(in: NSRange(location: 0, length: headLength))
-                renderedLines.removeFirst(overlapStart)
-                lineLengths.removeFirst(overlapStart)
-            }
-            if lines.count > overlap {
-                append(Array(lines[overlap...]), to: storage)
-            }
+        }
+
+        /// The rendered height of the leading `length` characters — what a
+        /// head-trim is about to delete. Everything above the viewport is
+        /// already laid out, so this is a lookup, not a fresh layout pass.
+        private func height(ofFirstCharacters length: Int) -> CGFloat {
+            guard length > 0, let textView, let layoutManager = textView.layoutManager,
+                  let container = textView.textContainer else { return 0 }
+            let glyphs = layoutManager.glyphRange(
+                forCharacterRange: NSRange(location: 0, length: length), actualCharacterRange: nil
+            )
+            return layoutManager.boundingRect(forGlyphRange: glyphs, in: container).height
         }
 
         private func rebuild(_ lines: [LogLine], in storage: NSTextStorage) {

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -19,6 +19,10 @@ struct LogcatView: View {
     /// One-shot: the App filter is seeded from the device bar's chosen bundle
     /// the first time the view appears, then left to the user.
     @State private var seededPackageFilter = false
+    /// Mirrors the log pane's follow state; drives the jump button.
+    @State private var isTailing = true
+    /// Incremented by the jump button to ask the pane to scroll to newest.
+    @State private var jumpToken = 0
 
     private static let levels: [(value: String, label: String)] = [
         ("All", "All levels"), ("V", "Verbose"), ("D", "Debug"),
@@ -194,39 +198,43 @@ struct LogcatView: View {
     }
 
     private func logList(visible: [LogLine]) -> some View {
-        // Newest lines append at the bottom; LogTailView follows them while the
-        // user is at the bottom and pauses the moment they scroll up.
-        LogTailView(entries: visible, newestEdge: .bottom) { line in
-            Text(attributedDisplay(line))
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(color(for: line.level))
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 8)
-                .contextMenu {
-                    if !line.tag.isEmpty {
-                        Button("Filter by tag \"\(line.tag)\"") { tagFilter = line.tag }
-                    }
-                    Button("Copy line") {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(line.raw, forType: .string)
-                    }
-                }
+        // An NSTextView-backed pane: real cross-line selection with drag
+        // autoscroll (the SwiftUI list trapped selection inside each row).
+        // It follows new lines while parked at the bottom and pauses the
+        // moment the user scrolls up.
+        ZStack(alignment: .bottomTrailing) {
+            SelectableLogView(
+                lines: visible,
+                search: search,
+                isTailing: $isTailing,
+                jumpToken: jumpToken,
+                onFilterTag: { tagFilter = $0 }
+            )
+            if !isTailing {
+                jumpButton
+                    .padding(16)
+                    .transition(.scale(scale: 0.85).combined(with: .opacity))
+            }
         }
+        .animation(.snappy(duration: 0.2), value: isTailing)
         .background(.background)
         .overlay { emptyOverlay }
     }
 
-    /// Search matches get a highlight instead of vanishing into the filter.
-    private func attributedDisplay(_ line: LogLine) -> AttributedString {
-        var attributed = AttributedString(display(line))
-        guard !search.isEmpty else { return attributed }
-        var searchStart = attributed.startIndex
-        while let range = attributed[searchStart...].range(of: search, options: .caseInsensitive) {
-            attributed[range].backgroundColor = .yellow.opacity(0.35)
-            searchStart = range.upperBound
+    private var jumpButton: some View {
+        Button {
+            jumpToken += 1
+        } label: {
+            Image(systemName: "arrow.down")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(.tint, in: Circle())
+                .shadow(radius: 4, y: 2)
         }
-        return attributed
+        .buttonStyle(.plain)
+        .help("Jump to the newest logs")
+        .accessibilityLabel("Jump to newest")
     }
 
     private func export() {
@@ -259,21 +267,6 @@ struct LogcatView: View {
                 "No log output", systemImage: "scroll",
                 description: Text("Logs will appear here as the device emits them.")
             )
-        }
-    }
-
-    private func display(_ line: LogLine) -> String {
-        line.level.isEmpty
-            ? line.raw
-            : "\(line.time)  \(line.pid)  \(line.level)/\(line.tag): \(line.message)"
-    }
-
-    private func color(for level: String) -> Color {
-        switch level {
-        case "E", "F": return .red
-        case "W": return .orange
-        case "I": return .primary
-        default: return .textMuted
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -236,7 +236,11 @@ struct TerminalView: View {
         // shells keep rendering into their scrollback instead of pausing.
         ZStack {
             ForEach(terminals.tabs) { tab in
-                NativeTerminalView(session: tab.session, serial: state.targetSerials.first)
+                NativeTerminalView(
+                    session: tab.session,
+                    serial: state.targetSerials.first,
+                    isActive: tab.id == terminals.activeID
+                )
                     .opacity(tab.id == terminals.activeID ? 1 : 0)
                     .allowsHitTesting(tab.id == terminals.activeID)
             }

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -1,9 +1,12 @@
 import ADBKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The Terminal feature's open shells. Owned by `AppState` (like
-/// `reactotronSession`) so every session, its scrollback, and the tab names
-/// survive leaving the feature. Each tab is an independent PTY-backed zsh.
+/// `reactotronSession`) so every session, its scrollback, the tab names, and
+/// the group layout survive leaving the feature. Each tab is an independent
+/// PTY-backed zsh; where each tab sits (groups, order) lives in the pure
+/// `TerminalTabs` model so the moves are unit-tested in ADBKit.
 @MainActor
 @Observable
 final class TerminalManager {
@@ -13,62 +16,126 @@ final class TerminalManager {
         let session: TerminalSession
     }
 
-    private(set) var tabs: [Tab] = []
+    private(set) var layout = TerminalTabs()
+    private var tabsByID: [UUID: Tab] = [:]
     var activeID: UUID?
     private var counter = 0
+    private var groupCounter = 0
 
     /// Set by `AppState`: a shell ended on its own (the user typed `exit`),
     /// so its tab should close through the same path as the × / ⌘W.
     var onShellExited: ((UUID) -> Void)?
 
-    var activeTab: Tab? {
-        tabs.first { $0.id == activeID }
+    /// Every open tab in display order (groups top to bottom).
+    var tabs: [Tab] {
+        layout.allTabIDs.compactMap { tabsByID[$0] }
     }
 
-    /// Open a fresh shell tab and focus it.
-    func newTab() {
+    var activeTab: Tab? {
+        activeID.flatMap { tabsByID[$0] }
+    }
+
+    func tab(_ id: UUID) -> Tab? { tabsByID[id] }
+
+    /// The tabs of one group, in that group's order.
+    func tabs(in group: TerminalTabs.Group) -> [Tab] {
+        group.tabIDs.compactMap { tabsByID[$0] }
+    }
+
+    /// Open a fresh shell tab and focus it. It lands in `group` when given,
+    /// else next to the active tab, else in the last group.
+    func newTab(inGroup group: UUID? = nil) {
         counter += 1
         let tab = Tab(name: "Terminal \(counter)", session: TerminalSession())
         tab.session.onProcessExit = { [weak self] in self?.onShellExited?(tab.id) }
-        tabs.append(tab)
+        tabsByID[tab.id] = tab
+        let destination = group ?? activeID.flatMap { layout.groupID(ofTab: $0) }
+        layout.add(tab: tab.id, toGroup: destination)
+        // A new shell in a collapsed group would be invisible — reveal it.
+        if let groupID = layout.groupID(ofTab: tab.id) {
+            layout.setCollapsed(groupID, false)
+        }
         activeID = tab.id
     }
 
     /// Kill the tab's shell and remove it. Focus falls to the neighbor that
     /// slid into its slot (mirroring the app's own tab-close behavior).
     func close(_ id: UUID) {
-        guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-        tabs[index].session.kill()
-        let wasActive = activeID == id
-        tabs.remove(at: index)
-        if wasActive {
-            activeID = tabs.isEmpty ? nil : tabs[min(index, tabs.count - 1)].id
-        }
+        guard let tab = tabsByID[id] else { return }
+        let neighbor = layout.neighbor(of: id)
+        tab.session.kill()
+        layout.remove(tab: id)
+        tabsByID[id] = nil
+        if activeID == id { activeID = neighbor }
     }
 
     func rename(_ id: UUID, to rawName: String) {
         let name = rawName.trimmingCharacters(in: .whitespaces)
-        guard !name.isEmpty, let index = tabs.firstIndex(where: { $0.id == id }) else { return }
-        tabs[index].name = name
+        guard !name.isEmpty, tabsByID[id] != nil else { return }
+        tabsByID[id]?.name = name
     }
 
     /// Kill every shell and clear the tabs — the Terminal feature tab was
     /// closed, and background shells without a UI would be orphans. The name
-    /// counter resets so a reopened feature starts at "Terminal 1" again.
+    /// counters reset so a reopened feature starts at "Terminal 1" again.
     func killAll() {
-        for tab in tabs {
+        for tab in tabsByID.values {
             tab.session.kill()
         }
-        tabs.removeAll()
+        tabsByID.removeAll()
+        layout = TerminalTabs()
         activeID = nil
         counter = 0
+        groupCounter = 0
     }
 
-    /// Focus the next (+1) / previous (-1) tab, wrapping.
+    /// Focus the next (+1) / previous (-1) tab, wrapping across groups.
     func cycle(by offset: Int) {
-        guard !tabs.isEmpty else { return }
-        let current = tabs.firstIndex { $0.id == activeID } ?? 0
-        activeID = tabs[(current + offset + tabs.count) % tabs.count].id
+        guard let current = activeID ?? layout.allTabIDs.first else { return }
+        activeID = layout.tab(offset: offset, from: current)
+    }
+
+    // MARK: - Groups
+
+    /// Add an empty group at the end, named "Group N" until the user renames.
+    @discardableResult
+    func addGroup() -> UUID {
+        groupCounter += 1
+        return layout.addGroup(named: "Group \(groupCounter)")
+    }
+
+    func renameGroup(_ id: UUID, to name: String) {
+        layout.renameGroup(id, to: name)
+    }
+
+    func toggleCollapsed(_ id: UUID) {
+        guard let group = layout.group(id) else { return }
+        layout.setCollapsed(id, !group.isCollapsed)
+    }
+
+    /// Kill every shell in the group and remove it. Focus falls off the last
+    /// closed tab's neighbor like a single close does.
+    func closeGroup(_ id: UUID) {
+        for tabID in layout.group(id)?.tabIDs ?? [] {
+            close(tabID)
+        }
+        layout.removeGroup(id)
+    }
+
+    func moveTab(_ id: UUID, before target: UUID) {
+        layout.move(tab: id, before: target)
+    }
+
+    func moveTab(_ id: UUID, toEndOfGroup group: UUID) {
+        layout.move(tab: id, toEndOfGroup: group)
+    }
+
+    func moveGroup(_ id: UUID, before target: UUID) {
+        layout.moveGroup(id, before: target)
+    }
+
+    func moveGroupToEnd(_ id: UUID) {
+        layout.moveGroupToEnd(id)
     }
 
     /// Set by the menu bar (⇧⌘R) to ask the Terminal view to open its rename
@@ -82,19 +149,27 @@ final class TerminalManager {
 }
 
 /// A real multi-tab terminal: each tab is its own PTY-backed login shell
-/// (SwiftTerm), with the selected device exported as ANDROID_SERIAL. Tabs are
-/// renameable (double-click or right-click) and every session keeps running —
-/// scrollback intact — while you work in other features.
+/// (SwiftTerm), with the selected device exported as ANDROID_SERIAL. Sessions
+/// are listed in a collapsible left rail, grouped into user-named groups —
+/// tabs drag-reorder within and across groups, groups drag-reorder among
+/// themselves — and every session keeps running (scrollback intact) while you
+/// work in other features.
 struct TerminalView: View {
     @Environment(AppState.self) private var state
     @State private var renaming: TerminalManager.Tab?
+    @State private var renamingGroup: TerminalTabs.Group?
     @State private var renameDraft = ""
+    @AppStorage("terminalRailCollapsed") private var railCollapsed = false
+    /// The tab/group being dragged in the rail; rows live-reorder as the drag
+    /// passes over them, so the drop itself only has to clear this.
+    @State private var draggedTabID: UUID?
+    @State private var draggedGroupID: UUID?
 
     private var terminals: TerminalManager { state.terminals }
 
     var body: some View {
-        VStack(spacing: 0) {
-            tabStrip
+        HStack(spacing: 0) {
+            rail
             Divider()
             content
         }
@@ -106,7 +181,7 @@ struct TerminalView: View {
         // The menu bar's Rename Terminal… (⇧⌘R) can't reach this view's dialog
         // state directly — it posts a request on the manager instead.
         .onChange(of: terminals.renameRequestID) { _, id in
-            guard let id, let tab = terminals.tabs.first(where: { $0.id == id }) else { return }
+            guard let id, let tab = terminals.tab(id) else { return }
             terminals.renameRequestID = nil
             beginRename(tab)
         }
@@ -120,9 +195,19 @@ struct TerminalView: View {
         } message: {
             Text("Give this shell a name that says what it's for.")
         }
+        .alert("Rename group", isPresented: renameGroupBinding) {
+            TextField("Name", text: $renameDraft)
+            Button("Rename") {
+                if let group = renamingGroup { terminals.renameGroup(group.id, to: renameDraft) }
+                renamingGroup = nil
+            }
+            Button("Cancel", role: .cancel) { renamingGroup = nil }
+        } message: {
+            Text("Name this group of shells.")
+        }
     }
 
-    /// Binding the alert can dismiss without losing which tab it targets.
+    /// Bindings the alerts can dismiss without losing which target they held.
     private var renameBinding: Binding<Bool> {
         Binding(
             get: { renaming != nil },
@@ -130,62 +215,133 @@ struct TerminalView: View {
         )
     }
 
-    /// The chips' natural width and the strip's full width, so the + button
-    /// can trail the last tab while everything fits and pin to the right edge
-    /// once the tabs overflow. The chips are measured without the button, so
-    /// the threshold can't feed back into itself.
-    @State private var chipsWidth: CGFloat = 0
-    @State private var stripWidth: CGFloat = .infinity
-
-    private var plusIsPinned: Bool {
-        // chips + inline button (28) + row spacing (4) + content padding (16)
-        chipsWidth + 48 > stripWidth
+    private var renameGroupBinding: Binding<Bool> {
+        Binding(
+            get: { renamingGroup != nil },
+            set: { if !$0 { renamingGroup = nil } }
+        )
     }
 
-    private var tabStrip: some View {
-        HStack(spacing: 4) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 4) {
-                    HStack(spacing: 4) {
-                        ForEach(terminals.tabs) { tab in
-                            chip(tab)
+    // MARK: - Rail
+
+    @ViewBuilder
+    private var rail: some View {
+        if railCollapsed {
+            collapsedRail
+        } else {
+            expandedRail
+        }
+    }
+
+    /// The thin strip the rail collapses to: expand + new-shell, nothing else.
+    private var collapsedRail: some View {
+        VStack(spacing: 6) {
+            railButton("sidebar.left", help: "Show the terminal list") {
+                railCollapsed = false
+            }
+            railButton("plus", help: "New terminal") {
+                terminals.newTab()
+            }
+            Spacer()
+        }
+        .padding(.vertical, 6)
+        .frame(width: 32)
+        .background(.bgSurface)
+    }
+
+    private var expandedRail: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(spacing: 1) {
+                    ForEach(terminals.layout.groups) { group in
+                        groupHeader(group)
+                        if !group.isCollapsed {
+                            ForEach(terminals.tabs(in: group)) { tab in
+                                tabRow(tab)
+                            }
                         }
                     }
-                    .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { chipsWidth = $0 }
-
-                    if !plusIsPinned {
-                        newTabButton
-                    }
                 }
-                .padding(.horizontal, 8)
+                .padding(6)
             }
+            // A drag released over the empty tail of the rail lands the tab at
+            // the very end (the last group), instead of dying with no target.
+            .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
+                terminals: terminals, draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+            ))
 
-            if plusIsPinned {
-                Spacer(minLength: 4)
-                newTabButton
-                    .padding(.trailing, 6)
+            Divider()
+
+            HStack(spacing: 4) {
+                railButton("plus", help: "New terminal") {
+                    terminals.newTab()
+                }
+                railButton("folder.badge.plus", help: "New group") {
+                    let id = terminals.addGroup()
+                    if let group = terminals.layout.group(id) { beginRenameGroup(group) }
+                }
+                Spacer()
+                railButton("sidebar.left", help: "Hide the terminal list") {
+                    railCollapsed = true
+                }
             }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 5)
         }
-        .frame(height: 36)
+        .frame(width: 190)
         .background(.bgSurface)
-        .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { stripWidth = $0 }
     }
 
-    private var newTabButton: some View {
-        Button {
-            terminals.newTab()
-        } label: {
-            Image(systemName: "plus")
+    private func railButton(_ symbol: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
                 .font(.callout.weight(.medium))
                 .foregroundStyle(.textMuted)
-                .frame(width: 28, height: 28)
+                .frame(width: 24, height: 24)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("New terminal")
+        .help(help)
     }
 
-    private func chip(_ tab: TerminalManager.Tab) -> some View {
+    private func groupHeader(_ group: TerminalTabs.Group) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 8, weight: .bold))
+                .rotationEffect(.degrees(group.isCollapsed ? 0 : 90))
+                .foregroundStyle(.textMuted)
+            Text(group.name)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .foregroundStyle(.textMuted)
+            Text("\(group.tabIDs.count)")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 6)
+        .frame(height: 24)
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2) { beginRenameGroup(group) }
+        .onTapGesture { terminals.toggleCollapsed(group.id) }
+        .contextMenu {
+            Button("New Terminal Here") { terminals.newTab(inGroup: group.id) }
+            Button("Rename…") { beginRenameGroup(group) }
+            Divider()
+            Button("Close Group") { state.closeTerminalGroup(group.id) }
+        }
+        .opacity(draggedGroupID == group.id ? 0.4 : 1)
+        .onDrag {
+            draggedGroupID = group.id
+            return NSItemProvider(object: "group:\(group.id.uuidString)" as NSString)
+        }
+        .onDrop(of: [.plainText], delegate: GroupHeaderDropDelegate(
+            group: group.id, terminals: terminals,
+            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+        ))
+    }
+
+    private func tabRow(_ tab: TerminalManager.Tab) -> some View {
         let isActive = tab.id == terminals.activeID
         return HStack(spacing: 6) {
             Image(systemName: "terminal")
@@ -195,6 +351,7 @@ struct TerminalView: View {
                 .font(.callout)
                 .lineLimit(1)
                 .foregroundStyle(isActive ? AnyShapeStyle(.textMain) : AnyShapeStyle(.textMuted))
+            Spacer(minLength: 0)
             Button {
                 state.closeTerminalShell(tab.id)
             } label: {
@@ -207,12 +364,11 @@ struct TerminalView: View {
             .buttonStyle(.plain)
             .help("Close this terminal (kills its shell)")
         }
-        .padding(.leading, 10)
+        .padding(.leading, 18)
         .padding(.trailing, 5)
-        .frame(height: 28)
-        .frame(maxWidth: 190)
+        .frame(height: 26)
         .background(
-            RoundedRectangle(cornerRadius: 7)
+            RoundedRectangle(cornerRadius: 6)
                 .fill(isActive ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear))
         )
         .contentShape(Rectangle())
@@ -220,8 +376,29 @@ struct TerminalView: View {
         .onTapGesture { terminals.activeID = tab.id }
         .contextMenu {
             Button("Rename…") { beginRename(tab) }
+            moveToGroupMenu(for: tab)
             Divider()
             Button("Close Terminal") { state.closeTerminalShell(tab.id) }
+        }
+        .opacity(draggedTabID == tab.id ? 0.4 : 1)
+        .onDrag {
+            draggedTabID = tab.id
+            return NSItemProvider(object: "tab:\(tab.id.uuidString)" as NSString)
+        }
+        .onDrop(of: [.plainText], delegate: TabRowDropDelegate(
+            row: tab.id, terminals: terminals,
+            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+        ))
+    }
+
+    @ViewBuilder
+    private func moveToGroupMenu(for tab: TerminalManager.Tab) -> some View {
+        let currentGroup = terminals.layout.groupID(ofTab: tab.id)
+        Menu("Move to Group") {
+            ForEach(terminals.layout.groups) { group in
+                Button(group.name) { terminals.moveTab(tab.id, toEndOfGroup: group.id) }
+                    .disabled(group.id == currentGroup)
+            }
         }
     }
 
@@ -229,6 +406,13 @@ struct TerminalView: View {
         renameDraft = tab.name
         renaming = tab
     }
+
+    private func beginRenameGroup(_ group: TerminalTabs.Group) {
+        renameDraft = group.name
+        renamingGroup = group
+    }
+
+    // MARK: - Content
 
     @ViewBuilder
     private var content: some View {
@@ -241,11 +425,87 @@ struct TerminalView: View {
                     serial: state.targetSerials.first,
                     isActive: tab.id == terminals.activeID
                 )
-                    .opacity(tab.id == terminals.activeID ? 1 : 0)
-                    .allowsHitTesting(tab.id == terminals.activeID)
+                .opacity(tab.id == terminals.activeID ? 1 : 0)
+                .allowsHitTesting(tab.id == terminals.activeID)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.black)
+    }
+}
+
+// MARK: - Rail drag & drop
+
+/// Rows reorder live as the drag passes over them (`dropEntered`), so these
+/// delegates never decode the item provider — the dragged id travels in the
+/// view's `draggedTabID`/`draggedGroupID` state instead.
+private struct TabRowDropDelegate: DropDelegate {
+    let row: UUID
+    let terminals: TerminalManager
+    @Binding var draggedTabID: UUID?
+    @Binding var draggedGroupID: UUID?
+
+    func dropEntered(info: DropInfo) {
+        guard let dragged = draggedTabID, dragged != row else { return }
+        terminals.moveTab(dragged, before: row)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedTabID = nil
+        draggedGroupID = nil
+        return true
+    }
+}
+
+/// A tab dragged onto a group header appends to that group (works for
+/// collapsed groups too); a group dragged onto another header reorders the
+/// groups.
+private struct GroupHeaderDropDelegate: DropDelegate {
+    let group: UUID
+    let terminals: TerminalManager
+    @Binding var draggedTabID: UUID?
+    @Binding var draggedGroupID: UUID?
+
+    func dropEntered(info: DropInfo) {
+        if let dragged = draggedTabID {
+            terminals.moveTab(dragged, toEndOfGroup: group)
+        } else if let dragged = draggedGroupID, dragged != group {
+            terminals.moveGroup(dragged, before: group)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedTabID = nil
+        draggedGroupID = nil
+        return true
+    }
+}
+
+/// The rail's empty tail: dropping a tab there sends it to the very end; a
+/// group goes last. Also the safety net that clears the drag state when the
+/// drop lands on no row at all.
+private struct RailTailDropDelegate: DropDelegate {
+    let terminals: TerminalManager
+    @Binding var draggedTabID: UUID?
+    @Binding var draggedGroupID: UUID?
+
+    func dropEntered(info: DropInfo) {
+        if let dragged = draggedTabID, let last = terminals.layout.groups.last {
+            terminals.moveTab(dragged, toEndOfGroup: last.id)
+        } else if let dragged = draggedGroupID {
+            terminals.moveGroupToEnd(dragged)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedTabID = nil
+        draggedGroupID = nil
+        return true
     }
 }

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -252,23 +252,33 @@ struct TerminalView: View {
     private var expandedRail: some View {
         VStack(spacing: 0) {
             ScrollView {
-                LazyVStack(spacing: 1) {
-                    ForEach(terminals.layout.groups) { group in
-                        groupHeader(group)
-                        if !group.isCollapsed {
-                            ForEach(terminals.tabs(in: group)) { tab in
-                                tabRow(tab)
+                VStack(spacing: 0) {
+                    LazyVStack(spacing: 1) {
+                        ForEach(terminals.layout.groups) { group in
+                            groupHeader(group)
+                            if !group.isCollapsed {
+                                ForEach(terminals.tabs(in: group)) { tab in
+                                    tabRow(tab)
+                                }
                             }
                         }
                     }
+                    .padding(6)
+
+                    // The empty tail below the rows: dropping a drag here
+                    // lands it at the very end. A bounded zone, not the whole
+                    // scroll view — a whole-view target also caught the drag
+                    // crossing the gaps between rows and teleported the tab
+                    // to the end mid-drag.
+                    Color.clear
+                        .frame(height: 48)
+                        .contentShape(Rectangle())
+                        .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
+                            terminals: terminals,
+                            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+                        ))
                 }
-                .padding(6)
             }
-            // A drag released over the empty tail of the rail lands the tab at
-            // the very end (the last group), instead of dying with no target.
-            .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
-                terminals: terminals, draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
-            ))
 
             Divider()
 

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -173,6 +173,18 @@ struct TerminalView: View {
             Divider()
             content
         }
+        // A rail drag released outside the rail (over the shells, most often)
+        // never reaches a rail drop delegate, which would leave the dragged
+        // row stuck dimmed. Catch those here and clear the drag state — only
+        // a target while a rail drag is in flight, so it never swallows text
+        // drops headed for the terminal.
+        .onDrop(of: [.plainText], delegate: TabDragCancelCatch(
+            isDragging: draggedTabID != nil || draggedGroupID != nil,
+            clear: {
+                draggedTabID = nil
+                draggedGroupID = nil
+            }
+        ))
         // A first visit opens a shell right away — an empty terminal screen
         // with a lone + button would just be a speed bump.
         .task {

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -166,10 +166,13 @@ struct TerminalView: View {
     @State private var renamingGroup: TerminalTabs.Group?
     @State private var renameDraft = ""
     @AppStorage("terminalRailCollapsed") private var railCollapsed = false
-    /// The tab/group being dragged in the rail; rows live-reorder as the drag
-    /// passes over them, so the drop itself only has to clear this.
+    /// The tab/group being dragged in the rail. Rows hold still while an accent
+    /// insertion guideline (`dropSlot`) shows where the drop will land; the move
+    /// itself happens on drop.
     @State private var draggedTabID: UUID?
     @State private var draggedGroupID: UUID?
+    /// Where the insertion guideline is drawn during a rail drag.
+    @State private var dropSlot: RailDropSlot?
 
     private var terminals: TerminalManager { state.terminals }
 
@@ -189,6 +192,7 @@ struct TerminalView: View {
             clear: {
                 draggedTabID = nil
                 draggedGroupID = nil
+                dropSlot = nil
             }
         ))
         // A first visit opens a shell right away — an empty terminal screen
@@ -298,9 +302,13 @@ struct TerminalView: View {
                         .frame(minHeight: 56)
                         .frame(maxHeight: .infinity)
                         .contentShape(Rectangle())
+                        .overlay(alignment: .top) {
+                            guideline(dropSlot == .railEnd).padding(.horizontal, 8)
+                        }
                         .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
                             terminals: terminals,
-                            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+                            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
+                            dropSlot: $dropSlot
                         ))
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
@@ -363,13 +371,18 @@ struct TerminalView: View {
             Button("Close Group") { state.closeTerminalGroup(group.id) }
         }
         .opacity(draggedGroupID == group.id ? 0.4 : 1)
+        // Above the header → a group reorders here; below it → a tab joins the
+        // group.
+        .overlay(alignment: .top) { guideline(dropSlot == .beforeGroup(group.id)).offset(y: -1) }
+        .overlay(alignment: .bottom) { guideline(dropSlot == .intoGroup(group.id)).offset(y: 1) }
         .onDrag {
             draggedGroupID = group.id
             return NSItemProvider(object: "group:\(group.id.uuidString)" as NSString)
         }
         .onDrop(of: [.plainText], delegate: GroupHeaderDropDelegate(
             group: group.id, terminals: terminals,
-            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
+            dropSlot: $dropSlot
         ))
     }
 
@@ -418,14 +431,39 @@ struct TerminalView: View {
             Button("Close Terminal") { state.closeTerminalShell(tab.id) }
         }
         .opacity(draggedTabID == tab.id ? 0.4 : 1)
+        // A tab drops before this row; a group dragged over a loose row
+        // interleaves before it. Both draw the guideline above the row.
+        .overlay(alignment: .top) {
+            guideline(dropSlot == .beforeTab(tab.id) || (!indented && dropSlot == .beforeGroup(tab.id)))
+                .offset(y: -1)
+        }
         .onDrag {
             draggedTabID = tab.id
             return NSItemProvider(object: "tab:\(tab.id.uuidString)" as NSString)
         }
         .onDrop(of: [.plainText], delegate: TabRowDropDelegate(
-            row: tab.id, terminals: terminals,
-            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
+            row: tab.id, isLoose: !indented, terminals: terminals,
+            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
+            dropSlot: $dropSlot
         ))
+    }
+
+    /// The accent insertion indicator shown at a drop slot — a thin capped line,
+    /// matching the sidebar's guideline.
+    @ViewBuilder
+    private func guideline(_ show: Bool) -> some View {
+        if show {
+            HStack(spacing: 0) {
+                guidelineCap
+                Rectangle().fill(Color.brandAccent).frame(height: 2)
+                guidelineCap
+            }
+            .frame(height: 6)
+        }
+    }
+
+    private var guidelineCap: some View {
+        RoundedRectangle(cornerRadius: 1).fill(Color.brandAccent).frame(width: 3, height: 6)
     }
 
     private func beginRename(_ tab: TerminalManager.Tab) {
@@ -462,83 +500,132 @@ struct TerminalView: View {
 
 // MARK: - Rail drag & drop
 
-/// Rows reorder live as the drag passes over them (`dropEntered`), so these
-/// delegates never decode the item provider — the dragged id travels in the
-/// view's `draggedTabID`/`draggedGroupID` state instead.
+/// Where the insertion guideline is drawn during a rail drag. The delegates
+/// set it as the drag moves and the matching row draws the accent line; the
+/// move is applied only on drop.
+private enum RailDropSlot: Equatable {
+    case beforeTab(UUID)     // guideline above a tab row
+    case intoGroup(UUID)     // guideline below a group header — a tab joins the group
+    case beforeGroup(UUID)   // guideline above a group header (or a loose tab) — a group reorders here
+    case railEnd             // guideline at the rail's bottom — loose end / group to end
+}
+
+/// One tab row's drop target. A dragged tab drops before this row (loose or
+/// grouped, matching the row's context); a dragged group interleaves before a
+/// *loose* row. Rows hold still — only `dropSlot` changes — until the drop.
 private struct TabRowDropDelegate: DropDelegate {
     let row: UUID
+    let isLoose: Bool
     let terminals: TerminalManager
     @Binding var draggedTabID: UUID?
     @Binding var draggedGroupID: UUID?
+    @Binding var dropSlot: RailDropSlot?
 
-    func dropEntered(info: DropInfo) {
-        if let dragged = draggedTabID, dragged != row {
-            // Before a loose row → stays loose; before a grouped row → joins
-            // that group. The model reads the target's context.
-            terminals.moveTab(dragged, before: row)
-        } else if let dragged = draggedGroupID {
-            // Dragging a group over a loose tab interleaves it there (a no-op
-            // over a grouped row, whose id isn't a top-level entry).
-            terminals.moveGroup(dragged, before: row)
-        }
+    private var slot: RailDropSlot? {
+        if let dragged = draggedTabID, dragged != row { return .beforeTab(row) }
+        // A group targets a loose row (its id is a top-level entry); a grouped
+        // row isn't, so a group drag there would be a no-op — offer no slot.
+        if draggedGroupID != nil, isLoose { return .beforeGroup(row) }
+        return nil
     }
 
-    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+    func validateDrop(info: DropInfo) -> Bool { slot != nil }
+    func dropEntered(info: DropInfo) { dropSlot = slot }
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        dropSlot = slot
+        return slot == nil ? nil : DropProposal(operation: .move)
+    }
+    func dropExited(info: DropInfo) { if dropSlot == slot { dropSlot = nil } }
 
     func performDrop(info: DropInfo) -> Bool {
-        draggedTabID = nil
-        draggedGroupID = nil
-        return true
+        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
+        if let dragged = draggedTabID, dragged != row {
+            terminals.moveTab(dragged, before: row)
+            return true
+        }
+        if let dragged = draggedGroupID, isLoose {
+            terminals.moveGroup(dragged, before: row)
+            return true
+        }
+        return false
     }
 }
 
-/// A tab dragged onto a group header appends to that group (works for
-/// collapsed groups too); a group dragged onto another header reorders the
-/// groups.
+/// A group header's drop target: a dragged tab joins the group (guideline
+/// below the header); a dragged group reorders before it (guideline above).
 private struct GroupHeaderDropDelegate: DropDelegate {
     let group: UUID
     let terminals: TerminalManager
     @Binding var draggedTabID: UUID?
     @Binding var draggedGroupID: UUID?
+    @Binding var dropSlot: RailDropSlot?
 
-    func dropEntered(info: DropInfo) {
-        if let dragged = draggedTabID {
-            terminals.moveTab(dragged, toEndOfGroup: group)
-        } else if let dragged = draggedGroupID, dragged != group {
-            terminals.moveGroup(dragged, before: group)
-        }
+    private var slot: RailDropSlot? {
+        if draggedTabID != nil { return .intoGroup(group) }
+        if let dragged = draggedGroupID, dragged != group { return .beforeGroup(group) }
+        return nil
     }
 
-    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+    func validateDrop(info: DropInfo) -> Bool { slot != nil }
+    func dropEntered(info: DropInfo) { dropSlot = slot }
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        dropSlot = slot
+        return slot == nil ? nil : DropProposal(operation: .move)
+    }
+    func dropExited(info: DropInfo) { if dropSlot == slot { dropSlot = nil } }
 
     func performDrop(info: DropInfo) -> Bool {
-        draggedTabID = nil
-        draggedGroupID = nil
-        return true
+        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
+        if let dragged = draggedTabID {
+            terminals.moveTab(dragged, toEndOfGroup: group)
+            return true
+        }
+        if let dragged = draggedGroupID, dragged != group {
+            terminals.moveGroup(dragged, before: group)
+            return true
+        }
+        return false
     }
 }
 
-/// The rail's empty tail: dropping a tab there sends it to the very end as a
-/// loose tab (also how a tab leaves its group); a group goes last. Also the
-/// safety net that clears the drag state when a drop lands on no row at all.
+/// The rail's empty tail: a tab drops to the very end as loose (also how a tab
+/// leaves its group); a group goes last. Also the safety net that clears the
+/// drag state when a drop lands on no row at all.
 private struct RailTailDropDelegate: DropDelegate {
     let terminals: TerminalManager
     @Binding var draggedTabID: UUID?
     @Binding var draggedGroupID: UUID?
+    @Binding var dropSlot: RailDropSlot?
 
-    func dropEntered(info: DropInfo) {
-        if let dragged = draggedTabID {
-            terminals.moveTabToLooseEnd(dragged)
-        } else if let dragged = draggedGroupID {
-            terminals.moveGroupToEnd(dragged)
-        }
+    private var isDragging: Bool { draggedTabID != nil || draggedGroupID != nil }
+
+    func validateDrop(info: DropInfo) -> Bool { isDragging }
+    func dropEntered(info: DropInfo) { if isDragging { dropSlot = .railEnd } }
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        if isDragging { dropSlot = .railEnd }
+        return isDragging ? DropProposal(operation: .move) : nil
     }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
+    func dropExited(info: DropInfo) { if dropSlot == .railEnd { dropSlot = nil } }
 
     func performDrop(info: DropInfo) -> Bool {
-        draggedTabID = nil
-        draggedGroupID = nil
-        return true
+        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
+        if let dragged = draggedTabID {
+            terminals.moveTabToLooseEnd(dragged)
+            return true
+        }
+        if let dragged = draggedGroupID {
+            terminals.moveGroupToEnd(dragged)
+            return true
+        }
+        return false
     }
+}
+
+/// Reset every rail drag binding once a drop resolves.
+private func clearRailDrag(
+    _ tab: inout UUID?, _ group: inout UUID?, _ slot: inout RailDropSlot?
+) {
+    tab = nil
+    group = nil
+    slot = nil
 }

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -42,8 +42,8 @@ final class TerminalManager {
         group.tabIDs.compactMap { tabsByID[$0] }
     }
 
-    /// Open a fresh shell tab and focus it. It lands in `group` when given,
-    /// else next to the active tab, else in the last group.
+    /// Open a fresh shell tab and focus it. It joins `group` when given, else
+    /// the active tab's group, else lands loose — a fresh rail has no groups.
     func newTab(inGroup group: UUID? = nil) {
         counter += 1
         let tab = Tab(name: "Terminal \(counter)", session: TerminalSession())
@@ -97,11 +97,12 @@ final class TerminalManager {
 
     // MARK: - Groups
 
-    /// Add an empty group at the end, named "Group N" until the user renames.
+    /// Wrap a tab in a new group, named "Group N" until the user renames it.
+    /// Returns the group id so the view can open its rename dialog.
     @discardableResult
-    func addGroup() -> UUID {
+    func newGroup(containing tab: UUID) -> UUID? {
         groupCounter += 1
-        return layout.addGroup(named: "Group \(groupCounter)")
+        return layout.newGroup(named: "Group \(groupCounter)", containing: tab)
     }
 
     func renameGroup(_ id: UUID, to name: String) {
@@ -114,12 +115,12 @@ final class TerminalManager {
     }
 
     /// Kill every shell in the group and remove it. Focus falls off the last
-    /// closed tab's neighbor like a single close does.
+    /// closed tab's neighbor like a single close does. (Each `close` empties
+    /// the group a tab at a time; the model drops it once the last one goes.)
     func closeGroup(_ id: UUID) {
         for tabID in layout.group(id)?.tabIDs ?? [] {
             close(tabID)
         }
-        layout.removeGroup(id)
     }
 
     func moveTab(_ id: UUID, before target: UUID) {
@@ -128,6 +129,11 @@ final class TerminalManager {
 
     func moveTab(_ id: UUID, toEndOfGroup group: UUID) {
         layout.move(tab: id, toEndOfGroup: group)
+    }
+
+    /// Drag a tab out to the end of the rail as a loose tab.
+    func moveTabToLooseEnd(_ id: UUID) {
+        layout.moveToLooseEnd(tab: id)
     }
 
     func moveGroup(_ id: UUID, before target: UUID) {
@@ -150,10 +156,10 @@ final class TerminalManager {
 
 /// A real multi-tab terminal: each tab is its own PTY-backed login shell
 /// (SwiftTerm), with the selected device exported as ANDROID_SERIAL. Sessions
-/// are listed in a collapsible left rail, grouped into user-named groups —
-/// tabs drag-reorder within and across groups, groups drag-reorder among
-/// themselves — and every session keeps running (scrollback intact) while you
-/// work in other features.
+/// are listed in a collapsible left rail — loose (ungrouped) by default; a
+/// right-click wraps a tab in a new group, tabs and groups drag-reorder and
+/// interleave, and a group deletes itself once its last tab leaves. Every
+/// session keeps running (scrollback intact) while you work in other features.
 struct TerminalView: View {
     @Environment(AppState.self) private var state
     @State private var renaming: TerminalManager.Tab?
@@ -265,31 +271,39 @@ struct TerminalView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 0) {
-                    LazyVStack(spacing: 1) {
-                        ForEach(terminals.layout.groups) { group in
-                            groupHeader(group)
-                            if !group.isCollapsed {
-                                ForEach(terminals.tabs(in: group)) { tab in
-                                    tabRow(tab)
+                    LazyVStack(spacing: 2) {
+                        // Loose tabs and groups interleave in one ordered list;
+                        // a tab dragged out of a group lands where it's dropped.
+                        ForEach(terminals.layout.entries) { entry in
+                            switch entry {
+                            case .tab(let id):
+                                if let tab = terminals.tab(id) { tabRow(tab, indented: false) }
+                            case .group(let group):
+                                groupHeader(group)
+                                if !group.isCollapsed {
+                                    ForEach(terminals.tabs(in: group)) { tab in
+                                        tabRow(tab, indented: true)
+                                    }
                                 }
                             }
                         }
                     }
-                    .padding(6)
+                    .padding(8)
 
                     // The empty tail below the rows: dropping a drag here
-                    // lands it at the very end. A bounded zone, not the whole
-                    // scroll view — a whole-view target also caught the drag
-                    // crossing the gaps between rows and teleported the tab
-                    // to the end mid-drag.
+                    // lands it at the very end (loose). A bounded zone, not the
+                    // whole scroll view — a whole-view target also caught the
+                    // drag crossing the gaps between rows and teleported it.
                     Color.clear
-                        .frame(height: 48)
+                        .frame(minHeight: 56)
+                        .frame(maxHeight: .infinity)
                         .contentShape(Rectangle())
                         .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
                             terminals: terminals,
                             draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
                         ))
                 }
+                .frame(maxHeight: .infinity, alignment: .top)
             }
 
             Divider()
@@ -298,19 +312,15 @@ struct TerminalView: View {
                 railButton("plus", help: "New terminal") {
                     terminals.newTab()
                 }
-                railButton("folder.badge.plus", help: "New group") {
-                    let id = terminals.addGroup()
-                    if let group = terminals.layout.group(id) { beginRenameGroup(group) }
-                }
                 Spacer()
                 railButton("sidebar.left", help: "Hide the terminal list") {
                     railCollapsed = true
                 }
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 5)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
         }
-        .frame(width: 190)
+        .frame(width: 210)
         .background(.bgSurface)
     }
 
@@ -319,7 +329,7 @@ struct TerminalView: View {
             Image(systemName: symbol)
                 .font(.callout.weight(.medium))
                 .foregroundStyle(.textMuted)
-                .frame(width: 24, height: 24)
+                .frame(width: 26, height: 26)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -327,22 +337,22 @@ struct TerminalView: View {
     }
 
     private func groupHeader(_ group: TerminalTabs.Group) -> some View {
-        HStack(spacing: 5) {
+        HStack(spacing: 6) {
             Image(systemName: "chevron.right")
-                .font(.system(size: 8, weight: .bold))
+                .font(.system(size: 9, weight: .bold))
                 .rotationEffect(.degrees(group.isCollapsed ? 0 : 90))
                 .foregroundStyle(.textMuted)
             Text(group.name)
-                .font(.caption.weight(.semibold))
+                .font(.callout.weight(.semibold))
                 .lineLimit(1)
                 .foregroundStyle(.textMuted)
             Text("\(group.tabIDs.count)")
-                .font(.caption2)
+                .font(.caption)
                 .foregroundStyle(.tertiary)
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 6)
-        .frame(height: 24)
+        .padding(.horizontal, 8)
+        .frame(height: 30)
         .contentShape(Rectangle())
         .onTapGesture(count: 2) { beginRenameGroup(group) }
         .onTapGesture { terminals.toggleCollapsed(group.id) }
@@ -363,11 +373,11 @@ struct TerminalView: View {
         ))
     }
 
-    private func tabRow(_ tab: TerminalManager.Tab) -> some View {
+    private func tabRow(_ tab: TerminalManager.Tab, indented: Bool) -> some View {
         let isActive = tab.id == terminals.activeID
-        return HStack(spacing: 6) {
+        return HStack(spacing: 8) {
             Image(systemName: "terminal")
-                .font(.caption)
+                .font(.body)
                 .foregroundStyle(isActive ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
             Text(tab.name)
                 .font(.callout)
@@ -378,19 +388,19 @@ struct TerminalView: View {
                 state.closeTerminalShell(tab.id)
             } label: {
                 Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: 10, weight: .bold))
                     .foregroundStyle(.textMuted)
-                    .frame(width: 16, height: 16)
+                    .frame(width: 20, height: 20)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .help("Close this terminal (kills its shell)")
         }
-        .padding(.leading, 18)
-        .padding(.trailing, 5)
-        .frame(height: 26)
+        .padding(.leading, indented ? 22 : 10)
+        .padding(.trailing, 6)
+        .frame(height: 34)
         .background(
-            RoundedRectangle(cornerRadius: 6)
+            RoundedRectangle(cornerRadius: 7)
                 .fill(isActive ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear))
         )
         .contentShape(Rectangle())
@@ -398,7 +408,12 @@ struct TerminalView: View {
         .onTapGesture { terminals.activeID = tab.id }
         .contextMenu {
             Button("Rename…") { beginRename(tab) }
-            moveToGroupMenu(for: tab)
+            Button("New Group…") {
+                if let id = terminals.newGroup(containing: tab.id),
+                   let group = terminals.layout.group(id) {
+                    beginRenameGroup(group)
+                }
+            }
             Divider()
             Button("Close Terminal") { state.closeTerminalShell(tab.id) }
         }
@@ -411,17 +426,6 @@ struct TerminalView: View {
             row: tab.id, terminals: terminals,
             draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID
         ))
-    }
-
-    @ViewBuilder
-    private func moveToGroupMenu(for tab: TerminalManager.Tab) -> some View {
-        let currentGroup = terminals.layout.groupID(ofTab: tab.id)
-        Menu("Move to Group") {
-            ForEach(terminals.layout.groups) { group in
-                Button(group.name) { terminals.moveTab(tab.id, toEndOfGroup: group.id) }
-                    .disabled(group.id == currentGroup)
-            }
-        }
     }
 
     private func beginRename(_ tab: TerminalManager.Tab) {
@@ -468,8 +472,15 @@ private struct TabRowDropDelegate: DropDelegate {
     @Binding var draggedGroupID: UUID?
 
     func dropEntered(info: DropInfo) {
-        guard let dragged = draggedTabID, dragged != row else { return }
-        terminals.moveTab(dragged, before: row)
+        if let dragged = draggedTabID, dragged != row {
+            // Before a loose row → stays loose; before a grouped row → joins
+            // that group. The model reads the target's context.
+            terminals.moveTab(dragged, before: row)
+        } else if let dragged = draggedGroupID {
+            // Dragging a group over a loose tab interleaves it there (a no-op
+            // over a grouped row, whose id isn't a top-level entry).
+            terminals.moveGroup(dragged, before: row)
+        }
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? { DropProposal(operation: .move) }
@@ -507,17 +518,17 @@ private struct GroupHeaderDropDelegate: DropDelegate {
     }
 }
 
-/// The rail's empty tail: dropping a tab there sends it to the very end; a
-/// group goes last. Also the safety net that clears the drag state when the
-/// drop lands on no row at all.
+/// The rail's empty tail: dropping a tab there sends it to the very end as a
+/// loose tab (also how a tab leaves its group); a group goes last. Also the
+/// safety net that clears the drag state when a drop lands on no row at all.
 private struct RailTailDropDelegate: DropDelegate {
     let terminals: TerminalManager
     @Binding var draggedTabID: UUID?
     @Binding var draggedGroupID: UUID?
 
     func dropEntered(info: DropInfo) {
-        if let dragged = draggedTabID, let last = terminals.layout.groups.last {
-            terminals.moveTab(dragged, toEndOfGroup: last.id)
+        if let dragged = draggedTabID {
+            terminals.moveTabToLooseEnd(dragged)
         } else if let dragged = draggedGroupID {
             terminals.moveGroupToEnd(dragged)
         }

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct DeviceBarView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
-    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
+    @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
     @State private var showBundleManager = false
     @State private var showInstalledApps = false
     @State private var refreshSpin = 0.0

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct DeviceBarView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
     @State private var showBundleManager = false
     @State private var showInstalledApps = false
     @State private var refreshSpin = 0.0
@@ -16,14 +17,16 @@ struct DeviceBarView: View {
         @Bindable var state = state
         HStack(spacing: 10) {
             Button {
-                state.toggleSidebar()
+                state.toggleSidebarMode()
             } label: {
-                Image(systemName: "sidebar.left")
+                Image(systemName: sidebarAutoHide ? "sidebar.leading" : "sidebar.left")
                     .contentShape(Rectangle())
             }
             .buttonStyle(IconButtonStyle())
-            .help("Show or hide the sidebar (⌘B)")
-            .accessibilityLabel("Toggle sidebar")
+            .help(sidebarAutoHide
+                ? "Pin the sidebar (auto-hide is on — hover the left edge to peek)"
+                : "Auto-hide the sidebar (⌘B shows it on demand)")
+            .accessibilityLabel("Toggle sidebar auto-hide")
 
             // Device and bundle are matching icon + pill pairs: identical inner
             // spacing, and both pills draw their own background (no hidden

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -6,7 +6,7 @@ struct RootView: View {
     @Environment(AppState.self) private var state
     @Environment(\.openWindow) private var openWindow
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
-    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
+    @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
     /// Left-pane fraction (0…1) of the editor split; the layout clamps it so
     /// neither pane collapses.
     @AppStorage("tabSplitFraction") private var splitFraction = 0.5

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -365,6 +365,16 @@ struct RootView: View {
                     .transition(.move(edge: .leading))
             }
         }
+        // The Settings ▸ Appearance toggle flips the mode without going
+        // through toggleSidebarMode — apply the same safeguard here: never
+        // leave BOTH the fixed sidebar and the overlay hidden (turning
+        // auto-hide off after ⌘B would silently vanish the sidebar).
+        .onChange(of: sidebarAutoHide) { _, autoHide in
+            state.sidebarOverlayShown = false
+            if !autoHide, !state.sidebarVisible {
+                withAnimation(.easeInOut(duration: 0.18)) { state.sidebarVisible = true }
+            }
+        }
     }
 
     private var overlaySidebarWidth: CGFloat {

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -6,6 +6,7 @@ struct RootView: View {
     @Environment(AppState.self) private var state
     @Environment(\.openWindow) private var openWindow
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
+    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
     /// Left-pane fraction (0…1) of the editor split; the layout clamps it so
     /// neither pane collapses.
     @AppStorage("tabSplitFraction") private var splitFraction = 0.5
@@ -294,7 +295,7 @@ struct RootView: View {
     /// full-height VS Code-style sidebar with a single continuous divider.
     private var split: some View {
         HStack(spacing: 0) {
-            if state.sidebarVisible {
+            if state.sidebarVisible && !sidebarAutoHide {
                 SidebarPaletteView()
                     .frame(width: min(max(sidebarWidth, 300), 460))
                     .transition(.move(edge: .leading).combined(with: .opacity))
@@ -341,6 +342,33 @@ struct RootView: View {
             isDragging: state.draggingTabID != nil,
             clear: { state.draggingTabID = nil }
         ))
+        // Dock-style auto-hide: the sidebar leaves the layout and rides over
+        // the content, revealed by pushing the mouse against the left edge
+        // (or ⌘B) and hidden again once the pointer moves past it. One
+        // continuous-hover tracker on the whole split decides both — a thin
+        // transparent hot-strip never received hover events reliably.
+        .onContinuousHover { phase in
+            guard sidebarAutoHide, case .active(let point) = phase else { return }
+            if point.x <= 8, !state.sidebarOverlayShown {
+                withAnimation(.easeOut(duration: 0.18)) { state.sidebarOverlayShown = true }
+            } else if state.sidebarOverlayShown, point.x > overlaySidebarWidth + 8 {
+                withAnimation(.easeIn(duration: 0.18)) { state.sidebarOverlayShown = false }
+            }
+        }
+        .overlay(alignment: .leading) {
+            if sidebarAutoHide && state.sidebarOverlayShown {
+                SidebarPaletteView()
+                    .frame(width: overlaySidebarWidth)
+                    .background(.bgSurface)
+                    .overlay(alignment: .trailing) { Divider() }
+                    .shadow(color: .black.opacity(0.35), radius: 14, x: 6)
+                    .transition(.move(edge: .leading))
+            }
+        }
+    }
+
+    private var overlaySidebarWidth: CGFloat {
+        min(max(sidebarWidth, 300), 460)
     }
 
     /// The editor area: one pane, or two side by side split by a draggable seam.

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -164,6 +164,7 @@ struct AppearanceSettingsView: View {
     @AppStorage("theme") private var theme = "dark"
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
+    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
     #if DEBUG
     @AppStorage(DevMetrics.overlayEnabledKey) private var showDevMetrics = true
     #endif
@@ -203,6 +204,13 @@ struct AppearanceSettingsView: View {
                     }
                 }
                 Text("Recolors buttons, toggles, selection, and active icons across the app.")
+                    .font(.footnote)
+                    .foregroundStyle(.textMuted)
+            }
+
+            Section("Sidebar") {
+                Toggle("Automatically hide and show the sidebar", isOn: $sidebarAutoHide)
+                Text("The sidebar slides over the content when you push the mouse against the window's left edge — ⌘B also shows it.")
                     .font(.footnote)
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -164,7 +164,7 @@ struct AppearanceSettingsView: View {
     @AppStorage("theme") private var theme = "dark"
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
     @AppStorage("showFeatureNotes") private var showFeatureNotes = false
-    @AppStorage("sidebarAutoHide") private var sidebarAutoHide = false
+    @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
     #if DEBUG
     @AppStorage(DevMetrics.overlayEnabledKey) private var showDevMetrics = true
     #endif

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -754,6 +754,13 @@ final class AppState {
         if terminals.tabs.isEmpty { closeTab("terminal") }
     }
 
+    /// Close a whole rail group, killing each shell in it. Like single
+    /// closes, the Terminal feature tab goes with the last shell.
+    func closeTerminalGroup(_ id: UUID) {
+        terminals.closeGroup(id)
+        if terminals.tabs.isEmpty { closeTab("terminal") }
+    }
+
     /// Give a pane keyboard focus — its `+` focuses it so a new tab lands there.
     func focusGroup(_ index: Int) { workspace.focus(index); persistTabs() }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -171,8 +171,30 @@ final class AppState {
     /// and scrollback survive leaving the feature.
     let terminals = TerminalManager()
 
+    /// With auto-hide on (Settings ▸ Appearance), the sidebar rides over the
+    /// content instead of sitting in the layout; this is that overlay's
+    /// visibility, driven by the left-edge hover zone and ⌘B.
+    var sidebarOverlayShown = false
+
     func toggleSidebar() {
-        withAnimation(.easeInOut(duration: 0.18)) { sidebarVisible.toggle() }
+        if UserDefaults.standard.bool(forKey: "sidebarAutoHide") {
+            withAnimation(.easeInOut(duration: 0.18)) { sidebarOverlayShown.toggle() }
+        } else {
+            withAnimation(.easeInOut(duration: 0.18)) { sidebarVisible.toggle() }
+        }
+    }
+
+    /// The device bar's sidebar button: switches between the fixed sidebar
+    /// and Dock-style auto-hide. Returning to fixed always shows the sidebar —
+    /// a mode flip that leaves everything hidden would read as a dead button.
+    func toggleSidebarMode() {
+        let defaults = UserDefaults.standard
+        let autoHide = !defaults.bool(forKey: "sidebarAutoHide")
+        withAnimation(.easeInOut(duration: 0.18)) {
+            defaults.set(autoHide, forKey: "sidebarAutoHide")
+            sidebarOverlayShown = false
+            if !autoHide { sidebarVisible = true }
+        }
     }
 
     // MARK: - Font scaling (⌘= / ⌘- / ⌘0)

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -4,6 +4,10 @@ import Foundation
 import Observation
 import SwiftUI
 
+/// UserDefaults key for the sidebar's Dock-style auto-hide mode — spelled
+/// once, read via `@AppStorage` in the views and directly here.
+let sidebarAutoHideDefaultsKey = "sidebarAutoHide"
+
 struct Toast: Identifiable, Equatable {
     enum Level: Equatable {
         case success, info, warning, error
@@ -177,7 +181,7 @@ final class AppState {
     var sidebarOverlayShown = false
 
     func toggleSidebar() {
-        if UserDefaults.standard.bool(forKey: "sidebarAutoHide") {
+        if UserDefaults.standard.bool(forKey: sidebarAutoHideDefaultsKey) {
             withAnimation(.easeInOut(duration: 0.18)) { sidebarOverlayShown.toggle() }
         } else {
             withAnimation(.easeInOut(duration: 0.18)) { sidebarVisible.toggle() }
@@ -189,9 +193,9 @@ final class AppState {
     /// a mode flip that leaves everything hidden would read as a dead button.
     func toggleSidebarMode() {
         let defaults = UserDefaults.standard
-        let autoHide = !defaults.bool(forKey: "sidebarAutoHide")
+        let autoHide = !defaults.bool(forKey: sidebarAutoHideDefaultsKey)
         withAnimation(.easeInOut(duration: 0.18)) {
-            defaults.set(autoHide, forKey: "sidebarAutoHide")
+            defaults.set(autoHide, forKey: sidebarAutoHideDefaultsKey)
             sidebarOverlayShown = false
             if !autoHide { sidebarVisible = true }
         }


### PR DESCRIPTION
## Terminal

- **Drag-select auto-scroll.** SwiftTerm computes an auto-scroll velocity when a selection drag passes the viewport edge but never schedules the timer that consumes it, and its mouse handlers are sealed (`public`, not `open`). `DroidTerminalView` hooks `selectionChanged` (open, fires when a drag-selection starts) and drives the scroll from a pointer-watching timer, replaying the drag so the selection extends into revealed rows. Scrolling engages inside an 8pt edge zone — the pane's bottom edge sits at the screen edge where macOS clamps the cursor, so a beyond-the-edge test alone can never fire there — and speeds up the farther the pointer pushes past the edge.
- **Right-click menu** — Copy / Paste / Select All / Find…, validated through SwiftTerm (Copy disabled without a selection).
- **Find bar** — ⌘F opens SwiftTerm's find bar over the scrollback, ⌘G / ⇧⌘G step matches (Edit menu, enabled only while the Terminal is active).
- **Focus on activation** — a shell takes keyboard focus when its tab becomes active, so typing works without a click.
- **Vertical tab rail with groups.** The horizontal chip strip is replaced by a collapsible left rail: user-named groups (create, rename, collapse, close), tabs drag-reorder within and across groups, groups drag-reorder among themselves, drop-on-header appends to that group, and a Move to Group context menu. The grouping/ordering model is a pure `TerminalTabs` type in ADBKit with 22 unit tests; `TerminalManager` keeps its `tabs` API so existing call sites (⌘N, ⇧⌘W, cycling, close prompts) are unchanged.

## Sidebar

- **Auto-hide mode.** The device bar's sidebar button toggles between the fixed sidebar and Dock-style auto-hide (also in Settings ▸ Appearance). Hidden, the sidebar leaves the layout entirely; pushing the mouse against the window's left edge (or ⌘B) slides it over the content, and it hides once the pointer moves past its right edge. The minimum-window-width calculation no longer counts an auto-hidden sidebar.

## Logcat

- **Cross-line selection.** The SwiftUI row list trapped text selection inside each row. The pane is now an `NSTextView`-backed `SelectableLogView`: continuous multi-line selection with native drag auto-scroll, ⌘C, and Select All across the whole buffer. Level colors, search highlighting, filter-by-tag / copy-line context menu, tail-follow with pause-on-scroll-up, and the jump-to-newest button carry over. Appends are incremental and the ring buffer's head-trim deletes characters instead of rebuilding; the follow state also syncs on append, since content growing below the viewport fires no scroll notification (previously the jump button could fail to appear). Reactotron and JS Console keep `LogTailView`.

## Testing

- `swift test`: 605 tests green (22 new for `TerminalTabs`).
- Build with warnings-as-errors clean.
- Verified live: one terminal drag selected 284 lines through scrollback (both directions); a logcat drag selected 308 lines while auto-scrolling; rail, groups, ⌘B overlay, and jump button exercised against a running emulator.