### PR TITLE
Scope device platforms and features to the user's role

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -204,8 +204,10 @@ public struct FieldDef: Sendable {
 
 public struct FeatureDef: Sendable, Identifiable {
     public let id: String
-    public let title: String
-    public let subtitle: String?
+    /// Mutable only so `FeatureRegistry.presented(_:for:)` can rename the
+    /// emulators screen per role — everything else treats defs as immutable.
+    public var title: String
+    public var subtitle: String?
     public let keywords: [String]
     public let category: FeatureCategory
     /// SF Symbol name (keeps ADBKit free of UI frameworks).

--- a/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
@@ -2,8 +2,22 @@ import Foundation
 
 extension FeatureRegistry {
     /// Short "what it does and how" notes, surfaced as ⓘ help in the UI.
-    public static func howTo(for featureID: String) -> String? {
-        notes[featureID]
+    /// `role` trims the emulators note to the platform(s) the role can see
+    /// (see `presented(_:for:)`); every other note is role-independent.
+    public static func howTo(for featureID: String, role: UserRole? = nil) -> String? {
+        if featureID == "emulators" {
+            switch role {
+            case .iosDeveloper:
+                return "Your Xcode iOS Simulators in one place: boot or shut them down. "
+                    + "Booted ones join the device bar. Simulators need Xcode."
+            case .some:
+                return "Your Android Studio AVDs in one place: launch normally, cold boot, or "
+                    + "wipe data first. Running ones join the device bar. AVDs need the SDK emulator."
+            case nil:
+                break
+            }
+        }
+        return notes[featureID]
     }
 
     private static let notes: [String: String] = [

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -670,6 +670,36 @@ public enum FeatureRegistry {
         (featuresByRole[role] ?? []).filter { byID[$0] != nil }
     }
 
+    /// The device platforms a role works with. The device bar, the virtual-
+    /// device launch lists, and the Emulators screen show only these; `nil`
+    /// ("all features") shows both. The iOS Developer role is simulator-only,
+    /// every other role is Android-only.
+    public static func visiblePlatforms(for role: UserRole?) -> Set<DevicePlatform> {
+        switch role {
+        case .iosDeveloper: return [.iosSimulator]
+        case nil: return [.android, .iosSimulator]
+        default: return [.android]
+        }
+    }
+
+    /// The def as `role` presents it: the emulators screen renames itself to
+    /// the platform(s) the role can see ("Simulators" for iOS Developer,
+    /// "Emulators" for the Android-only roles, the combined title with no
+    /// role). Only display strings change — id, kind, icon, and behavior
+    /// don't, so ids stay a stable contract.
+    public static func presented(_ def: FeatureDef, for role: UserRole?) -> FeatureDef {
+        guard def.id == "emulators", let role else { return def }
+        var adapted = def
+        if role == .iosDeveloper {
+            adapted.title = "Simulators"
+            adapted.subtitle = "Boot and shut down iOS Simulators"
+        } else {
+            adapted.title = "Emulators"
+            adapted.subtitle = "Launch and stop Android emulators"
+        }
+        return adapted
+    }
+
     /// The grouped-sidebar category order implied by a role: each category in
     /// the order its first curated feature appears. `seedRole` applies this so
     /// the sections follow the same workflow order as the features within them,

--- a/ADBKit/Tests/ADBKitTests/RolePresentationTests.swift
+++ b/ADBKit/Tests/ADBKitTests/RolePresentationTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import ADBKit
+
+/// Role-scoped platform visibility: which device platforms a role sees, and
+/// how the emulators screen renames itself to match.
+@Suite struct RolePresentationTests {
+    @Test func iosDeveloperSeesOnlySimulators() {
+        #expect(FeatureRegistry.visiblePlatforms(for: .iosDeveloper) == [.iosSimulator])
+    }
+
+    @Test func nilRoleSeesBothPlatforms() {
+        #expect(FeatureRegistry.visiblePlatforms(for: nil) == [.android, .iosSimulator])
+    }
+
+    @Test(arguments: [
+        UserRole.androidDeveloper, .reactNativeDeveloper, .qaTester, .supportTriage, .securityTester,
+    ])
+    func everyNonIOSRoleSeesOnlyAndroid(role: UserRole) {
+        #expect(FeatureRegistry.visiblePlatforms(for: role) == [.android])
+    }
+
+    @Test func emulatorsRenamesPerRole() throws {
+        let emulators = try #require(FeatureRegistry.byID["emulators"])
+        #expect(FeatureRegistry.presented(emulators, for: nil).title == "Emulators & Simulators")
+        #expect(FeatureRegistry.presented(emulators, for: .iosDeveloper).title == "Simulators")
+        for role in UserRole.allCases where role != .iosDeveloper {
+            #expect(FeatureRegistry.presented(emulators, for: role).title == "Emulators")
+        }
+    }
+
+    @Test func presentationNeverChangesIdentityOrBehavior() throws {
+        let emulators = try #require(FeatureRegistry.byID["emulators"])
+        for role in UserRole.allCases {
+            let adapted = FeatureRegistry.presented(emulators, for: role)
+            #expect(adapted.id == emulators.id)
+            #expect(adapted.kind == emulators.kind)
+            #expect(adapted.icon == emulators.icon)
+            #expect(adapted.platforms == emulators.platforms)
+        }
+    }
+
+    @Test func nonEmulatorsDefsAreUntouched() throws {
+        let logcat = try #require(FeatureRegistry.byID["logcat"])
+        #expect(FeatureRegistry.presented(logcat, for: .iosDeveloper).title == logcat.title)
+        #expect(FeatureRegistry.presented(logcat, for: .iosDeveloper).subtitle == logcat.subtitle)
+    }
+
+    @Test func emulatorsHowToNoteFollowsTheRole() {
+        let combined = FeatureRegistry.howTo(for: "emulators")
+        #expect(combined?.contains("AVD") == true)
+        #expect(combined?.contains("Simulators") == true)
+
+        let iosNote = FeatureRegistry.howTo(for: "emulators", role: .iosDeveloper)
+        #expect(iosNote?.contains("Simulators") == true)
+        #expect(iosNote?.contains("AVD") == false)
+
+        let androidNote = FeatureRegistry.howTo(for: "emulators", role: .qaTester)
+        #expect(androidNote?.contains("AVD") == true)
+        #expect(androidNote?.contains("Simulator") == false)
+
+        // Other features keep one role-independent note.
+        #expect(FeatureRegistry.howTo(for: "logcat", role: .iosDeveloper)
+            == FeatureRegistry.howTo(for: "logcat"))
+    }
+}

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -31,7 +31,7 @@ struct FeatureDetailView: View {
         VStack(spacing: 0) {
             detail(for: feature)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if showFeatureNotes, let note = FeatureRegistry.howTo(for: feature.id) {
+            if showFeatureNotes, let note = FeatureRegistry.howTo(for: feature.id, role: state.selectedRole) {
                 FeatureDescription(note: note)
             }
         }

--- a/App/Sources/FeatureDetail/Views/EmulatorsView.swift
+++ b/App/Sources/FeatureDetail/Views/EmulatorsView.swift
@@ -15,13 +15,15 @@ struct EmulatorsView: View {
     @State private var wipeTarget: Avd?
     @State private var showAllSimulators = false
 
-    /// iOS-first presentation for the iOS Developer role: simulators section
-    /// on top and never truncated. Every other role leads with the Android
-    /// emulators and keeps the (long) simulator list cut to its head behind
-    /// "Show all".
-    private var simulatorsLead: Bool {
-        state.selectedRole == .iosDeveloper
+    /// The role decides which platforms this screen shows at all: iOS
+    /// Developer sees only the simulators section (titled "Simulators"),
+    /// the Android-first roles only the AVDs ("Emulators"), and "all
+    /// features" both. The load skips the hidden platform entirely.
+    private var visiblePlatforms: Set<DevicePlatform> {
+        FeatureRegistry.visiblePlatforms(for: state.selectedRole)
     }
+    private var showsAndroid: Bool { visiblePlatforms.contains(.android) }
+    private var showsSimulators: Bool { visiblePlatforms.contains(.iosSimulator) }
 
     private static let collapsedSimulatorCount = 5
 
@@ -40,24 +42,29 @@ struct EmulatorsView: View {
                 list
             }
         }
-        // Re-resolves running state as devices come and go.
-        .task(id: "\(state.devices.map(\.serial).joined())|\(reloadToken)") {
+        // Re-resolves running state as devices come and go, or when a role
+        // change re-scopes which platforms the screen shows.
+        .task(id: "\(state.devices.map(\.serial).joined())|\(reloadToken)|\(state.selectedRole?.rawValue ?? "all")") {
             await load()
         }
     }
 
     private var emptyStateAdvice: String {
         var advice: [String] = []
-        advice.append(
-            emulatorMissing
-                ? "Install the Android Emulator from Android Studio → SDK Manager → SDK Tools."
-                : "Create a virtual device in Android Studio → Device Manager, then refresh."
-        )
-        advice.append(
-            simctlMissing
-                ? "Install Xcode for iOS Simulators."
-                : "Add iOS Simulators from Xcode → Window → Devices and Simulators."
-        )
+        if showsAndroid {
+            advice.append(
+                emulatorMissing
+                    ? "Install the Android Emulator from Android Studio → SDK Manager → SDK Tools."
+                    : "Create a virtual device in Android Studio → Device Manager, then refresh."
+            )
+        }
+        if showsSimulators {
+            advice.append(
+                simctlMissing
+                    ? "Install Xcode for iOS Simulators."
+                    : "Add iOS Simulators from Xcode → Window → Devices and Simulators."
+            )
+        }
         return advice.joined(separator: "\n")
     }
 
@@ -79,13 +86,8 @@ struct EmulatorsView: View {
             Divider()
 
             List {
-                if simulatorsLead {
-                    simulatorsSection
-                    emulatorsSection
-                } else {
-                    emulatorsSection
-                    simulatorsSection
-                }
+                emulatorsSection
+                simulatorsSection
             }
         }
         .confirmationDialog(
@@ -115,11 +117,13 @@ struct EmulatorsView: View {
     private var simulatorsSection: some View {
         if let simulators, !simulators.isEmpty {
             let ordered = SimulatorListParser.prioritized(simulators)
-            let expanded = simulatorsLead || showAllSimulators
+            // A simulator-only role gets the full list; alongside the (short)
+            // AVD list the (long) simulator list is cut behind "Show all".
+            let expanded = !showsAndroid || showAllSimulators
             let visible = expanded ? ordered : Array(ordered.prefix(Self.collapsedSimulatorCount))
             Section("iOS Simulators") {
                 ForEach(visible) { simulatorRow($0) }
-                if ordered.count > Self.collapsedSimulatorCount, !simulatorsLead {
+                if ordered.count > Self.collapsedSimulatorCount, showsAndroid {
                     Button {
                         showAllSimulators.toggle()
                     } label: {
@@ -230,7 +234,7 @@ struct EmulatorsView: View {
     private func load() async {
         emulatorMissing = !(await state.env.engine.emulators.emulatorInstalled())
         let loadedAvds: [Avd]
-        if emulatorMissing {
+        if emulatorMissing || !showsAndroid {
             loadedAvds = []
         } else {
             loadedAvds = await CommandLog.userInitiated {
@@ -238,7 +242,7 @@ struct EmulatorsView: View {
             }
         }
         simctlMissing = !state.env.engine.simctl.available
-        let loadedSimulators = simctlMissing
+        let loadedSimulators = simctlMissing || !showsSimulators
             ? []
             : await CommandLog.userInitiated { await state.env.engine.simulators.listAll() }
                 .filter(\.isAvailable)

--- a/App/Sources/FeatureDetail/Views/RolePickerView.swift
+++ b/App/Sources/FeatureDetail/Views/RolePickerView.swift
@@ -123,7 +123,10 @@ private struct RoleCard: View {
     private var curated: [String] { FeatureRegistry.featuresByRole[role] ?? [] }
 
     private var previewFeatures: [FeatureDef] {
+        // Presented for the card's role, so the iOS card previews
+        // "Simulators" while the Android-first cards preview "Emulators".
         curated.prefix(2).compactMap { FeatureRegistry.byID[$0] }
+            .map { FeatureRegistry.presented($0, for: role) }
     }
 
     var body: some View {

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -134,7 +134,11 @@ struct TourView: View {
             rest = rest.dropFirst()
         }
         if !rest.isEmpty {
-            caps.append(rest == "␣" ? "space" : String(rest))
+            // KeyboardShortcuts describes space with an open-box glyph —
+            // spell it out (and match by name too, in case a library update
+            // changes the glyph).
+            let isSpace = ["␣", "⎵"].contains(String(rest)) || rest.lowercased() == "space"
+            caps.append(isSpace ? "space" : String(rest))
         }
         return caps
     }
@@ -292,12 +296,27 @@ private struct KeyCapView: View {
     let label: String
     let pressed: Bool
 
+    /// Key names printed under the modifier symbols, like the legends on a
+    /// real Mac keyboard — ⇧ alone reads as an up arrow to anyone who doesn't
+    /// know the glyph.
+    private static let modifierNames: [String: String] = [
+        "⌃": "control", "⌥": "option", "⇧": "shift", "⌘": "command",
+    ]
+    private var name: String? { Self.modifierNames[label] }
+
     /// Named keys ("space") get a wide cap; symbols stay square.
     private var isWide: Bool { label.count > 1 }
 
     var body: some View {
-        Text(label)
-            .font(.app(size: isWide ? 26 : 38, weight: .medium))
+        VStack(spacing: 3) {
+            Text(label)
+                .font(.app(size: isWide ? 26 : (name == nil ? 38 : 32), weight: .medium))
+            if let name {
+                Text(name)
+                    .font(.app(size: 13, weight: .medium))
+                    .opacity(0.75)
+            }
+        }
             .foregroundStyle(pressed ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMain))
             .frame(width: isWide ? 210 : 84, height: 84)
             .background(

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -178,7 +178,7 @@ struct DeviceBarView: View {
             Button {
                 state.requestFeature("emulators")
             } label: {
-                Label("Manage emulators & simulators…", systemImage: "square.stack.3d.up")
+                Label(manageVirtualDevicesLabel, systemImage: "square.stack.3d.up")
             }
             Button {
                 state.refreshDevices()
@@ -235,6 +235,14 @@ struct DeviceBarView: View {
         if device.isReady { return .brandAccent }
         if device.state == "unauthorized" { return .orange }
         return .red
+    }
+
+    /// "Manage emulators & simulators…" trimmed to the platform(s) the
+    /// current role can see, matching the screen it opens.
+    private var manageVirtualDevicesLabel: String {
+        let title = FeatureRegistry.byID["emulators"]
+            .map { state.presented($0).title } ?? "Emulators & Simulators"
+        return "Manage \(title.lowercased())…"
     }
 
     /// A booted iOS Simulator gets the Apple mark so the platform in charge

--- a/App/Sources/Root/PaletteWindowView.swift
+++ b/App/Sources/Root/PaletteWindowView.swift
@@ -29,6 +29,7 @@ struct PaletteWindowView: View {
             enabled: state.layout.effectiveEnabledIDs,
             favorites: state.layout.favorites
         )
+        .map(state.presented)
     }
 
     private var visibleMatches: [FeatureDef] { Array(matches.prefix(8)) }

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -338,12 +338,29 @@ struct QuickActionsView: View {
         .padding(.vertical, 16)
     }
 
+    /// Copy for the Emulators screen, trimmed to the platform(s) the current
+    /// role can see (matching the screen's rows, which come from the
+    /// role-gated `availableAvds`/`availableSimulators`).
+    private var virtualDevicesBootPlaceholder: String {
+        let platforms = FeatureRegistry.visiblePlatforms(for: state.selectedRole)
+        if !platforms.contains(.android) { return "Boot a simulator…" }
+        if !platforms.contains(.iosSimulator) { return "Boot an emulator…" }
+        return "Boot an emulator or simulator…"
+    }
+
+    private var virtualDevicesPlural: String {
+        let platforms = FeatureRegistry.visiblePlatforms(for: state.selectedRole)
+        if !platforms.contains(.android) { return "simulators" }
+        if !platforms.contains(.iosSimulator) { return "emulators" }
+        return "emulators or simulators"
+    }
+
     private var searchPlaceholder: String {
         switch screen {
         case .root: return "Run a quick action…"
         case .apps: return "Search installed apps…"
         case .appActions(_, let display): return display
-        case .emulators: return "Boot an emulator or simulator…"
+        case .emulators: return virtualDevicesBootPlaceholder
         case .pickDevice: return "Pick a device for this action…"
         case .pickBundle: return "Pick an app for this command…"
         case .apk(let urls):
@@ -466,8 +483,8 @@ struct QuickActionsView: View {
         case .apps where panelTargetSerial == nil: return "Connect a device to manage its apps"
         case .apps where installedApps == nil: return "Loading apps…"
         case .apps: return "No matching apps"
-        case .emulators where emulatorsLoading: return "Looking for emulators and simulators…"
-        case .emulators: return "No emulators or simulators found"
+        case .emulators where emulatorsLoading: return "Looking for \(virtualDevicesPlural)…"
+        case .emulators: return "No \(virtualDevicesPlural) found"
         case .pickDevice: return "No ready devices"
         case .pickBundle where state.bundles.isEmpty && panelTargetSerial == nil:
             return "Connect a device to list its apps, or save a bundle in the app"
@@ -641,13 +658,15 @@ struct QuickActionsView: View {
                 pushes: true, action: .push(.apps)
             ))
         }
-        if enabled.contains("emulators"), matchesNative(title: "Emulators", keywords: [
-            "emulator", "simulator", "avd", "boot", "launch", "virtual",
-        ]) {
+        if enabled.contains("emulators"),
+           let emulators = FeatureRegistry.byID["emulators"].map(state.presented),
+           matchesNative(title: emulators.title, keywords: [
+               "emulator", "simulator", "avd", "boot", "launch", "virtual",
+           ]) {
             rows.append(QuickRow(
                 id: "screen:emulators", icon: "play.display",
-                title: "Emulators",
-                subtitle: "Boot an Android emulator or iOS Simulator",
+                title: emulators.title,
+                subtitle: emulators.subtitle,
                 pushes: true, action: .push(.emulators)
             ))
         }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -547,7 +547,7 @@ struct RootView: View {
         case "home": return "Home"
         case "catalog": return "Feature Catalog"
         case "about": return "About & Feedback"
-        case let id?: return FeatureRegistry.byID[id]?.title ?? ""
+        case let id?: return FeatureRegistry.byID[id].map { state.presented($0).title } ?? ""
         }
     }
 }

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -141,7 +141,7 @@ struct TabStripView: View {
 
     private func chip(_ id: String) -> some View {
         TabChip(
-            title: Self.title(id),
+            title: Self.title(id, role: state.selectedRole),
             icon: Self.icon(id),
             isActive: id == activeID,
             isRecording: state.tabIsRecording(id),
@@ -245,14 +245,17 @@ struct TabStripView: View {
         .help("New tab (⌘T)")
     }
 
-    /// Title shown on a tab chip — the registry title, or the standalone
-    /// Home / Manage Features / About screens which aren't registry features.
-    static func title(_ id: String) -> String {
+    /// Title shown on a tab chip — the role-presented registry title, or the
+    /// standalone Home / Manage Features / About screens which aren't
+    /// registry features.
+    static func title(_ id: String, role: UserRole?) -> String {
         switch id {
         case "home": return "Home"
         case "catalog": return "Manage Features"
         case "about": return "About"
-        default: return FeatureRegistry.byID[id]?.title ?? id
+        default:
+            return FeatureRegistry.byID[id]
+                .map { FeatureRegistry.presented($0, for: role).title } ?? id
         }
     }
 

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -619,6 +619,7 @@ struct HotkeysSettingsView: View {
             !shown.contains($0.id)
                 && KeyboardShortcuts.getShortcut(for: HotkeyManager.featureName($0.id)) != nil
         }
+        .map(state.presented)
     }
 
     var body: some View {

--- a/App/Sources/State/AppState+Emulators.swift
+++ b/App/Sources/State/AppState+Emulators.swift
@@ -8,7 +8,8 @@ extension AppState {
     /// Refresh `availableAvds` from `emulator -list-avds`, tagging which are
     /// already running. A no-op (clears the list) when the SDK emulator is absent.
     func refreshAvds() async {
-        guard await env.engine.emulators.emulatorInstalled() else {
+        guard FeatureRegistry.visiblePlatforms(for: selectedRole).contains(.android),
+              await env.engine.emulators.emulatorInstalled() else {
             availableAvds = []
             return
         }
@@ -27,6 +28,10 @@ extension AppState {
     /// device-bar menu (Xcode installs ~30 sims; the Emulators screen lists
     /// them all). Empty without Xcode.
     func refreshSimulators() async {
+        guard FeatureRegistry.visiblePlatforms(for: selectedRole).contains(.iosSimulator) else {
+            availableSimulators = []
+            return
+        }
         availableSimulators = SimulatorListParser.quickPicks(await env.simulatorMonitor.list())
     }
 

--- a/App/Sources/State/AppState+Sidebar.swift
+++ b/App/Sources/State/AppState+Sidebar.swift
@@ -13,7 +13,17 @@ extension AppState {
     /// via search (`disabledMatches`) and hotkeys.
     var enabledFeatures: [FeatureDef] {
         let enabled = layout.effectiveEnabledIDs
-        return FeatureRegistry.all.filter { enabled.contains($0.id) && !$0.isAbsorbedByHub }
+        return FeatureRegistry.all
+            .filter { enabled.contains($0.id) && !$0.isAbsorbedByHub }
+            .map(presented)
+    }
+
+    /// A def as the current role displays it (the emulators screen renames
+    /// itself to the platforms the role can see). Every surface that shows a
+    /// feature's title/subtitle must read through this — directly or via the
+    /// accessors here that already map through it.
+    func presented(_ def: FeatureDef) -> FeatureDef {
+        FeatureRegistry.presented(def, for: selectedRole)
     }
 
     /// Pinned features in the user's order — the sidebar's Pinned section,
@@ -120,6 +130,7 @@ extension AppState {
     /// order — the contents of one catalog section.
     func catalogFeatures(in category: FeatureCategory) -> [FeatureDef] {
         ordered(FeatureRegistry.all.filter { $0.category == category && !$0.isAbsorbedByHub })
+            .map(presented)
     }
 
     /// Enabled, non-pinned features in grouped display order, flattened — the
@@ -153,6 +164,7 @@ extension AppState {
         return FeatureRegistry.all.filter {
             !shown.contains($0.id) && !$0.isAbsorbedByHub && $0.matches(searchText)
         }
+        .map(presented)
     }
 
     /// Catalog features not currently on the sidebar — drives the "+N more
@@ -330,10 +342,11 @@ extension AppState {
         let native = ["apps", "emulators", "install-app"]
             .filter { layout.effectiveEnabledIDs.contains($0) }
             .compactMap { FeatureRegistry.byID[$0] }
-        return native + PaletteSearch.quickActions(
+        return (native + PaletteSearch.quickActions(
             query: "", implemented: FeatureEngine.implementedIDs,
             enabled: layout.effectiveEnabledIDs, favorites: layout.favorites
-        )
+        ))
+        .map(presented)
     }
 
     func persistLayout() {
@@ -353,9 +366,9 @@ extension AppState {
     /// always-on quick actions).
     var menuBarFeatures: [FeatureDef] {
         if let chosen = layout.menuBarItems, !chosen.isEmpty {
-            return chosen.compactMap { FeatureRegistry.byID[$0] }
+            return chosen.compactMap { FeatureRegistry.byID[$0] }.map(presented)
         }
-        let favorites = layout.favorites.compactMap { FeatureRegistry.byID[$0] }
+        let favorites = layout.favorites.compactMap { FeatureRegistry.byID[$0] }.map(presented)
         if !favorites.isEmpty { return favorites }
         return enabledFeatures.filter {
             $0.kind == .instantAction && $0.id != "screenshot" && $0.id != "scrcpy"

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -522,6 +522,12 @@ final class AppState {
     }
 
     private func devicesChanged(_ devices: [Device]) {
+        // The role scopes which platforms exist for this user: iOS Developer
+        // sees only simulators, the Android-first roles only adb devices, and
+        // "all features" both. Filter here — the single merge point — so the
+        // bar, pickers, and run targets all agree.
+        let platforms = FeatureRegistry.visiblePlatforms(for: selectedRole)
+        let devices = devices.filter { platforms.contains($0.platform) }
         self.devices = devices
         let ready = devices.filter(\.isReady)
         // "Run on all" only makes sense with more than one device.
@@ -1369,6 +1375,14 @@ final class AppState {
             layout.seedEverything()
         }
         roleChosenThisSession = true
+        // Re-apply the role's platform visibility: drop devices the new role
+        // can't see and refresh the device-bar launch lists (a hidden
+        // platform's list empties, which removes its menu section).
+        devicesChanged(androidDevices + simulatorDevices)
+        Task {
+            await refreshAvds()
+            await refreshSimulators()
+        }
         // Start the freshly-chosen role on a single Home tab, no split. The
         // reset drops every open tab without routing through performClose, so
         // stop each one's background work explicitly — otherwise kept-alive


### PR DESCRIPTION
## What this does

The chosen role now filters which device platforms exist in the app, instead of only seeding the first-run sidebar:

- **iOS Developer** sees only iOS Simulators: the device dropdown lists simulators alone (no Android devices, no "Start an emulator" section), and the virtual-devices feature is titled **Simulators**, showing just the untruncated simulator list.
- **Every other role** (Android, React Native, QA, Support, Security) sees only Android devices: booted iOS Simulators no longer appear in the device bar, the "Start an iOS Simulator" section is gone, and the feature is titled **Emulators** with only the AVD section.
- **No role ("all features")** keeps both platforms and the combined **Emulators & Simulators** title.

## How

- ADBKit: `FeatureRegistry.visiblePlatforms(for:)` maps a role to its platform set; `FeatureRegistry.presented(_:for:)` returns the emulators def with the role-adapted title/subtitle (id, kind, and icon never change); `FeatureRegistry.howTo` gains a role parameter that trims the emulators note to the visible platform. `FeatureDef.title/subtitle` become `var` to allow the copy.
- App: `AppState.devicesChanged` filters the merged Android+simulator device list by the role's platforms; `refreshAvds`/`refreshSimulators` return empty for a hidden platform, which removes the device-bar menu sections; `chooseRole` re-applies both immediately. All title surfaces (sidebar, tabs, window title, Home, catalog, ⌘K palette, menu bar, Settings lists, Quick Actions panel, role-picker preview chips) read through the role-presented def via `AppState.presented`. `EmulatorsView` shows only the visible platform's section and skips probing the hidden toolchain.
- Also: the welcome tour's try-it keycaps print each modifier's name under its symbol (⇧ read as an up arrow), and the space key is matched by name as well as glyph.

## Tests

New `RolePresentationTests` suite covers the role→platform mapping, the per-role rename, identity preservation, and the role-scoped how-to note. `swift test`: 751 tests green; `make build` clean with warnings as errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)