### PR TITLE
UX round: Home, window floor, Reactotron, JS console, onboarding tour

### DIFF
--- a/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/UsageStats.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// Per-feature usage tally, persisted to `usage.json`. Used to re-rank a role's
-/// curated feature order on the Home launchpad by how the user actually works,
-/// so "frequently used" becomes personal over time.
+/// Per-feature usage tally, persisted to `usage.json`. Drives Home's
+/// "Frequently used" strip, so it becomes personal over time.
 ///
 /// `CommandLog` is session-only (an in-memory actor), so cross-launch ranking
 /// needs this durable store rather than the command log.
@@ -32,27 +31,6 @@ public struct UsageStats: Codable, Sendable, Equatable {
         stat.count += 1
         stat.lastUsed = date
         byFeature[featureID] = stat
-    }
-
-    /// Re-rank `ids` (a curated, ordered list) by real usage: most-used first,
-    /// most-recent use breaks count ties, and the original curated order is the
-    /// stable fallback for unused or otherwise-tied features. The comparator is
-    /// a total order (curated index is the final tiebreak), so the result is
-    /// deterministic regardless of `sorted`'s stability guarantees.
-    public func rank(_ ids: [String]) -> [String] {
-        ids.enumerated()
-            .sorted { lhs, rhs in
-                let a = byFeature[lhs.element]
-                let b = byFeature[rhs.element]
-                let countA = a?.count ?? 0
-                let countB = b?.count ?? 0
-                if countA != countB { return countA > countB }
-                if countA > 0, let lastA = a?.lastUsed, let lastB = b?.lastUsed, lastA != lastB {
-                    return lastA > lastB
-                }
-                return lhs.offset < rhs.offset
-            }
-            .map(\.element)
     }
 
     /// The ids used at least `minUses` times, ordered strictly by use count

