### PR TITLE
Add a reverse-order button to Logcat, JS Console, and Reactotron

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorTransport.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorTransport.swift
@@ -179,7 +179,13 @@ public actor MirrorTransport {
         process.standardError = errorPipe
         errorPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty else { return }
+            guard !data.isEmpty else {
+                // EOF (the server exited). Without clearing the handler the
+                // callback refires in a tight loop forever — a full core spent
+                // on a dead pipe (SystemProcessRunner does the same).
+                handle.readabilityHandler = nil
+                return
+            }
             let text = String(decoding: data, as: UTF8.self)
             Task { await self?.appendServerLog(text) }
         }

--- a/App/Sources/FeatureDetail/SelectableLogView.swift
+++ b/App/Sources/FeatureDetail/SelectableLogView.swift
@@ -7,13 +7,20 @@ import SwiftUI
 /// selection with native drag autoscroll, ⌘C, and Select All over the whole
 /// buffer. Appends are incremental and the ring buffer's head-trim deletes
 /// characters instead of rebuilding, so a full 5000-line buffer streams
-/// smoothly.
+/// smoothly. With `newestFirst` on, the same surgical edits run mirrored —
+/// new lines prepend at the top and ring trims delete from the bottom — so
+/// the reversed feed streams just as smoothly.
 struct SelectableLogView: NSViewRepresentable {
+    /// Chronological (oldest first) regardless of display order — the
+    /// coordinator reverses at the rendering boundary.
     let lines: [LogLine]
     let search: String
+    /// Display order: false reads oldest-top/newest-bottom (terminal style),
+    /// true flips the feed so new lines land at the top.
+    let newestFirst: Bool
     /// Which ends the viewport touches and whether it can scroll at all — the
     /// caller feeds this to the shared `LogJumpControls`. While parked at the
-    /// bottom the view follows new lines; scrolling away pauses that.
+    /// newest edge the view follows new lines; scrolling away pauses that.
     @Binding var edges: LogScrollEdges
     /// Bump the token to snap the view to the requested edge.
     let jump: LogJumpRequest?
@@ -53,7 +60,7 @@ struct SelectableLogView: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.onFilterTag = onFilterTag
-        context.coordinator.update(lines: lines, search: search)
+        context.coordinator.update(lines: lines, search: search, newestFirst: newestFirst)
         context.coordinator.handleJump(jump)
     }
 
