### PR TITLE
Register blog HTML entries in the Vite build

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,8 +1,28 @@
-import { readFileSync } from "node:fs"
+import { readdirSync, readFileSync } from "node:fs"
 import path from "node:path"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig, type Plugin } from "vite"
+
+// Every blog/**/index.html is a static entry (the index plus one per post).
+// Scanning keeps Rollup's input list in sync as posts are added — regenerate
+// the HTML with scripts/gen-blog-html.mjs and the new page is picked up here.
+function blogInputs(): Record<string, string> {
+  const blogDir = path.resolve(__dirname, "blog")
+  const inputs: Record<string, string> = {}
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name === "index.html") {
+        const rel = path.relative(__dirname, full).replace(/[/\\]index\.html$/, "")
+        inputs[rel.replace(/[/\\]/g, "-")] = full
+      }
+    }
+  }
+  walk(blogDir)
+  return inputs
+}
 
 // Keeps index.html's JSON-LD "softwareVersion" in lockstep with the single
 // version source, APP_VERSION in src/lib/content.ts — no manual bump needed.
@@ -38,6 +58,7 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, "index.html"),
         changelog: path.resolve(__dirname, "changelog/index.html"),
+        ...blogInputs(),
       },
       output: {
         manualChunks: {


### PR DESCRIPTION
## Problem

`/blog/` and all posts 404 in production even though PR #139 merged and CI deployed successfully.

## Cause

The blog source, HTML entries, and `site/blog-media` all landed on `main`, but the `vite.config.ts` change that registers the blog HTML files as Rollup inputs (`blogInputs()`) was accidentally left unstaged in #139's commit. So Vite only built `main` + `changelog`, and `dist/blog/**` was never emitted. The static passthrough (sitemap with blog URLs, blog-media images) deployed normally, which masked the gap.

## Fix

Add `blogInputs()` back to `vite.config.ts` — it scans `blog/**/index.html` and adds each as a build input.

## Verification

Clean build now emits all 8 blog pages:
```
dist/blog/index.html
dist/blog/command-palette-for-android-debugging/index.html
dist/blog/adb-workflow-without-the-terminal/index.html
dist/blog/react-native-debugging-on-mac/index.html
dist/blog/ios-simulator-companion/index.html
dist/blog/qa-bug-workflow/index.html
dist/blog/android-support-diagnostics/index.html
dist/blog/android-pentest-toolkit/index.html
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)