### PR TITLE
Bump site hero version to v2.9.0

### DIFF
--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -16,7 +16,7 @@ export const GITHUB_URL = "https://github.com/Droidective/Droidective"
 export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const LATEST_RELEASE_URL = `${GITHUB_URL}/releases/latest`
-export const APP_VERSION = "v2.8.3"
+export const APP_VERSION = "v2.9.0"
 
 export interface PaletteCommand {
   icon: LucideIcon


### PR DESCRIPTION
Follow-up to the v2.9.0 release: `APP_VERSION` in `website/src/lib/content.ts` was still `v2.8.3`, so the hero line ("auto-updates via Sparkle · vX.Y.Z") advertised the old version. Bumps it to `v2.9.0`. Merging redeploys the site via the `pages` job.

The release itself (DMG, GitHub release, appcast) is already correct — this is site copy only.