### PR TITLE
Reactotron: network filters, visible app name, disconnect reasons

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronProtocol.swift
@@ -167,6 +167,45 @@ public enum ReactotronEvent: Sendable, Equatable {
     case unknown(type: String, payload: JSONValue?)
 }
 
+/// An HTTP status bucket for filtering API responses. `failure` is status 0 —
+/// how a request that never got a response (network error) arrives from the
+/// reactotron client.
+public enum HTTPStatusClass: Int, CaseIterable, Sendable, Identifiable {
+    case failure = 0
+    case success = 2
+    case redirect = 3
+    case clientError = 4
+    case serverError = 5
+
+    public var id: Int { rawValue }
+
+    public var label: String {
+        self == .failure ? "Failed" : "\(rawValue)xx"
+    }
+
+    /// The bucket for a concrete status code; nil for codes outside the
+    /// buckets (1xx, or garbage like a negative).
+    public init?(status: Int) {
+        guard status >= 0 else { return nil }
+        self.init(rawValue: status / 100)
+    }
+}
+
+public extension ReactotronEvent {
+    /// The HTTP method of an `apiResponse` event (uppercased at parse time);
+    /// nil for every other event.
+    var apiMethod: String? {
+        guard case let .apiResponse(method, _, _, _, _, _) = self else { return nil }
+        return method
+    }
+
+    /// The HTTP status of an `apiResponse` event; nil for every other event.
+    var apiStatus: Int? {
+        guard case let .apiResponse(_, _, status, _, _, _) = self else { return nil }
+        return status
+    }
+}
+
 public extension ReactotronEvent {
     /// Parse a raw frame into a typed timeline event.
     init(command: ReactotronCommand) {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import os
 
 /// A Reactotron-compatible WebSocket server. The RN app (running
 /// `reactotron-react-native`) is the client; this is the server it connects to
@@ -24,6 +25,21 @@ public actor ReactotronServer {
         }
     }
 
+    /// Why a client connection ended, carried on `.disconnected` so the UI can
+    /// say more than a yellow dot. A clean close with `goingAway` (WS 1001)
+    /// from an Android client is OkHttp bailing out after its outgoing queue
+    /// passed 16 MiB — the app produced events faster than the transport could
+    /// drain them (huge console.log payloads, typically).
+    public enum DisconnectReason: Sendable, Equatable {
+        case clientClosed(goingAway: Bool)
+        case transportError(String)
+    }
+
+    /// The disconnect reason for a client-sent WS close frame.
+    public static func closeReason(_ code: NWProtocolWebSocket.CloseCode) -> DisconnectReason {
+        .clientClosed(goingAway: code == .protocolCode(.goingAway))
+    }
+
     /// Events surfaced to the UI as the server runs. `frameBytes` is the wire
     /// size of the frame a command was decoded from, so the timeline can keep
     /// its retained payloads within a byte budget.
@@ -31,7 +47,8 @@ public actor ReactotronServer {
         case listening(port: UInt16)
         case connected(connectionId: Int, intro: ReactotronCommand, frameBytes: Int)
         case command(connectionId: Int, command: ReactotronCommand, frameBytes: Int)
-        case disconnected(connectionId: Int)
+        /// `reason` is nil for teardown-driven drops (stop, listener death).
+        case disconnected(connectionId: Int, reason: DisconnectReason?)
         case failed(reason: String, portInUse: Bool)
     }
 
@@ -42,6 +59,10 @@ public actor ReactotronServer {
     }
 
     private static let queue = DispatchQueue(label: "com.rohindh.droidective.reactotron-server")
+    /// Why a client dropped is invisible in the UI (the dot just goes yellow) —
+    /// keep the transport's own words in the unified log for field diagnosis:
+    /// `log show --predicate 'subsystem == "com.rohindh.droidective"'`.
+    private static let log = Logger(subsystem: "com.rohindh.droidective", category: "reactotron-server")
 
     private let port: UInt16
     private var listener: NWListener?
@@ -149,8 +170,12 @@ public actor ReactotronServer {
 
         box.connection.stateUpdateHandler = { [weak self] state in
             switch state {
-            case .failed, .cancelled:
-                Task { await self?.dropConnection(id) }
+            case let .failed(error):
+                Self.log.error("connection #\(id) failed: \(error, privacy: .public)")
+                Task { await self?.dropConnection(id, reason: .transportError("\(error)")) }
+            case .cancelled:
+                Self.log.notice("connection #\(id) cancelled")
+                Task { await self?.dropConnection(id, reason: nil) }
             default:
                 break
             }
@@ -159,10 +184,13 @@ public actor ReactotronServer {
         Self.receiveLoop(box, id: id, server: self)
     }
 
-    private func dropConnection(_ id: Int) {
+    /// Drops the connection and reports why. Racing drop paths (close frame,
+    /// then the socket error, then cancelled) all land here; the first wins,
+    /// which is the most specific one — the close frame beats its aftermath.
+    private func dropConnection(_ id: Int, reason: DisconnectReason?) {
         guard let box = connections.removeValue(forKey: id) else { return }
         box.connection.cancel()
-        continuation?.yield(.disconnected(connectionId: id))
+        continuation?.yield(.disconnected(connectionId: id, reason: reason))
     }
 
     /// Recursive receive loop, off the actor (like `MirrorTransport.receiveLoop`).
@@ -180,14 +208,17 @@ public actor ReactotronServer {
                         Task { await server.handleFrame(connectionId: id, data: content) }
                     }
                 case .close:
-                    Task { await server.dropConnection(id) }
+                    log.notice("connection #\(id): client sent WS close, code=\(String(describing: metadata.closeCode), privacy: .public)")
+                    let reason = closeReason(metadata.closeCode)
+                    Task { await server.dropConnection(id, reason: reason) }
                     return
                 default:
                     break
                 }
             }
-            if error != nil {
-                Task { await server.dropConnection(id) }
+            if let error {
+                log.error("connection #\(id) receive failed: \(error, privacy: .public)")
+                Task { await server.dropConnection(id, reason: .transportError("\(error)")) }
                 return
             }
             receiveLoop(box, id: id, server: server)

--- a/ADBKit/Tests/ADBKitTests/ReactotronProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronProtocolTests.swift
@@ -272,4 +272,54 @@ import Testing
         }
         #expect(type == "some.future.command")
     }
+
+    // MARK: API filter accessors — back the timeline's method/status filters.
+
+    @Test func apiAccessorsExposeMethodAndStatus() throws {
+        let command = try ReactotronCommand.decode(
+            #"{"type":"api.response","important":false,"date":"d","deltaTime":1,"payload":{"duration":10,"request":{"method":"post","url":"https://api.example.com/orders"},"response":{"status":404}}}"#
+        )
+        let event = ReactotronEvent(command: command)
+        #expect(event.apiMethod == "POST")
+        #expect(event.apiStatus == 404)
+    }
+
+    @Test func apiAccessorsAreNilForOtherEvents() {
+        let event = ReactotronEvent.log(level: .debug, message: "GET /not-an-api", stack: [])
+        #expect(event.apiMethod == nil)
+        #expect(event.apiStatus == nil)
+    }
+
+    @Test func statusClassBucketsCodes() {
+        #expect(HTTPStatusClass(status: 200) == .success)
+        #expect(HTTPStatusClass(status: 204) == .success)
+        #expect(HTTPStatusClass(status: 302) == .redirect)
+        #expect(HTTPStatusClass(status: 404) == .clientError)
+        #expect(HTTPStatusClass(status: 503) == .serverError)
+    }
+
+    @Test func statusZeroIsTheFailureBucket() {
+        // A request that never got a response arrives with status 0.
+        #expect(HTTPStatusClass(status: 0) == .failure)
+        #expect(HTTPStatusClass.failure.label == "Failed")
+    }
+
+    @Test func statusClassRejectsOutOfRangeCodes() {
+        #expect(HTTPStatusClass(status: 100) == nil)   // 1xx: not a filter bucket
+        #expect(HTTPStatusClass(status: 601) == nil)
+        #expect(HTTPStatusClass(status: -1) == nil)
+    }
+
+    // MARK: Disconnect reasons — the timeline's "why did streaming stop" row.
+
+    @Test func goingAwayCloseMapsToTheQueueOverflowReason() {
+        // OkHttp (RN Android) sends 1001 when its 16 MiB send queue overflows.
+        #expect(ReactotronServer.closeReason(.protocolCode(.goingAway))
+            == .clientClosed(goingAway: true))
+    }
+
+    @Test func normalCloseIsAPlainClientClose() {
+        #expect(ReactotronServer.closeReason(.protocolCode(.normalClosure))
+            == .clientClosed(goingAway: false))
+    }
 }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import os
 import SwiftUI
 
 /// The live Reactotron session — server, adb-reverse tunnels, and the whole
