### PR TITLE
Add hang-triage context to telemetry and unify the install id

### DIFF
--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -110,6 +110,7 @@ struct RootView: View {
             .onChange(of: state.presentRolePicker) { _, showing in rolePickerVisibilityChanged(showing) }
             .onChange(of: colorScheme) { _, _ in updateDockIcon() }
             .onChange(of: state.activeTabID) { _, id in Telemetry.shared.featureBecameActive(id) }
+            .onChange(of: state.openFeatureIDs) { _, ids in Telemetry.shared.openFeaturesChanged(ids) }
             .confirmationDialog(
                 state.pendingGuard?.title ?? "",
                 isPresented: Binding(
@@ -173,6 +174,7 @@ struct RootView: View {
         Telemetry.shared.applyRole(state.selectedRole?.rawValue)
         Telemetry.shared.trackAppLaunched(launchCount: launchCount)
         Telemetry.shared.featureBecameActive(state.activeTabID)
+        Telemetry.shared.openFeaturesChanged(state.openFeatureIDs)
         installCloseTabMonitor()
         installDragJanitor()
         installFocusRelease()

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -9,8 +9,9 @@ import Sentry
 /// Anonymous by design: no device serials, package ids, file paths, IPs, or
 /// command contents are ever sent — only which feature was used and the app's
 /// own resource numbers. The only stable identifier is a random per-install
-/// UUID (`deviceID`, no PII), which lets PostHog count distinct installs,
-/// retention, and funnels. Both sinks are on by default and opt-out in
+/// UUID (`deviceID`, no PII), set on both sinks so distinct-install counts
+/// agree and a Sentry crash/hang cross-references the same install's PostHog
+/// usage. Both sinks are on by default and opt-out in
 /// Settings → Privacy; the first-run consent disclosure is deferred for the
 /// first few launches (gated in RootView).
 @MainActor
@@ -98,9 +99,26 @@ final class Telemetry {
 
         if crashReportingEnabled, sentryRunning {
             SentrySDK.configureScope { $0.setTag(value: feature, key: "active_feature") }
+            let crumb = Breadcrumb(level: .info, category: "navigation")
+            crumb.message = "feature → \(feature)"
+            SentrySDK.addBreadcrumb(crumb)
         }
         if analyticsEnabled, postHogReady {
             PostHogSDK.shared.register(["active_feature": feature])
+        }
+    }
+
+    /// The set of open (kept-alive) feature tabs changed. Tags every crash and
+    /// hang with what else is running: a hidden tab's stream can be the real
+    /// workload while `active_feature` names whatever is on screen, so the tag
+    /// pair is what attributes an incident correctly.
+    func openFeaturesChanged(_ ids: [String]) {
+        let joined = ids.isEmpty ? "none" : ids.sorted().joined(separator: ",")
+        if crashReportingEnabled, sentryRunning {
+            SentrySDK.configureScope { $0.setTag(value: joined, key: "open_features") }
+        }
+        if analyticsEnabled, postHogReady {
+            PostHogSDK.shared.register(["open_features": joined])
         }
     }
 
@@ -154,6 +172,12 @@ final class Telemetry {
             "device_model": model ?? "unknown",
             "is_wireless": isWireless,
         ])
+        if crashReportingEnabled, sentryRunning {
+            let crumb = Breadcrumb(level: .info, category: "device")
+            let kind = isEmulator ? "emulator" : (isWireless ? "wireless" : "usb")
+            crumb.message = "connected: \(model ?? "unknown") · Android \(androidVersion ?? "?") · \(kind)"
+            SentrySDK.addBreadcrumb(crumb)
+        }
     }
 
     // MARK: - Performance
@@ -272,6 +296,11 @@ final class Telemetry {
             options.debug = true  // verbose Sentry logs in dev builds only
             #endif
         }
+        // The same anonymous per-install UUID PostHog identifies with, so
+        // distinct-install counts match across sinks and a Sentry incident can
+        // be joined to that install's PostHog usage. Not PII — random, local.
+        let user = User(userId: Self.deviceID)
+        SentrySDK.setUser(user)
         sentryRunning = true
     }
 


### PR DESCRIPTION
## What

- **Unify the anonymous install id across sinks.** The random per-install UUID PostHog identifies with is now also set as the Sentry user (`SentrySDK.setUser` in `startSentry()`), so distinct-install counts agree and a Sentry crash/hang cross-references the same install's PostHog usage. Previously Sentry used its own auto-generated install id.
- **Tag every crash/hang with `open_features`.** New `Telemetry.openFeaturesChanged(_:)` sets a Sentry scope tag and PostHog super-property listing the open keep-alive tabs, wired from `RootView` via `.onChange(of: state.openFeatureIDs)` and seeded at launch. During the v2.8.3 hang triage, `active_feature` said `emulators` while the stacks implicated a hidden Logcat tab's stream — this tag pair makes that attribution direct.
- **Leave breadcrumbs for triage context.** Feature switches add a `navigation` crumb (`feature → logcat`), and device connections add a `device` crumb (model, Android version, emulator/wireless/USB — no serial), so hang/crash reports carry the trail leading up to the incident.

No PII: feature ids and device model/version only. Both additions respect the existing Settings ▸ Privacy consent toggles (each sink guards its own).

## Testing

- `make build` — zero warnings (App-layer only; no ADBKit changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)