### PR TITLE
Remove the Homebrew install flow

### DIFF
--- a/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
+++ b/ADBKit/Sources/ADBKit/Exec/ToolLocator.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum Tool: String, Sendable, CaseIterable {
     case adb
     case scrcpy
-    case brew
     case ffmpeg
     case emulator
 }
@@ -19,14 +18,15 @@ public enum AdbError: Error, LocalizedError, Sendable {
     }
 }
 
-/// Resolves absolute paths to external CLI tools (adb, scrcpy, brew, ffmpeg).
+/// Resolves absolute paths to external CLI tools (adb, scrcpy, ffmpeg).
 ///
 /// A GUI app launched from Finder inherits a minimal PATH that usually
-/// excludes Homebrew and the Android SDK, so we never call a bare `adb`. We
-/// probe well-known install locations and, as a fallback, ask the user's
-/// login shell (which loads their full PATH) to resolve it. Found paths are
-/// cached until `clearCache()` (e.g. after a tool install); "not found"
-/// expires after `notFoundTTL` so installing a tool mid-session is noticed.
+/// excludes package-manager prefixes and the Android SDK, so we never call a
+/// bare `adb`. We probe well-known install locations and, as a fallback, ask
+/// the user's login shell (which loads their full PATH) to resolve it. Found
+/// paths are cached until `clearCache()` (e.g. after a tool install); "not
+/// found" expires after `notFoundTTL` so installing a tool mid-session is
+/// noticed.
 public actor ToolLocator {
     /// One finished lookup. `expiresAt` is set only on negative results;
     /// found and seeded paths never expire on their own.
@@ -86,7 +86,7 @@ public actor ToolLocator {
             resolved = await resolveViaLoginShell(tool)
         }
         // "Not found" is cached with a TTL; Settings → Tools → "Re-detect"
-        // and the brew-install flow still call clearCache() to heal at once.
+        // still calls clearCache() to heal at once.
         cache[tool] = CachedLookup(
             path: resolved,
             expiresAt: resolved == nil ? now().addingTimeInterval(Self.notFoundTTL) : nil
@@ -101,8 +101,8 @@ public actor ToolLocator {
     }
 
     /// Newest SDK build-tools directory (e.g. …/build-tools/34.0.0), or nil when
-    /// none are installed. aapt2 / apksigner / zipalign all ship here (not via
-    /// Homebrew). Cached; cleared by `clearCache`.
+    /// none are installed. aapt2 / apksigner / zipalign all ship here (SDK
+    /// only). Cached; cleared by `clearCache`.
     public func buildToolsDir() async -> String? {
         if let cached = buildToolsDirCache { return cached }
         var resolved: String?
@@ -209,17 +209,19 @@ public actor ToolLocator {
     }
 
     private func candidatePaths(for tool: Tool) -> [String] {
-        let brewPrefixes = ["/opt/homebrew/bin", "/usr/local/bin"]
+        // The standard third-party install prefixes on macOS (Apple Silicon
+        // then Intel) — wherever the user's package manager put the binary.
+        let installPrefixes = ["/opt/homebrew/bin", "/usr/local/bin"]
 
         switch tool {
         case .adb:
             return sdkRoots.map { "\($0)/platform-tools/adb" }
-                + brewPrefixes.map { "\($0)/adb" }
+                + installPrefixes.map { "\($0)/adb" }
         case .emulator:
-            // The emulator launcher only ships with the SDK, not Homebrew.
+            // The emulator launcher only ships with the SDK.
             return sdkRoots.map { "\($0)/emulator/emulator" }
-        case .scrcpy, .brew, .ffmpeg:
-            return brewPrefixes.map { "\($0)/\(tool.rawValue)" }
+        case .scrcpy, .ffmpeg:
+            return installPrefixes.map { "\($0)/\(tool.rawValue)" }
         }
     }
 
@@ -228,7 +230,7 @@ public actor ToolLocator {
     }
 
     /// Ask the user's login shell (which loads their full PATH) to resolve a
-    /// command by name — the fallback for Homebrew/SDK tools off the app's PATH.
+    /// command by name — the fallback for tools installed off the app's PATH.
     private func resolveViaLoginShellCommand(_ name: String) async -> String? {
         let output = await runner.run(
             executable: "/bin/zsh",

--- a/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyServerLocator.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyServerLocator.swift
@@ -14,10 +14,10 @@ public struct ScrcpyServerInfo: Sendable, Equatable {
 
 /// Resolves `ScrcpyServerInfo`. The path/version parsing is pure and unit-tested;
 /// `resolve` wires it to the real toolchain. For now the server is reused from
-/// the installed scrcpy (Homebrew lays it beside the binary); bundling it in the
-/// app is a later packaging step.
+/// the installed scrcpy (its package lays the jar beside the binary); bundling
+/// it in the app is a later packaging step.
 public enum ScrcpyServerLocator {
-    /// Homebrew layout: `<prefix>/bin/scrcpy` → `<prefix>/share/scrcpy/scrcpy-server`.
+    /// Standard layout: `<prefix>/bin/scrcpy` → `<prefix>/share/scrcpy/scrcpy-server`.
     public static func jarPath(forBinary binaryPath: String) -> String {
         let binDir = (binaryPath as NSString).deletingLastPathComponent
         let prefix = (binDir as NSString).deletingLastPathComponent

--- a/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
@@ -7,15 +7,15 @@ public struct ToolStatus: Sendable, Equatable {
     public let installHint: String
 }
 
-/// Detects whether adb / scrcpy are installed and offers a one-click
-/// Homebrew install through the user's login shell.
+/// Detects whether the external tools are installed, with an install hint
+/// per missing one (shown by the Doctor and the device bar).
 public struct ToolDetectionService: Sendable {
     static let installHints: [Tool: String] = [
-        .adb: "Install Android platform-tools — `brew install --cask android-platform-tools` (or Android Studio).",
-        .scrcpy: "Install scrcpy to mirror the screen — `brew install scrcpy`.",
-        .ffmpeg: "Install ffmpeg for video editing & export — `brew install ffmpeg`.",
+        .adb: "Install Android platform-tools — via Android Studio, or from "
+            + "developer.android.com/tools/releases/platform-tools — then re-check.",
+        .scrcpy: "Install scrcpy from github.com/Genymobile/scrcpy (optional — the app bundles its own mirror server).",
+        .ffmpeg: "Install ffmpeg from ffmpeg.org (optional — the app bundles its own for video export).",
         .emulator: "Bundled with the Android SDK — install it via Android Studio → SDK Manager.",
-        .brew: "Install Homebrew from https://brew.sh, then re-check.",
     ]
 
     /// The flag each tool prints its version with.
@@ -24,7 +24,6 @@ public struct ToolDetectionService: Sendable {
         .scrcpy: ["--version"],
         .emulator: ["-version"],
         .ffmpeg: ["-version"],
-        .brew: ["--version"],
     ]
 
     let locator: ToolLocator
@@ -70,27 +69,4 @@ public struct ToolDetectionService: Sendable {
         return ToolStatus(installed: true, path: path, version: version, installHint: hint)
     }
 
-    /// Install a tool via Homebrew. Slow (minutes) — callers should show
-    /// progress and refresh detection afterwards.
-    public func installViaBrew(_ tool: Tool) async -> FeatureResult {
-        guard let brew = await locator.resolve(.brew) else {
-            return FeatureResult(
-                ok: false,
-                message: "Homebrew isn't installed. Install it from https://brew.sh, then try again."
-            )
-        }
-        let command = tool == .adb
-            ? "\(brew) install --cask android-platform-tools"
-            : "\(brew) install \(tool.rawValue)"
-        let output = await runner.run(
-            executable: "/bin/zsh", arguments: ["-lc", command],
-            timeout: .seconds(300), maxOutputBytes: 10 * 1024 * 1024
-        )
-        if output.exitCode == 0 {
-            await locator.clearCache()
-            return FeatureResult(ok: true, message: "\(tool.rawValue) installed successfully.")
-        }
-        let reason = output.stderrText.split(whereSeparator: \.isNewline).last.map(String.init) ?? "brew failed"
-        return FeatureResult(ok: false, message: "Couldn't install \(tool.rawValue): \(reason)")
-    }
 }

--- a/App/Sources/Bundled/BundledTools.swift
+++ b/App/Sources/Bundled/BundledTools.swift
@@ -2,7 +2,8 @@ import ADBKit
 import Foundation
 
 /// Single source of truth for the third-party binaries shipped inside the app
-/// bundle, so Droidective is self-contained (no `brew install scrcpy`/`ffmpeg`).
+/// bundle, so Droidective is self-contained (no separate scrcpy/ffmpeg
+/// install needed).
 ///
 /// **Updating a bundled tool** (scalable on purpose): run
 /// `scripts/update-bundled-tools.sh`, which downloads the pinned versions into

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import AppKit
 import SwiftUI
 
 /// Persistent device context above the detail pane, on a single row: the device
@@ -57,11 +58,15 @@ struct DeviceBarView: View {
                     Label("adb not found", systemImage: "exclamationmark.triangle.fill")
                         .font(.app(.footnote))
                         .foregroundStyle(.orange)
-                    Button(state.installingTool == .adb ? "Installing…" : "Install") {
-                        state.installTool(.adb)
+                    // Opens Google's platform-tools page — the app doesn't
+                    // install tools itself.
+                    Button("How to install") {
+                        NSWorkspace.shared.open(
+                            URL(string: "https://developer.android.com/tools/releases/platform-tools")!
+                        )
                     }
                     .controlSize(.mini)
-                    .disabled(state.installingTool != nil)
+                    .help("adb ships with Android platform-tools — install it via Android Studio or this download page, then re-check in Settings ▸ Doctor")
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -458,9 +458,9 @@ struct PrivacySettingsView: View {
     }
 }
 
-/// Setup Doctor: verifies the external toolchain (adb / emulator / Homebrew),
-/// shows each tool's version and path, and offers a Homebrew install for the
-/// brew-installable ones. scrcpy and ffmpeg aren't listed — the app bundles them.
+/// Setup Doctor: verifies the external toolchain (adb / emulator), shows each
+/// tool's version and path, and points at the install source when one is
+/// missing. scrcpy and ffmpeg aren't listed — the app bundles them.
 struct DoctorSettingsView: View {
     @Environment(AppState.self) private var state
     @State private var report: [Tool: ToolStatus] = [:]
@@ -470,21 +470,17 @@ struct DoctorSettingsView: View {
         let tool: Tool
         let name: String
         let purpose: String
-        /// false for tools we can't `brew install` (emulator ships with the
-        /// SDK; brew installs itself).
-        let brewInstallable: Bool
     }
 
     private static let checks: [Check] = [
-        Check(tool: .adb, name: "adb", purpose: "Required — powers every device action", brewInstallable: true),
-        Check(tool: .emulator, name: "emulator", purpose: "Launch & manage Android emulators", brewInstallable: false),
-        Check(tool: .brew, name: "Homebrew", purpose: "Installs the tools above", brewInstallable: false),
+        Check(tool: .adb, name: "adb", purpose: "Required — powers every device action"),
+        Check(tool: .emulator, name: "emulator", purpose: "Launch & manage Android emulators"),
     ]
 
-    /// Missing tools that actually block features (Homebrew alone isn't one).
+    /// Missing tools that actually block features.
     private var blockingMissing: [Tool] {
         Self.checks
-            .filter { $0.tool != .brew && report[$0.tool]?.installed == false }
+            .filter { report[$0.tool]?.installed == false }
             .map(\.tool)
     }
 
@@ -493,12 +489,7 @@ struct DoctorSettingsView: View {
             Section { summary }
             Section("Toolchain") {
                 ForEach(Self.checks, id: \.tool) { check in
-                    ToolRow(
-                        check: check,
-                        status: report[check.tool],
-                        installingTool: state.installingTool,
-                        onInstall: { state.installTool($0) }
-                    )
+                    ToolRow(check: check, status: report[check.tool])
                 }
             }
             Section {
@@ -512,10 +503,6 @@ struct DoctorSettingsView: View {
         }
         .formStyle(.grouped)
         .task { await redetect() }
-        .onChange(of: state.installingTool) { _, installing in
-            // A brew install finished — refresh so the row flips to installed.
-            if installing == nil { Task { await redetect() } }
-        }
     }
 
     @ViewBuilder
@@ -537,14 +524,12 @@ struct DoctorSettingsView: View {
     }
 
     /// One compact row: a status icon + the tool name, expandable to reveal
-    /// version, path, and (when missing) the install action. Uses a separate
+    /// version, path, and (when missing) the install hint. Uses a separate
     /// struct so each row owns its own isExpanded state, enabling a full-width
     /// Button label that makes the entire row tappable (not just the chevron).
     private struct ToolRow: View {
         let check: Check
         let status: ToolStatus?
-        let installingTool: Tool?
-        let onInstall: (Tool) -> Void
         @State private var isExpanded = false
 
         var body: some View {
@@ -561,17 +546,10 @@ struct DoctorSettingsView: View {
                             detailRow("Path", path)
                         }
                         if !status.installed {
-                            if check.brewInstallable {
-                                Button(installingTool == check.tool ? "Installing…" : "Install via Homebrew") {
-                                    onInstall(check.tool)
-                                }
-                                .disabled(installingTool != nil)
-                            } else {
-                                Text(status.installHint)
-                                    .font(.app(.callout))
-                                    .foregroundStyle(.textMuted)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                            Text(status.installHint)
+                                .font(.app(.callout))
+                                .foregroundStyle(.textMuted)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                     }
                 }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -261,7 +261,6 @@ final class AppState {
     var bundles: [AppBundle] = []
     var selectedBundleId: String?
     var adbStatus: ToolStatus?
-    var installingTool: Tool?
     /// APKs opened from Finder (double-click / Open With), handed to the Install
     /// App feature to stage for an explicit install. The view consumes (clears)
     /// it once shown.
@@ -520,17 +519,6 @@ final class AppState {
 
     func refreshToolStatus() async {
         adbStatus = await env.engine.toolDetection.detectAdb()
-    }
-
-    func installTool(_ tool: Tool) {
-        guard installingTool == nil else { return }
-        installingTool = tool
-        Task {
-            let result = await env.engine.toolDetection.installViaBrew(tool)
-            showToast(Toast(message: result.message, ok: result.ok))
-            await refreshToolStatus()
-            installingTool = nil
-        }
     }
 
     private func devicesChanged(_ devices: [Device]) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Two layers, strictly separated so a second **Apple** UI (iPad/visionOS) could
 reuse ADBKit almost as-is. Note the honest scope: a Linux/Windows port re-does
 the UI **plus** the macOS-bound seams inside ADBKit — the Mirror media stack
 (CoreMedia/VideoToolbox/AVFoundation), the Network.framework socket servers,
-`ToolLocator`'s Homebrew/SDK paths + `zsh -lc`, and `.lzma`/`tar` extraction;
+`ToolLocator`'s macOS install/SDK paths + `zsh -lc`, and `.lzma`/`tar` extraction;
 an iOS companion can't run `Process` at all, so it would need a remote-host
 protocol, not just a UI swap. Keep the existing seams (`ProcessRunning`,
 injected directories) and don't pre-abstract the rest until a port is scheduled.
@@ -78,7 +78,7 @@ The agent loop I use: edit → `cd ADBKit && swift test` → `xcodegen generate`
 lands at `DerivedData/Build/Products/Debug/Droidective.app`.
 
 `brew install xcodegen` if missing. App is ad-hoc signed, sandbox OFF (it must
-spawn adb/scrcpy/emulator/brew).
+spawn adb/scrcpy/emulator).
 
 ## Marketing site
 
@@ -97,8 +97,9 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
 ## Key types (ADBKit)
 
 - `Exec/`: `ProcessRunning` protocol → `SystemProcessRunner` (real) +
-  `MockProcessRunner` (tests). `ToolLocator` (actor) resolves adb/scrcpy/brew/
-  ffmpeg/emulator via SDK paths → Homebrew → `zsh -lc` fallback, cached.
+  `MockProcessRunner` (tests). `ToolLocator` (actor) resolves adb/scrcpy/
+  ffmpeg/emulator via SDK paths → the standard install prefixes → `zsh -lc`
+  fallback, cached.
   `AdbClient` (structured `AdbResult`, never throws on non-zero exit, only on
   `.adbNotFound`). `SimctlClient` (AdbClient's `xcrun simctl` twin for iOS
   Simulators — same `AdbResult` shape, throws only on missing Xcode).
@@ -148,8 +149,9 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   `ScreenRecordOptions` struct. **Bundled binaries** (scrcpy-server + a static
   GPLv3 ffmpeg) live in `App/Resources/`, resolved by the App-layer `BundledTools`
   (single version source); `scripts/update-bundled-tools.sh` refreshes them. The
-  app needs no `brew install scrcpy`/`ffmpeg`; the Doctor only checks adb /
-  emulator / Homebrew.
+  app needs no separate scrcpy/ffmpeg install; the Doctor only checks adb /
+  emulator (pointing at the install source when one is missing — the app
+  never installs tools itself).
 - `Persistence/`: `JSONStore<T>` (actor, atomic write, sets aside corrupt
   files as `.corrupt`), `Stores` (Bundles, DeepLinks, CustomCommands,
   LayoutState, Presets, OverridesMap, Prefs) in

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ and `⌘=`/`⌘-` font zoom. Files pulled from the device always ask where to sa
 - macOS 14 (Sonoma) or later
 - [Android platform-tools](https://developer.android.com/tools/releases/platform-tools)
   (`adb`) — found automatically via `ANDROID_HOME`, `~/Library/Android/sdk`, or
-  Homebrew; the app offers a one-click install if it's missing.
+  the standard install prefixes; if it's missing the app links to the download.
 - Optional: the Android SDK `emulator` (AVD management). The `scrcpy` server
-  payload and a static `ffmpeg` ship **inside the app** — no `brew install` needed.
+  payload and a static `ffmpeg` ship **inside the app** — no separate install needed.
 
 ## Building
 
@@ -101,7 +101,7 @@ make run                  # build and launch
 after a fresh clone if you want to open it in Xcode.
 
 The app runs **without the App Sandbox** (it must spawn `adb`, the bundled
-`ffmpeg`, the `emulator`, and `brew`). Local builds are ad-hoc signed; release
+`ffmpeg`, and the `emulator`). Local builds are ad-hoc signed; release
 builds are signed with a Developer ID and notarized (see [`RELEASING.md`](RELEASING.md)).
 
 ## Install a release build

--- a/docs/review/SECURITY.md
+++ b/docs/review/SECURITY.md
@@ -1,7 +1,7 @@
 # Security
 
 Droidective is an **open-source, public repo** that spawns local tools (adb,
-scrcpy, emulator, ffmpeg, brew) and runs commands against a connected device. The
+scrcpy, emulator, ffmpeg) and runs commands against a connected device. The
 threat model is small but real: leaked secrets in git history, shell injection
 through device-side commands, and unsafe file operations on the user's machine.
 
@@ -68,7 +68,7 @@ exports, persisted state).
 
 ## External tools & supply chain
 
-- The app resolves adb/scrcpy/brew/ffmpeg/emulator via `ToolLocator`. Don't add a
+- The app resolves adb/scrcpy/ffmpeg/emulator via `ToolLocator`. Don't add a
   new external binary dependency without justification — each is attack surface.
 - Bundled binaries (scrcpy-server, static ffmpeg) are refreshed by a script and
   versioned in one place (`BundledTools`); a new or bumped binary is reviewed for


### PR DESCRIPTION
The app no longer installs tools via Homebrew:

- **Removed**: the `.brew` tool case, `ToolDetectionService.installViaBrew`, the Doctor's Homebrew row, its "Install via Homebrew" buttons, and `AppState.installTool`/`installingTool`.
- **Doctor** now checks adb + emulator only and shows each missing tool's install hint (Android Studio / the platform-tools download page) — the app never runs an installer.
- **Device bar**: the adb-missing "Install" button becomes "How to install", opening Google's platform-tools page.
- Install hints, CLAUDE.md, README, and the security review doc lose their brew phrasing.

**Deliberately kept**: tool *discovery*. `ToolLocator` still probes `/opt/homebrew/bin` and `/usr/local/bin` (the standard macOS install prefixes) plus the login shell's PATH — an adb that's already installed keeps resolving no matter how it got there. Also untouched: the Homebrew **cask** distribution in the release pipeline and `brew install xcodegen` in the dev setup, which are about distributing/building the app, not features inside it.

## Testing
- `cd ADBKit && swift test` — 728 tests green.
- `make build` — zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)