### PR TITLE
Hide Logcat and JS Console toolbars when idle

### DIFF
--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -154,6 +154,11 @@ final class JSConsoleSession {
 
     var isConnected: Bool { connectedTarget != nil }
 
+    /// Whether the console holds any output at all (unfiltered). The filter row
+    /// keys off this, so an active filter that hides every row still leaves a
+    /// way to clear it.
+    var hasEntries: Bool { !buffer.entries.isEmpty }
+
     init(adb: AdbClient) {
         self.adb = adb
         let savedPort = UserDefaults.standard.integer(forKey: Self.portKey)
@@ -619,15 +624,28 @@ struct JSConsoleView: View {
 
     private var session: JSConsoleSession { state.jsConsoleSession }
 
+    /// The filter row earns its space once the console is live or already holds
+    /// output. Gated on the *unfiltered* buffer (`hasEntries`), so an active
+    /// filter that hides every row can't strand the user with no way to clear it.
+    private var showFilterBar: Bool {
+        session.isConnected || session.hasEntries
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             connectionBar
             Divider()
-            filterBar
-            Divider()
-            if session.findVisible {
-                findBar
+            // The filter / levels / find / clear row is only useful once there's
+            // something in the console. While it's waiting for a target with an
+            // empty buffer, hide it (and the find bar it opens) — the connection
+            // bar above stays so the target can still be chosen.
+            if showFilterBar {
+                filterBar
                 Divider()
+                if session.findVisible {
+                    findBar
+                    Divider()
+                }
             }
             logArea
             Divider()

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -38,10 +38,15 @@ struct LogcatView: View {
         // instead of each re-scanning the full buffer while searching.
         let visible = visibleLines
         return VStack(spacing: 0) {
-            toolbar
-            Divider()
-            statusBar(visible: visible)
-            Divider()
+            // With no device there's nothing to filter, pause, export, or clear —
+            // hide the toolbar and status strip and let the empty state below
+            // carry the "connect a device" message.
+            if !state.targetSerials.isEmpty {
+                toolbar
+                Divider()
+                statusBar(visible: visible)
+                Divider()
+            }
             logList(visible: visible)
         }
         .task(id: taskKey) { await streamLoop() }


### PR DESCRIPTION
## What changed

Logcat and the JS Console now hide their filter/action toolbars when there's
nothing to act on:

- **Logcat** — with no device connected, the level/app/search toolbar and the
  status strip are hidden; only the "No device connected" empty state shows.
  The toolbar returns as soon as a device connects (so level/app filters can be
  set before logs arrive).
- **JS Console** — the filter row (Filter, level picker, find, Time, clear) and
  the find bar it opens are hidden until the console is connected or already
  holds output. The connection bar above (status, target picker, port, adb
  reverse) stays, since that's how a target is chosen.

## Why

On both screens the toolbars rendered a full row of controls that did nothing in
the idle state — Logcat with no device, JS Console while it waits for a React
Native target with an empty buffer. The controls read as actionable when they
weren't. The empty-state views already say what to do next, so the toolbars are
noise until there's something to filter, pause, export, or clear.

The JS Console filter row is gated on the *unfiltered* buffer (a new
`hasEntries` on `JSConsoleSession`), not on the visible rows — so a filter that
happens to hide every row can't make the filter bar vanish and strand the user
with no way to clear it.

## Impact area

- Isolated to two feature views (`LogcatView`, `JSConsoleView`) plus one
  read-only computed added to `JSConsoleSession`. No shared ADBKit service,
  registry, persistence, or release change.

## How verified

- [x] `make test` green (675 tests, 106 suites)
- [x] `make build` succeeds with zero warnings
- [ ] Live: with no device, open Logcat — only the empty state shows, no
  toolbar; connect a device and the toolbar returns. Open the JS Console with
  no target — the filter row is hidden, the connection bar remains; once a
  target connects (or logs arrive) the filter row appears.

## Risks / follow-ups

- The JS Console input bar and Logcat's behavior once a device is connected are
  unchanged. If the input bar should also hide while disconnected, that's a
  small follow-up.