@@ -95,6 +96,11 @@ final class ReactotronSession {
 
     func applyReverse(serials: [String]) async {
         guard let service else { return }
+        // In the unified log next to the server's connection-drop lines: a
+        // reverse re-apply that coincides with a drop is the tell that adb
+        // rebinding the tunnel killed the live socket.
+        Logger(subsystem: "com.rohindh.droidective", category: "reactotron-session")
+            .notice("re-applying adb reverse for \(serials.count) device(s)")
         reversedSerials = serials
         await service.reverse(serials: serials)
     }
@@ -388,7 +394,21 @@ final class ReactotronSession {
                 event: parsed, command: command, connectionId: connectionId,
                 important: command.isImportant, frameBytes: frameBytes
             ))
-        case let .disconnected(connectionId):
+        case let .disconnected(connectionId, reason):
+            // Before forgetting the client (its name captions the notice):
+            // spell out *why* the stream ended, in the timeline where the user
+            // is looking — a silent yellow dot reads as "Droidective broke".
+            if let notice = Self.disconnectNotice(
+                reason, app: clients.first { $0.id == connectionId }?.name
+            ) {
+                // Headline in the (one-line) row; the full explanation rides the
+                // command payload, which is what the row expands to.
+                enqueue(RtItem(
+                    event: .unknown(type: "disconnected", payload: .string(notice.headline)),
+                    command: ReactotronCommand(type: "disconnected", payload: .string(notice.detail)),
+                    connectionId: connectionId, important: true, frameBytes: 0
+                ))
+            }
             clients.removeAll { $0.id == connectionId }
             if selectedClient == connectionId { selectedClient = nil }
             if clients.isEmpty { commands.removeAll() }
