### PR TITLE
Release v2.9.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,39 @@
+## Droidective v2.9.2
+
+Screen-mirror quality of life — a pop-out mirror window and reliable device
+switching — plus video-editor and save-flow fixes.
+
+### New features
+
+- **Mirror in its own window** — a window button on the mirror's control bar
+  moves the live mirror into a dedicated "Screen Mirror" window (also in the
+  macOS Window menu), so it can sit beside the main workspace or other apps.
+  The window follows the device-bar selection, and an in-window recording still
+  guards quit and device switches.
+
+### Improvements
+
+- **The mirror follows device switches reliably** — reconnects are serialized,
+  so switching devices quickly can't tangle two sessions or leave one streaming
+  in the background, and the stopped/failed screens gain a **Reconnect** button.
+- **"Open in Finder" everywhere** — every "Reveal" button now says Open in
+  Finder, and the first quick save asks once where captures should go
+  (changeable anytime in Settings ▸ Privacy).
+- Toasts dismiss from a macOS-notification-style close button on the top-left
+  corner.
+- Anonymous hang reports carry more triage context (opt-out in
+  Settings ▸ Privacy).
+
+### Fixes
+
+- **Video editor controls no longer collapse on portrait clips** — the player
+  takes the full pane (the video letterboxes inside), so the native playback
+  controls and the trim strip get the full width. Trimming long recordings is
+  workable again, and cancelling a trim no longer leaves an empty controls pill
+  floating over the video.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.9.1
 
 Adds Home feature search and a Frequently-used strip, font and accent-color

--- a/project.yml
+++ b/project.yml
@@ -99,7 +99,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.9.1"
+        MARKETING_VERSION: "2.9.2"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://droidective.com/changelog/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://droidective.com/for-android-developers.html</loc>
     <lastmod>2026-06-27</lastmod>
     <changefreq>monthly</changefreq>

--- a/website/changelog/index.html
+++ b/website/changelog/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>Changelog — Droidective</title>
+  <meta name="description" content="Every Droidective release — new features, improvements, and fixes for the free, open-source Android & React Native debugging tool for macOS." />
+  <meta name="author" content="Rohindh R" />
+  <meta name="robots" content="index, follow" />
+  <meta name="theme-color" content="#0d0f0e" />
+  <link rel="canonical" href="https://droidective.com/changelog/" />
+
+  <link rel="icon" type="image/png" href="/assets/icon.png" media="(prefers-color-scheme: dark)" />
+  <link rel="icon" type="image/png" href="/assets/icon-light.png" media="(prefers-color-scheme: light)" />
+  <link rel="apple-touch-icon" href="/assets/icon.png" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Droidective" />
+  <meta property="og:title" content="Changelog — Droidective" />
+  <meta property="og:description" content="Every Droidective release — new features, improvements, and fixes." />
+  <meta property="og:url" content="https://droidective.com/changelog/" />
+  <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+
+  <script src="/analytics.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/changelog-main.tsx"></script>
+</body>
+</html>

--- a/website/src/changelog-main.tsx
+++ b/website/src/changelog-main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { ChangelogPage } from '@/components/site/ChangelogPage'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <ChangelogPage />
+  </StrictMode>,
+)

--- a/website/src/components/site/Changelog.tsx
+++ b/website/src/components/site/Changelog.tsx
@@ -1,52 +1,22 @@
-import { Reveal } from "@/components/site/Reveal"
+import { ReleaseTimeline } from "@/components/site/ReleaseTimeline"
 import { SectionHead } from "@/components/site/SectionHead"
 import { Button } from "@/components/ui/button"
