### PR TITLE
Waive CPU overuse incidents during screen mirroring

### DIFF
--- a/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
+++ b/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
@@ -92,10 +92,18 @@ public struct ResourceWatchdog: Sendable {
     }
 
     /// Feed the next sample; returns the threshold events it triggered.
-    public mutating func ingest(_ sample: ResourceSample) -> [ResourceEvent] {
+    ///
+    /// `cpuLimitOverride` replaces the configured CPU limit for this sample only.
+    /// The App layer raises it (to `.infinity`) while a feature that legitimately
+    /// pegs the CPU is on screen — live screen mirroring and recording decode
+    /// H.264 in-process, so ~two busy cores is expected there, not an incident.
+    /// Memory is always judged against the configured limit.
+    public mutating func ingest(
+        _ sample: ResourceSample, cpuLimitOverride: Double? = nil
+    ) -> [ResourceEvent] {
         var events: [ResourceEvent] = []
         if let percent = cpuPercent(for: sample) {
-            Self.step(.cpu, state: &cpu, value: percent, limit: limits.cpuPercent,
+            Self.step(.cpu, state: &cpu, value: percent, limit: cpuLimitOverride ?? limits.cpuPercent,
                       limits: limits, at: sample.uptime, into: &events)
         }
         Self.step(.memory, state: &memory, value: Double(sample.footprintBytes),

--- a/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
@@ -105,6 +105,35 @@ import Testing
         let events = dog.ingest(ResourceSample(uptime: 5, cpuTimeSeconds: 15, footprintBytes: UInt64(1_500 * mb)))
         #expect(events == [.began(metric: .cpu, value: 300, limit: 200)])
     }
+
+    // MARK: - CPU limit override (expected-heavy features)
+
+    @Test func cpuOverrideSuppressesTheIncidentUnderExpectedLoad() {
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1))
+        _ = dog.ingest(cpuSample(at: 0, cpuTime: 0))
+        // 300% CPU, but a mirroring feature is on screen this tick, so it's expected.
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 15), cpuLimitOverride: .infinity).isEmpty)
+    }
+
+    @Test func cpuOverrideRetiresAnInFlightEpisode() {
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1, resetFraction: 0.8))
+        _ = dog.ingest(cpuSample(at: 0, cpuTime: 0))
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 15)).count == 1)   // began at 300%
+        // Mirroring starts mid-episode: the override ends it instead of stranding it.
+        #expect(dog.ingest(cpuSample(at: 10, cpuTime: 25), cpuLimitOverride: .infinity)
+            == [.ended(metric: .cpu, peak: 300, seconds: 5)])
+    }
+
+    @Test func cpuOverrideStillWatchesMemory() {
+        var dog = ResourceWatchdog(limits: .init(
+            cpuPercent: 200, memoryBytes: 1_000 * mb, sustainedSamples: 1))
+        _ = dog.ingest(ResourceSample(uptime: 0, cpuTimeSeconds: 0, footprintBytes: UInt64(100 * mb)))
+        // CPU is waived (mirroring), but a memory-overuse incident still fires.
+        let events = dog.ingest(
+            ResourceSample(uptime: 5, cpuTimeSeconds: 15, footprintBytes: UInt64(1_500 * mb)),
+            cpuLimitOverride: .infinity)
+        #expect(events == [.began(metric: .memory, value: 1_500 * mb, limit: 1_000 * mb)])
+    }
 }
 
 @Suite struct ProcessStatsTests {

--- a/App/Sources/Telemetry/PerformanceMonitor.swift
+++ b/App/Sources/Telemetry/PerformanceMonitor.swift
@@ -18,6 +18,20 @@ final class PerformanceMonitor {
         let openFeatures: [String]
     }
 
+    /// Features that legitimately peg the CPU while on screen: live screen
+    /// mirroring and recording both decode H.264 in-process, so ~two busy cores
+    /// is expected, not an incident. CPU overuse is not reported while one of
+    /// these is on screen; the per-feature baseline (`feature_perf`) still
+    /// records it, and memory is watched regardless.
+    private static let cpuIntensiveFeatures: Set<String> = ["scrcpy", "screen-record"]
+
+    /// Whether a CPU-intensive feature is on screen (focused or open in either
+    /// pane), so CPU-overuse incidents should be waived for this sample.
+    private static func cpuExpectedHigh(_ context: FeatureContext) -> Bool {
+        if let active = context.activeFeature, cpuIntensiveFeatures.contains(active) { return true }
+        return context.openFeatures.contains { cpuIntensiveFeatures.contains($0) }
+    }
+
     private var poller: Task<Void, Never>?
     private var watchdog = ResourceWatchdog()
     private var perFeature = FeaturePerfAggregator()
@@ -34,7 +48,8 @@ final class PerformanceMonitor {
                 guard let self else { return }
                 guard let sample = ProcessStats.sample() else { continue }
                 let context = context()
-                for event in self.watchdog.ingest(sample) {
+                let cpuLimitOverride = Self.cpuExpectedHigh(context) ? Double.infinity : nil
+                for event in self.watchdog.ingest(sample, cpuLimitOverride: cpuLimitOverride) {
                     Telemetry.shared.reportResourceEvent(event, context: context)
                 }
                 if let record = self.perFeature.ingest(sample, feature: context.activeFeature ?? "none") {


### PR DESCRIPTION
## What

The resource watchdog reports a Sentry/PostHog performance incident when the app's own CPU stays over 200% for ~15s. Screen mirroring (`scrcpy`) and screen recording decode H.264 in-process, so ~two busy cores is expected there — the incident fired on 201% against the 200% limit (Sentry `DROIDECTIVE-MAC-16`, seen on `2.8.3+273`). PostHog shows this is the only performance incident recorded in the last 45 days.

## Change

- `ResourceWatchdog.ingest` takes an optional per-sample `cpuLimitOverride`, keeping the threshold logic pure in ADBKit.
- `PerformanceMonitor` raises the CPU limit while `scrcpy` or `screen-record` is on screen, so CPU overuse is not reported for those features. Memory is still watched; the per-feature baseline (`feature_perf`) still records their CPU.
- Three `ResourceWatchdogTests` cover suppression under sustained load, a mid-episode override retiring the episode, and memory incidents still firing.

## Verification

- `swift test` — 587 ADBKit tests pass with `-warnings-as-errors`.
- `make build` succeeds with zero warnings.

Fixes DROIDECTIVE-MAC-16