@@ -67,12 +74,14 @@ struct SelectableLogView: NSViewRepresentable {
         private weak var textView: LogTextView?
         private weak var scrollView: NSScrollView?
 
-        /// What the text storage currently shows, line by line. `lineLengths`
-        /// holds each line's UTF-16 length (newline included) so a head-trim
-        /// knows exactly how many characters to delete.
+        /// What the text storage currently shows, line by line, in *display*
+        /// order (reversed from the stream when `renderedNewestFirst` is on).
+        /// `lineLengths` holds each line's UTF-16 length (newline included) so
+        /// a trim knows exactly how many characters to delete.
         private var renderedLines: [LogLine] = []
         private var lineLengths: [Int] = []
         private var renderedSearch = ""
+        private var renderedNewestFirst = false
         private var lastJumpToken: Int?
 
         init(edges: Binding<LogScrollEdges>) {
@@ -123,9 +132,12 @@ struct SelectableLogView: NSViewRepresentable {
             )
         }
 
-        /// Following new lines is the bottom-edge state; `update` consults it
-        /// before appending to decide whether to keep the view pinned there.
-        private var isAtBottom: Bool { measuredEdges.atBottom }
+        /// Whether the viewport touches the edge new lines land on — `update`
+        /// consults it before editing to decide whether to keep the view
+        /// pinned there (the follow behavior).
+        private func isAtNewestEdge(newestFirst: Bool) -> Bool {
+            newestFirst ? measuredEdges.atTop : measuredEdges.atBottom
+        }
 
         func handleJump(_ request: LogJumpRequest?) {
             guard let request, request.token != lastJumpToken else { return }
@@ -139,36 +151,57 @@ struct SelectableLogView: NSViewRepresentable {
         // MARK: Content diffing
 
         /// The stream only ever drops lines at the head (ring trim) and
-        /// appends at the tail, so those paths are surgical edits; anything
-        /// else (filter change, clear, search change) rebuilds.
-        func update(lines: [LogLine], search: String) {
+        /// appends at the tail, so those paths are surgical edits — mirrored
+        /// (prepend + tail-trim) when the display order is newest-first;
+        /// anything else (filter change, clear, search change, an order flip)
+        /// rebuilds.
+        func update(lines: [LogLine], search: String, newestFirst: Bool) {
             guard let storage = textView?.textStorage else { return }
-            let wasTailing = renderedLines.isEmpty || isAtBottom
+            // Judged against the *rendered* orientation, so flipping the order
+            // while parked on the newest line keeps following it at the other
+            // edge.
+            let wasTailing = renderedLines.isEmpty || isAtNewestEdge(newestFirst: renderedNewestFirst)
 
             defer {
-                if wasTailing { scrollToBottom() }
-                // Appends below the viewport don't fire a scroll notification,
+                if wasTailing { newestFirst ? scrollToTop() : scrollToBottom() }
+                // Edits outside the viewport don't fire a scroll notification,
                 // so the edge state must also sync here or the jump buttons
                 // never update while parked in scrollback.
                 syncEdges()
             }
 
-            if search != renderedSearch {
+            if search != renderedSearch || newestFirst != renderedNewestFirst {
                 renderedSearch = search
+                renderedNewestFirst = newestFirst
                 rebuild(lines, in: storage)
                 return
             }
-            switch LogStreamDiff.plan(rendered: renderedLines.map(\.id), incoming: lines.map(\.id)) {
+            // The plan speaks stream order; rendered lines are display order.
+            let renderedStreamIDs = newestFirst
+                ? renderedLines.reversed().map(\.id)
+                : renderedLines.map(\.id)
+            switch LogStreamDiff.plan(rendered: renderedStreamIDs, incoming: lines.map(\.id)) {
             case .unchanged:
                 return
             case .rebuild:
                 rebuild(lines, in: storage)
             case .edit(let dropHead, let appendFrom):
-                if dropHead > 0 {
-                    trimHead(dropHead, in: storage, keepScrollPlace: !wasTailing)
-                }
-                if lines.count > appendFrom {
-                    append(Array(lines[appendFrom...]), to: storage)
+                if newestFirst {
+                    // Mirrored: the stream's head-trim is the *bottom* of the
+                    // display, its tail-append the *top*.
+                    if dropHead > 0 {
+                        trimTail(dropHead, in: storage)
+                    }
+                    if lines.count > appendFrom {
+                        prepend(Array(lines[appendFrom...]), to: storage, keepScrollPlace: !wasTailing)
+                    }
+                } else {
+                    if dropHead > 0 {
+                        trimHead(dropHead, in: storage, keepScrollPlace: !wasTailing)
+                    }
+                    if lines.count > appendFrom {
+                        append(Array(lines[appendFrom...]), to: storage)
+                    }
                 }
             }
         }
@@ -193,8 +226,9 @@ struct SelectableLogView: NSViewRepresentable {
         }
 
         /// The rendered height of the leading `length` characters — what a
-        /// head-trim is about to delete. Everything above the viewport is
-        /// already laid out, so this is a lookup, not a fresh layout pass.
+        /// head-trim is about to delete, or what a prepend just inserted. For
+        /// a trim everything above the viewport is already laid out, so this
+        /// is a lookup; for a prepend it lays out just the fresh batch.
         private func height(ofFirstCharacters length: Int) -> CGFloat {
             guard length > 0, let textView, let layoutManager = textView.layoutManager,
                   let container = textView.textContainer else { return 0 }
@@ -204,11 +238,21 @@ struct SelectableLogView: NSViewRepresentable {
             return layoutManager.boundingRect(forGlyphRange: glyphs, in: container).height
         }
 
+        /// Deletes the last `count` rendered lines — the stream's ring trim in
+        /// newest-first display. Nothing above the deletion moves, so unlike
+        /// `trimHead` the scrollback needs no offset compensation.
+        private func trimTail(_ count: Int, in storage: NSTextStorage) {
+            let tailLength = lineLengths.suffix(count).reduce(0, +)
+            storage.deleteCharacters(in: NSRange(location: storage.length - tailLength, length: tailLength))
+            renderedLines.removeLast(count)
+            lineLengths.removeLast(count)
+        }
+
         private func rebuild(_ lines: [LogLine], in storage: NSTextStorage) {
             renderedLines = []
             lineLengths = []
             storage.setAttributedString(NSAttributedString())
-            append(lines, to: storage)
+            append(renderedNewestFirst ? Array(lines.reversed()) : lines, to: storage)
         }
 
         private func append(_ lines: [LogLine], to storage: NSTextStorage) {
@@ -221,6 +265,34 @@ struct SelectableLogView: NSViewRepresentable {
             }
             renderedLines.append(contentsOf: lines)
             storage.append(batch)
+        }
+
+        /// Inserts a chronological batch above the current content — the
+        /// newest-first twin of `append` (fresh lines land at the top, newest
+        /// leading). While the user is parked in scrollback the inserted
+        /// height is added to the scroll offset so the lines being read hold
+        /// still — the mirror of `trimHead`'s compensation.
+        private func prepend(_ lines: [LogLine], to storage: NSTextStorage, keepScrollPlace: Bool) {
+            guard !lines.isEmpty else { return }
+            let displayLines = Array(lines.reversed())
+            let batch = NSMutableAttributedString()
+            var batchLengths: [Int] = []
+            for line in displayLines {
+                let attributed = Self.attributedLine(line, search: renderedSearch)
+                batchLengths.append(attributed.length)
+                batch.append(attributed)
+            }
+            storage.insert(batch, at: 0)
+            renderedLines.insert(contentsOf: displayLines, at: 0)
+            lineLengths.insert(contentsOf: batchLengths, at: 0)
+            guard keepScrollPlace, let scrollView else { return }
+            let insertedHeight = height(ofFirstCharacters: batch.length)
+            guard insertedHeight > 0 else { return }
+            let clip = scrollView.contentView
+            var origin = clip.bounds.origin
+            origin.y += insertedHeight
+            clip.scroll(to: origin)
+            scrollView.reflectScrolledClipView(clip)
         }
 
         private func scrollToBottom() {

--- a/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/DeviceInfoView.swift
@@ -246,7 +246,10 @@ struct DeviceInfoView: View {
 
         return Group {
             if matches.isEmpty {
+                // Without the infinity frame the enclosing VStack centers as a
+                // block, floating the filter field to mid-window.
                 ContentUnavailableView.search(text: search)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List(matches, id: \.key) { prop in
                     HStack(alignment: .firstTextBaseline) {

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -124,14 +124,15 @@ struct JSEntry: Identifiable {
 final class JSConsoleSession {
     static let maxEntries = 2000
     private static let portKey = "jsConsoleMetroPort"
-    private static let timestampsKey = "jsConsoleShowTimestamps"
+    private static let newestFirstKey = "jsConsoleNewestFirst"
 
     /// The capped feed plus its filtered (level + text) projection, maintained
     /// incrementally (ADBKit's `FilteredLogBuffer`): a flush filters only the new
     /// batch against searchable text cached per entry, and a full recompute
     /// happens only when the filter itself changes — so a console burst costs
     /// O(batch) per flush, not O(buffer × object size). Chronological (oldest
-    /// first), which is the feed's display order — newest at the bottom.
+    /// first); the feed renders it as-is (newest at the bottom) or reversed
+    /// when `newestFirst` is on.
     // The 128 MB byte budget (Reactotron's figure) matters as much as the
     // count cap: 2000 entries each holding a multi-megabyte logged string
     // would otherwise retain gigabytes.
@@ -150,7 +151,16 @@ final class JSConsoleSession {
     var port: Int { didSet { UserDefaults.standard.set(port, forKey: Self.portKey) } }
     var searchText = "" { didSet { refilter() } }
     var hiddenLevels: Set<JSLevel> = [] { didSet { refilter() } }
-    var showTimestamps: Bool { didSet { UserDefaults.standard.set(showTimestamps, forKey: Self.timestampsKey) } }
+    /// Reversed feed: newest at the top instead of Chrome's newest-at-bottom.
+    /// Persisted per feature; the ⌘F match order follows the display order, so
+    /// flipping rebuilds the matches and restarts from the first visible one.
+    var newestFirst: Bool {
+        didSet {
+            UserDefaults.standard.set(newestFirst, forKey: Self.newestFirstKey)
+            findIndex = 0
+            rebuildFindMatches()
+        }
+    }
 
     /// ⌘F find-in-console: highlights matches across the (filtered) feed and
     /// navigates between them — separate from the Filter field, which hides rows.
@@ -209,7 +219,7 @@ final class JSConsoleSession {
         self.adb = adb
         let savedPort = UserDefaults.standard.integer(forKey: Self.portKey)
         port = (1 ... 65535).contains(savedPort) ? savedPort : 8081
-        showTimestamps = UserDefaults.standard.bool(forKey: Self.timestampsKey)
+        newestFirst = UserDefaults.standard.bool(forKey: Self.newestFirstKey)
     }
 
     /// Reset the connection back-references so the next connect re-welcomes.
@@ -658,9 +668,12 @@ final class JSConsoleSession {
             return
         }
         findMatchIDs = PerfLog.measure(PerfLog.console, "find scan over \(buffer.filtered.count) entries") {
-            buffer.filtered
+            let ids = buffer.filtered
                 .filter { query.matches($0.searchableText) }
                 .map(\.id)
+            // Match order follows the display order, so ⏎/⇧⏎ walk down/up the
+            // feed regardless of which end is newest.
+            return newestFirst ? ids.reversed() : ids
         }
     }
 
@@ -969,7 +982,11 @@ struct JSConsoleView: View {
                 .buttonStyle(IconButtonStyle())
                 .help("Find & highlight in console (⌘F)")
                 .keyboardShortcut("f", modifiers: .command)
-            Toggle("Time", isOn: $session.showTimestamps).toggleStyle(.checkbox).font(.app(.caption))
+            Button { session.newestFirst.toggle() } label: { Image(systemName: "arrow.up.arrow.down") }
+                .buttonStyle(IconButtonStyle())
+                .help(session.newestFirst
+                    ? "Newest at top — click to show newest at bottom"
+                    : "Newest at bottom — click to show newest at top")
             Button { session.clear() } label: { Image(systemName: "trash") }
                 .buttonStyle(IconButtonStyle())
                 .help("Clear the console")
@@ -1058,22 +1075,29 @@ struct JSConsoleView: View {
         .environment(\.colorScheme, .dark)
     }
 
-    /// Chrome-style: newest at the bottom. LogTailViewV2 tails that edge, pauses
-    /// when the user scrolls off (new lines keep rendering without moving their
-    /// reading), overlays the jump-to-top/bottom buttons, and drives the ⌘F
-    /// match into view via `focusID`.
+    /// Chrome-style newest-at-bottom by default, flipped when the toolbar's
+    /// reverse button turns `newestFirst` on. LogTailViewV2 tails the newest
+    /// edge, pauses when the user scrolls off (new lines keep rendering without
+    /// moving their reading), overlays the jump-to-top/bottom buttons, and
+    /// drives the ⌘F match into view via `focusID`.
+    @ViewBuilder
     private func scrollingLog(_ visible: [JSEntry]) -> some View {
         // No connection gate on the jump buttons: the buffer outlives the
         // connection, and scrolling those logs is exactly what a disconnected
         // session is for.
-        LogTailViewV2(entries: visible, newestEdge: .bottom,
-                      focusID: session.currentFindID) { jsRow($0) }
+        if session.newestFirst {
+            LogTailViewV2(entries: visible.reversed(), newestEdge: .top,
+                          focusID: session.currentFindID) { jsRow($0) }
+        } else {
+            LogTailViewV2(entries: visible, newestEdge: .bottom,
+                          focusID: session.currentFindID) { jsRow($0) }
+        }
     }
 
     @ViewBuilder
     private func jsRow(_ entry: JSEntry) -> some View {
         let band = levelBand(entry)
-        JSEntryRow(entry: entry, session: session, showTimestamp: session.showTimestamps)
+        JSEntryRow(entry: entry, session: session)
             .padding(.horizontal, 12)
             .padding(.vertical, 5)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1170,7 +1194,6 @@ struct JSConsoleView: View {
 private struct JSEntryRow: View {
     let entry: JSEntry
     let session: JSConsoleSession
-    let showTimestamp: Bool
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
     private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
@@ -1180,12 +1203,10 @@ private struct JSEntryRow: View {
             glyph
             content
                 .frame(maxWidth: .infinity, alignment: .leading)
-            if showTimestamp {
-                Text(entry.at, format: .dateTime.hour().minute().second())
-                    .font(.app(.caption2).monospacedDigit())
-                    .foregroundStyle(JSConsoleTheme.muted)
-                    .padding(.top, 1)
-            }
+            Text(entry.at, format: .dateTime.hour().minute().second())
+                .font(.app(.caption2).monospacedDigit())
+                .foregroundStyle(JSConsoleTheme.muted)
+                .padding(.top, 1)
         }
         .contextMenu {
             Button("Copy") { copyToPasteboard(jsEntryPlainText(entry.kind)) }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -27,6 +27,9 @@ struct LogcatView: View {
     @State private var edges = LogScrollEdges()
     /// Set by the jump buttons to ask the pane to snap to an edge.
     @State private var jump: LogJumpRequest?
+    /// Reversed feed: newest lines at the top instead of the terminal-style
+    /// newest-at-bottom. Persisted per feature.
+    @AppStorage("logcatNewestFirst") private var newestFirst = false
 
     private static let levels: [(value: String, label: String)] = [
         ("All", "All levels"), ("V", "Verbose"), ("D", "Debug"),
@@ -105,6 +108,16 @@ struct LogcatView: View {
                 }
 
             Spacer()
+
+            Button {
+                newestFirst.toggle()
+            } label: {
+                Image(systemName: "arrow.up.arrow.down")
+            }
+            .buttonStyle(IconButtonStyle())
+            .help(newestFirst
+                ? "Newest at top — click to show newest at bottom"
+                : "Newest at bottom — click to show newest at top")
 
             Button {
                 paused.toggle()
@@ -226,6 +239,7 @@ struct LogcatView: View {
         SelectableLogView(
             lines: visible,
             search: search,
+            newestFirst: newestFirst,
             edges: $edges,
             jump: jump,
             onFilterTag: { tagFilter = $0 }
@@ -234,7 +248,7 @@ struct LogcatView: View {
             LogJumpControls(
                 edges: edges,
                 enabled: !visible.isEmpty,
-                newestEdge: .bottom,
+                newestEdge: newestFirst ? .top : .bottom,
                 onJumpToTop: { requestJump(to: .top) },
                 onJumpToBottom: { requestJump(to: .bottom) }
             )

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1403,9 +1403,11 @@ private enum RtEventKind: String, CaseIterable, Identifiable {
 
 // MARK: - Timeline pane
 
-/// One scrollable timeline column with its own filter, search and sort order, fed
-/// from the shared event buffer. Used once on its own or twice side-by-side (the
-/// VSCode-style split), so each pane can watch a different slice at the same time.
+/// One scrollable timeline column with its own filter and search, fed from the
+/// shared event buffer. Used once on its own or twice side-by-side (the
+/// VSCode-style split), so each pane can watch a different slice at the same
+/// time. The sort order is a per-feature preference (`@AppStorage`), so split
+/// panes flip together and the choice survives relaunches.
 private struct TimelinePane: View {
     let items: [RtItem]
     let targetEmpty: Bool
@@ -1431,6 +1433,10 @@ private struct TimelinePane: View {
     @State private var methodFilter: String?
     @State private var statusFilter: HTTPStatusClass?
     @State private var showFilterSheet = false
+    /// Newest at the top (the Reactotron app's order) unless the toolbar's
+    /// reverse button flips the feed to chronological. Persisted per feature —
+    /// split panes share the key, so they stay in sync.
+    @AppStorage("reactotronNewestFirst") private var newestFirst = true
 
     var body: some View {
         // Filter once per render — the count badge, export button, and timeline
@@ -1439,10 +1445,7 @@ private struct TimelinePane: View {
         return VStack(spacing: 0) {
             paneToolbar(visible: visible)
             Divider()
-            // Newest first: the fixed timeline order (matches the Reactotron
-            // app). Lazily reversed — materializing a 2000-item copy per
-            // render was measurable during streaming bursts.
-            timeline(ordered: visible.reversed())
+            timeline(visible: visible)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -1476,6 +1479,16 @@ private struct TimelinePane: View {
                     .font(.app(.caption))
                     .foregroundStyle(.textMuted)
             }
+
+            Button {
+                newestFirst.toggle()
+            } label: {
+                Image(systemName: "arrow.up.arrow.down")
+            }
+            .buttonStyle(IconButtonStyle())
+            .help(newestFirst
+                ? "Newest at top — click to show newest at bottom"
+                : "Newest at bottom — click to show newest at top")
 
             Button {
                 onExport(visible)
@@ -1617,16 +1630,28 @@ private struct TimelinePane: View {
         }
     }
 
-    private func timeline(ordered: ReversedCollection<[RtItem]>) -> some View {
-        // Newest events land at the top — LogTailViewV2 follows that edge, pauses
-        // when the user scrolls off, and overlays the jump-to-top/bottom buttons.
+    private func timeline(visible: [RtItem]) -> some View {
+        // LogTailViewV2 follows the newest edge, pauses when the user scrolls
+        // off, and overlays the jump-to-top/bottom buttons. Newest-first is
+        // lazily reversed — materializing a 2000-item copy per render was
+        // measurable during streaming bursts.
         GeometryReader { pane in
-            LogTailViewV2(
-                entries: ordered, newestEdge: .top,
-                contentWidth: max(pane.size.width, minContentWidth)
-            ) { item in
-                RtRow(item: item)
-                Divider()
+            if newestFirst {
+                LogTailViewV2(
+                    entries: visible.reversed(), newestEdge: .top,
+                    contentWidth: max(pane.size.width, minContentWidth)
+                ) { item in
+                    RtRow(item: item)
+                    Divider()
+                }
+            } else {
+                LogTailViewV2(
+                    entries: visible, newestEdge: .bottom,
+                    contentWidth: max(pane.size.width, minContentWidth)
+                ) { item in
+                    RtRow(item: item)
+                    Divider()
+                }
             }
         }
         .background(.background)

--- a/App/Sources/LogTailViewV2.swift
+++ b/App/Sources/LogTailViewV2.swift
@@ -16,7 +16,8 @@ private final class TailMeasure {
 /// Logcat's NSTextView pane mirrors its behavior through the same controls).
 ///
 /// - `entries` are in display order (top → bottom); `newestEdge` says which end
-///   new lines land on. The order is fixed per feed — there is no user toggle.
+///   new lines land on. A feed with a reverse-order control flips both together
+///   (reversed entries + the other edge) — every mechanic below is edge-agnostic.
 /// - While the viewport is parked at the newest edge it follows new lines; the
 ///   instant the user scrolls away it pauses (their reading wins) and new lines
 ///   keep rendering without shifting what they're looking at; returning to the
@@ -58,11 +59,12 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
     var focusID: Data.Element.ID? = nil
     /// When set, the feed lays out at this fixed width and rides inside a
     /// horizontal scroll view — rows wider than the viewport are reached by
-    /// scrolling the pane, not by truncating. The horizontal offset lives on
-    /// the *outer* scroll view, so tail-follow writes to `.scrollPosition`
-    /// (vertical, on the inner one) can't reset it. Pass
-    /// `max(viewportWidth, widestRow)` so the feed always fills the pane.
-    /// `.top` feeds only — the `.bottom` flip would mirror the horizontal bar.
+    /// scrolling the pane, not by truncating. Tail-follow writes go through
+    /// `.scrollPosition` with a nil anchor, so they never touch the horizontal
+    /// offset. Pass `max(viewportWidth, widestRow)` so the feed always fills
+    /// the pane. On `.bottom` feeds the flip would render the horizontal
+    /// indicator mirrored at the pane's top edge, so it's hidden there —
+    /// two-finger panning still scrolls horizontally.
     var contentWidth: CGFloat? = nil
     @ViewBuilder var row: (Data.Element) -> Row
 
@@ -99,6 +101,14 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
 
     /// -1 flips `.bottom` feeds so a newest-first layout reads newest-at-bottom.
     private var flip: CGFloat { newestEdge == .bottom ? -1 : 1 }
+
+    /// The `.bottom` flip mirrors the whole scroll view, which would draw the
+    /// horizontal indicator upside down at the pane's top edge — hide it in
+    /// that mode (the vertical indicator mirrors consistently with the flipped
+    /// content, so it stays).
+    private var horizontalIndicatorVisibility: ScrollIndicatorVisibility {
+        newestEdge == .bottom && contentWidth != nil ? .hidden : .automatic
+    }
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -149,6 +159,7 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
             // nil scrolls minimally, which still pins the newest (topmost) row
             // vertically and never touches the horizontal offset.
             .scrollPosition(id: $leadingID, anchor: contentWidth == nil ? .top : nil)
+            .scrollIndicators(horizontalIndicatorVisibility, axes: .horizontal)
             .scaleEffect(x: 1, y: flip, anchor: .center)    // identity for .top feeds
             .onAppear { leadingID = newestID }
             .onChange(of: leadingID) { _, id in

--- a/App/Sources/LogTailViewV2.swift
+++ b/App/Sources/LogTailViewV2.swift
@@ -121,16 +121,17 @@ struct LogTailViewV2<Data: RandomAccessCollection, Row: View>: View
                     // The fixed feed width (widest row) when horizontal
                     // scrolling is on; a nil width is a no-op.
                     .frame(width: contentWidth, alignment: .leading)
-                    // Short `.bottom` feeds: stretch the content to the
-                    // viewport and pin the rows at the content's *end* — the
-                    // flip renders that at the visual top, so a handful of
-                    // lines reads top-down instead of sitting at the bottom
-                    // of a screen of empty space. A no-op once the content
-                    // overflows (and for `.top` feeds, which are unstretched),
-                    // so the layout never switches structure.
+                    // Short feeds: stretch the content to the viewport so a
+                    // handful of lines reads from the visual top instead of
+                    // floating in empty space (a two-axis scroll view centers
+                    // undersized content vertically). `.bottom` pins the rows
+                    // at the content's *end* — the flip renders that at the
+                    // visual top; `.top` pins them at the start. A no-op once
+                    // the content overflows, so the layout never switches
+                    // structure.
                     .frame(
-                        minHeight: newestEdge == .bottom && fillHeight > 0 ? fillHeight : nil,
-                        alignment: .bottom
+                        minHeight: fillHeight > 0 ? fillHeight : nil,
+                        alignment: newestEdge == .bottom ? .bottom : .top
                     )
                     .onGeometryChange(for: CGRect.self, of: { $0.frame(in: .named("logtail")) }) { frame in
                         measure.geometry.contentLeadingOffset = frame.minY


### PR DESCRIPTION
## What

### Reverse-order buttons (per-feature, persisted)
Each feed's toolbar gains an order toggle (`arrow.up.arrow.down`) that flips which end new lines land on, remembered per feature across relaunches:

- **Logcat** (`logcatNewestFirst`, default newest at bottom) — the NSTextView pane runs its surgical stream edits mirrored when reversed: appends become top-prepends, ring head-trims become bottom deletions, and the prepended height is added to the scroll offset while parked in scrollback so the lines being read hold still. No per-batch rebuilds in either direction.
- **JS Console** (`jsConsoleNewestFirst`, default newest at bottom) — lives on `JSConsoleSession` next to the persisted Metro port. ⌘F match order and the "N of M" counter follow the display order.
- **Reactotron** (`reactotronNewestFirst`, default newest at top) — split panes share the key and flip together. This lifts the "`.top` feeds only" restriction on `LogTailViewV2.contentWidth`; in the flipped mode the horizontal scroll indicator would render mirrored at the pane's top edge, so it's hidden there (two-finger panning still works).

### JS Console timestamps
The "Time" checkbox is gone; entry timestamps always render.

### Fixes found while verifying live
- **Short feeds floated mid-pane** in the two-axis scroll mode (a two-axis `ScrollView` centers undersized content; latent since the horizontal-scroll commit). Short content now stretches to the viewport for both edges, pinning rows at the newest-edge-correct end.
- **Device Info's no-results search state** was missing the infinity frame, centering the enclosing VStack and floating the filter field to mid-window.
- **`MirrorTransport` pipe spin**: the scrcpy server's stderr `readabilityHandler` returned on empty data without clearing itself, so a dead server pipe refired the EOF callback in a tight loop — a full core per dead pipe, kept alive by the background Mirror session. Clear the handler at EOF, matching `SystemProcessRunner`. Pre-existing; profiled at 100–200% CPU before, ~1% after.

## Testing

- `swift test`: 756 tests green; `make build` clean with warnings-as-errors.
- Verified live against an emulator running a streaming RN app: all three feeds flipped in both directions while streaming, tailing/jump buttons/⌘F follow the order, Logcat's preference survived a relaunch, and CPU idles at ~1% after the pipe fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)