### PR TITLE
Fix the stable-named DMG copy in the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,9 @@ jobs:
       # /releases/latest/download/Droidective.dmg URL — always the newest
       # release, no appcast fetch, no Pages/browser cache staleness.
       - name: Add a stable-named copy for the latest-download link
-        run: cp "DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg" \
-               "DerivedData/Build/Products/Release/Droidective.dmg"
+        run: |
+          cp "DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg" \
+             "DerivedData/Build/Products/Release/Droidective.dmg"
       - name: Publish release with build
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:


### PR DESCRIPTION
## What changed

The "Add a stable-named copy for the latest-download link" step used a plain-scalar `run:` folded across two lines. YAML joins those with a space, so bash received `cp "src" \ "dst"` — the backslash escaped the space and the destination path gained a leading space, failing with `No such file or directory`. A literal block scalar (`run: |`) keeps the line continuation intact.

This killed the v3.0.0 tag run after notarization and before anything published (no GitHub release, no appcast commit), so the tag will be moved and re-pushed once this merges.

## How verified
- `actionlint` passes.