@@ -409,6 +429,34 @@ final class ReactotronSession {
 
     private func isWholeStorePath(_ path: String?) -> Bool {
         path == nil || path?.isEmpty == true
+    }
+
+    /// The timeline row explaining a client drop; nil for teardown-driven
+    /// drops (server stop), which need no explanation. `headline` fits the
+    /// one-line row; `detail` is the expanded body.
+    private static func disconnectNotice(
+        _ reason: ReactotronServer.DisconnectReason?, app: String?
+    ) -> (headline: String, detail: String)? {
+        let name = app ?? "The app"
+        switch reason {
+        case .clientClosed(goingAway: true):
+            return (
+                headline: "\(name) hung up — events outpaced the connection (WS 1001). Expand for the fix.",
+                detail: "\(name) produced Reactotron events faster than the connection could "
+                    + "send them, so Android's WebSocket closed itself once 16 MB were queued "
+                    + "(close code 1001, going-away).\n\nVery large console.log / action payloads "
+                    + "are the usual cause — log IDs and summaries instead of whole objects.\n\n"
+                    + "Reload the app to reconnect."
+            )
+        case .clientClosed(goingAway: false):
+            let text = "\(name) closed the connection (app reloaded or exited)."
+            return (headline: text, detail: text)
+        case let .transportError(detail):
+            return (headline: "\(name) dropped: \(detail)",
+                    detail: "\(name) dropped: \(detail)")
+        case nil:
+            return nil
+        }
     }
 
     private func refreshConnectionState() {
@@ -589,13 +637,23 @@ struct ReactotronView: View {
 
     private var topTabs: some View {
         HStack(spacing: 8) {
-            // Connection state folded in here as a dot (full status on hover) —
-            // the detailed "Listening on :9090…" guidance lives in the timeline's
+            // Connection state as a dot plus the connected app's name — the
+            // detailed "Listening on :9090…" guidance lives in the timeline's
             // empty state, so a dedicated status bar would just repeat it.
-            Circle()
-                .fill(session.connection.color)
-                .frame(width: 7, height: 7)
-                .help(session.connection.text(app: session.connectedApp))
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(session.connection.color)
+                    .frame(width: 7, height: 7)
+                if let app = session.connectedApp {
+                    Text(app)
+                        .font(.app(.caption).weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .frame(maxWidth: 160, alignment: .leading)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+            }
+            .help(session.connection.text(app: session.connectedApp))
 
             Picker("View", selection: $tab) {
                 Text("Timeline").tag(RtTab.timeline)
@@ -1097,6 +1155,10 @@ private struct TimelinePane: View {
 
     @State private var search = ""
     @State private var filter: RtFilter = .all
+    /// Network-only refinements, shown while the Network category is selected
+    /// and cleared when it isn't: HTTP method and status class (2xx…5xx/Failed).
+    @State private var methodFilter: String?
+    @State private var statusFilter: HTTPStatusClass?
 
     var body: some View {
         // Filter once per render — the count badge, export button, and timeline
@@ -1119,6 +1181,16 @@ private struct TimelinePane: View {
             }
             .labelsHidden()
             .frame(width: 110)
+            .onChange(of: filter) { _, newFilter in
+                if newFilter != .network {
+                    methodFilter = nil
+                    statusFilter = nil
+                }
+            }
+
+            if filter == .network {
+                networkFilters
+            }
 
             SearchField(prompt: "Search…", text: $search)
                 .frame(maxWidth: 200)
@@ -1145,14 +1217,49 @@ private struct TimelinePane: View {
         .padding(.vertical, 6)
     }
 
+    /// The HTTP methods present in the buffer's API events, for the method
+    /// picker — only what the app actually sent, not a canned list.
+    private var seenMethods: [String] {
+        Array(Set(items.compactMap { $0.event.apiMethod })).sorted()
+    }
+
     private var filteredItems: [RtItem] {
         let query = search.trimmingCharacters(in: .whitespaces).lowercased()
         return items.filter { item in
             if filter != .all, item.event.category != filter { return false }
+            if let methodFilter, item.event.apiMethod != methodFilter { return false }
+            if let statusFilter,
+               item.event.apiStatus.flatMap({ HTTPStatusClass(status: $0) }) != statusFilter {
+                return false
+            }
             // item.searchText is lowercased at creation, so this is a plain,
             // allocation-free substring check.
             if !query.isEmpty, !item.searchText.contains(query) { return false }
             return true
+        }
+    }
+
+    private var networkFilters: some View {
+        HStack(spacing: 6) {
+            Picker("Method", selection: $methodFilter) {
+                Text("Method").tag(String?.none)
+                ForEach(seenMethods, id: \.self) { method in
+                    Text(method).tag(Optional(method))
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            .help("Show only requests with this HTTP method")
+
+            Picker("Status", selection: $statusFilter) {
+                Text("Status").tag(HTTPStatusClass?.none)
+                ForEach(HTTPStatusClass.allCases) { statusClass in
+                    Text(statusClass.label).tag(Optional(statusClass))
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+            .help("Show only responses in this status class")
         }
     }
 
@@ -2335,6 +2442,14 @@ private extension ReactotronEvent {
         case .replResult:
             return RtPresentation(badge: "REPL", badgeColor: .rtBadge, primary: "result", primaryColor: .primary)
         case let .unknown(type, payload):
+            // The session's synthetic drop notice — not a wire event; it gets
+            // warning styling and an untruncated headline.
+            if type == "disconnected" {
+                return RtPresentation(
+                    badge: "DISCONNECTED", badgeColor: .orange,
+                    primary: payload?.stringValue ?? "", primaryColor: .primary
+                )
+            }
             return RtPresentation(
                 badge: type.uppercased(), badgeColor: .secondary,
                 primary: payload?.stringValue.map { String($0.prefix(140)) } ?? "", primaryColor: .secondary


### PR DESCRIPTION
## What

Three Reactotron improvements from a debugging session against a real RN app.

### Network filters
Selecting the **Network** category in a timeline pane reveals two refinements beside it:
- **Method** — populated from the HTTP methods the app has actually sent, not a canned list
- **Status** — 2xx / 3xx / 4xx / 5xx / Failed (status 0 = the request never got a response)

Both compose with text search, reset when leaving the category, and work per-pane in split view. Backed by ADBKit `apiMethod`/`apiStatus` accessors and an `HTTPStatusClass` bucketing type.

### Visible app name
The connected app's name renders next to the status dot (it previously existed only in the dot's hover tooltip). Multiple clients show "N apps"; the per-app picker is unchanged.

### Disconnect reasons — why did streaming stop?
Client drops used to be a silent yellow dot. `ReactotronServer.Event.disconnected` now carries a `DisconnectReason` (clean client close vs transport error), and the session renders an expandable orange **DISCONNECTED** row in the timeline at the exact point streaming stopped.

The motivating case, diagnosed live with three-sided capture (unified log + device logcat + socket sampler): an app logging megabyte-scale payloads (whole RxJS observer graphs, full GraphQL subscription objects) outruns what the adb-reverse pipe drains; Android RN's WebSocket is OkHttp, which **closes the socket itself once 16 MB of unsent frames queue up** (clean close, code 1001 going-away). The Mac side is idle and healthy throughout, and `reactotron-core-client` never reconnects until app reload — so the stream just "stops" after a couple hundred events. Reproduced identically against the official Reactotron desktop app. The new row names the app, explains the mechanism, and says how to fix it (log summaries, not whole objects; reload to reconnect). Drop reasons also go to the unified log (`subsystem == "com.rohindh.droidective"`) for field diagnosis.

## Tests
- 8 new ADBKit tests: api accessor extraction, status-class bucketing (incl. status 0 and out-of-range codes), and close-code → reason mapping (1001 → queue-overflow, 1000 → plain close). 675 total green.
- Verified live: filters against a streaming RN app; the DISCONNECTED row appearing at the stall point with the correct app name and expandable detail.