### PR TITLE
Fix chrome clipping at minimum window width

### DIFF
--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -174,7 +174,11 @@ struct DeviceBarView: View {
         // back the boxed button affordance the borderless style drops — both
         // derived from the resolved title color, so they adapt to light and dark.
         .menuStyle(.borderlessButton)
-        .fixedSize()
+        // Cap-and-truncate rather than `.fixedSize()`: a rigid pill made the
+        // whole bar incompressible, so a narrow pane (or a bundle pill on top)
+        // pushed the bar past the window and clipped it on both edges. A max
+        // width lets a long device label truncate and the bar shrink to fit.
+        .frame(maxWidth: 200, alignment: .leading)
         .controlSize(.large)
         .foregroundStyle(pillTextColor)
         // The borderless pop-up tints its title with the control accent (the
@@ -313,7 +317,9 @@ struct DeviceBarView: View {
         // the default pop-up button carries its own leading inset, which made
         // the icon→pill gap read wider than the device pair's.
         .menuStyle(.borderlessButton)
-        .fixedSize()
+        // Same cap-and-truncate as the device pill (not `.fixedSize()`) so the
+        // bundle pair can compress instead of forcing the whole bar off-screen.
+        .frame(maxWidth: 240, alignment: .leading)
         .controlSize(.large)
         .foregroundStyle(pillTextColor)
         // Same accent-asset tinting escape as the device pill above.
@@ -332,6 +338,9 @@ struct DeviceBarView: View {
                 Text(bundle.nickname)
                     .fontWeight(.semibold)
                     .lineLimit(1)
+                    // The nickname is the identifier — when the pill is squeezed
+                    // narrow, let the package id truncate first.
+                    .layoutPriority(1)
                 Text(bundle.packageId)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -357,7 +357,8 @@ struct RootView: View {
             split
                 .frame(
                     width: geo.size.width / state.fontScale,
-                    height: geo.size.height / state.fontScale
+                    height: geo.size.height / state.fontScale,
+                    alignment: .topLeading
                 )
                 .scaleEffect(state.fontScale, anchor: .topLeading)
         }


### PR DESCRIPTION
## What changed

The device bar's device- and bundle-pills now cap-and-truncate
(`.frame(maxWidth:)`) instead of `.fixedSize()`, so the bar can compress when the
pane is narrow; a long device label or package id truncates rather than forcing
the bar wider than the window. The root content frame is anchored to
`.topLeading` instead of its default centering. The bundle pill's package id
truncates before its nickname.

## Why

At the minimum window width the device bar could not shrink — its pills were
rigid. On the tabs that also show the bundle pill (Memory Usage, Custom Commands,
Logcat, Performance) the bar grew wider than the pane, which pushed the whole
`split` past the window. Because the root frame centered its content, the
overflow was clipped on both edges: the sidebar's row icons were cut off on the
left and the trailing device-bar controls (and each pane's header buttons) were
cut off on the right. Tabs with no bundle pill (Emulators, Connection) fit within
the bar, which is why they rendered correctly — they were the reference for the
fix.

## Impact area

- Shared Root chrome — `DeviceBarView` and `RootView`'s content frame sit above
  every feature tab, so this affects the device bar and layout on all tabs, not
  one feature.

Not touched: `ADBKit` services, `FeatureRegistry`/`FeatureNotes`, persisted
state, bundled tools / release / signing.

## How verified

- [x] `make test` green (675 tests, 106 suites)
- [x] `make build` succeeds with zero warnings
- [ ] Live: resize the window to its minimum width and confirm the sidebar row
  icons and the trailing device-bar controls stay fully visible on Memory Usage,
  Custom Commands, Logcat, and Performance (pills should truncate, not clip).

## Risks / follow-ups

- At the absolute minimum single-pane width with no device connected, the "No
  device connected" label may truncate slightly. If that reads poorly, bump the
  single-pane minimum window width (`minWindowWidth` in `App/Sources/ADTApp.swift`).