-import { RELEASES_URL, releases } from "@/lib/content"
-import { cn } from "@/lib/utils"
+import { releases } from "@/lib/content"
 
 export function Changelog() {
   return (
     <section id="changelog" className="mx-auto max-w-[1120px] px-6 py-26 max-[620px]:py-18">
       <SectionHead center eyebrow="changelog" title="Shipped, and still moving.">
-        Sixteen releases since the first public build — automatic in-app updates since v2.1.0, and Apple-notarized
-        builds since v2.4.0.
+        The latest releases — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.
       </SectionHead>
-      <Reveal className="relative mx-auto max-w-190 pl-7.5 before:absolute before:top-2 before:bottom-2 before:left-1.25 before:w-px before:bg-border-2">
-        {releases.map((release) => (
-          <div key={release.version} className="relative pb-9 last:pb-0">
-            <span
-              className={cn(
-                "absolute top-1.5 -left-[29px] size-2.75 rounded-full border-2",
-                release.latest
-                  ? "border-green bg-green shadow-[0_0_12px_rgba(155,224,33,0.3)]"
-                  : "border-green-dim bg-ink-850",
-              )}
-            />
-            <div className="mb-1.75 flex flex-wrap items-baseline gap-3">
-              <span className="font-mono text-[15px] font-bold text-green">{release.version}</span>
-              {release.latest && (
-                <span className="rounded-full bg-green px-2 py-px font-mono text-[11px] font-bold text-ink-900">
-                  latest
-                </span>
-              )}
-              <span className="ml-auto font-mono text-xs text-faint max-[620px]:ml-0 max-[620px]:w-full">
-                {release.date}
-              </span>
-            </div>
-            <p
-              className="m-0 text-[14.5px] text-muted [&_b]:font-semibold [&_b]:text-text [&_code]:font-mono"
-              dangerouslySetInnerHTML={{ __html: release.html }}
-            />
-          </div>
-        ))}
-      </Reveal>
+      <ReleaseTimeline items={releases.slice(0, 3)} />
       <div className="mt-11 text-center">
         <Button
           asChild
           variant="outline"
           className="h-auto rounded-xl border-border-2 bg-white/4 px-5 py-3 text-[15px] font-semibold hover:bg-white/8"
         >
-          <a href={RELEASES_URL}>All releases on GitHub →</a>
+          <a href="/changelog/">Full changelog →</a>
         </Button>
       </div>
     </section>

--- a/website/src/components/site/ChangelogPage.tsx
+++ b/website/src/components/site/ChangelogPage.tsx
@@ -1,0 +1,45 @@
+import { Footer } from "@/components/site/Footer"
+import { ReleaseTimeline } from "@/components/site/ReleaseTimeline"
+import { SectionHead } from "@/components/site/SectionHead"
+import { Button } from "@/components/ui/button"
+import { RELEASES_URL, releases } from "@/lib/content"
+
+/** The /changelog/ page: the full release history (the landing page's
+ *  changelog section shows only the latest few). */
+export function ChangelogPage() {
+  return (
+    <>
+      <header className="border-b border-border px-6 py-4">
+        <div className="mx-auto flex max-w-[1120px] items-center justify-between gap-4">
+          <a href="/" className="flex items-center gap-2.75 text-base font-bold tracking-[-0.01em]">
+            <img src="/assets/icon.png" alt="" width={26} height={26} className="rounded-md" />
+            Droidective
+          </a>
+          <a
+            href="/"
+            className="font-mono text-[13px] text-muted transition-colors duration-150 hover:text-green"
+          >
+            ← back to droidective.com
+          </a>
+        </div>
+      </header>
+      <main className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-12">
+        <SectionHead center eyebrow="changelog" title="Every release.">
+          {releases.length} releases since the first public build — automatic in-app updates since v2.1.0, and
+          Apple-notarized builds since v2.4.0.
+        </SectionHead>
+        <ReleaseTimeline items={releases} />
+        <div className="mt-11 text-center">
+          <Button
+            asChild
+            variant="outline"
+            className="h-auto rounded-xl border-border-2 bg-white/4 px-5 py-3 text-[15px] font-semibold hover:bg-white/8"
+          >
+            <a href={RELEASES_URL}>All releases on GitHub →</a>
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/website/src/components/site/ReleaseTimeline.tsx
+++ b/website/src/components/site/ReleaseTimeline.tsx
@@ -1,0 +1,39 @@
+import { Reveal } from "@/components/site/Reveal"
+import { releases } from "@/lib/content"
+import { cn } from "@/lib/utils"
+
+/** The vertical release timeline — the landing section shows the latest few,
+ *  the /changelog/ page shows the full history. */
+export function ReleaseTimeline({ items }: { items: typeof releases }) {
+  return (
+    <Reveal className="relative mx-auto max-w-190 pl-7.5 before:absolute before:top-2 before:bottom-2 before:left-1.25 before:w-px before:bg-border-2">
+      {items.map((release) => (
+        <div key={release.version} className="relative pb-9 last:pb-0">
+          <span
+            className={cn(
+              "absolute top-1.5 -left-[29px] size-2.75 rounded-full border-2",
+              release.latest
+                ? "border-green bg-green shadow-[0_0_12px_rgba(155,224,33,0.3)]"
+                : "border-green-dim bg-ink-850",
+            )}
+          />
+          <div className="mb-1.75 flex flex-wrap items-baseline gap-3">
+            <span className="font-mono text-[15px] font-bold text-green">{release.version}</span>
+            {release.latest && (
+              <span className="rounded-full bg-green px-2 py-px font-mono text-[11px] font-bold text-ink-900">
+                latest
+              </span>
+            )}
+            <span className="ml-auto font-mono text-xs text-faint max-[620px]:ml-0 max-[620px]:w-full">
+              {release.date}
+            </span>
+          </div>
+          <p
+            className="m-0 text-[14.5px] text-muted [&_b]:font-semibold [&_b]:text-text [&_code]:font-mono"
+            dangerouslySetInnerHTML={{ __html: release.html }}
+          />
+        </div>
+      ))}
+    </Reveal>
+  )
+}

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -16,7 +16,7 @@ export const GITHUB_URL = "https://github.com/Droidective/Droidective"
 export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const LATEST_RELEASE_URL = `${GITHUB_URL}/releases/latest`
-export const APP_VERSION = "v2.9.1"
+export const APP_VERSION = "v2.9.2"
 
 export interface PaletteCommand {
   icon: LucideIcon
@@ -163,7 +163,8 @@ export const galleryShots = [
 ]
 
 export const releases: { version: string; date: string; latest?: boolean; html: string }[] = [
-  { version: "v2.9.1", date: "Jul 2026", latest: true, html: "<b>Home search &amp; a Frequently used strip</b> — find any tool from the Home screen and jump to your most-used ones — plus <b>font and accent-color customization</b> in Settings ▸ Appearance. Fixes: the React Native dev-server host now writes <code>debug_http_host</code> so it works on physical devices, text fields release focus when you click away, <kbd>⌘,</kbd> no longer opens Settings behind the Quick Actions panel, and drop-to-split works again in the Terminal. The command palette moves to <kbd>⌘T</kbd>." },
+  { version: "v2.9.2", date: "Jul 2026", latest: true, html: "<b>Mirror in its own window</b> — pop the live mirror out beside your workspace from a button on its control bar; it follows the device-bar selection, which now <b>switches sessions reliably</b>, with a Reconnect button when a stream dies. The <b>video editor</b> gets full-width native controls and trim strip (no more cramped portrait layout), every Reveal button becomes <b>Open in Finder</b>, and the first quick save asks once where captures should go." },
+  { version: "v2.9.1", date: "Jul 2026", html: "<b>Home search &amp; a Frequently used strip</b> — find any tool from the Home screen and jump to your most-used ones — plus <b>font and accent-color customization</b> in Settings ▸ Appearance. Fixes: the React Native dev-server host now writes <code>debug_http_host</code> so it works on physical devices, text fields release focus when you click away, <kbd>⌘,</kbd> no longer opens Settings behind the Quick Actions panel, and drop-to-split works again in the Terminal. The command palette moves to <kbd>⌘T</kbd>." },
   { version: "v2.9.0", date: "Jul 2026", html: "<b>Background mode &amp; a global Quick Actions panel</b> — closing the window keeps Droidective running in the menu bar, and a non-activating Raycast-style panel on a global hotkey runs any adb action, manages apps, boots emulators, and installs APKs without the main window — with per-device targeting and Finder APK routing. Plus a <b>terminal tab rail</b> with a find bar and a <b>Dock-style auto-hiding sidebar</b>." },
   { version: "v2.8.3", date: "Jul 2026", html: "<b>iOS Simulator support</b> — booted iOS Simulators sit in the same device bar as Android devices, and features adapt to the selection: screenshot, dark mode, demo mode, fake battery, and deep links run through <code>xcrun simctl</code>, with push notifications as a Simulator-only tool and a new iOS Developer role. Plus a <b>redesigned role picker</b>, <b>per-feature product analytics</b> (anonymous, opt-out), and Reactotron/log readability fixes." },
   { version: "v2.8.2", date: "Jul 2026", html: "<b>JS Console reconnect fix</b> — a race killed each fresh Metro connection and leaked the old socket, so the console reconnected in a loop and spammed the dev server; connections are now generation-guarded with a bounded handshake, so it connects once and stays connected. Plus <b>anonymous performance self-monitoring</b> — sustained high CPU or memory in the app is reported with the features open at the time (opt-out in Settings → Privacy)." },

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -197,7 +197,7 @@ export const faqs: { q: string; html: string }[] = [
 export const footerLinks = [
   { label: "GitHub", href: GITHUB_URL },
   { label: "Releases", href: RELEASES_URL },
-  { label: "Changelog", href: "#changelog" },
+  { label: "Changelog", href: "/changelog/" },
   { label: "Issues", href: `${GITHUB_URL}/issues` },
   { label: "License", href: `${GITHUB_URL}/blob/main/LICENSE` },
   { label: "Privacy", href: "/privacy.html" },

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
+      // Two HTML entries: the landing page and the full-changelog page —
+      // GitHub Pages serves dist/changelog/index.html at /changelog/.
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        changelog: path.resolve(__dirname, "changelog/index.html"),
+      },
       output: {
         manualChunks: {
           react: ["react", "react-dom"],


### PR DESCRIPTION
Bumps the app to v2.9.2 and adds its release-notes section and site entry.

Shipping since v2.9.1:
- Mirror in its own window (pop-out button + Window menu), following the device-bar selection
- Reliable mirror device switching (serialized reconnects) and an in-place Reconnect button
- Video editor: full-pane native controls and trim strip (fixes the collapsed portrait layout and the stranded trim pill)
- "Reveal" → "Open in Finder" everywhere; one-time capture-folder ask on the first silent save
- Toast dismiss moves to a macOS-style top-left close button
- Hang telemetry carries triage context; unified install id (#115)

After merge: `git tag v2.9.2 && git push origin v2.9.2` triggers the release job (signed/notarized DMG, appcast, cask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)