### PR TITLE
Align gallery tiles to a uniform 16:10 crop

### DIFF
--- a/website/src/components/site/Screenshots.tsx
+++ b/website/src/components/site/Screenshots.tsx
@@ -96,7 +96,7 @@ export function Screenshots() {
         {galleryShots.map((shot) => (
           <figure key={shot.title} className="m-0">
             <div className="overflow-hidden rounded-[14px] border border-border-2 shadow-[0_30px_70px_-28px_rgba(0,0,0,0.7)]">
-              <img src={shot.image} alt={shot.alt} width={1600} height={1012} loading="lazy" className="block h-auto w-full" />
+              <img src={shot.image} alt={shot.alt} width={1600} height={1000} loading="lazy" className="block aspect-[16/10] w-full object-cover object-top" />
             </div>
             <figcaption className="mt-3.5 text-sm leading-normal text-muted">
               <b className="block text-[15px] font-semibold text-text">{shot.title}</b>


### PR DESCRIPTION
The Global hotkeys screenshot in the "Real screens" gallery is near-square (1600×1565) while every other gallery shot is 16:10 (1600×1012). Rendered at natural height (`h-auto`), that tile grew taller than its row and pushed its caption below "File explorer" and "Device info".

This locks every gallery image to a 16:10 box with a top-anchored cover crop (`aspect-[16/10] object-cover object-top`), so all rows stay aligned. The Hotkeys panel crops from the bottom, keeping its tab bar and the global-shortcut rows visible; the other shots are unaffected since they are already 16:10.

One line changed in `website/src/components/site/Screenshots.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)