### PR TITLE
Add a Sparkle beta update channel with a Settings opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,15 @@ jobs:
         run: awk '/^## /{c++} c==1{print} c==2{exit}' RELEASE_NOTES.md > release-body.md
       # A stable-named copy backs the site's download button via the permanent
       # /releases/latest/download/Droidective.dmg URL — always the newest
-      # release, no appcast fetch, no Pages/browser cache staleness.
+      # release, no appcast fetch, no Pages/browser cache staleness. Safe on a
+      # beta too: /releases/latest only ever resolves to a non-prerelease.
       - name: Add a stable-named copy for the latest-download link
         run: |
           cp "DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg" \
              "DerivedData/Build/Products/Release/Droidective.dmg"
+      # A hyphen in the tag (v3.3.0-beta.1) marks a beta: the GitHub release is
+      # a prerelease, the appcast item rides the Sparkle beta channel, and the
+      # Homebrew cask is left alone.
       - name: Publish release with build
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
@@ -177,6 +181,7 @@ jobs:
             DerivedData/Build/Products/Release/Droidective.dmg
           body_path: release-body.md
           fail_on_unmatched_files: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
       - name: Sign update and publish appcast to main
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -200,6 +205,7 @@ jobs:
         run: |
           [[ -n "${HOMEBREW_TAP_TOKEN:-}" ]] || { echo "no HOMEBREW_TAP_TOKEN — skipping cask update"; exit 0; }
           VERSION="${GITHUB_REF_NAME#v}"
