### PR TITLE
Stop JS console reconnect loop and kill sessions with their UI

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -77,6 +77,11 @@ public actor JSConsoleClient {
     ) async throws -> AsyncStream<Event> {
         teardown(reason: "reconnecting", notify: true)
         let task = URLSession.shared.webSocketTask(with: Self.debuggerRequest(for: url))
+        // The default cap is 1 MiB, and a single CDP frame can far exceed it —
+        // an app logging big objects trips it on the post-connect replay, the
+        // socket dies with close code 1009 ("message too big"), and the
+        // reconnect replays the same buffer: an endless connect/close loop.
+        task.maximumMessageSize = 64 << 20
         self.task = task
         let generation = generation
         let (stream, continuation) = AsyncStream.makeStream(of: Event.self)

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -49,9 +49,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// icon. The app stays resident for the menu bar icon, global hotkeys, and
     /// the Quick Actions panel; quit still exits fully.
     @MainActor @objc private func windowWillClose(_ notification: Notification) {
-        guard !isQuitting, let appState,
-              UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true
-        else { return }
+        guard !isQuitting, let appState else { return }
         // Structural identification, not identifiers: SwiftUI re-stamps the
         // main window's identifier (`main-AppWindow-1`) by close time, so the
         // `droidective-main` tag can't be trusted here. Background mode starts
@@ -67,8 +65,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 && $0.canBecomeMain && !($0 is NSPanel)
         }
         guard !remaining else { return }
+        // Feature work always stops with the last window — sessions must not
+        // run behind a closed window in either mode. The background pref only
+        // decides whether the app then goes accessory (menu bar / hotkeys /
+        // Quick Actions) or stays a regular Dock app.
         appState.enterBackground()
-        if NSApp.activationPolicy() == .regular {
+        if UserDefaults.standard.object(forKey: keepRunningInBackgroundKey) as? Bool ?? true,
+           NSApp.activationPolicy() == .regular {
             NSApp.setActivationPolicy(.accessory)
         }
     }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -132,6 +132,9 @@ final class JSConsoleSession {
     @ObservationIgnored private var pendingEntries: [JSEntry] = []
     @ObservationIgnored private var flushTask: Task<Void, Never>?
     @ObservationIgnored private var welcomeTask: Task<Void, Never>?
+    /// The discovery/connection loop, owned by the session so tab close and
+    /// window close can stop it without going through a view update.
+    @ObservationIgnored private var discoveryTask: Task<Void, Never>?
     /// Console/exception events received on the current connection — used to tell
     /// when the post-connect replay burst has settled so the welcome can land.
     @ObservationIgnored private var receivedCount = 0
@@ -166,11 +169,30 @@ final class JSConsoleSession {
 
     // MARK: Lifecycle
 
-    /// Run discovery + connection for as long as the view is on screen. Driven by
-    /// the view's `.task`, so SwiftUI cancels it on disappear; the connection is
-    /// then torn down (the log buffer and the sticky target preference persist,
-    /// so re-opening the console reconnects to the same app and shows prior logs).
-    func activate(serials: [String]) async {
+    /// Begin discovery + connection. Idempotent: a running loop is kept. The
+    /// session owns the loop's `Task` (not the view's `.task`) so `AppState`
+    /// can stop it when the tab or the main window closes — a view inside a
+    /// closed-but-retained window may never process another update, so view-
+    /// keyed cancellation can't be trusted for that.
+    func start(serials: [String]) {
+        self.serials = serials
+        guard discoveryTask == nil else { return }
+        discoveryTask = Task { [weak self] in
+            await self?.activate(serials: serials)
+        }
+    }
+
+    /// Stop discovery and drop the connection. The log buffer and the sticky
+    /// target preference persist, so a later `start` reconnects to the same app
+    /// and shows prior logs. Idempotent.
+    func stop() {
+        discoveryTask?.cancel()
+        discoveryTask = nil
+    }
+
+    /// Run discovery + connection until cancelled; tears the connection down on
+    /// the way out.
+    private func activate(serials: [String]) async {
         self.serials = serials
         activateGeneration += 1
         let generation = activateGeneration
@@ -612,7 +634,11 @@ struct JSConsoleView: View {
             inputBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task { await session.activate(serials: state.targetSerials) }
+        .onAppear { session.start(serials: state.targetSerials) }
+        // A real unmount (tab closed) — keep-alive tab switches never fire
+        // this. AppState also stops the session on tab/window close; both
+        // paths are idempotent.
+        .onDisappear { session.stop() }
         .onChange(of: state.targetSerials) { _, serials in session.updateSerials(serials) }
         .onAppear { portText = String(session.port) }
         .onChange(of: session.port) { _, newPort in portText = String(newPort) }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -371,6 +371,13 @@ final class AppState {
             NSApp.setActivationPolicy(.regular)
             Task { self.bringMainWindowFront() }
         }
+        // Window close stopped the JS console's discovery (the view stays
+        // mounted, so its lifecycle hooks won't re-fire) — resume it for a
+        // still-open tab. Reactotron stays down: its screen offers an explicit
+        // Retry, and restarting a server socket shouldn't be a side effect.
+        if openFeatureIDs.contains("js-console") {
+            jsConsoleSession.start(serials: targetSerials)
+        }
     }
 
     private func bringMainWindowFront() {
@@ -891,6 +898,7 @@ final class AppState {
             Task { await reactotronSession.stop() }
         }
         if id == "js-console" {
+            jsConsoleSession.stop()
             Task { await jsConsoleSession.removeReverseTunnels() }
         }
         if id == "terminal" {


### PR DESCRIPTION
## What

Two user-visible fixes for the JS console (and session lifecycle generally).

### 1. Endless connect/close loop
Metro's log showed `Connection established → Connection closed code=1009` repeating forever, with the console cycling "Choose a target → connecting…".

`JSConsoleClient` never raised `URLSessionWebSocketTask`'s default 1 MiB message cap. An app logging large objects exceeds it on the post-connect replay burst; the socket dies with close code 1009 ("message too big"), and every reconnect replays the same oversized buffer. The cap is now 64 MiB.

### 2. Sessions no longer outlive their UI
- **Tab close** — `JSConsoleSession` owns its discovery/connection loop (`start()`/`stop()`) instead of riding the view's `.task`. A view inside a closed-but-retained window may never process another update, so view-keyed cancellation couldn't be trusted to stop it. Closing the tab stops the session from both sides (view unmount + `stopBackgroundWork`), and both paths are idempotent. Reactotron already stopped on tab close.
- **Window close (red traffic light)** — `windowWillClose` now always stops feature work (JS console discovery + CDP, Reactotron server, terminal shells, reverse tunnels) when the last primary window closes. The background pref only decides whether the app then goes accessory (menu bar / hotkeys / Quick Actions) or stays a regular Dock app — previously, with the pref off, closing the window stopped nothing at all.
- **Window reopen** — a still-open JS console tab resumes discovery via `activateMainWindow` (its mounted view can't re-fire lifecycle hooks). Reactotron stays down deliberately: its screen offers an explicit Retry, and re-binding a server socket shouldn't be a side effect of fronting a window.

## Tests
- 668 ADBKit tests green; zero-warning build.
- The message-size cap is a property on the private socket task (no seam to assert it without restructuring the client); verified live instead: an RN app with a multi-MB console replay now connects once and stays connected, Metro goes quiet on tab close and on window close in both background-pref states.