### PR TITLE
Fix upside-down rows when reversing a multi-view log feed

### DIFF
--- a/App/Sources/LogTailView.swift
+++ b/App/Sources/LogTailView.swift
@@ -120,11 +120,16 @@ struct LogTailView<Data: RandomAccessCollection, Row: View>: View
     }
 
     /// Rows laid out newest-first. `.bottom` feeds reverse the display order and
-    /// un-flip each row (the scroll view flip above mirrors the whole stack).
+    /// un-flip each row (the scroll view flip above mirrors the whole stack). The
+    /// per-row flip is wrapped in a `VStack` so it applies to one settled view: a
+    /// `row` builder returning multiple views (e.g. a row + `Divider`) is a bare
+    /// `TupleView`, and `scaleEffect` on that doesn't un-flip cleanly, which left
+    /// the rows upside-down.
     @ViewBuilder private var orderedRows: some View {
         if newestEdge == .bottom {
             ForEach(entries.reversed()) { entry in
-                row(entry).scaleEffect(x: 1, y: -1, anchor: .center)
+                VStack(spacing: 0) { row(entry) }
+                    .scaleEffect(x: 1, y: -1, anchor: .center)
             }
         } else {
             ForEach(entries) { entry in


### PR DESCRIPTION
## Problem

Reversing the Reactotron timeline order rendered every row upside-down.

## Cause

`LogTailView`'s newest-at-bottom layout flips the whole scroll view `y: -1` and un-flips each row with a per-row `scaleEffect(y: -1)`. That un-flip only works when the `row` builder returns a single view. Reactotron's closure returns two (`RtRow` + `Divider`), so `row(entry)` is a bare `TupleView`, and `scaleEffect` on a `TupleView` doesn't un-flip cleanly. JS Console passes a single view per row, so it was unaffected.

## Fix

Wrap the flipped row in `VStack(spacing: 0)` so the per-row flip applies to one settled view regardless of how many views the `row` builder returns. This lives in the shared component, so it also hardens JS Console and Logcat against the same trap.

Verified against a live Reactotron session: the timeline reads right-side-up in both newest-first and oldest-first order. Build is warning-free.