### PR TITLE
Release v2.9.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,49 @@
+## Droidective v2.9.3
+
+The streaming log feeds — Logcat, JS Console, and the Reactotron timeline —
+rebuilt around one scroll behavior, plus JS-console connection fixes and
+Reactotron network filters.
+
+### New features
+
+- **Jump to top / bottom in every log feed** — floating buttons overlay Logcat,
+  the JS Console, and the Reactotron timeline; each hides while you're at its
+  edge, and both hide when there's nothing to scroll. Jumping to the newest
+  edge resumes live following.
+- **Reactotron network filters** — pick the Network view in a timeline pane and
+  filter by HTTP method (the ones your app actually sent) and status class
+  (2xx–5xx, plus Failed for requests that never got a response) — per pane, so
+  a split view can watch two slices.
+- **Reactotron explains disconnects** — when a client drops, an expandable
+  DISCONNECTED row lands in the timeline where streaming stopped, naming the
+  app and the reason — including the Android case where the app queues events
+  faster than the connection drains and its WebSocket hangs up at a 16 MB
+  backlog.
+
+### Improvements
+
+- **Interruption-free reading while streaming** — scroll away from the newest
+  line and new logs keep rendering without dragging your view; return to the
+  edge (or tap the jump button) and following resumes. The reverse-order
+  toggles are gone: JS Console and Logcat tail at the bottom, Reactotron keeps
+  newest at top.
+- **Steady under event storms** — the feeds no longer re-render per scrolled
+  pixel or per streamed event, which could peg the CPU and hang the app under
+  a fast Reactotron stream.
+- The connected app's name shows next to Reactotron's status dot.
+
+### Fixes
+
+- **JS console no longer loops "connecting…"** — apps logging large objects
+  tripped a 1 MiB socket cap on the post-connect replay (close code 1009), and
+  every reconnect replayed the same burst. The cap is now 64 MiB.
+- **Consoles stop with their UI** — closing the JS console or Reactotron tab,
+  or the main window (in either background-mode setting), tears the connection
+  down instead of leaving it reconnecting in the background; reopening the
+  window resumes the JS console's discovery.
+
+Installed copies update in place via Sparkle.
+
 ## Droidective v2.9.2
 
 Screen-mirror quality of life — a pop-out mirror window and reliable device

--- a/project.yml
+++ b/project.yml
@@ -99,7 +99,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "2.9.2"
+        MARKETING_VERSION: "2.9.3"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -16,7 +16,7 @@ export const GITHUB_URL = "https://github.com/Droidective/Droidective"
 export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const LATEST_RELEASE_URL = `${GITHUB_URL}/releases/latest`
-export const APP_VERSION = "v2.9.2"
+export const APP_VERSION = "v2.9.3"
 
 export interface PaletteCommand {
   icon: LucideIcon
@@ -163,7 +163,8 @@ export const galleryShots = [
 ]
 
 export const releases: { version: string; date: string; latest?: boolean; html: string }[] = [
-  { version: "v2.9.2", date: "Jul 2026", latest: true, html: "<b>Mirror in its own window</b> — pop the live mirror out beside your workspace from a button on its control bar; it follows the device-bar selection, which now <b>switches sessions reliably</b>, with a Reconnect button when a stream dies. The <b>video editor</b> gets full-width native controls and trim strip (no more cramped portrait layout), every Reveal button becomes <b>Open in Finder</b>, and the first quick save asks once where captures should go." },
+  { version: "v2.9.3", date: "Jul 2026", latest: true, html: "<b>Log feeds rebuilt</b> — Logcat, the JS Console, and the Reactotron timeline share one scroll behavior: jump-to-top/bottom buttons, interruption-free reading while logs stream, and no more CPU spikes under event storms. The <b>JS console</b> stops looping “connecting…” on large payloads, both consoles shut down with their tab or window, and <b>Reactotron</b> adds HTTP method/status filters, shows the connected app's name, and explains client disconnects right in the timeline." },
+  { version: "v2.9.2", date: "Jul 2026", html: "<b>Mirror in its own window</b> — pop the live mirror out beside your workspace from a button on its control bar; it follows the device-bar selection, which now <b>switches sessions reliably</b>, with a Reconnect button when a stream dies. The <b>video editor</b> gets full-width native controls and trim strip (no more cramped portrait layout), every Reveal button becomes <b>Open in Finder</b>, and the first quick save asks once where captures should go." },
   { version: "v2.9.1", date: "Jul 2026", html: "<b>Home search &amp; a Frequently used strip</b> — find any tool from the Home screen and jump to your most-used ones — plus <b>font and accent-color customization</b> in Settings ▸ Appearance. Fixes: the React Native dev-server host now writes <code>debug_http_host</code> so it works on physical devices, text fields release focus when you click away, <kbd>⌘,</kbd> no longer opens Settings behind the Quick Actions panel, and drop-to-split works again in the Terminal. The command palette moves to <kbd>⌘T</kbd>." },
   { version: "v2.9.0", date: "Jul 2026", html: "<b>Background mode &amp; a global Quick Actions panel</b> — closing the window keeps Droidective running in the menu bar, and a non-activating Raycast-style panel on a global hotkey runs any adb action, manages apps, boots emulators, and installs APKs without the main window — with per-device targeting and Finder APK routing. Plus a <b>terminal tab rail</b> with a find bar and a <b>Dock-style auto-hiding sidebar</b>." },
   { version: "v2.8.3", date: "Jul 2026", html: "<b>iOS Simulator support</b> — booted iOS Simulators sit in the same device bar as Android devices, and features adapt to the selection: screenshot, dark mode, demo mode, fake battery, and deep links run through <code>xcrun simctl</code>, with push notifications as a Simulator-only tool and a new iOS Developer role. Plus a <b>redesigned role picker</b>, <b>per-feature product analytics</b> (anonymous, opt-out), and Reactotron/log readability fixes." },


### PR DESCRIPTION
## v2.9.3

Version bump + release notes + site changelog for the log-feed release. Scope since v2.9.2 (#118, #119, #120, #121):

### New
- Jump-to-top/bottom buttons on every streaming feed (Logcat, JS Console, Reactotron timeline), hiding at their own edge and when there's nothing to scroll
- Reactotron network filters: HTTP method (from what the app actually sent) + status class (2xx–5xx/Failed), per pane
- Reactotron disconnect diagnostics: an expandable DISCONNECTED timeline row naming the app and the reason (including Android's 16 MB WebSocket-backlog hangup)

### Improvements
- Interruption-free reading while streaming; reverse-order toggles removed (JS Console/Logcat tail at bottom, Reactotron newest at top)
- Feeds no longer re-render per scrolled pixel / per event — no more CPU spikes and hangs under a fast Reactotron stream
- Connected app's name next to Reactotron's status dot

### Fixes
- JS console "connecting…" loop on large payloads (1 MiB socket cap → 64 MiB)
- JS console/Reactotron sessions stop on tab close and window close in both background-mode settings; window reopen resumes JS-console discovery

Contents: `MARKETING_VERSION` 2.9.3, RELEASE_NOTES.md section, site changelog entry + `APP_VERSION`. Appcast untouched (the release pipeline owns it). 675 ADBKit tests green on this branch.