### PR TITLE
Release v2.9.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,42 @@
-## Droidective v2.9.0
+## Droidective v2.9.1
 
-Adds a background mode with a global Quick Actions panel, a terminal tab rail
-with a find bar, and a Dock-style auto-hiding sidebar.
+Adds Home feature search and a Frequently-used strip, font and accent-color
+customization, and a round of fixes.
+
+### New features
+
+- **Home feature search & Frequently-used strip** — an inline search under the
+  Home header finds any tool (⏎ opens the top match, Esc clears), and a
+  Frequently-used strip surfaces the features you open most, ordered by use
+  count.
+- **Font customization** — Settings ▸ Appearance gains a font-family picker over
+  the installed macOS families and a text-size scale; every UI font follows the
+  choice (the terminal and screenshot-annotation canvas keep their own).
+- **Accent-color customization** — pick from preset swatches, the color well, or
+  a hex field (`#RRGGBB` / `#RGB`), and the accent now reaches the surfaces that
+  used to ignore it (device/bundle pills, list selection in Apps and the
+  decompile tree, success toasts).
+
+### Improvements
+
+- The command palette shortcut moves to **⌘T** everywhere.
+- The **⌘T palette** now runs instant actions in place (e.g. Copy Device IP
+  copies and shows a toast) instead of opening a detail tab.
+- **Reactotron** gains **Copy as JSON** on the state tree, subscriptions, and
+  snapshots.
+
+### Fixes
+
+- **Set Dev Server Host** now works on physical devices: it writes React
+  Native's `debug_http_host` preference via `run-as` and relaunches the app,
+  falling back to `setprop metro.host` and the dev menu.
+- **Text fields release focus when you click away** — clicking outside a field
+  no longer leaves it holding the keyboard.
+- **⌘,** no longer opens Settings hidden behind the Quick Actions panel.
+- **Drop-to-split works again in the Terminal** — a leftover whole-view drop
+  target had blocked dropping a tab into a pane.
+
+Installed copies update in place via Sparkle.
 
 ### New features
 

--- a/project.yml
+++ b/project.yml
@@ -99,7 +99,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.9.0"
+        MARKETING_VERSION: "2.9.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -16,7 +16,7 @@ export const GITHUB_URL = "https://github.com/Droidective/Droidective"
 export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const LATEST_RELEASE_URL = `${GITHUB_URL}/releases/latest`
-export const APP_VERSION = "v2.9.0"
+export const APP_VERSION = "v2.9.1"
 
 export interface PaletteCommand {
   icon: LucideIcon
@@ -163,7 +163,8 @@ export const galleryShots = [
 ]
 
 export const releases: { version: string; date: string; latest?: boolean; html: string }[] = [
-  { version: "v2.9.0", date: "Jul 2026", latest: true, html: "<b>Background mode &amp; a global Quick Actions panel</b> — closing the window keeps Droidective running in the menu bar, and a non-activating Raycast-style panel on a global hotkey runs any adb action, manages apps, boots emulators, and installs APKs without the main window — with per-device targeting and Finder APK routing. Plus a <b>terminal tab rail</b> with a find bar and a <b>Dock-style auto-hiding sidebar</b>." },
+  { version: "v2.9.1", date: "Jul 2026", latest: true, html: "<b>Home search &amp; a Frequently used strip</b> — find any tool from the Home screen and jump to your most-used ones — plus <b>font and accent-color customization</b> in Settings ▸ Appearance. Fixes: the React Native dev-server host now writes <code>debug_http_host</code> so it works on physical devices, text fields release focus when you click away, <kbd>⌘,</kbd> no longer opens Settings behind the Quick Actions panel, and drop-to-split works again in the Terminal. The command palette moves to <kbd>⌘T</kbd>." },
+  { version: "v2.9.0", date: "Jul 2026", html: "<b>Background mode &amp; a global Quick Actions panel</b> — closing the window keeps Droidective running in the menu bar, and a non-activating Raycast-style panel on a global hotkey runs any adb action, manages apps, boots emulators, and installs APKs without the main window — with per-device targeting and Finder APK routing. Plus a <b>terminal tab rail</b> with a find bar and a <b>Dock-style auto-hiding sidebar</b>." },
   { version: "v2.8.3", date: "Jul 2026", html: "<b>iOS Simulator support</b> — booted iOS Simulators sit in the same device bar as Android devices, and features adapt to the selection: screenshot, dark mode, demo mode, fake battery, and deep links run through <code>xcrun simctl</code>, with push notifications as a Simulator-only tool and a new iOS Developer role. Plus a <b>redesigned role picker</b>, <b>per-feature product analytics</b> (anonymous, opt-out), and Reactotron/log readability fixes." },
   { version: "v2.8.2", date: "Jul 2026", html: "<b>JS Console reconnect fix</b> — a race killed each fresh Metro connection and leaked the old socket, so the console reconnected in a loop and spammed the dev server; connections are now generation-guarded with a bounded handshake, so it connects once and stays connected. Plus <b>anonymous performance self-monitoring</b> — sustained high CPU or memory in the app is reported with the features open at the time (opt-out in Settings → Privacy)." },
   { version: "v2.8.1", date: "Jul 2026", html: "<b>Built-in Terminal</b> — multi-tab PTY login shells with the selected device exported as ANDROID_SERIAL — plus <b>shell custom commands</b> through zsh, a <b>Security / Pentest role</b> with reworked per-role sidebars, a <b>Device Info</b> rework, and a round of performance fixes (launch hang, Reactotron memory, JS console search)." },


### PR DESCRIPTION
Cuts v2.9.1: everything on `main` since v2.9.0 (PRs #111 and #112).

Bumps `MARKETING_VERSION` to 2.9.1, adds the `RELEASE_NOTES.md` entry, and updates the marketing site (`APP_VERSION` + a new `releases` entry, `latest` moved off v2.9.0). The appcast is untouched — CI regenerates and signs it on the tag.

### New features
- **Home feature search & Frequently-used strip.**
- **Font customization** (family picker + text-size scale) in Settings ▸ Appearance.
- **Accent-color customization** (preset swatches, color well, hex field), reaching surfaces that previously ignored it.

### Improvements
- Command palette shortcut moves to **⌘T** everywhere.
- ⌘T palette runs instant actions in place instead of opening a detail tab.
- Reactotron **Copy as JSON** on the state tree, subscriptions, and snapshots.

### Fixes
- **Set Dev Server Host** works on physical devices (writes `debug_http_host` via `run-as`, with `setprop`/dev-menu fallbacks).
- Text fields release focus when you click away.
- ⌘, no longer opens Settings behind the Quick Actions panel.
- Drop-to-split works again in the Terminal.

### Verification
- ADBKit `swift test -Xswiftc -warnings-as-errors`: 668 passed.
- App build: clean, zero warnings.

Note: this ships new features, which would normally be a minor (v2.10.0); cut as 2.9.1 as requested.