--- a/ADBKit/Sources/ADBKit/Services/AppNameMatcher.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppNameMatcher.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Matches a human app display name (what a Reactotron client or Metro target
+/// reports about itself, e.g. "Food Hub") against installed package ids, so
+/// the restart flows can auto-detect which app to restart. Pure and
+/// conservative: a match is returned only when it's unambiguous.
+public enum AppNameMatcher {
+    /// The single package matching `appName`, or nil when none or several do.
+    /// An exact match on the package's last segment wins ("My App" →
+    /// `com.acme.myapp`); otherwise the name appearing anywhere in the package
+    /// id is accepted if exactly one package qualifies ("Food Hub" →
+    /// `com.foodhub.driver.dev`).
+    public static func match(appName: String, in packages: [String]) -> String? {
+        let name = normalize(appName)
+        guard !name.isEmpty else { return nil }
+        let lastSegment = packages.filter {
+            normalize(String($0.split(separator: ".").last ?? "")) == name
+        }
+        if lastSegment.count == 1 { return lastSegment[0] }
+        if lastSegment.count > 1 { return nil }
+        let containing = packages.filter { normalize($0).contains(name) }
+        return containing.count == 1 ? containing[0] : nil
+    }
+
+    /// Lowercased alphanumerics only, so "Food Hub" and `foodhub` compare equal.
+    private static func normalize(_ text: String) -> String {
+        String(text.lowercased().unicodeScalars.filter {
+            CharacterSet.alphanumerics.contains($0)
+        })
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
@@ -32,9 +32,20 @@ public struct FilteredLogBuffer<Entry: Identifiable> where Entry.ID: Comparable 
     public private(set) var entries: [Entry] = []
     public private(set) var filtered: [Entry] = []
     private let capacity: Int
+    /// Optional retained-size ceiling: when the summed `cost` of the buffer
+    /// exceeds it, oldest entries are evicted (the newest always survives).
+    /// Guards against a count cap alone retaining gigabytes when every entry
+    /// carries a multi-megabyte payload.
+    private let byteBudget: Int
+    private let cost: (Entry) -> Int
+    /// Per-entry costs aligned with `entries`, so eviction never re-measures.
+    private var costs: [Int] = []
+    private var totalCost = 0
 
-    public init(capacity: Int) {
+    public init(capacity: Int, byteBudget: Int = .max, cost: @escaping (Entry) -> Int = { _ in 0 }) {
         self.capacity = max(1, capacity)
+        self.byteBudget = byteBudget
+        self.cost = cost
     }
 
     /// Append a batch, extending `filtered` with just the batch's matches.
@@ -42,6 +53,11 @@ public struct FilteredLogBuffer<Entry: Identifiable> where Entry.ID: Comparable 
     /// with; pass `nil` when no filter is active (the fast path).
     public mutating func append(_ batch: [Entry], isIncluded: ((Entry) -> Bool)?) {
         entries.append(contentsOf: batch)
+        for entry in batch {
+            let entryCost = cost(entry)
+            costs.append(entryCost)
+            totalCost += entryCost
+        }
         if let isIncluded {
             filtered.append(contentsOf: batch.filter(isIncluded))
         } else {
@@ -63,13 +79,24 @@ public struct FilteredLogBuffer<Entry: Identifiable> where Entry.ID: Comparable 
     public mutating func removeAll() {
         entries.removeAll()
         filtered.removeAll()
+        costs.removeAll()
+        totalCost = 0
     }
 
     private mutating func evictOverflow() {
-        let overflow = entries.count - capacity
-        guard overflow > 0 else { return }
-        let lastEvictedID = entries[overflow - 1].id
-        entries.removeFirst(overflow)
+        var evict = max(0, entries.count - capacity)
+        var freed = costs.prefix(evict).reduce(0, +)
+        // Byte budget: keep growing the eviction window while over, always
+        // leaving the newest entry (one oversized entry mustn't empty the feed).
+        while totalCost - freed > byteBudget, evict < entries.count - 1 {
+            freed += costs[evict]
+            evict += 1
+        }
+        guard evict > 0 else { return }
+        let lastEvictedID = entries[evict - 1].id
+        entries.removeFirst(evict)
+        costs.removeFirst(evict)
+        totalCost -= freed
         let evictedFromFiltered = filtered.prefix { $0.id <= lastEvictedID }.count
         if evictedFromFiltered > 0 { filtered.removeFirst(evictedFromFiltered) }
     }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/JSConsoleClient.swift
@@ -139,6 +139,25 @@ public actor JSConsoleClient {
         return result?["result"]?["value"]?.stringValue
     }
 
+    /// Ask the app to reload its JS bundle — the mechanism React Native
+    /// DevTools' ⌘R uses: the app's inspector integration handles
+    /// `Page.reload` itself, no `Page` domain enable needed. The reply is
+    /// bounded by `replyTimeout` because a proxy relaying to a dead page never
+    /// answers, and an unbounded wait would suspend the caller forever;
+    /// runtimes without native reload support answer with a method-not-found
+    /// error, which lands here as `ClientError.transport` so the caller can
+    /// fall back to another mechanism.
+    public func reloadPage(replyTimeout: Duration = .seconds(5)) async throws {
+        let id = nextId
+        let deadline = Task { [weak self] in
+            try? await Task.sleep(for: replyTimeout)
+            guard !Task.isCancelled else { return }
+            await self?.resolve(id: id, .failure(ClientError.transport("Page.reload went unanswered.")))
+        }
+        defer { deadline.cancel() }
+        _ = try await send(method: "Page.reload", params: [:])
+    }
+
     /// Release the `console` object group — drops the device-side handles for
     /// everything evaluated/logged so far. Called when the console is cleared so
     /// remote objects don't accumulate. Best-effort.

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/RemoteObjectDisplay.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/RemoteObjectDisplay.swift
@@ -50,6 +50,26 @@ public extension RemoteObject {
     /// and copy, so they never diverge from what's shown.
     var inlineSummary: String { tokens.map(\.text).joined() }
 
+    /// `inlineSummary` bounded to roughly `limit` characters. String values
+    /// take a prefix without materializing the full value — a multi-megabyte
+    /// `console.log` string must not be copied whole just to index its head
+    /// (that copy, once per replayed entry, was the reload CPU spike).
+    /// Non-string values are already small (object previews are truncated on
+    /// the device).
+    func inlineSummary(limit: Int) -> String {
+        if type == "string", let text = value?.stringValue, text.utf8.count > limit {
+            return "\"\(String(text.prefix(limit)))"
+        }
+        let full = inlineSummary
+        return full.utf8.count <= limit ? full : String(full.prefix(limit))
+    }
+
+    /// A rough retained-size estimate in bytes — the string payloads dominate;
+    /// O(1) on native strings. Drives the console buffer's byte budget.
+    var approximateBytes: Int {
+        (value?.stringValue?.utf8.count ?? 0) + (description?.utf8.count ?? 0) + 512
+    }
+
     private var numberString: String {
         // -0 / Infinity / NaN come back via description/unserializableValue.
         description ?? value.map(CDP.displayString) ?? unserializableValue ?? "0"

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -8,6 +8,10 @@ public struct LogLine: Sendable, Equatable, Identifiable {
     public let level: String
     public let tag: String
     public let message: String
+    /// `raw` lowercased once at ingest, so the search filter is a plain
+    /// substring check per line instead of a locale-aware case-insensitive
+    /// scan re-done for the full buffer on every streamed batch.
+    public let searchKey: String
 
     public init(raw: String, time: String, pid: String, level: String, tag: String, message: String) {
         self.id = UUID()
@@ -17,6 +21,7 @@ public struct LogLine: Sendable, Equatable, Identifiable {
         self.level = level
         self.tag = tag
         self.message = message
+        searchKey = raw.lowercased()
     }
 
     public static func == (lhs: LogLine, rhs: LogLine) -> Bool {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/JSONValue.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/JSONValue.swift
@@ -77,4 +77,87 @@ public extension JSONValue {
               let text = String(data: data, encoding: .utf8) else { return "" }
         return text.replacing(/"~~~ (.+?) ~~~"/) { match in String(match.1) }
     }
+
+    /// A bounded compact-JSON preview: reads like `jsonString` (sorted keys,
+    /// `~~~ … ~~~` markers unwrapped) but STOPS serializing once `maxLength`
+    /// characters are produced, so previewing a row costs O(maxLength) no
+    /// matter how big the payload is — `jsonString` walks the whole value,
+    /// which stalls the parse thread on a multi-megabyte `console.log`. The
+    /// result may cut off mid-token; it's a preview, not valid JSON.
+    func compactPreview(maxLength: Int) -> String {
+        var out = ""
+        out.reserveCapacity(min(maxLength, 512))
+        var remaining = maxLength
+        appendCompact(to: &out, remaining: &remaining)
+        return out
+    }
+
+    private func appendCompact(to out: inout String, remaining: inout Int) {
+        guard remaining > 0 else { return }
+        func emit(_ chunk: String) {
+            let piece = chunk.count <= remaining ? chunk : String(chunk.prefix(remaining))
+            out += piece
+            remaining -= piece.count
+        }
+        switch self {
+        case .null:
+            emit("null")
+        case let .bool(flag):
+            emit(flag ? "true" : "false")
+        case let .number(number):
+            emit(number.truncatingRemainder(dividingBy: 1) == 0 && abs(number) < 9e15
+                ? String(Int(number)) : String(number))
+        case let .string(text):
+            // The prefix/suffix guard keeps the anchored regex off megabyte
+            // strings — markers are short serialized functions/values.
+            if text.count < 2048, text.hasPrefix("~~~ "), text.hasSuffix(" ~~~"),
+               let marker = text.wholeMatch(of: /~~~ (.+) ~~~/) {
+                emit(String(marker.1))
+            } else {
+                emit("\"")
+                emit(Self.escapeForPreview(text, maxLength: remaining))
+                emit("\"")
+            }
+        case let .array(items):
+            emit("[")
+            for (index, item) in items.enumerated() {
+                guard remaining > 0 else { return }
+                if index > 0 { emit(",") }
+                item.appendCompact(to: &out, remaining: &remaining)
+            }
+            emit("]")
+        case let .object(dict):
+            emit("{")
+            // Sorted keys match `jsonString` for stable previews, but sorting
+            // a pathological 100k-key object isn't worth it — dictionary
+            // order is fine once nothing human is reading every key anyway.
+            let keys = dict.count <= 128 ? dict.keys.sorted() : Array(dict.keys)
+            for (index, key) in keys.enumerated() {
+                guard remaining > 0 else { return }
+                if index > 0 { emit(",") }
+                emit("\"")
+                emit(Self.escapeForPreview(key, maxLength: remaining))
+                emit("\":")
+                dict[key]?.appendCompact(to: &out, remaining: &remaining)
+            }
+            emit("}")
+        }
+    }
+
+    /// Minimal JSON string escaping over at most `maxLength` characters of
+    /// input — never walks a megabyte string to preview its head.
+    private static func escapeForPreview(_ text: String, maxLength: Int) -> String {
+        var out = ""
+        for character in text.prefix(maxLength) {
+            switch character {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default: out.append(character)
+            }
+        }
+        return out
+    }
 }

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronProtocol.swift
@@ -325,8 +325,11 @@ public extension ReactotronEvent {
         guard let value else { return "" }
         switch value {
         case let .string(text): return String(text.prefix(500))
-        case let .object(dict): return "{ \(dict.count) }"
-        case let .array(items): return "[ \(items.count) ]"
+        // Compact JSON so `console.log(object)` / multi-arg logs preview their
+        // content on the collapsed row (like Reactotron's desktop timeline),
+        // not an opaque element count. Bounded: serializing costs O(500)
+        // however big the logged object is.
+        case .object, .array: return value.compactPreview(maxLength: 500)
         case let .number(number):
             return number.truncatingRemainder(dividingBy: 1) == 0 && abs(number) < 9e15
                 ? String(Int(number)) : String(number)

--- a/ADBKit/Tests/ADBKitTests/AppNameMatcherTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppNameMatcherTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct AppNameMatcherTests {
+    private let installed = [
+        "com.acme.myapp",
+        "com.foodhub.driver.dev",
+        "com.example.shop",
+        "org.another.shop",
+    ]
+
+    @Test func matchesExactLastSegmentIgnoringCaseAndSpaces() {
+        #expect(AppNameMatcher.match(appName: "My App", in: installed) == "com.acme.myapp")
+        #expect(AppNameMatcher.match(appName: "MYAPP", in: installed) == "com.acme.myapp")
+    }
+
+    @Test func fallsBackToUniqueSubstringMatchForVariantSuffixes() {
+        // Dev builds carry a variant suffix, so the last segment ("dev")
+        // never equals the app name — the substring pass must find it.
+        #expect(AppNameMatcher.match(appName: "FoodHub Driver", in: installed) == "com.foodhub.driver.dev")
+    }
+
+    @Test func ambiguousMatchesReturnNilInsteadOfGuessing() {
+        // Two packages end in "shop" — restarting the wrong app is worse
+        // than asking, so ambiguity must not resolve arbitrarily.
+        #expect(AppNameMatcher.match(appName: "Shop", in: installed) == nil)
+    }
+
+    @Test func noMatchAndEmptyInputsReturnNil() {
+        #expect(AppNameMatcher.match(appName: "Untracked", in: installed) == nil)
+        #expect(AppNameMatcher.match(appName: "", in: installed) == nil)
+        #expect(AppNameMatcher.match(appName: "My App", in: []) == nil)
+        #expect(AppNameMatcher.match(appName: "…", in: installed) == nil)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -183,6 +183,29 @@ import Testing
         RemoteObject(json: (try? JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))) ?? .null)
     }
 
+    @Test func boundedInlineSummaryTakesAPrefixOfHugeStrings() {
+        // A multi-megabyte logged string must not be materialized whole to
+        // index its head — the bounded summary takes a prefix directly.
+        let huge = RemoteObject(json: .object([
+            "type": .string("string"), "value": .string(String(repeating: "x", count: 1_000_000)),
+        ]))
+        let summary = huge.inlineSummary(limit: 100)
+        #expect(summary == "\"" + String(repeating: "x", count: 100))
+        // Small values render exactly like the unbounded summary.
+        let small = remote(#"{"type":"string","value":"hi"}"#)
+        #expect(small.inlineSummary(limit: 100) == small.inlineSummary)
+        let number = remote(#"{"type":"number","value":42}"#)
+        #expect(number.inlineSummary(limit: 100) == "42")
+    }
+
+    @Test func approximateBytesTracksStringPayloadSize() {
+        let huge = RemoteObject(json: .object([
+            "type": .string("string"), "value": .string(String(repeating: "x", count: 5000)),
+        ]))
+        #expect(huge.approximateBytes >= 5000)
+        #expect(remote(#"{"type":"number","value":42}"#).approximateBytes < 1024)
+    }
+
     @Test func inlineSummaryRendersPrimitives() {
         #expect(remote(#"{"type":"string","value":"hi"}"#).inlineSummary == "\"hi\"")
         #expect(remote(#"{"type":"number","value":42}"#).inlineSummary == "42")

--- a/ADBKit/Tests/ADBKitTests/ConsoleFilteringTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleFilteringTests.swift
@@ -77,6 +77,32 @@ private struct Row: Identifiable, Equatable {
         #expect(buffer.filtered.isEmpty)
     }
 
+    @Test func byteBudgetEvictsOldestWhenCountCapIsNowhereNear() {
+        // 10-entry cap but a 100-byte budget: three 40-byte rows exceed it, so
+        // the oldest goes even though the count cap alone would keep all three.
+        var buffer = FilteredLogBuffer<Row>(capacity: 10, byteBudget: 100, cost: { _ in 40 })
+        buffer.append([Row(1), Row(2), Row(3)], isIncluded: nil)
+        #expect(buffer.entries.map(\.id) == [2, 3])
+        #expect(buffer.filtered == buffer.entries)
+    }
+
+    @Test func byteBudgetAlwaysKeepsTheNewestEntry() {
+        // One entry alone over budget must not empty the feed.
+        var buffer = FilteredLogBuffer<Row>(capacity: 10, byteBudget: 100, cost: { _ in 500 })
+        buffer.append([Row(1)], isIncluded: nil)
+        buffer.append([Row(2)], isIncluded: nil)
+        #expect(buffer.entries.map(\.id) == [2])
+    }
+
+    @Test func byteBudgetEvictionDropsEvictedRowsFromFiltered() {
+        var buffer = FilteredLogBuffer<Row>(capacity: 10, byteBudget: 90, cost: { _ in 40 })
+        let filter: (Row) -> Bool = { $0.id % 2 == 1 }
+        buffer.append([Row(1), Row(2)], isIncluded: filter)
+        buffer.append([Row(3)], isIncluded: filter)   // over budget → Row(1) evicted
+        #expect(buffer.entries.map(\.id) == [2, 3])
+        #expect(buffer.filtered.map(\.id) == [3])
+    }
+
     @Test func textQueryIncrementalAppendMatchesFullRecompute() {
         let query = ConsoleQuery("Error")
         let match: (Row) -> Bool = { query.matches($0.text) }

--- a/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSConsoleClientTests.swift
@@ -108,6 +108,38 @@ import Testing
     }
 
     @Test(.timeLimit(.minutes(1)))
+    func reloadPageSendsPageReloadOverTheSocket() async throws {
+        let server = CDPTestServer()
+        let port = try await server.start()
+        defer { Task { await server.stop() } }
+
+        let client = JSConsoleClient()
+        let url = try #require(URL(string: "ws://127.0.0.1:\(port)"))
+        _ = try await client.connect(to: url)
+        try await client.reloadPage()
+        #expect(await server.receivedMethods.contains("Page.reload"))
+        await client.disconnect()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func reloadPageTimesOutInsteadOfHangingWhenUnanswered() async throws {
+        // A proxy relaying to a dead page never answers; the bounded wait must
+        // fail the call rather than suspend the caller forever.
+        let server = CDPTestServer()
+        let port = try await server.start()
+        defer { Task { await server.stop() } }
+
+        let client = JSConsoleClient()
+        let url = try #require(URL(string: "ws://127.0.0.1:\(port)"))
+        _ = try await client.connect(to: url)
+        await server.setMuted(true)
+        await #expect(throws: JSConsoleClient.ClientError.self) {
+            try await client.reloadPage(replyTimeout: .milliseconds(300))
+        }
+        await client.disconnect()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
     func closingTheSocketSurfacesClosedAndEndsTheStream() async throws {
         let server = CDPTestServer()
         let port = try await server.start()
@@ -143,6 +175,9 @@ private actor CDPTestServer {
     /// When muted, requests are read but never answered — a proxy holding a
     /// socket open for a page that will never respond.
     private var muted = false
+    /// Every CDP method received, in arrival order — lets tests assert what
+    /// actually went over the wire.
+    private(set) var receivedMethods: [String] = []
 
     func setMuted(_ muted: Bool) { self.muted = muted }
 
@@ -222,10 +257,11 @@ private actor CDPTestServer {
     }
 
     private func handleFrame(_ data: Data) {
-        guard !muted,
-              let root = try? JSONDecoder().decode(JSONValue.self, from: data),
+        guard let root = try? JSONDecoder().decode(JSONValue.self, from: data),
               let id = root["id"]?.intValue,
               let method = root["method"]?.stringValue else { return }
+        receivedMethods.append(method)
+        guard !muted else { return }
         send(.object(["id": .number(Double(id)), "result": replyResult(for: method)]))
     }
 

--- a/ADBKit/Tests/ADBKitTests/LogcatParserTests.swift
+++ b/ADBKit/Tests/ADBKitTests/LogcatParserTests.swift
@@ -11,6 +11,9 @@ import Testing
         #expect(line.level == "E")
         #expect(line.tag == "ReactNativeJS")
         #expect(line.message == "TypeError: undefined is not a function")
+        // The cached search key backs the view's per-keystroke filter — it
+        // must be the lowercased raw line.
+        #expect(line.searchKey == line.raw.lowercased())
     }
 
     @Test func parsesEmptyMessage() {

--- a/ADBKit/Tests/ADBKitTests/ReactotronProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronProtocolTests.swift
@@ -78,6 +78,58 @@ import Testing
         #expect(stack.first?.columnNumber == 7)
     }
 
+    @Test func logObjectAndArrayMessagesPreviewTheirContent() throws {
+        // `console.log({user})` and multi-arg logs must show the values on the
+        // collapsed row, not an opaque "{ 1 }" / "[ 2 ]" element count.
+        let object = try ReactotronCommand.decode(
+            #"{"type":"log","important":false,"date":"d","deltaTime":1,"payload":{"level":"debug","message":{"user":"Sam"}}}"#
+        )
+        guard case let .log(_, objectMessage, _) = ReactotronEvent(command: object) else {
+            Issue.record("expected .log"); return
+        }
+        #expect(objectMessage == #"{"user":"Sam"}"#)
+
+        let array = try ReactotronCommand.decode(
+            #"{"type":"log","important":false,"date":"d","deltaTime":1,"payload":{"level":"debug","message":["cart",{"count":2}]}}"#
+        )
+        guard case let .log(_, arrayMessage, _) = ReactotronEvent(command: array) else {
+            Issue.record("expected .log"); return
+        }
+        #expect(arrayMessage == #"["cart",{"count":2}]"#)
+    }
+
+    @Test func compactPreviewMatchesCompactJSONForSmallValues() {
+        let value = JSONValue.object([
+            "b": .array([.number(1), .bool(true), .null]),
+            "a": .string("hi \"there\"\n"),
+            "fn": .string("~~~ register() ~~~"),
+        ])
+        #expect(value.compactPreview(maxLength: 500) == #"{"a":"hi \"there\"\n","b":[1,true,null],"fn":register()}"#)
+    }
+
+    @Test func compactPreviewStopsAtTheBudgetOnHugeValues() {
+        // A megabyte string and a 50k-element array must cost O(budget) to
+        // preview — the old full-serialize-then-prefix stalled the parse path.
+        let huge = JSONValue.object([
+            "blob": .string(String(repeating: "x", count: 1_000_000)),
+            "list": .array(Array(repeating: JSONValue.number(7), count: 50_000)),
+        ])
+        let preview = huge.compactPreview(maxLength: 500)
+        #expect(preview.count == 500)   // emit clamps every chunk to the budget
+        #expect(preview.hasPrefix(#"{"blob":"xxx"#))
+    }
+
+    @Test func logMessagePreviewIsCappedAt500Characters() throws {
+        let long = String(repeating: "x", count: 600)
+        let command = try ReactotronCommand.decode(
+            #"{"type":"log","important":false,"date":"d","deltaTime":1,"payload":{"level":"debug","message":{"blob":"\#(long)"}}}"#
+        )
+        guard case let .log(_, message, _) = ReactotronEvent(command: command) else {
+            Issue.record("expected .log"); return
+        }
+        #expect(message.count == 500)
+    }
+
     @Test func parsesDisplay() throws {
         let command = try ReactotronCommand.decode(
             #"{"type":"display","important":false,"date":"d","deltaTime":1,"payload":{"name":"User","value":{"id":7,"name":"Sam"},"preview":"Sam"}}"#

--- a/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/UsageStatsTests.swift
@@ -14,22 +14,6 @@ import Testing
         #expect(stats.count(for: "screenshot") == 0)
     }
 
-    @Test func rankPutsMostUsedFirstThenRecencyThenCuratedOrder() {
-        var stats = UsageStats()
-        // screenshot used most; logcat and apps tie on count, apps more recent.
-        for t in [10.0, 20, 30] { stats.record("screenshot", at: date(t)) }
-        stats.record("logcat", at: date(40))
-        stats.record("apps", at: date(50))
-        let curated = ["send-text", "logcat", "apps", "screenshot", "device-info"]
-        #expect(stats.rank(curated) == ["screenshot", "apps", "logcat", "send-text", "device-info"])
-    }
-
-    @Test func rankPreservesCuratedOrderWhenUnused() {
-        let stats = UsageStats()
-        let curated = ["a", "b", "c", "d"]
-        #expect(stats.rank(curated) == curated)
-    }
-
     @Test func frequentKeepsOnlyIdsAtOrAboveTheThresholdOrderedByCount() {
         var stats = UsageStats()
         for t in [1.0, 2] { stats.record("a", at: date(t)) }        // count 2

--- a/App/Sources/FeatureDetail/Views/HomeView.swift
+++ b/App/Sources/FeatureDetail/Views/HomeView.swift
@@ -3,10 +3,10 @@ import AppKit
 import SwiftUI
 
 /// The landing screen, now a role-aware launchpad: an inline feature search, a
-/// strip of the features used most, a grid of the user's curated tools (sorted
-/// by what they use most), an expandable "More features" section to add the
-/// rest, the keyboard shortcuts that drive the app, and the no-device
-/// onboarding when nothing is connected.
+/// strip of the features used most, the pinned features, a grid of the user's
+/// curated tools in the same order as the sidebar, an expandable "More
+/// features" section to add the rest, the keyboard shortcuts that drive the
+/// app, and the no-device onboarding when nothing is connected.
 struct HomeView: View {
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
@@ -27,6 +27,7 @@ struct HomeView: View {
                         connectCard
                     }
                     frequentSection
+                    pinnedSection
                     launchpadSection
                     moreFeaturesSection
                     shortcutsSection
@@ -197,12 +198,33 @@ struct HomeView: View {
         .help("Your role decides which tools start here — change it anytime")
     }
 
+    // MARK: - Pinned
+
+    /// The sidebar's Pinned section, mirrored on Home in the same order.
+    @ViewBuilder private var pinnedSection: some View {
+        let pinned = state.pinnedFeatures
+        if !pinned.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionTitle("Pinned")
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 210), spacing: 12)],
+                    alignment: .leading,
+                    spacing: 12
+                ) {
+                    ForEach(pinned) { feature in
+                        FeatureCard(feature: feature) { state.openFeature(feature) }
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Launchpad
 
     private var launchpadSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle("Your tools")
-            Text("Your most-used features, front and center. Add more below or from the sidebar.")
+            Text("Everything on your sidebar, in the same order. Add more below or from the sidebar.")
                 .font(.app(.callout))
                 .foregroundStyle(.textMuted)
             LazyVGrid(

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -61,23 +61,55 @@ struct JSEntry: Identifiable {
     let id: Int
     let kind: Kind
     let at: Date
-    /// Lowercased plain-text rendering, derived once at creation so the filter
-    /// and ⌘F never re-tokenize the value tree per flush (a Sentry-reported
-    /// main-thread hang during console bursts). Capped like Reactotron's
-    /// search text: a `console.log` of a megabyte string must not retain a
-    /// megabyte copy per row and turn every filter/⌘F keystroke into a
-    /// buffer-wide megabyte scan — matching runs against the head.
+    /// Lowercased plain-text head for the filter and ⌘F, derived once at
+    /// creation so they never re-tokenize the value tree per flush (a
+    /// Sentry-reported main-thread hang during console bursts). Capped like
+    /// Reactotron's search text AND built without materializing full values —
+    /// copying a replayed multi-megabyte string per entry just to keep this
+    /// head was the bulk of the reload CPU spike. Matching runs on the head.
     let searchableText: String
+    /// Rough retained size (the string payloads dominate; O(1) per arg) —
+    /// drives the buffer's byte budget.
+    let approximateBytes: Int
 
     init(id: Int, kind: Kind, at: Date) {
         self.id = id
         self.kind = kind
         self.at = at
-        let plain = jsEntryPlainText(kind)
-        if plain.count > 100_000 {
-            PerfLog.console.warning("ingested huge console entry: \(plain.count, privacy: .public) chars")
+        let size = Self.approximateSize(kind)
+        approximateBytes = size
+        if size > 1_000_000 {
+            PerfLog.console.warning("ingested huge console entry: ~\(size, privacy: .public) bytes")
         }
-        searchableText = String(plain.prefix(2000)).lowercased()
+        searchableText = Self.boundedSearchable(kind)
+    }
+
+    private static func boundedSearchable(_ kind: Kind, limit: Int = 2000) -> String {
+        switch kind {
+        case let .input(text): return String(text.prefix(limit)).lowercased()
+        case let .result(object): return object.inlineSummary(limit: limit).lowercased()
+        case let .evalError(details): return String(details.message.prefix(limit)).lowercased()
+        case let .notice(text): return String(text.prefix(limit)).lowercased()
+        case let .log(_, args, _):
+            var out = ""
+            for arg in args {
+                let remaining = limit - out.utf8.count
+                guard remaining > 0 else { break }
+                if !out.isEmpty { out += " " }
+                out += arg.inlineSummary(limit: remaining)
+            }
+            return out.lowercased()
+        }
+    }
+
+    private static func approximateSize(_ kind: Kind) -> Int {
+        switch kind {
+        case let .input(text): text.utf8.count + 256
+        case let .result(object): object.approximateBytes
+        case let .evalError(details): details.message.utf8.count + 512
+        case let .notice(text): text.utf8.count + 256
+        case let .log(_, args, _): args.reduce(256) { $0 + $1.approximateBytes }
+        }
     }
 }
 
@@ -100,7 +132,14 @@ final class JSConsoleSession {
     /// happens only when the filter itself changes — so a console burst costs
     /// O(batch) per flush, not O(buffer × object size). Chronological (oldest
     /// first), which is the feed's display order — newest at the bottom.
-    private var buffer = FilteredLogBuffer<JSEntry>(capacity: JSConsoleSession.maxEntries)
+    // The 128 MB byte budget (Reactotron's figure) matters as much as the
+    // count cap: 2000 entries each holding a multi-megabyte logged string
+    // would otherwise retain gigabytes.
+    private var buffer = FilteredLogBuffer<JSEntry>(
+        capacity: JSConsoleSession.maxEntries,
+        byteBudget: 128 << 20,
+        cost: { $0.approximateBytes }
+    )
     var filteredEntries: [JSEntry] { buffer.filtered }
     fileprivate var phase: JSPhase = .searching
     fileprivate var targets: [CDPTarget] = []
@@ -1714,10 +1753,13 @@ func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool) -> Text
     var remaining = jsDisplayCharacterLimit
     var hidden = 0
     for token in tokens {
-        guard remaining > 0 else { hidden += token.text.count; continue }
-        let piece = token.text.count <= remaining ? token.text : String(token.text.prefix(remaining))
-        hidden += token.text.count - piece.count
-        remaining -= piece.count
+        // utf8.count is O(1) on native strings; .count would re-walk a 3MB
+        // token's characters on every render just to size the note.
+        let tokenLength = token.text.utf8.count
+        guard remaining > 0 else { hidden += tokenLength; continue }
+        let piece = tokenLength <= remaining ? token.text : String(token.text.prefix(remaining))
+        hidden += tokenLength - piece.utf8.count
+        remaining -= piece.utf8.count
         var segment = AttributedString(piece)
         segment.foregroundColor = jsColor(token.kind)
         attr += segment
@@ -1735,7 +1777,7 @@ func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool) -> Text
 func highlightedText(_ string: String, query: String, base: Color, current: Bool = false) -> Text {
     var attr = AttributedString(String(string.prefix(jsDisplayCharacterLimit)))
     attr.foregroundColor = base
-    let hidden = string.count - jsDisplayCharacterLimit
+    let hidden = string.utf8.count - jsDisplayCharacterLimit
     if hidden > 0 {
         PerfLog.console.warning("line render truncated: \(hidden, privacy: .public) chars over the display cap")
         attr += jsTruncationNote(hiddenCharacters: hidden)

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -63,14 +63,21 @@ struct JSEntry: Identifiable {
     let at: Date
     /// Lowercased plain-text rendering, derived once at creation so the filter
     /// and ⌘F never re-tokenize the value tree per flush (a Sentry-reported
-    /// main-thread hang during console bursts).
+    /// main-thread hang during console bursts). Capped like Reactotron's
+    /// search text: a `console.log` of a megabyte string must not retain a
+    /// megabyte copy per row and turn every filter/⌘F keystroke into a
+    /// buffer-wide megabyte scan — matching runs against the head.
     let searchableText: String
 
     init(id: Int, kind: Kind, at: Date) {
         self.id = id
         self.kind = kind
         self.at = at
-        searchableText = jsEntryPlainText(kind).lowercased()
+        let plain = jsEntryPlainText(kind)
+        if plain.count > 100_000 {
+            PerfLog.console.warning("ingested huge console entry: \(plain.count, privacy: .public) chars")
+        }
+        searchableText = String(plain.prefix(2000)).lowercased()
     }
 }
 
@@ -470,6 +477,100 @@ final class JSConsoleSession {
         ))
     }
 
+    /// Reload the app's JS bundle: `Page.reload` over the live CDP socket —
+    /// what React Native DevTools' ⌘R sends, handled natively by the app's
+    /// inspector integration. Runtimes without native reload support answer
+    /// with an error; fall back to the dev-menu double-R keyevent then.
+    func reloadJS() {
+        guard isConnected else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await cdp.reloadPage()
+            } catch {
+                await reloadViaKeyevent()
+            }
+        }
+    }
+
+    private func reloadViaKeyevent() async {
+        let serials = serials
+        guard !serials.isEmpty else {
+            app?.showToast(Toast(message: "Reload failed — the runtime didn't accept Page.reload.", ok: false))
+            return
+        }
+        await CommandLog.userInitiated {
+            for serial in serials {
+                _ = try? await adb.run(on: serial, ["shell", "input", "keyevent", "46", "46"])
+            }
+        }
+    }
+
+    /// Force-stop and relaunch the app under debug. While connected the app is
+    /// auto-detected: the target's `appId` (the application id Metro reports
+    /// for the exact app being debugged), else the user's last manual pick,
+    /// else the selected bundle. Disconnected — or when detection/relaunch
+    /// fails — the installed-apps picker opens instead. Discovery reconnects
+    /// by logical-device id once the app is back.
+    func restartApp() {
+        Task { [weak self] in await self?.performRestart() }
+    }
+
+    /// Drives the fallback installed-apps picker sheet.
+    var restartPickerVisible = false
+    /// The user's manual pick from the restart sheet, reused on later restarts
+    /// whenever the connected target doesn't report its own `appId`.
+    private var manualRestartPackage: String?
+
+    private func performRestart() async {
+        guard !serials.isEmpty else {
+            app?.showToast(Toast(message: "Can't restart — no device selected.", ok: false))
+            return
+        }
+        // Disconnected: no target reports an appId, and guessing from a stale
+        // pick or the selected bundle could restart the wrong app — ask.
+        let detected: String? = isConnected
+            ? connectedTarget?.appId ?? manualRestartPackage ?? app?.selectedBundle?.packageId
+            : nil
+        if let detected, await restart(package: detected) { return }
+        restartPickerVisible = true
+    }
+
+    /// A pick from the fallback sheet: restart it and remember the choice.
+    func restartPicked(_ package: String) {
+        manualRestartPackage = package
+        Task { [weak self] in
+            guard let self else { return }
+            if !(await restart(package: package)) {
+                app?.showToast(Toast(
+                    message: "Couldn't relaunch \(package) — is it installed on the selected device?",
+                    ok: false
+                ))
+            }
+        }
+    }
+
+    /// Force-stop + relaunch on every target device; true when any relaunch
+    /// worked (the toast reports success; failures fall back to the picker).
+    private func restart(package: String) async -> Bool {
+        let serials = serials
+        let control = AppControlService(client: adb)
+        let relaunched = await CommandLog.userInitiated {
+            var relaunched = 0
+            for serial in serials {
+                _ = try? await control.control(serial: serial, packageId: package, action: .stop)
+                if let result = try? await control.control(serial: serial, packageId: package, action: .open),
+                   result.ok {
+                    relaunched += 1
+                }
+            }
+            return relaunched
+        }
+        guard relaunched > 0 else { return false }
+        app?.showToast(Toast(message: "Restarting \(package)…", ok: true))
+        return true
+    }
+
     /// Remove the `adb reverse` bindings this console installed. Called when the
     /// tab closes (mirrors `ReactotronService.stop`), not on a tab switch.
     func removeReverseTunnels() async {
@@ -500,7 +601,9 @@ final class JSConsoleSession {
     /// Full recompute — only for when the filter itself changes (query text,
     /// level chips) or the feed is cleared; appends go through `appendEntries`.
     private func refilter() {
-        buffer.refilter(isIncluded: activeFilter)
+        PerfLog.measure(PerfLog.console, "refilter \(buffer.filtered.count) entries") {
+            buffer.refilter(isIncluded: activeFilter)
+        }
         rebuildFindMatches()
     }
 
@@ -510,9 +613,11 @@ final class JSConsoleSession {
             if !findMatchIDs.isEmpty { findMatchIDs = [] }
             return
         }
-        findMatchIDs = buffer.filtered
-            .filter { query.matches($0.searchableText) }
-            .map(\.id)
+        findMatchIDs = PerfLog.measure(PerfLog.console, "find scan over \(buffer.filtered.count) entries") {
+            buffer.filtered
+                .filter { query.matches($0.searchableText) }
+                .map(\.id)
+        }
     }
 
     // MARK: Appending (batched)
@@ -542,7 +647,9 @@ final class JSConsoleSession {
         guard !pendingEntries.isEmpty else { return }
         let batch = pendingEntries
         pendingEntries.removeAll(keepingCapacity: true)
-        appendEntries(batch)
+        PerfLog.measure(PerfLog.console, "flush \(batch.count) entries into \(buffer.filtered.count)") {
+            appendEntries(batch)
+        }
     }
 
     /// An entry that must appear now (user input, eval result, the welcome banner).
@@ -674,11 +781,26 @@ struct JSConsoleView: View {
     // MARK: Connection bar
 
     private var connectionBar: some View {
-        HStack(spacing: 10) {
+        @Bindable var session = state.jsConsoleSession
+        return HStack(spacing: 10) {
             statusBadge
             targetPicker
             portField
             Spacer(minLength: 8)
+            if session.isConnected {
+                Button { session.reloadJS() } label: {
+                    Label("Reload JS", systemImage: "arrow.clockwise")
+                }
+                .help("Reload the JS bundle — what ⌘R in React Native DevTools does")
+            }
+            if !state.targetSerials.isEmpty {
+                Button { session.restartApp() } label: {
+                    Label("Restart app", systemImage: "restart.circle")
+                }
+                .help(session.isConnected
+                    ? "Force-stop and relaunch the connected app on the device"
+                    : "Pick an app to force-stop and relaunch")
+            }
             if !state.targetSerials.isEmpty, !session.isConnected {
                 Button { Task { await session.reverseMetro() } } label: {
                     Label("adb reverse", systemImage: "arrow.left.arrow.right")
@@ -688,6 +810,11 @@ struct JSConsoleView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .sheet(isPresented: $session.restartPickerVisible) {
+            RestartAppPickerSheet(serial: state.targetSerials.first) { package in
+                session.restartPicked(package)
+            }
+        }
     }
 
     private var statusBadge: some View {
@@ -1282,22 +1409,32 @@ private struct SnapChildrenView: View {
     let session: JSConsoleSession
     var query: String = ""
 
+    /// Rows shown per level while an in-object search is active. The search
+    /// auto-expands every matching container, and the rows are not lazy — an
+    /// uncapped broad query over a big snapshot (the device allows up to
+    /// 20 000 nodes) laid out tens of thousands of views in one pass.
+    private static let maxSearchRows = 100
+
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             if node.type == "array", let items = node.items {
-                let shown = items.enumerated().filter { query.isEmpty || $0.element.matches(query) }
+                let matched = items.enumerated().filter { query.isEmpty || $0.element.matches(query) }
+                let shown = query.isEmpty ? matched : Array(matched.prefix(Self.maxSearchRows))
                 if shown.isEmpty { emptyRow }
                 ForEach(shown, id: \.offset) { index, child in
                     SnapValueView(label: String(index), node: child, session: session, query: query)
                 }
                 if query.isEmpty, let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
+                if matched.count > shown.count { moreRow("…(+\(matched.count - shown.count) more matches — narrow the search)") }
             } else if let entries = node.entries {
-                let shown = entries.enumerated().filter { query.isEmpty || $0.element.node.matches(query, key: $0.element.name) }
+                let matched = entries.enumerated().filter { query.isEmpty || $0.element.node.matches(query, key: $0.element.name) }
+                let shown = query.isEmpty ? matched : Array(matched.prefix(Self.maxSearchRows))
                 if shown.isEmpty { emptyRow }
                 ForEach(shown, id: \.offset) { _, entry in
                     SnapValueView(label: entry.name, node: entry.node, session: session, query: query)
                 }
                 if query.isEmpty, node.truncated == true { moreRow("…(more)") }
+                if matched.count > shown.count { moreRow("…(+\(matched.count - shown.count) more matches — narrow the search)") }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1557,22 +1694,52 @@ func jsColor(_ kind: JSTokenKind) -> Color {
     JSConsoleTheme.token(kind)
 }
 
+/// The most characters one console text block renders. A `console.log` of a
+/// multi-megabyte string otherwise becomes a `Text` whose layout stalls the
+/// app for seconds and skews the lazy feed's height estimates into a huge
+/// blank scroll canvas (the "empty space, then logs, then a hang" report).
+/// Copy paths keep the untruncated value; the cutoff note says what's hidden.
+let jsDisplayCharacterLimit = 10_000
+
+private func jsTruncationNote(hiddenCharacters: Int) -> AttributedString {
+    var note = AttributedString("  …(+\(hiddenCharacters) more characters — truncated for display)")
+    note.foregroundColor = JSConsoleTheme.muted
+    return note
+}
+
 /// Syntax-colored `Text` for a value's tokens, with find matches highlighted.
+/// Bounded to `jsDisplayCharacterLimit` characters.
 func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool) -> Text {
     var attr = AttributedString()
+    var remaining = jsDisplayCharacterLimit
+    var hidden = 0
     for token in tokens {
-        var segment = AttributedString(token.text)
+        guard remaining > 0 else { hidden += token.text.count; continue }
+        let piece = token.text.count <= remaining ? token.text : String(token.text.prefix(remaining))
+        hidden += token.text.count - piece.count
+        remaining -= piece.count
+        var segment = AttributedString(piece)
         segment.foregroundColor = jsColor(token.kind)
         attr += segment
+    }
+    if hidden > 0 {
+        PerfLog.console.warning("row render truncated: \(hidden, privacy: .public) chars over the display cap")
+        attr += jsTruncationNote(hiddenCharacters: hidden)
     }
     applyFindHighlight(&attr, query: query, current: current)
     return Text(attr)
 }
 
-/// A single-color `Text` (input/notice/error lines) with find matches highlighted.
+/// A single-color `Text` (input/notice/error lines) with find matches
+/// highlighted. Bounded to `jsDisplayCharacterLimit` characters.
 func highlightedText(_ string: String, query: String, base: Color, current: Bool = false) -> Text {
-    var attr = AttributedString(string)
+    var attr = AttributedString(String(string.prefix(jsDisplayCharacterLimit)))
     attr.foregroundColor = base
+    let hidden = string.count - jsDisplayCharacterLimit
+    if hidden > 0 {
+        PerfLog.console.warning("line render truncated: \(hidden, privacy: .public) chars over the display cap")
+        attr += jsTruncationNote(hiddenCharacters: hidden)
+    }
     applyFindHighlight(&attr, query: query, current: current)
     return Text(attr)
 }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -13,6 +13,10 @@ struct LogcatView: View {
     @State private var level = "All"
     @State private var packageFilter: String?
     @State private var tagFilter: String?
+    /// What the user is typing; debounced into `search` (which triggers a full
+    /// re-filter and NSTextView rebuild) so a fast typist over a full buffer
+    /// pays for one rebuild per pause, not one per keystroke.
+    @State private var searchInput = ""
     @State private var search = ""
     @State private var waitingForPackage: String?
     @State private var streamingPid: Int?
@@ -84,9 +88,16 @@ struct LogcatView: View {
             }
             .font(.app(.callout))
 
-            TextField("Search lines…", text: $search)
+            TextField("Search lines…", text: $searchInput)
                 .brandField()
                 .frame(maxWidth: 220)
+                .task(id: searchInput) {
+                    if !search.isEmpty || !searchInput.isEmpty {
+                        try? await Task.sleep(for: .milliseconds(200))
+                    }
+                    guard !Task.isCancelled else { return }
+                    search = searchInput
+                }
 
             Spacer()
 
@@ -190,9 +201,14 @@ struct LogcatView: View {
     // MARK: - Log list
 
     private var visibleLines: [LogLine] {
-        lines.filter { line in
+        // Lowercase the query once and match the per-line cached `searchKey` —
+        // this runs on every streamed batch, and a locale-aware scan over a
+        // full 5000-line buffer was the hottest part of searching while
+        // streaming.
+        let query = search.lowercased()
+        return lines.filter { line in
             if let tagFilter, line.tag != tagFilter { return false }
-            if !search.isEmpty && !line.raw.localizedCaseInsensitiveContains(search) { return false }
+            if !query.isEmpty && !line.searchKey.contains(query) { return false }
             return true
         }
     }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -587,6 +587,14 @@ struct ReactotronView: View {
     /// host-wide, so any connected device should be able to reach it.
     private var readySerials: [String] { state.devices.filter(\.isReady).map(\.serial) }
 
+    /// The app name the Restart button should target: the selected client's,
+    /// else the lone connected client's. Nil (several clients, none selected —
+    /// or none connected) leaves detection to the foreground-app fallback.
+    private var restartClientName: String? {
+        if let id = session.selectedClient { return session.clients.first { $0.id == id }?.name }
+        return session.clients.count == 1 ? session.clients[0].name : nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             topTabs
@@ -682,9 +690,9 @@ struct ReactotronView: View {
                 .controlSize(.small)
                 .fixedSize()
             }
-            RestartAppMenu()
+            RestartAppMenu(clientName: restartClientName)
                 .controlSize(.small)
-                .help("Force-stop and relaunch an app so it reconnects")
+                .help("Force-stop and relaunch the connected app so it reconnects")
             Button {
                 session.reverseNow(serials: readySerials)
             } label: {
@@ -1125,19 +1133,40 @@ private struct ClientInfo: Identifiable {
     }
 }
 
-private enum RtFilter: String, CaseIterable, Identifiable {
-    case all, log, network, state, display, other
+/// The timeline's filterable event kinds — the same set, grouping, and display
+/// names as the Reactotron desktop app's timeline filter dialog. Events the
+/// dialog doesn't cover (REPL, custom commands, state responses) are always
+/// shown.
+private enum RtEventKind: String, CaseIterable, Identifiable {
+    case log, image, display
+    case connection, benchmark, api
+    case asyncStorage
+    case action, saga, subscription
+
     var id: String { rawValue }
+
     var label: String {
         switch self {
-        case .all: "All"
-        case .log: "Logs"
-        case .network: "Network"
-        case .state: "State"
-        case .display: "Display"
-        case .other: "Other"
+        case .log: "Log"
+        case .image: "Image"
+        case .display: "Custom Display"
+        case .connection: "Connection"
+        case .benchmark: "Benchmark"
+        case .api: "API"
+        case .asyncStorage: "Mutations"
+        case .action: "Action"
+        case .saga: "Saga"
+        case .subscription: "Subscription Changed"
         }
     }
+
+    /// The filter popover's sections, mirroring Reactotron's dialog.
+    static let groups: [(name: String, kinds: [RtEventKind])] = [
+        ("Informational", [.log, .image, .display]),
+        ("General", [.connection, .benchmark, .api]),
+        ("Async Storage", [.asyncStorage]),
+        ("State & Sagas", [.action, .saga, .subscription]),
+    ]
 }
 
 // MARK: - Timeline pane
@@ -1154,50 +1183,55 @@ private struct TimelinePane: View {
     let onRetry: () -> Void
 
     @State private var search = ""
-    @State private var filter: RtFilter = .all
-    /// Network-only refinements, shown while the Network category is selected
-    /// and cleared when it isn't: HTTP method and status class (2xx…5xx/Failed).
+    /// Event kinds toggled off in the filter popover — empty means everything
+    /// shows, matching Reactotron's hide-what-you-untick model.
+    @State private var hiddenKinds: Set<RtEventKind> = []
+    /// API-only refinements, set from the filter popover and cleared when the
+    /// API kind is hidden: HTTP method and status class (2xx…5xx/Failed).
     @State private var methodFilter: String?
     @State private var statusFilter: HTTPStatusClass?
+    @State private var showFilterSheet = false
 
     var body: some View {
         // Filter once per render — the count badge, export button, and timeline
         // all read the same result instead of each recomputing the filter.
         let visible = filteredItems
-        // Newest first: the fixed timeline order (matches the Reactotron app).
-        let ordered = Array(visible.reversed())
         return VStack(spacing: 0) {
             paneToolbar(visible: visible)
             Divider()
-            timeline(ordered: ordered)
+            // Newest first: the fixed timeline order (matches the Reactotron
+            // app). Lazily reversed — materializing a 2000-item copy per
+            // render was measurable during streaming bursts.
+            timeline(ordered: visible.reversed())
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    /// Whether any popover filter narrows the timeline (drives the filled
+    /// filter icon and the count badge).
+    private var isFiltering: Bool {
+        !hiddenKinds.isEmpty || methodFilter != nil || statusFilter != nil
+    }
+
     private func paneToolbar(visible: [RtItem]) -> some View {
         HStack(spacing: 10) {
-            Picker("Filter", selection: $filter) {
-                ForEach(RtFilter.allCases) { Text($0.label).tag($0) }
+            Button {
+                showFilterSheet = true
+            } label: {
+                Image(systemName: isFiltering
+                    ? "line.3.horizontal.decrease.circle.fill"
+                    : "line.3.horizontal.decrease.circle")
             }
-            .labelsHidden()
-            .frame(width: 110)
-            .onChange(of: filter) { _, newFilter in
-                if newFilter != .network {
-                    methodFilter = nil
-                    statusFilter = nil
-                }
-            }
-
-            if filter == .network {
-                networkFilters
-            }
+            .buttonStyle(IconButtonStyle())
+            .help("Filter the timeline by event type")
+            .sheet(isPresented: $showFilterSheet) { filterSheet }
 
             SearchField(prompt: "Search…", text: $search)
                 .frame(maxWidth: 200)
 
             Spacer()
 
-            if !search.isEmpty || filter != .all {
+            if !search.isEmpty || isFiltering {
                 Text("\(visible.count)")
                     .font(.app(.caption))
                     .foregroundStyle(.textMuted)
@@ -1226,7 +1260,7 @@ private struct TimelinePane: View {
     private var filteredItems: [RtItem] {
         let query = search.trimmingCharacters(in: .whitespaces).lowercased()
         return items.filter { item in
-            if filter != .all, item.event.category != filter { return false }
+            if let kind = item.event.kind, hiddenKinds.contains(kind) { return false }
             if let methodFilter, item.event.apiMethod != methodFilter { return false }
             if let statusFilter,
                item.event.apiStatus.flatMap({ HTTPStatusClass(status: $0) }) != statusFilter {
@@ -1237,6 +1271,82 @@ private struct TimelinePane: View {
             if !query.isEmpty, !item.searchText.contains(query) { return false }
             return true
         }
+    }
+
+    /// The Reactotron-style filter dialog, presented as a modal sheet like the
+    /// desktop app's "Timeline Filter": every event kind as a checkbox in the
+    /// same groups, the API method/status refinements nested under the API
+    /// toggle, and Check all / Uncheck all shortcuts.
+    private var filterSheet: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Timeline Filter")
+                    .font(.app(.title3).bold())
+                Text("Checked event types appear in the timeline.")
+                    .font(.app(.callout))
+                    .foregroundStyle(.textMuted)
+            }
+            ForEach(RtEventKind.groups, id: \.name) { group in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(group.name)
+                        .font(.app(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                    HStack(spacing: 16) {
+                        ForEach(group.kinds) { kind in
+                            Toggle(kind.label, isOn: shows(kind))
+                                .toggleStyle(.checkbox)
+                        }
+                    }
+                    if group.kinds.contains(.api), !hiddenKinds.contains(.api) {
+                        // Indented + captioned so the pickers read as API
+                        // refinements, not filters for the whole group.
+                        HStack(spacing: 8) {
+                            Text("API only")
+                                .font(.app(size: 10))
+                                .foregroundStyle(.tertiary)
+                            networkFilters
+                        }
+                        .padding(.leading, 18)
+                    }
+                }
+            }
+            Divider()
+            HStack(spacing: 10) {
+                Button("Check all") { hiddenKinds = [] }
+                    .disabled(hiddenKinds.isEmpty)
+                Button("Uncheck all") {
+                    hiddenKinds = Set(RtEventKind.allCases)
+                    methodFilter = nil
+                    statusFilter = nil
+                }
+                .disabled(hiddenKinds.count == RtEventKind.allCases.count)
+                Spacer()
+                Button("Done") { showFilterSheet = false }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 430, alignment: .leading)
+        .onExitCommand { showFilterSheet = false }
+    }
+
+    /// Whether `kind` is currently shown; hiding API also clears its
+    /// method/status refinements so they can't filter invisibly.
+    private func shows(_ kind: RtEventKind) -> Binding<Bool> {
+        Binding(
+            get: { !hiddenKinds.contains(kind) },
+            set: { shown in
+                if shown {
+                    hiddenKinds.remove(kind)
+                } else {
+                    hiddenKinds.insert(kind)
+                    if kind == .api {
+                        methodFilter = nil
+                        statusFilter = nil
+                    }
+                }
+            }
+        )
     }
 
     private var networkFilters: some View {
@@ -1263,7 +1373,7 @@ private struct TimelinePane: View {
         }
     }
 
-    private func timeline(ordered: [RtItem]) -> some View {
+    private func timeline(ordered: ReversedCollection<[RtItem]>) -> some View {
         // Newest events land at the top — LogTailViewV2 follows that edge, pauses
         // when the user scrolls off, and overlays the jump-to-top/bottom buttons.
         LogTailViewV2(entries: ordered, newestEdge: .top) { item in
@@ -1300,6 +1410,8 @@ private struct RtRow: View {
     let item: RtItem
     @State private var expanded = false
     @State private var apiTab: ApiTab = .response
+    @State private var hovering = false
+    @State private var copiedLine = false
 
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -1356,11 +1468,25 @@ private struct RtRow: View {
                     .truncationMode(.middle)
             }
             Spacer(minLength: 8)
+            if hovering || copiedLine {
+                Button {
+                    copyToPasteboard(presentation.copyText)
+                    copiedLine = true
+                    Task { try? await Task.sleep(for: .seconds(1.5)); copiedLine = false }
+                } label: {
+                    Image(systemName: copiedLine ? "checkmark" : "doc.on.doc")
+                        .font(.app(size: 11))
+                        .foregroundStyle(copiedLine ? .green : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Copy this line (right-click for the full object)")
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .contentShape(Rectangle())
         .onTapGesture { if canExpand { expanded.toggle() } }
+        .onHover { hovering = $0 }
     }
 
     @ViewBuilder
@@ -1385,6 +1511,7 @@ private struct RtRow: View {
         VStack(alignment: .leading, spacing: 8) {
             if let caption, !caption.isEmpty {
                 Text(caption).font(.app(size: 12)).foregroundStyle(.primary)
+                    .textSelection(.enabled)
             }
             RtImageThumbnail(uri: uri)
             if let width, let height {
@@ -1466,6 +1593,7 @@ private struct RtRow: View {
                         Text("\(frame.functionName.isEmpty ? "?" : frame.functionName)  \(frame.fileName):\(frame.lineNumber.map(String.init) ?? "?")")
                             .font(.app(size: 10, design: .monospaced))
                             .foregroundStyle(.textMuted)
+                            .textSelection(.enabled)
                     }
                 }
                 .padding(8)
@@ -2030,195 +2158,89 @@ private struct ReactotronOnboarding: View {
     }
 }
 
-/// Picks an installed third-party app and restarts it (force-stop → relaunch) so
-/// it reconnects to the Reactotron server. Opens a searchable dropdown — the
-/// package list is fetched per device.
+/// Restarts (force-stop → relaunch) the app being debugged so it reconnects to
+/// the Reactotron server. Detects the app automatically — the connected
+/// client's reported name matched against installed packages, else the
+/// foreground app — and only opens the searchable picker when detection or
+/// the relaunch fails.
 private struct RestartAppMenu: View {
+    /// The connected Reactotron client's app name, when one is connected —
+    /// the strongest detection signal (it names the exact app to restart).
+    var clientName: String?
+
     @Environment(AppState.self) private var state
-    @State private var apps: [String] = []
-    @State private var loading = false
+    @State private var restarting = false
     @State private var showPicker = false
-    @State private var search = ""
-    @FocusState private var searchFocused: Bool
 
     private var serial: String? {
         state.selectedSerial ?? state.devices.first(where: \.isReady)?.serial
     }
 
-    private var filtered: [String] {
-        guard !search.isEmpty else { return apps }
-        return apps.filter {
-            $0.localizedCaseInsensitiveContains(search)
-                || restartAppDisplayName($0).localizedCaseInsensitiveContains(search)
-        }
-    }
-
     var body: some View {
         Button {
-            showPicker = true
+            Task { await smartRestart() }
         } label: {
             Label("Restart app", systemImage: "arrow.clockwise.circle")
         }
-        .disabled(serial == nil)
-        .task(id: serial) { await load() }
-        .onChange(of: showPicker) { _, open in
-            if open {
-                search = ""
-                if apps.isEmpty { Task { await load() } }
-                Task { @MainActor in searchFocused = true }
-            }
-        }
-        .sheet(isPresented: $showPicker) { picker }
-    }
-
-    private var picker: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                ZStack {
-                    Circle().fill(Color.brandAccent.opacity(0.16)).frame(width: 30, height: 30)
-                    Image(systemName: "arrow.clockwise")
-                        .font(.app(size: 13, weight: .semibold))
-                        .foregroundStyle(.brandAccent)
-                }
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Restart app")
-                        .font(.app(size: 13, weight: .semibold))
-                    Text("Force-stop and relaunch so it reconnects")
-                        .font(.app(size: 10))
-                        .foregroundStyle(.textMuted)
-                }
-                Spacer()
-                Button { showPicker = false } label: {
-                    Image(systemName: "xmark.circle.fill").font(.app(size: 15))
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.tertiary)
-                .keyboardShortcut(.cancelAction)
-            }
-            .padding(12)
-
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .font(.app(size: 11))
-                    .foregroundStyle(.tertiary)
-                TextField("Search apps…", text: $search)
-                    .textFieldStyle(.plain)
-                    .font(.app(size: 12))
-                    .focused($searchFocused)
-                if !search.isEmpty {
-                    Button { search = "" } label: { Image(systemName: "xmark.circle.fill") }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
-            .background(Color.bgRoot, in: RoundedRectangle(cornerRadius: 8))
-            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle))
-            .padding(.horizontal, 12)
-            .padding(.bottom, 10)
-
-            Divider()
-            content
-        }
-        .frame(width: 360, height: 440)
-        .background(Color.bgSurface)
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if loading {
-            hint("Loading apps…")
-        } else if apps.isEmpty {
-            hint("No third-party apps found")
-        } else if filtered.isEmpty {
-            hint("No matches")
-        } else {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(filtered, id: \.self) { package in
-                        AppPickerRow(package: package, serial: serial ?? "") {
-                            showPicker = false
-                            restart(package)
-                        }
+        .disabled(serial == nil || restarting)
+        .sheet(isPresented: $showPicker) {
+            RestartAppPickerSheet(serial: serial) { package in
+                Task {
+                    if !(await restart(package)) {
+                        state.showToast(Toast(message: "Couldn't restart \(package)", ok: false))
                     }
                 }
-                .padding(.vertical, 4)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
-    private func hint(_ text: String) -> some View {
-        Text(text)
-            .font(.app(.caption))
-            .foregroundStyle(.textMuted)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    /// Restart the detected app; fall back to the picker when nothing (or the
+    /// wrong thing) is detected, or the relaunch fails. With no client
+    /// connected there is nothing trustworthy to detect — the foreground app
+    /// could be anything — so ask straight away.
+    private func smartRestart() async {
+        guard serial != nil else { return }
+        guard clientName != nil else {
+            showPicker = true
+            return
+        }
+        restarting = true
+        defer { restarting = false }
+        if let detected = await detectPackage(), await restart(detected) { return }
+        showPicker = true
     }
 
-    private func load() async {
-        guard let serial else { apps = []; return }
-        loading = true
-        defer { loading = false }
+    /// The app to restart: the connected client's name matched against the
+    /// installed third-party packages, else the foreground app (only when it's
+    /// a third-party app — never the launcher). Nil means ask the user.
+    private func detectPackage() async -> String? {
+        guard let serial else { return nil }
+        return await CommandLog.userInitiated {
+            let control = AppControlService(client: state.env.client)
+            let installed = (try? await control.listInstalledPackages(serial: serial)) ?? []
+            if let clientName,
+               let matched = AppNameMatcher.match(appName: clientName, in: installed) {
+                return matched
+            }
+            if let foreground = try? await state.env.engine.inspection.getForegroundPackage(serial: serial),
+               installed.contains(foreground) {
+                return foreground
+            }
+            return nil
+        }
+    }
+
+    private func restart(_ package: String) async -> Bool {
+        guard let serial else { return false }
         let service = AppControlService(client: state.env.client)
-        apps = (try? await service.listInstalledPackages(serial: serial)) ?? []
-    }
-
-    private func restart(_ package: String) {
-        guard let serial else { return }
-        Task {
-            let service = AppControlService(client: state.env.client)
+        let result = await CommandLog.userInitiated {
             _ = try? await service.control(serial: serial, packageId: package, action: .stop)
-            let result = try? await service.control(serial: serial, packageId: package, action: .open)
-            if result?.ok == true {
-                state.showToast(Toast(message: "Restarting \(package)…", ok: true))
-            } else {
-                state.showToast(Toast(message: result?.message ?? "Couldn't restart \(package)", ok: false))
-            }
+            return try? await service.control(serial: serial, packageId: package, action: .open)
         }
+        guard result?.ok == true else { return false }
+        state.showToast(Toast(message: "Restarting \(package)…", ok: true))
+        return true
     }
-}
-
-private struct AppPickerRow: View {
-    let package: String
-    let serial: String
-    let action: () -> Void
-    @State private var hovering = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                AppIconView(packageId: package, name: restartAppDisplayName(package), serial: serial)
-                    .frame(width: 28, height: 28)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(restartAppDisplayName(package))
-                        .font(.app(size: 12, weight: .medium))
-                        .lineLimit(1)
-                    Text(package)
-                        .font(.app(size: 10, design: .monospaced))
-                        .foregroundStyle(.textMuted)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(hovering ? Color.brandAccent.opacity(0.16) : Color.clear, in: RoundedRectangle(cornerRadius: 6))
-            .contentShape(Rectangle())
-            .padding(.horizontal, 6)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering = $0 }
-    }
-}
-
-/// Friendly app name from a package id ("com.foo.bar" → "Bar"), mirroring the
-/// Apps feature's `AppListing.displayName`.
-private func restartAppDisplayName(_ packageId: String) -> String {
-    packageId.split(separator: ".").last
-        .map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? packageId
 }
 
 // MARK: - State tab building blocks
@@ -2383,13 +2405,24 @@ private func rtShortPath(_ url: String) -> String {
 }
 
 private extension ReactotronEvent {
-    var category: RtFilter {
+    /// The filterable kind matching Reactotron's filter dialog; nil for events
+    /// the dialog doesn't cover, which are always shown. Sagas arrive as
+    /// `.unknown` (the parser has no typed case), and the session's synthetic
+    /// disconnect notice rides the Connection toggle with `clientIntro`.
+    var kind: RtEventKind? {
         switch self {
         case .log: .log
-        case .apiResponse: .network
-        case .stateAction, .stateValuesChange: .state
-        case .display, .image: .display
-        default: .other
+        case .image: .image
+        case .display: .display
+        case .clientIntro: .connection
+        case .benchmark: .benchmark
+        case .apiResponse: .api
+        case .asyncStorage: .asyncStorage
+        case .stateAction: .action
+        case .stateValuesChange: .subscription
+        case let .unknown(type, _) where type == "saga.task.complete": .saga
+        case let .unknown(type, _) where type == "disconnected": .connection
+        default: nil
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/RestartAppPickerSheet.swift
+++ b/App/Sources/FeatureDetail/Views/RestartAppPickerSheet.swift
@@ -1,0 +1,164 @@
+import ADBKit
+import SwiftUI
+
+/// Searchable installed-app picker shared by the restart flows (Reactotron,
+/// JS Console), shown when the running app can't be detected automatically —
+/// or when restarting the detected one failed. Lists the device's third-party
+/// packages; picking one calls `onPick` and closes.
+struct RestartAppPickerSheet: View {
+    let serial: String?
+    let onPick: (String) -> Void
+
+    @Environment(AppState.self) private var state
+    @Environment(\.dismiss) private var dismiss
+    @State private var apps: [String] = []
+    @State private var loading = false
+    @State private var search = ""
+    @FocusState private var searchFocused: Bool
+
+    private var filtered: [String] {
+        guard !search.isEmpty else { return apps }
+        return apps.filter {
+            $0.localizedCaseInsensitiveContains(search)
+                || restartAppDisplayName($0).localizedCaseInsensitiveContains(search)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle().fill(Color.brandAccent.opacity(0.16)).frame(width: 30, height: 30)
+                    Image(systemName: "arrow.clockwise")
+                        .font(.app(size: 13, weight: .semibold))
+                        .foregroundStyle(.brandAccent)
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Restart app")
+                        .font(.app(size: 13, weight: .semibold))
+                    Text("Couldn't detect the running app — pick it to force-stop and relaunch")
+                        .font(.app(size: 10))
+                        .foregroundStyle(.textMuted)
+                }
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill").font(.app(size: 15))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tertiary)
+                .keyboardShortcut(.cancelAction)
+            }
+            .padding(12)
+
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.app(size: 11))
+                    .foregroundStyle(.tertiary)
+                TextField("Search apps…", text: $search)
+                    .textFieldStyle(.plain)
+                    .font(.app(size: 12))
+                    .focused($searchFocused)
+                if !search.isEmpty {
+                    Button { search = "" } label: { Image(systemName: "xmark.circle.fill") }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(Color.bgRoot, in: RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.borderSubtle))
+            .padding(.horizontal, 12)
+            .padding(.bottom, 10)
+
+            Divider()
+            content
+        }
+        .frame(width: 360, height: 440)
+        .background(Color.bgSurface)
+        .task { searchFocused = true; await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if loading {
+            hint("Loading apps…")
+        } else if apps.isEmpty {
+            hint("No third-party apps found")
+        } else if filtered.isEmpty {
+            hint("No matches")
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered, id: \.self) { package in
+                        RestartAppPickerRow(package: package, serial: serial ?? "") {
+                            dismiss()
+                            onPick(package)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func hint(_ text: String) -> some View {
+        Text(text)
+            .font(.app(.caption))
+            .foregroundStyle(.textMuted)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func load() async {
+        guard let serial else { apps = []; return }
+        loading = true
+        defer { loading = false }
+        let service = AppControlService(client: state.env.client)
+        apps = await CommandLog.userInitiated {
+            (try? await service.listInstalledPackages(serial: serial)) ?? []
+        }
+    }
+}
+
+private struct RestartAppPickerRow: View {
+    let package: String
+    let serial: String
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                AppIconView(packageId: package, name: restartAppDisplayName(package), serial: serial)
+                    .frame(width: 28, height: 28)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(restartAppDisplayName(package))
+                        .font(.app(size: 12, weight: .medium))
+                        .lineLimit(1)
+                    Text(package)
+                        .font(.app(size: 10, design: .monospaced))
+                        .foregroundStyle(.textMuted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(hovering ? Color.brandAccent.opacity(0.16) : Color.clear, in: RoundedRectangle(cornerRadius: 6))
+            .contentShape(Rectangle())
+            .padding(.horizontal, 6)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+    }
+}
+
+/// Friendly app name from a package id ("com.foo.bar" → "Bar"), mirroring the
+/// Apps feature's `AppListing.displayName`.
+func restartAppDisplayName(_ packageId: String) -> String {
+    packageId.split(separator: ".").last
+        .map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? packageId
+}

--- a/App/Sources/LogTailViewV2.swift
+++ b/App/Sources/LogTailViewV2.swift
@@ -7,6 +7,9 @@ import SwiftUI
 @MainActor
 private final class TailMeasure {
     var geometry = TailGeometry()
+    /// Last content height reported to PerfLog, so geometry logging fires on
+    /// meaningful jumps instead of per pixel.
+    var lastLoggedContentHeight: CGFloat = -1
 }
 
 /// The v2 log scroller, shared by every streaming feed (JS Console, Reactotron;
@@ -20,6 +23,10 @@ private final class TailMeasure {
 ///   edge resumes.
 /// - Jump-to-top / jump-to-bottom buttons overlay the feed; each hides at its
 ///   own edge, both hide when the feed is empty or too short to scroll.
+/// - `.bottom`-feed content shorter than the viewport is stretched to fill it
+///   with the rows pinned at the visual top — a handful of lines must not sit
+///   under a screen of empty space. Structural layout never switches (the
+///   stretch is a `minHeight` that overflowing content makes a no-op).
 /// - `focusID` scrolls an externally-selected row (e.g. a ⌘F match) into view.
 ///
 /// Tailing is decided by the `.scrollPosition` *binding*, not the measured
@@ -77,6 +84,11 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
         newestEdge == .bottom ? entries.first?.id : entries.last?.id
     }
 
+    /// The viewport height, mirrored into state (guarded, half-point
+    /// tolerance) so short `.bottom` feeds can stretch their content to fill
+    /// it — see the `minHeight` note on `orderedRows` below.
+    @State private var fillHeight: CGFloat = 0
+
     /// -1 flips `.bottom` feeds so a newest-first layout reads newest-at-bottom.
     private var flip: CGFloat { newestEdge == .bottom ? -1 : 1 }
 
@@ -85,6 +97,17 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) { orderedRows }
                     .scrollTargetLayout()
+                    // Short `.bottom` feeds: stretch the content to the
+                    // viewport and pin the rows at the content's *end* — the
+                    // flip renders that at the visual top, so a handful of
+                    // lines reads top-down instead of sitting at the bottom
+                    // of a screen of empty space. A no-op once the content
+                    // overflows (and for `.top` feeds, which are unstretched),
+                    // so the layout never switches structure.
+                    .frame(
+                        minHeight: newestEdge == .bottom && fillHeight > 0 ? fillHeight : nil,
+                        alignment: .bottom
+                    )
                     .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .named("logtail")) }) { frame in
                         measure.geometry.contentLeadingOffset = frame.minY
                         measure.geometry.contentHeight = frame.height
@@ -95,6 +118,7 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
             .onGeometryChange(for: CGFloat.self, of: { $0.size.height }) { height in
                 measure.geometry.viewportHeight = height
                 syncEdges()
+                if abs(fillHeight - height) > 0.5 { fillHeight = height }
             }
             // Let a row scroll its own header into view (e.g. when an object is
             // expanded). In the flipped newest-at-bottom layout the per-row flip
@@ -121,7 +145,16 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
                 // A feed (re)starting from empty always tails — a clear while
                 // paused must not leave the next stream un-followed.
                 if old == nil { setTailing(true) }
-                if isTailing, let newest { leadingID = newest }   // cheap: first row, offset 0
+                if isTailing, let newest {
+                    leadingID = newest   // cheap: first row, offset 0
+                } else if let anchored = leadingID, !entries.contains(where: { $0.id == anchored }) {
+                    // The anchored row was cleared/trimmed away while paused —
+                    // without a live anchor the scroll view can park the
+                    // viewport in empty space past the content. Snap back to
+                    // the newest edge and resume tailing.
+                    setTailing(true)
+                    leadingID = newest
+                }
             }
             .onChange(of: focusID) { _, id in
                 guard let id else { return }
@@ -181,6 +214,23 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
             derived.atBottom = isTailing
         }
         if derived != edges { edges = derived }
+        logGeometryIfNotable()
+    }
+
+    /// PerfLog trace for the blank-canvas investigation: content height vs
+    /// entry count exposes inflated lazy estimates, and offset shows where the
+    /// viewport is parked. Logged on ≥500pt content-height jumps only.
+    private func logGeometryIfNotable() {
+        let geometry = measure.geometry
+        guard abs(geometry.contentHeight - measure.lastLoggedContentHeight) > 500 else { return }
+        measure.lastLoggedContentHeight = geometry.contentHeight
+        PerfLog.feed.info("""
+            geometry: content=\(Int(geometry.contentHeight), privacy: .public) \
+            viewport=\(Int(geometry.viewportHeight), privacy: .public) \
+            offset=\(Int(geometry.contentLeadingOffset), privacy: .public) \
+            entries=\(entries.count, privacy: .public) \
+            fill=\(Int(fillHeight), privacy: .public)
+            """)
     }
 
     /// Both jumps move by SETTING the binding — never `proxy.scrollTo`, whose

--- a/App/Sources/PerfLog.swift
+++ b/App/Sources/PerfLog.swift
@@ -1,0 +1,29 @@
+import os
+
+/// Performance instrumentation for the streaming log feeds (JS Console,
+/// Reactotron, the shared scroller). Watch it live while exercising the app:
+///
+///     log stream --info --predicate 'subsystem == "com.rohindh.droidective.perf"'
+///
+/// Everything logs `.public` — the payload is sizes and durations, never
+/// content. Cheap when Console isn't attached (os.Logger no-ops early).
+enum PerfLog {
+    static let console = Logger(subsystem: "com.rohindh.droidective.perf", category: "js-console")
+    static let feed = Logger(subsystem: "com.rohindh.droidective.perf", category: "log-feed")
+
+    /// Run `body`, logging a warning when it exceeds `thresholdMs`.
+    @discardableResult
+    static func measure<T>(
+        _ logger: Logger, _ label: String, thresholdMs: Double = 4, _ body: () -> T
+    ) -> T {
+        let start = ContinuousClock.now
+        let result = body()
+        let elapsed = ContinuousClock.now - start
+        let ms = Double(elapsed.components.seconds) * 1000
+            + Double(elapsed.components.attoseconds) / 1e15
+        if ms >= thresholdMs {
+            logger.warning("\(label, privacy: .public) took \(ms, format: .fixed(precision: 1), privacy: .public)ms")
+        }
+        return result
+    }
+}

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -86,6 +86,7 @@ struct RootView: View {
                     window.setFrame(screen.visibleFrame, display: true)
                 }
                 window.setFrameAutosaveName(autosaveName)
+                WindowMinSizeGuard.shared.attach(to: window)
             })
             .overlay {
                 // Full-window takeover (macOS has no fullScreenCover), shown
@@ -690,6 +691,56 @@ private final class WindowReaderView: NSView {
         guard !resolved, let window else { return }
         resolved = true
         onWindow?(window)
+    }
+}
+
+/// Keeps the main window at or above 85% of its screen's usable area — the
+/// dense multi-pane layout degrades below that. Sets `NSWindow.minSize` (so
+/// resize drags stop at the floor) and re-applies when the window changes
+/// screens or the display configuration changes, growing the window back if a
+/// restored/saved frame is under the floor of the current screen.
+@MainActor
+final class WindowMinSizeGuard {
+    static let shared = WindowMinSizeGuard()
+    static let screenFraction = 0.85
+    private weak var window: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+
+    func attach(to window: NSWindow) {
+        self.window = window
+        let center = NotificationCenter.default
+        observers.forEach(center.removeObserver)
+        let reapply: @Sendable (Notification) -> Void = { _ in
+            MainActor.assumeIsolated { WindowMinSizeGuard.shared.apply() }
+        }
+        observers = [
+            center.addObserver(
+                forName: NSWindow.didChangeScreenNotification, object: window, queue: .main,
+                using: reapply),
+            center.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification, object: nil,
+                queue: .main, using: reapply),
+        ]
+        apply()
+    }
+
+    private func apply() {
+        guard let window, let screen = window.screen ?? NSScreen.main else { return }
+        let visible = screen.visibleFrame
+        let floor = NSSize(
+            width: (visible.width * Self.screenFraction).rounded(),
+            height: (visible.height * Self.screenFraction).rounded())
+        window.minSize = floor
+        guard !window.styleMask.contains(.fullScreen) else { return }
+        var frame = window.frame
+        guard frame.width < floor.width || frame.height < floor.height else { return }
+        frame.size.width = max(frame.width, floor.width)
+        frame.size.height = max(frame.height, floor.height)
+        // Growing can push the frame past the screen edge — slide it back in
+        // (the floor is 85% of `visible`, so it always fits).
+        frame.origin.x = min(max(frame.origin.x, visible.minX), visible.maxX - frame.width)
+        frame.origin.y = min(max(frame.origin.y, visible.minY), visible.maxY - frame.height)
+        window.setFrame(frame, display: true)
     }
 }
 

--- a/App/Sources/State/AppState+Sidebar.swift
+++ b/App/Sources/State/AppState+Sidebar.swift
@@ -16,13 +16,22 @@ extension AppState {
         return FeatureRegistry.all.filter { enabled.contains($0.id) && !$0.isAbsorbedByHub }
     }
 
-    /// The launchpad grid: the role-curated enabled set in its curated order,
-    /// re-ranked by real usage (most-used first), with the curated order as the
-    /// stable fallback. Hub members stay excluded, exactly like the sidebar.
+    /// Pinned features in the user's order — the sidebar's Pinned section,
+    /// shared with Home so both surfaces show the same list.
+    var pinnedFeatures: [FeatureDef] {
+        ordered(enabledFeatures.filter { layout.favorites.contains($0.id) })
+    }
+
+    /// The launchpad grid: the enabled, non-pinned set in the exact order the
+    /// sidebar shows it (grouped by category order, or the flat order when
+    /// grouping is off) — Home mirrors the sidebar instead of re-ranking.
+    /// Collapsed groups still contribute their features; collapsing is a
+    /// sidebar-space affordance, not a preference against the feature.
     var launchpadFeatures: [FeatureDef] {
-        let curated = ordered(enabledFeatures)
-        let byID = Dictionary(uniqueKeysWithValues: curated.map { ($0.id, $0) })
-        return usageStats.rank(curated.map(\.id)).compactMap { byID[$0] }
+        let grouped = UserDefaults.standard.object(forKey: "groupSidebar") as? Bool ?? true
+        return grouped
+            ? orderedCategories.flatMap { enabledFeatures(in: $0) }
+            : orderedEnabledFeatures
     }
 
     /// Home's "Frequently used" strip: enabled features used more than once,
@@ -158,12 +167,7 @@ extension AppState {
     /// active search. Lets the Hotkeys settings list mirror the sidebar instead
     /// of dumping the full registry.
     var sidebarFeatures: [FeatureDef] {
-        let grouped = UserDefaults.standard.object(forKey: "groupSidebar") as? Bool ?? true
-        let pinned = ordered(enabledFeatures.filter { layout.favorites.contains($0.id) })
-        let rest = grouped
-            ? orderedCategories.flatMap { enabledFeatures(in: $0) }
-            : orderedEnabledFeatures
-        return pinned + rest
+        pinnedFeatures + launchpadFeatures
     }
 
     /// Every sidebar row in the order it's rendered right now — Pinned, then


### PR DESCRIPTION
## Home & window
- Home's launchpad follows the sidebar order with a Pinned section mirroring the sidebar's; the "Frequently used" strip stays usage-based. Dead `UsageStats.rank` removed.
- Home is no longer a closable tab or a sidebar button: a permanent house icon leads the tab strip.
- The main window can't be resized below 85% of the screen's visible frame (`WindowMinSizeGuard`).

## Reactotron
- The timeline filter is a "Timeline Filter" modal matching the Reactotron app's dialog (grouped checkboxes, API-only method/status refinements, Check all / Uncheck all).
- Log rows preview object messages as bounded compact JSON (`JSONValue.compactPreview`); rows get a hover copy button; the action/log text itself is selectable (the whole-row tap gesture swallowed drag-to-select).
- Restart app auto-detects the running app (client name matched against installed packages via `AppNameMatcher`, else the foreground app) and opens a searchable picker when disconnected or detection fails.
- A one-time intro sheet on first open plays a recorded demo of the split timeline with a different filter per pane.

## JS Console
- Reload JS (CDP `Page.reload`, bounded reply, dev-menu fallback) and Restart app (force-stop + relaunch the target's `appId`; picker when disconnected).
- Bulletproofing for huge payloads: row text renders at most 10k chars (a 3MB `console.log` stalled layout and blew up the feed's scroll canvas), search text builds from bounded summaries, and the buffer adds a 128MB byte budget over the 2000-entry cap.
- The in-object search caps auto-expansion at 100 rows per level.

## Log feeds & performance
- Short bottom feeds fill the viewport with rows pinned at the visual top; a cleared scroll anchor snaps back to the newest edge.
- Logcat search matches per-line lowercased keys and debounces the NSTextView rebuild.
- `PerfLog` (subsystem `com.rohindh.droidective.perf`) reports flush/filter/find timings, render truncations, and feed geometry.

## Onboarding tour
- Rebuilt around five pages, each led by a looping screen recording of the real app (`App/Resources/Tour`, ~5MB total, drawn animated fallbacks, still frame under Reduce Motion): sidebar, tabs & drag-to-split, roles, settings & hotkeys, and Quick Actions summoned over a browser.
- The final page folds in the Quick Actions hotkey ask; Skip from any page jumps straight there.
- The role picker gains a close button + Esc when reopened from Home — previously the only exit re-seeded the curated set and reset all tabs.

## Tests
- 688 ADBKit tests pass (was 654): compact-preview bounds, `Page.reload` wire tests, `AppNameMatcher`, buffer byte budget, bounded summaries, logcat search key.
- Verified live against a running RN app session (Reactotron timeline, JS console, reload/restart, tour playback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)