### PR TITLE
Fix Release-build compile error blocking the v2.9.1 release

### DIFF
--- a/App/Sources/Root/DragTypes.swift
+++ b/App/Sources/Root/DragTypes.swift
@@ -21,15 +21,13 @@ extension UTType {
 /// state (`draggingTabID` and friends), so the payload is only a marker that
 /// keeps the item off the plain-text type.
 func privateDragItem(_ type: UTType, _ payload: String) -> NSItemProvider {
-    let provider = NSItemProvider()
-    // `.all` visibility, not `.ownProcess`: macOS bridges the item to the
-    // system drag pasteboard, and a process-restricted representation can be
-    // dropped in that bridge — the payload is a non-sensitive marker anyway.
-    provider.registerDataRepresentation(
-        forTypeIdentifier: type.identifier, visibility: .all
-    ) { completion in
-        completion(Data(payload.utf8), nil)
-        return nil
-    }
-    return provider
+    // Register the marker eagerly (`init(item:typeIdentifier:)`) rather than
+    // through a `registerDataRepresentation` load handler: the payload is a
+    // small static marker known up front, so there's nothing to load lazily,
+    // and the closure-based API's completion is imported main-actor-isolated —
+    // calling it from the handler's nonisolated context fails to compile under
+    // whole-module (Release) builds (Debug's incremental build missed it).
+    // Legacy item registration is process-global (equivalent to `.all`
+    // visibility), so the drag still survives macOS's system-pasteboard bridge.
+    NSItemProvider(item: Data(payload.utf8) as NSData, typeIdentifier: type.identifier)
 }


### PR DESCRIPTION
The v2.9.1 release job failed: the Release-configuration App build hit a Swift 6 concurrency error in `privateDragItem` (`DragTypes.swift`, from #111) —

```
error: call to main actor-isolated parameter 'completion' in a synchronous nonisolated context
```

`NSItemProvider.registerDataRepresentation(forTypeIdentifier:visibility:loadHandler:)` imports its completion as main-actor-isolated, so calling it from the load handler's nonisolated context is rejected under whole-module optimization. CI's `build` job only compiles **Debug** (incremental), which never surfaced it; the Release build runs only in the tag-triggered `release` job, so it slipped through PR CI.

Fix: register the static marker data eagerly with `NSItemProvider(item:typeIdentifier:)` — there's nothing to load lazily (the payload is a small fixed marker), so no load handler is needed. Legacy item registration is process-global (equivalent to the previous `.all` visibility), so the drag still survives macOS's system-pasteboard bridge.

Verified with a local **Release**-configuration build (`xcodebuild -configuration Release`): BUILD SUCCEEDED, which the Debug build did not catch.

Once merged, I re-tag v2.9.1 on the new `main` (the previous tag published nothing — the build failed before signing).