### PR TITLE
Fix tab drag-and-drop: split/move blocked by mounted Terminal, stuck guideline

### DIFF
--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -187,7 +187,7 @@ struct TerminalView: View {
         // row stuck dimmed. Catch those here and clear the drag state — only
         // a target while a rail drag is in flight, so it never swallows text
         // drops headed for the terminal.
-        .onDrop(of: [.plainText], delegate: TabDragCancelCatch(
+        .onDrop(of: [.terminalRailItem], delegate: TabDragCancelCatch(
             isDragging: draggedTabID != nil || draggedGroupID != nil,
             clear: {
                 draggedTabID = nil
@@ -305,7 +305,7 @@ struct TerminalView: View {
                         .overlay(alignment: .top) {
                             guideline(dropSlot == .railEnd).padding(.horizontal, 8)
                         }
-                        .onDrop(of: [.plainText], delegate: RailTailDropDelegate(
+                        .onDrop(of: [.terminalRailItem], delegate: RailTailDropDelegate(
                             terminals: terminals,
                             draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
                             dropSlot: $dropSlot
@@ -377,9 +377,9 @@ struct TerminalView: View {
         .overlay(alignment: .bottom) { guideline(dropSlot == .intoGroup(group.id)).offset(y: 1) }
         .onDrag {
             draggedGroupID = group.id
-            return NSItemProvider(object: "group:\(group.id.uuidString)" as NSString)
+            return privateDragItem(.terminalRailItem, "group:\(group.id.uuidString)")
         }
-        .onDrop(of: [.plainText], delegate: GroupHeaderDropDelegate(
+        .onDrop(of: [.terminalRailItem], delegate: GroupHeaderDropDelegate(
             group: group.id, terminals: terminals,
             draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
             dropSlot: $dropSlot
@@ -439,9 +439,9 @@ struct TerminalView: View {
         }
         .onDrag {
             draggedTabID = tab.id
-            return NSItemProvider(object: "tab:\(tab.id.uuidString)" as NSString)
+            return privateDragItem(.terminalRailItem, "tab:\(tab.id.uuidString)")
         }
-        .onDrop(of: [.plainText], delegate: TabRowDropDelegate(
+        .onDrop(of: [.terminalRailItem], delegate: TabRowDropDelegate(
             row: tab.id, isLoose: !indented, terminals: terminals,
             draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
             dropSlot: $dropSlot

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -22,6 +22,30 @@ final class TerminalManager {
     private var counter = 0
     private var groupCounter = 0
 
+    /// The rail's drag-in-flight state — which row/group is dragged and where
+    /// the insertion guideline sits. On the manager, not view `@State`, so the
+    /// root drag janitor can clear it when a drag ends without a drop. The
+    /// whole-view drop catch that used to do that job claimed the drag region
+    /// for the entire feature area and killed the pane's tab drops (SwiftUI
+    /// routes a drop to the deepest region under the cursor by *geometry*,
+    /// regardless of whether its declared types match the drag).
+    fileprivate var railDraggedTabID: UUID?
+    fileprivate var railDraggedGroupID: UUID?
+    fileprivate var railDropSlot: RailDropSlot?
+
+    /// True while a rail row/group drag is in flight (the janitor's guard).
+    var railDragActive: Bool {
+        railDraggedTabID != nil || railDraggedGroupID != nil || railDropSlot != nil
+    }
+
+    /// Reset the rail drag state — a drop resolved, or the janitor caught a
+    /// drag that ended with no drop (released over the shells or outside).
+    func clearRailDrag() {
+        railDraggedTabID = nil
+        railDraggedGroupID = nil
+        railDropSlot = nil
+    }
+
     /// Set by `AppState`: a shell ended on its own (the user typed `exit`),
     /// so its tab should close through the same path as the × / ⌘W.
     var onShellExited: ((UUID) -> Void)?
@@ -166,14 +190,6 @@ struct TerminalView: View {
     @State private var renamingGroup: TerminalTabs.Group?
     @State private var renameDraft = ""
     @AppStorage("terminalRailCollapsed") private var railCollapsed = false
-    /// The tab/group being dragged in the rail. Rows hold still while an accent
-    /// insertion guideline (`dropSlot`) shows where the drop will land; the move
-    /// itself happens on drop.
-    @State private var draggedTabID: UUID?
-    @State private var draggedGroupID: UUID?
-    /// Where the insertion guideline is drawn during a rail drag.
-    @State private var dropSlot: RailDropSlot?
-
     private var terminals: TerminalManager { state.terminals }
 
     var body: some View {
@@ -182,19 +198,12 @@ struct TerminalView: View {
             Divider()
             content
         }
-        // A rail drag released outside the rail (over the shells, most often)
-        // never reaches a rail drop delegate, which would leave the dragged
-        // row stuck dimmed. Catch those here and clear the drag state — only
-        // a target while a rail drag is in flight, so it never swallows text
-        // drops headed for the terminal.
-        .onDrop(of: [.terminalRailItem], delegate: TabDragCancelCatch(
-            isDragging: draggedTabID != nil || draggedGroupID != nil,
-            clear: {
-                draggedTabID = nil
-                draggedGroupID = nil
-                dropSlot = nil
-            }
-        ))
+        // No whole-view drop catch here: SwiftUI routes a drop to the deepest
+        // drop region under the cursor by geometry, regardless of type match,
+        // so a feature-wide target — even one listening for a type a tab drag
+        // doesn't carry — killed the pane's drop-to-split while a terminal tab
+        // was mounted. Rail drags that end without a drop are cleared by the
+        // root drag janitor (`RootView.installDragJanitor`) instead.
         // A first visit opens a shell right away — an empty terminal screen
         // with a lone + button would just be a speed bump.
         .task {
@@ -303,12 +312,10 @@ struct TerminalView: View {
                         .frame(maxHeight: .infinity)
                         .contentShape(Rectangle())
                         .overlay(alignment: .top) {
-                            guideline(dropSlot == .railEnd).padding(.horizontal, 8)
+                            guideline(terminals.railDropSlot == .railEnd).padding(.horizontal, 8)
                         }
                         .onDrop(of: [.terminalRailItem], delegate: RailTailDropDelegate(
-                            terminals: terminals,
-                            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
-                            dropSlot: $dropSlot
+                            terminals: terminals
                         ))
                 }
                 .frame(maxHeight: .infinity, alignment: .top)
@@ -370,19 +377,21 @@ struct TerminalView: View {
             Divider()
             Button("Close Group") { state.closeTerminalGroup(group.id) }
         }
-        .opacity(draggedGroupID == group.id ? 0.4 : 1)
+        .opacity(terminals.railDraggedGroupID == group.id ? 0.4 : 1)
         // Above the header → a group reorders here; below it → a tab joins the
         // group.
-        .overlay(alignment: .top) { guideline(dropSlot == .beforeGroup(group.id)).offset(y: -1) }
-        .overlay(alignment: .bottom) { guideline(dropSlot == .intoGroup(group.id)).offset(y: 1) }
+        .overlay(alignment: .top) {
+            guideline(terminals.railDropSlot == .beforeGroup(group.id)).offset(y: -1)
+        }
+        .overlay(alignment: .bottom) {
+            guideline(terminals.railDropSlot == .intoGroup(group.id)).offset(y: 1)
+        }
         .onDrag {
-            draggedGroupID = group.id
+            terminals.railDraggedGroupID = group.id
             return privateDragItem(.terminalRailItem, "group:\(group.id.uuidString)")
         }
         .onDrop(of: [.terminalRailItem], delegate: GroupHeaderDropDelegate(
-            group: group.id, terminals: terminals,
-            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
-            dropSlot: $dropSlot
+            group: group.id, terminals: terminals
         ))
     }
 
@@ -430,21 +439,22 @@ struct TerminalView: View {
             Divider()
             Button("Close Terminal") { state.closeTerminalShell(tab.id) }
         }
-        .opacity(draggedTabID == tab.id ? 0.4 : 1)
+        .opacity(terminals.railDraggedTabID == tab.id ? 0.4 : 1)
         // A tab drops before this row; a group dragged over a loose row
         // interleaves before it. Both draw the guideline above the row.
         .overlay(alignment: .top) {
-            guideline(dropSlot == .beforeTab(tab.id) || (!indented && dropSlot == .beforeGroup(tab.id)))
-                .offset(y: -1)
+            guideline(
+                terminals.railDropSlot == .beforeTab(tab.id)
+                    || (!indented && terminals.railDropSlot == .beforeGroup(tab.id))
+            )
+            .offset(y: -1)
         }
         .onDrag {
-            draggedTabID = tab.id
+            terminals.railDraggedTabID = tab.id
             return privateDragItem(.terminalRailItem, "tab:\(tab.id.uuidString)")
         }
         .onDrop(of: [.terminalRailItem], delegate: TabRowDropDelegate(
-            row: tab.id, isLoose: !indented, terminals: terminals,
-            draggedTabID: $draggedTabID, draggedGroupID: $draggedGroupID,
-            dropSlot: $dropSlot
+            row: tab.id, isLoose: !indented, terminals: terminals
         ))
     }
 
@@ -512,38 +522,38 @@ private enum RailDropSlot: Equatable {
 
 /// One tab row's drop target. A dragged tab drops before this row (loose or
 /// grouped, matching the row's context); a dragged group interleaves before a
-/// *loose* row. Rows hold still — only `dropSlot` changes — until the drop.
+/// *loose* row. Rows hold still — only the manager's `railDropSlot` changes —
+/// until the drop.
 private struct TabRowDropDelegate: DropDelegate {
     let row: UUID
     let isLoose: Bool
     let terminals: TerminalManager
-    @Binding var draggedTabID: UUID?
-    @Binding var draggedGroupID: UUID?
-    @Binding var dropSlot: RailDropSlot?
 
     private var slot: RailDropSlot? {
-        if let dragged = draggedTabID, dragged != row { return .beforeTab(row) }
+        if let dragged = terminals.railDraggedTabID, dragged != row { return .beforeTab(row) }
         // A group targets a loose row (its id is a top-level entry); a grouped
         // row isn't, so a group drag there would be a no-op — offer no slot.
-        if draggedGroupID != nil, isLoose { return .beforeGroup(row) }
+        if terminals.railDraggedGroupID != nil, isLoose { return .beforeGroup(row) }
         return nil
     }
 
     func validateDrop(info: DropInfo) -> Bool { slot != nil }
-    func dropEntered(info: DropInfo) { dropSlot = slot }
+    func dropEntered(info: DropInfo) { terminals.railDropSlot = slot }
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        dropSlot = slot
+        terminals.railDropSlot = slot
         return slot == nil ? nil : DropProposal(operation: .move)
     }
-    func dropExited(info: DropInfo) { if dropSlot == slot { dropSlot = nil } }
+    func dropExited(info: DropInfo) {
+        if terminals.railDropSlot == slot { terminals.railDropSlot = nil }
+    }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
-        if let dragged = draggedTabID, dragged != row {
+        defer { terminals.clearRailDrag() }
+        if let dragged = terminals.railDraggedTabID, dragged != row {
             terminals.moveTab(dragged, before: row)
             return true
         }
-        if let dragged = draggedGroupID, isLoose {
+        if let dragged = terminals.railDraggedGroupID, isLoose {
             terminals.moveGroup(dragged, before: row)
             return true
         }
@@ -556,31 +566,32 @@ private struct TabRowDropDelegate: DropDelegate {
 private struct GroupHeaderDropDelegate: DropDelegate {
     let group: UUID
     let terminals: TerminalManager
-    @Binding var draggedTabID: UUID?
-    @Binding var draggedGroupID: UUID?
-    @Binding var dropSlot: RailDropSlot?
 
     private var slot: RailDropSlot? {
-        if draggedTabID != nil { return .intoGroup(group) }
-        if let dragged = draggedGroupID, dragged != group { return .beforeGroup(group) }
+        if terminals.railDraggedTabID != nil { return .intoGroup(group) }
+        if let dragged = terminals.railDraggedGroupID, dragged != group {
+            return .beforeGroup(group)
+        }
         return nil
     }
 
     func validateDrop(info: DropInfo) -> Bool { slot != nil }
-    func dropEntered(info: DropInfo) { dropSlot = slot }
+    func dropEntered(info: DropInfo) { terminals.railDropSlot = slot }
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        dropSlot = slot
+        terminals.railDropSlot = slot
         return slot == nil ? nil : DropProposal(operation: .move)
     }
-    func dropExited(info: DropInfo) { if dropSlot == slot { dropSlot = nil } }
+    func dropExited(info: DropInfo) {
+        if terminals.railDropSlot == slot { terminals.railDropSlot = nil }
+    }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
-        if let dragged = draggedTabID {
+        defer { terminals.clearRailDrag() }
+        if let dragged = terminals.railDraggedTabID {
             terminals.moveTab(dragged, toEndOfGroup: group)
             return true
         }
-        if let dragged = draggedGroupID, dragged != group {
+        if let dragged = terminals.railDraggedGroupID, dragged != group {
             terminals.moveGroup(dragged, before: group)
             return true
         }
@@ -593,39 +604,31 @@ private struct GroupHeaderDropDelegate: DropDelegate {
 /// drag state when a drop lands on no row at all.
 private struct RailTailDropDelegate: DropDelegate {
     let terminals: TerminalManager
-    @Binding var draggedTabID: UUID?
-    @Binding var draggedGroupID: UUID?
-    @Binding var dropSlot: RailDropSlot?
 
-    private var isDragging: Bool { draggedTabID != nil || draggedGroupID != nil }
+    private var isDragging: Bool {
+        terminals.railDraggedTabID != nil || terminals.railDraggedGroupID != nil
+    }
 
     func validateDrop(info: DropInfo) -> Bool { isDragging }
-    func dropEntered(info: DropInfo) { if isDragging { dropSlot = .railEnd } }
+    func dropEntered(info: DropInfo) { if isDragging { terminals.railDropSlot = .railEnd } }
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        if isDragging { dropSlot = .railEnd }
+        if isDragging { terminals.railDropSlot = .railEnd }
         return isDragging ? DropProposal(operation: .move) : nil
     }
-    func dropExited(info: DropInfo) { if dropSlot == .railEnd { dropSlot = nil } }
+    func dropExited(info: DropInfo) {
+        if terminals.railDropSlot == .railEnd { terminals.railDropSlot = nil }
+    }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { clearRailDrag(&draggedTabID, &draggedGroupID, &dropSlot) }
-        if let dragged = draggedTabID {
+        defer { terminals.clearRailDrag() }
+        if let dragged = terminals.railDraggedTabID {
             terminals.moveTabToLooseEnd(dragged)
             return true
         }
-        if let dragged = draggedGroupID {
+        if let dragged = terminals.railDraggedGroupID {
             terminals.moveGroupToEnd(dragged)
             return true
         }
         return false
     }
-}
-
-/// Reset every rail drag binding once a drop resolves.
-private func clearRailDrag(
-    _ tab: inout UUID?, _ group: inout UUID?, _ slot: inout RailDropSlot?
-) {
-    tab = nil
-    group = nil
-    slot = nil
 }

--- a/App/Sources/Root/DragTypes.swift
+++ b/App/Sources/Root/DragTypes.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Private, same-process drag types for the app's own drag-and-drop. These
+/// exist because a plain-text (`NSString`) drag is claimed at the AppKit level
+/// by any mounted text view registered for string drags — SwiftTerm's terminal
+/// and logcat's NSTextView both are — *before* SwiftUI's drop targets see it,
+/// and `opacity(0)` / `allowsHitTesting(false)` on a hidden keep-alive tab
+/// don't unregister an NSView's dragged types. A tab dragged over an open (or
+/// merely mounted) Terminal or logcat silently went nowhere. Carrying the
+/// drags under types those views never registered for keeps them SwiftUI's.
+extension UTType {
+    /// A workspace tab dragged from a pane's tab strip (reorder / move across
+    /// panes / drop-to-split).
+    static let workspaceTab = UTType(exportedAs: "com.rohindh.droidective.workspace-tab")
+    /// A Terminal-rail shell tab or group dragged within the rail.
+    static let terminalRailItem = UTType(exportedAs: "com.rohindh.droidective.terminal-rail-item")
+}
+
+/// A drag item carried under a private `type`. The drop delegates key off view
+/// state (`draggingTabID` and friends), so the payload is only a marker that
+/// keeps the item off the plain-text type.
+func privateDragItem(_ type: UTType, _ payload: String) -> NSItemProvider {
+    let provider = NSItemProvider()
+    // `.all` visibility, not `.ownProcess`: macOS bridges the item to the
+    // system drag pasteboard, and a process-restricted representation can be
+    // dropped in that bridge — the payload is a non-sensitive marker anyway.
+    provider.registerDataRepresentation(
+        forTypeIdentifier: type.identifier, visibility: .all
+    ) { completion in
+        completion(Data(payload.utf8), nil)
+        return nil
+    }
+    return provider
+}

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -171,6 +171,7 @@ struct RootView: View {
         Telemetry.shared.trackAppLaunched(launchCount: launchCount)
         Telemetry.shared.featureBecameActive(state.activeTabID)
         installCloseTabMonitor()
+        installDragJanitor()
         switch LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
             starPromptShown: starPromptShown,
@@ -211,6 +212,24 @@ struct RootView: View {
             else { return event }
             state.closeActiveTab()
             return nil
+        }
+    }
+
+    private static var dragJanitorInstalled = false
+
+    /// A drag has no "ended without a drop" callback: releasing a dragged tab
+    /// outside the window (or cancelling with Esc) fires no drop delegate, so
+    /// `draggingTabID` — and the insertion guideline keyed off it — stayed
+    /// stuck. Normal mouse events don't flow while a drag session runs, so the
+    /// first one arriving with drag state still set means exactly that ending;
+    /// clear it there. Installed once.
+    private func installDragJanitor() {
+        guard !RootView.dragJanitorInstalled else { return }
+        RootView.dragJanitorInstalled = true
+        let state = self.state
+        NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDown]) { event in
+            if state.draggingTabID != nil { state.draggingTabID = nil }
+            return event
         }
     }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -1,6 +1,7 @@
 import ADBKit
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct RootView: View {
     @Environment(AppState.self) private var state
@@ -352,7 +353,7 @@ struct RootView: View {
         // split-create overlay stuck blocking the pane. Catch those here and
         // clear it. Only a target while a tab drag is in flight; returns false so
         // it never swallows a real drop (inner targets are hit first).
-        .onDrop(of: [.text], delegate: TabDragCancelCatch(
+        .onDrop(of: [.workspaceTab], delegate: TabDragCancelCatch(
             isDragging: state.draggingTabID != nil,
             clear: { state.draggingTabID = nil }
         ))
@@ -536,7 +537,7 @@ private struct EditorPane: View {
             TabStripView(group: index)
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .onDrop(of: [.text], delegate: TabPaneDrop(
+                .onDrop(of: [.workspaceTab], delegate: TabPaneDrop(
                     draggingID: state.draggingTabID,
                     onDrop: { id in
                         if state.isSplit {
@@ -549,7 +550,11 @@ private struct EditorPane: View {
                     onTargetedChange: { contentTargeted = $0 }
                 ))
                 .overlay(alignment: .trailing) {
-                    if !state.isSplit, contentTargeted { splitPreview }
+                    // Only promise a split the model will honor: `split()`
+                    // requires >1 tab (something must stay behind), so a
+                    // single-tab drag shows no preview instead of a dead one.
+                    if !state.isSplit, contentTargeted,
+                       state.openTabIDs(inGroup: index).count > 1 { splitPreview }
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -218,17 +218,20 @@ struct RootView: View {
     private static var dragJanitorInstalled = false
 
     /// A drag has no "ended without a drop" callback: releasing a dragged tab
-    /// outside the window (or cancelling with Esc) fires no drop delegate, so
-    /// `draggingTabID` — and the insertion guideline keyed off it — stayed
+    /// (or a terminal rail row) outside any drop target fires no delegate, so
+    /// the drag state — and the insertion guideline keyed off it — stayed
     /// stuck. Normal mouse events don't flow while a drag session runs, so the
     /// first one arriving with drag state still set means exactly that ending;
-    /// clear it there. Installed once.
+    /// clear it there. Installed once. This is also what lets the Terminal
+    /// drop its whole-view cleanup catch, which blocked the pane's tab drops
+    /// (drops route to the deepest region by geometry, not type).
     private func installDragJanitor() {
         guard !RootView.dragJanitorInstalled else { return }
         RootView.dragJanitorInstalled = true
         let state = self.state
         NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDown]) { event in
             if state.draggingTabID != nil { state.draggingTabID = nil }
+            if state.terminals.railDragActive { state.terminals.clearRailDrag() }
             return event
         }
     }

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -1,5 +1,6 @@
 import ADBKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// One editor pane's tab strip. Tabs scroll sideways when they overflow (‹ ›
 /// arrows appear); the active one is highlighted and kept in view. A recording
@@ -65,6 +66,17 @@ struct TabStripView: View {
         .frame(height: 36)
         .background(.bgSurface)
         .overlay(alignment: .bottom) { Divider() }
+        // The strip's dead space (past the last chip, around the + button) is
+        // a drop target too: dropping there appends the tab to this pane —
+        // the natural way to drag a tab across a split. Chip drops sit deeper,
+        // so precise before/after placement still wins over this catch-all.
+        .onDrop(of: [.workspaceTab], delegate: TabPaneDrop(
+            draggingID: state.draggingTabID,
+            onDrop: { id in
+                state.dropTab(id, intoGroup: group, before: nil)
+                state.draggingTabID = nil
+            }
+        ))
         // A drop that lands outside this strip's chips (the pane content, dead
         // strip space, the other pane) never reaches the chips' drop delegates,
         // so their `setSlot(nil)` cleanup can't run and the insertion guideline
@@ -131,9 +143,12 @@ struct TabStripView: View {
         .overlay(alignment: .trailing) { guideline(visible: dropSlot == TabDropSlot(targetID: id, after: true)) }
         .onDrag {
             state.draggingTabID = id
-            return NSItemProvider(object: id as NSString)
+            // A private type, not an NSString: a plain-text drag is captured at
+            // the AppKit level by any mounted text view (SwiftTerm, logcat)
+            // before SwiftUI's drop targets see it — see `DragTypes.swift`.
+            return privateDragItem(.workspaceTab, id)
         }
-        .onDrop(of: [.text], delegate: TabReorderDrop(
+        .onDrop(of: [.workspaceTab], delegate: TabReorderDrop(
             targetID: id,
             width: chipWidths[id] ?? 0,
             order: tabIDs,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,20 @@ platforms annotation without a runner.
 - **`.task(id:)` keys must include readiness** (`targetSerials.first`), not just
   serial — a device authorizing keeps the same serial and the view must reload.
   Guard `!Task.isCancelled` before writing fetched results into @State.
+- **Drops route by geometry, not type — and drags need declared UTIs.** SwiftUI
+  hands a drop to the *deepest* drop region under the cursor even when that
+  target's `onDrop(of:)` types don't match the drag (no fallthrough to
+  ancestors), and hidden keep-alive tabs (`opacity(0)` +
+  `allowsHitTesting(false)`) still register their drop regions — so a
+  whole-view `.onDrop` inside a feature silently kills the pane's tab drops
+  whenever that tab is merely open (this broke drop-to-split from v2.8.1 until
+  the Terminal's catch-all was removed). Never attach a feature-wide `.onDrop`;
+  scope targets tightly and let `RootView.installDragJanitor` clear abandoned
+  drag state (normal mouse events don't flow during a drag session, so the
+  first one that arrives with drag state set means the drag ended dropless).
+  In-app drags ride private UTIs (`DragTypes.swift`) that must be declared in
+  `UTExportedTypeDeclarations` (project.yml) — macOS won't put an undeclared
+  UTI on the drag pasteboard, which kills the drag *silently*.
 - **Empty states under a toolbar must `.frame(maxWidth/maxHeight: .infinity)`** —
   otherwise the whole VStack centers and the toolbar floats mid-window.
 - **`HSplitView` ignores SwiftUI safe-area insets** (it's NSSplitView-backed) —

--- a/project.yml
+++ b/project.yml
@@ -74,6 +74,19 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - apk
+        # The app's private drag types (DragTypes.swift). macOS only writes a
+        # custom UTI to the drag pasteboard when the app declares it, so an
+        # undeclared type makes every .onDrag with it die silently — no drop
+        # target ever matches.
+        UTExportedTypeDeclarations:
+          - UTTypeIdentifier: com.rohindh.droidective.workspace-tab
+            UTTypeDescription: Droidective workspace tab
+            UTTypeConformsTo:
+              - public.data
+          - UTTypeIdentifier: com.rohindh.droidective.terminal-rail-item
+            UTTypeDescription: Droidective terminal rail item
+            UTTypeConformsTo:
+              - public.data
         CFBundleDocumentTypes:
           - CFBundleTypeName: Android Package
             CFBundleTypeRole: Viewer


### PR DESCRIPTION
Fixes workspace tab drag-and-drop, broken in three compounding ways — most visibly: drop-to-split and cross-pane moves did nothing whenever a Terminal tab was open (selected or not). Regressed in v2.8.1, so this is v2.9.1 material.

## Root causes and fixes (one commit each)

**1. Tab drags were plain text, and drops route by geometry, not type.**
SwiftUI hands a drop to the deepest drop region under the cursor and does not fall through to ancestors when that region's declared types don't match — and hidden keep-alive tabs (`opacity(0)` + `allowsHitTesting(false)`) still register their drop regions. The Terminal's feature-wide rail-cleanup `.onDrop` therefore swallowed every pane drop while a terminal tab was mounted. Tab and rail drags now travel under private UTIs (`DragTypes.swift`), declared in `UTExportedTypeDeclarations` — macOS silently refuses to put an undeclared UTI on the drag pasteboard, which is its own silent failure mode. Also: the strip's dead space (past the last chip) is now a drop target that appends the tab to that pane, and the drop-to-split preview only shows when the pane has more than one tab, matching what `split()` will do.

**2. A drag that ended without a drop left its state — and the insertion guideline — stuck.**
Releasing outside the window or cancelling with Esc fires no drop delegate. A local event monitor now clears drag state on the first normal mouse event that arrives while it's still set (normal mouse events don't flow during a drag session, so that's an exact "ended droplessly" signal).

**3. The Terminal's whole-view drop catch removed.**
Because of the geometry routing in (1), retyping alone wasn't enough — any feature-wide drop region blocks pane drops while its tab is mounted. The catch is deleted; the rail's drag state moved into `TerminalManager` so the janitor from (2) does the cleanup the catch existed for. The routing gotcha is documented in CLAUDE.md.

## Verified (live, interactive)

- Tab reorder within the strip, including drops past the last chip.
- Drop-to-split with a Terminal tab open (selected and unselected) and after closing it.
- Cross-pane moves in both directions, onto pane content and onto the strip background.
- Stuck guideline clears after an abandoned drag (released outside the window / Esc).
- Terminal rail reorder/grouping unaffected; a rail drag released over the shells un-sticks via the janitor.

No ADBKit changes; `swift test` untouched (654 green on the branch base), Debug build clean with warnings-as-errors.