+          [[ "$VERSION" == *-* ]] && { echo "beta release — skipping cask update"; exit 0; }
           DMG="DerivedData/Build/Products/Release/Droidective-${GITHUB_REF_NAME}.dmg"
           URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/Droidective-${GITHUB_REF_NAME}.dmg"
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Rohindh-R/homebrew-tap.git" tap

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -54,6 +54,9 @@ struct GeneralSettingsView: View {
     @State private var openAtLoginOn = false
     @State private var showMenuItems = false
     @State private var showQuickActionToggles = false
+    #if !APPSTORE
+    @ObservedObject private var updater = SparkleUpdater.shared
+    #endif
 
     /// True when the login item is registered (enabled, or pending the user's
     /// approval in System Settings).
@@ -160,14 +163,8 @@ struct GeneralSettingsView: View {
 
             #if !APPSTORE
             Section("Updates") {
-                Toggle("Automatically check for updates", isOn: Binding(
-                    get: { SparkleUpdater.shared.automaticallyChecksForUpdates },
-                    set: { SparkleUpdater.shared.automaticallyChecksForUpdates = $0 }
-                ))
-                Toggle("Receive beta updates", isOn: Binding(
-                    get: { SparkleUpdater.shared.receivesBetaUpdates },
-                    set: { SparkleUpdater.shared.receivesBetaUpdates = $0 }
-                ))
+                Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
+                Toggle("Receive beta updates", isOn: $updater.receivesBetaUpdates)
                 Text("Updates are delivered via Sparkle from GitHub Releases. Beta builds arrive ahead of stable releases and may be rougher; switching beta off keeps the installed build until the next stable release.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -164,7 +164,11 @@ struct GeneralSettingsView: View {
                     get: { SparkleUpdater.shared.automaticallyChecksForUpdates },
                     set: { SparkleUpdater.shared.automaticallyChecksForUpdates = $0 }
                 ))
-                Text("Updates are delivered via Sparkle from GitHub Releases.")
+                Toggle("Receive beta updates", isOn: Binding(
+                    get: { SparkleUpdater.shared.receivesBetaUpdates },
+                    set: { SparkleUpdater.shared.receivesBetaUpdates = $0 }
+                ))
+                Text("Updates are delivered via Sparkle from GitHub Releases. Beta builds arrive ahead of stable releases and may be rougher; switching beta off keeps the installed build until the next stable release.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/Updates/SparkleUpdater.swift
+++ b/App/Sources/Updates/SparkleUpdater.swift
@@ -41,6 +41,20 @@ final class UpdaterViewModel: NSObject, ObservableObject {
         set { controller?.updater.automaticallyChecksForUpdates = newValue }
     }
 
+    /// Opt-in to the beta update channel (appcast items tagged
+    /// `<sparkle:channel>beta</sparkle:channel>`). Stored in UserDefaults and
+    /// read by `allowedChannels(for:)` on every appcast load, so flipping it
+    /// applies to the next check — which opting in triggers right away (in the
+    /// background: silent unless a beta is actually available), instead of
+    /// leaving the user to wait out the twice-daily schedule.
+    var receivesBetaUpdates: Bool {
+        get { UserDefaults.standard.bool(forKey: receiveBetaUpdatesKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: receiveBetaUpdatesKey)
+            if newValue { controller?.updater.checkForUpdatesInBackground() }
+        }
+    }
+
     /// True once `generate_keys`' output has replaced the project.yml placeholder.
     private static var signingKeyConfigured: Bool {
         let key = Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String ?? ""
@@ -48,7 +62,19 @@ final class UpdaterViewModel: NSObject, ObservableObject {
     }
 }
 
+/// UserDefaults key for the beta update channel opt-in (Settings ▸ General ▸
+/// Updates). Off by default: everyone stays on stable-only.
+let receiveBetaUpdatesKey = "receiveBetaUpdates"
+
 extension UpdaterViewModel: SPUUpdaterDelegate {
+    /// Sparkle includes appcast items whose `<sparkle:channel>` is in this set;
+    /// untagged (stable) items are always included. Turning beta off later
+    /// never downgrades — the installed build simply waits for the next stable
+    /// release with a higher build number.
+    nonisolated func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        UserDefaults.standard.bool(forKey: receiveBetaUpdatesKey) ? ["beta"] : []
+    }
+
     /// Sparkle reports how the user resolved the update alert. Closing or
     /// skipping records the version for the once-per-launch reminder — no
     /// notification fires now, the user just declined the alert. Installing

--- a/App/Sources/Updates/SparkleUpdater.swift
+++ b/App/Sources/Updates/SparkleUpdater.swift
@@ -36,9 +36,16 @@ final class UpdaterViewModel: NSObject, ObservableObject {
         controller?.updater.checkForUpdates()
     }
 
+    /// Settings toggles bind to these computed properties, whose truth lives
+    /// outside SwiftUI (Sparkle / UserDefaults) — the explicit
+    /// `objectWillChange` is what re-renders the observing view, otherwise the
+    /// toggle snaps back visually while the underlying value did change.
     var automaticallyChecksForUpdates: Bool {
         get { controller?.updater.automaticallyChecksForUpdates ?? false }
-        set { controller?.updater.automaticallyChecksForUpdates = newValue }
+        set {
+            objectWillChange.send()
+            controller?.updater.automaticallyChecksForUpdates = newValue
+        }
     }
 
     /// Opt-in to the beta update channel (appcast items tagged
@@ -50,6 +57,7 @@ final class UpdaterViewModel: NSObject, ObservableObject {
     var receivesBetaUpdates: Bool {
         get { UserDefaults.standard.bool(forKey: receiveBetaUpdatesKey) }
         set {
+            objectWillChange.send()
             UserDefaults.standard.set(newValue, forKey: receiveBetaUpdatesKey)
             if newValue { controller?.updater.checkForUpdatesInBackground() }
         }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -216,6 +216,33 @@ offer the update automatically.
 > won't auto-update *to* the first Sparkle-enabled build — download that one
 > manually. Every release after it updates in place.
 
+## Beta releases
+
+A tag with a pre-release suffix rides the beta channel — only installs with
+Settings ▸ General ▸ Updates ▸ "Receive beta updates" switched on see it:
+
+```sh
+git tag vX.Y.Z-beta.1
+git push origin vX.Y.Z-beta.1
+```
+
+Same pipeline, three differences:
+
+- the GitHub release is marked **prerelease**, so the site's
+  `/releases/latest/download/Droidective.dmg` button keeps serving the latest
+  stable;
+- the appcast item carries `<sparkle:channel>beta</sparkle:channel>`, and
+  `update-appcast.sh` keeps the current stable item alongside it (a newer beta
+  replaces the previous beta item);
+- the Homebrew cask is not touched.
+
+Put the beta's notes as the top `## ` section of `RELEASE_NOTES.md` — the notes
+extraction always takes the first section. Shipping the stable `vX.Y.Z`
+afterwards writes a stable-only appcast (the beta cycle ends) and beta installs
+move to it automatically: the run-number `CFBundleVersion` keeps increasing, so
+the stable is an upgrade for them. Opting out of beta never downgrades anyone —
+the install just waits for the next stable.
+
 ## Release checklist
 
 Copy this into the release PR and tick each item.

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Sign a built DMG with Sparkle's EdDSA key and (re)write the appcast feed.
-# Produces a single-item appcast whose enclosure points at the GitHub release
-# asset and whose <description> carries the release notes inline as HTML — so
-# Sparkle renders the notes in its update window instead of loading the GitHub
-# release web page (which dragged in the whole site chrome).
+# Produces an appcast whose enclosure points at the GitHub release asset and
+# whose <description> carries the release notes inline as HTML — so Sparkle
+# renders the notes in its update window instead of loading the GitHub release
+# web page (which dragged in the whole site chrome).
+#
+# Channels: a pre-release version (anything with a hyphen, e.g. 3.3.0-beta.1)
+# is tagged <sparkle:channel>beta</sparkle:channel> — only clients that opted
+# in (Settings ▸ General ▸ Updates) see it — and the existing stable item is
+# preserved alongside it, so stable-only clients keep updating. A stable
+# version writes a single untagged item, ending any beta cycle: betas are
+# dropped, and beta clients move to the stable via its higher build number.
 #
 # Usage:
 #   update-appcast.sh <dmg> <short-version> <build-version> <download-url> <notes-md> [appcast-out]
@@ -59,6 +66,24 @@ else
   enclosure_attrs="$("$SIGN_UPDATE" "$DMG")"
 fi
 
+# A hyphen marks a pre-release (3.3.0-beta.1) — it ships on the beta channel.
+channel_tag=""
+preserved_items=""
+if [[ "$SHORT_VERSION" == *-* ]]; then
+  channel_tag="
+      <sparkle:channel>beta</sparkle:channel>"
+  # Keep the current stable item (any item without a <sparkle:channel>) so
+  # stable-only clients still see their latest release. A previous beta item
+  # is intentionally not kept — this beta supersedes it.
+  if [[ -f "$APPCAST" ]]; then
+    command -v xmllint >/dev/null || {
+      echo "error: xmllint required to carry the stable item into a beta appcast" >&2
+      exit 1
+    }
+    preserved_items="$(xmllint --xpath '//item[not(*[local-name()="channel"])]' "$APPCAST" 2>/dev/null || true)"
+  fi
+fi
+
 pub_date="$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S +0000')"
 mkdir -p "$(dirname "$APPCAST")"
 
@@ -71,7 +96,7 @@ cat >"$APPCAST" <<XML
     <description>Most recent Droidective updates.</description>
     <language>en</language>
     <item>
-      <title>Droidective ${SHORT_VERSION}</title>
+      <title>Droidective ${SHORT_VERSION}</title>${channel_tag}
       <sparkle:version>${BUILD_VERSION}</sparkle:version>
       <sparkle:shortVersionString>${SHORT_VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
@@ -94,6 +119,7 @@ ${notes_html}
       <pubDate>${pub_date}</pubDate>
       <enclosure url="${DOWNLOAD_URL}" ${enclosure_attrs} type="application/octet-stream" />
     </item>
+    ${preserved_items}
   </channel>
 </rss>
 XML


### PR DESCRIPTION
## What

Adds an opt-in beta channel to the Sparkle update pipeline.

**App**
- Settings ▸ General ▸ Updates gains a "Receive beta updates" toggle, off by default, stored in UserDefaults (`receiveBetaUpdates`).
- `UpdaterViewModel` implements `allowedChannels(for:)`, returning `["beta"]` when opted in. Untagged (stable) appcast items remain visible to everyone.
- Turning the toggle on runs an immediate background update check so an available beta is offered right away. Turning it off never downgrades — the install waits for the next stable, which always has a higher run-number build version.

**Pipeline**
- `update-appcast.sh`: a version with a pre-release suffix (`3.3.0-beta.1`) writes its item with `<sparkle:channel>beta</sparkle:channel>` and carries the existing stable item (any item without a channel tag) into the new appcast, so stable-only clients keep updating. A newer beta replaces the previous beta item. A stable version writes a single untagged item, ending the beta cycle.
- `ci.yml`: beta tags publish as GitHub prereleases (`prerelease: contains(ref_name, '-')`), so `/releases/latest/download/Droidective.dmg` keeps serving the latest stable; the Homebrew cask step exits early on beta versions.
- RELEASING.md documents the beta flow: tag format, the three pipeline differences, and that release notes extraction always takes the top section of RELEASE_NOTES.md.

## Verification

- `make build` clean (warnings as errors).
- `shellcheck`, `shfmt -i 2 -d`, `actionlint`, and `zizmor` pass on the touched script and workflow.
- `update-appcast.sh` exercised end-to-end with a stubbed `sign_update` against the live `site/appcast.xml`: beta publish preserves the stable item (signature intact), a second beta replaces the first while keeping stable, and a stable publish drops beta items. All outputs pass the script's `xmllint` validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)