### PR TITLE
Fix Reactotron copy-as-cURL dropping request params

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
@@ -126,37 +126,65 @@ public struct AppInspectionService: Sendable {
         var info = Self.parseAppInfo(dump.stdout, packageId: packageId)
         guard info.installed else { return info }
 
-        if let apkPath = try await firstApkPath(serial: serial, packageId: packageId) {
-            info.apkPath = apkPath
-            let stat = try await client.run(on: serial, ["shell", "stat", "-c", "%s", shellQuote(apkPath)])
-            info.apkSizeBytes = Int(stat.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        let paths = try await apkPaths(serial: serial, packageId: packageId)
+        if let basePath = paths.first {
+            info.apkPath = basePath
+            let stat = try await client.run(
+                on: serial, ["shell", "stat", "-c", "%s"] + paths.map(shellQuote))
+            // Sum every split — base.apk alone understates an App Bundle
+            // install, often by most of its size.
+            let total = stat.stdout.split(whereSeparator: \.isNewline)
+                .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                .reduce(0, +)
+            info.apkSizeBytes = total > 0 ? total : nil
         }
         return info
     }
 
-    func firstApkPath(serial: String, packageId: String) async throws(AdbError) -> String? {
+    /// Every APK the package installs, base first — App Bundle installs list
+    /// `base.apk` plus `split_config.*` companions.
+    func apkPaths(serial: String, packageId: String) async throws(AdbError) -> [String] {
         let output = try await client.run(on: serial, ["shell", "pm", "path", shellQuote(packageId)])
-        return output.stdout.split(whereSeparator: \.isNewline)
-            .map { $0.replacingOccurrences(of: "package:", with: "").trimmingCharacters(in: .whitespacesAndNewlines) }
-            .first { !$0.isEmpty }
+        var paths = ApkInspectionService.parsePmPath(output.stdout)
+        if let baseIndex = paths.firstIndex(where: { $0.hasSuffix("/base.apk") }), baseIndex != 0 {
+            paths.swapAt(0, baseIndex)
+        }
+        return paths
     }
 
-    public func pullApk(serial: String, packageId: String, to destination: URL? = nil) async throws -> URL {
-        guard let apkPath = try await firstApkPath(serial: serial, packageId: packageId) else {
-            throw PullError.apkNotFound
-        }
-        let dest: URL
+    /// Pull everything the package installs. A single-APK app lands exactly at
+    /// `destination`; a split install writes base.apk there and each split
+    /// alongside it as `<name>.<split>.apk` — pulling base.apk alone produces
+    /// a file that *looks* complete but can't be reinstalled
+    /// (`INSTALL_FAILED_MISSING_SPLIT`). Returns the written files, base first.
+    public func pullApk(serial: String, packageId: String, to destination: URL? = nil) async throws -> [URL] {
+        let paths = try await apkPaths(serial: serial, packageId: packageId)
+        guard !paths.isEmpty else { throw PullError.apkNotFound }
+        let base: URL
         if let destination {
-            dest = destination
+            base = destination
         } else {
             let dir = try ScreenCaptureService.ensureCaptureDir()
-            dest = dir.appendingPathComponent("\(packageId)_\(ScreenCaptureService.stamp()).apk")
+            base = dir.appendingPathComponent("\(packageId)_\(ScreenCaptureService.stamp()).apk")
         }
-        let result = try await client.run(on: serial, ["pull", apkPath, dest.path], timeout: .seconds(120))
-        guard result.succeeded else {
-            throw PullError.failed(friendlyAdbError(result, fallback: "Failed to pull APK"))
+        var saved: [URL] = []
+        for path in paths {
+            let dest = saved.isEmpty ? base : Self.splitDestination(base: base, splitPath: path)
+            let result = try await client.run(on: serial, ["pull", path, dest.path], timeout: .seconds(120))
+            guard result.succeeded else {
+                throw PullError.failed(friendlyAdbError(result, fallback: "Failed to pull APK"))
+            }
+            saved.append(dest)
         }
-        return dest
+        return saved
+    }
+
+    /// Where a split lands next to the chosen base file:
+    /// `com.foo.apk` + `…/split_config.en.apk` → `com.foo.split_config.en.apk`.
+    static func splitDestination(base: URL, splitPath: String) -> URL {
+        let splitName = URL(fileURLWithPath: splitPath).lastPathComponent
+        let stem = base.deletingPathExtension().lastPathComponent
+        return base.deletingLastPathComponent().appendingPathComponent("\(stem).\(splitName)")
     }
 
     public enum PullError: Error, LocalizedError {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
@@ -35,7 +35,9 @@ public enum ReactotronCurl {
         }
         if let form {
             for (name, value) in form {
-                parts.append("-F \(shellQuote("\(name)=\(value)"))")
+                // --form-string, not -F: a value starting with "@" or "<"
+                // would otherwise be read as a local file/stdin reference.
+                parts.append("--form-string \(shellQuote("\(name)=\(value)"))")
             }
         }
         if let body {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronCurl.swift
@@ -9,22 +9,33 @@ public enum ReactotronCurl {
     /// - Parameters:
     ///   - method: the HTTP verb as captured (any case).
     ///   - url: the request URL.
-    ///   - request: the Reactotron `request` payload, read for `headers` and `data`.
+    ///   - request: the Reactotron `request` payload, read for `headers`,
+    ///     `data`, and `params`.
     public static func command(method: String, url: String, request: JSONValue?) -> String {
         let verb = method.uppercased()
-        let body = requestBody(request)
+        let fullURL = urlMergingParams(url, params: request?["params"])
+        let form = formParts(request?["data"])
+        let body = form == nil ? requestBody(request) : nil
         var parts: [String] = ["curl"]
         // `curl` switches to POST the moment a body is present, so the verb must
         // be stated explicitly whenever it isn't a plain body-less GET —
         // otherwise copying a GET that carries a body silently produces a POST.
-        if verb != "GET" || body != nil {
+        if verb != "GET" || body != nil || form != nil {
             parts.append("-X \(verb)")
         }
-        parts.append(shellQuote(url))
+        parts.append(shellQuote(fullURL))
         if let headers = request?["headers"]?.objectValue {
             for (key, value) in headers.sorted(by: { $0.key < $1.key }) {
+                // A multipart body is rebuilt as -F fields below, so the captured
+                // content-type's boundary is stale — curl must mint its own.
+                if form != nil, key.lowercased() == "content-type" { continue }
                 let rendered = value.stringValue ?? value.jsonString
                 parts.append("-H \(shellQuote("\(key): \(rendered)"))")
+            }
+        }
+        if let form {
+            for (name, value) in form {
+                parts.append("-F \(shellQuote("\(name)=\(value)"))")
             }
         }
         if let body {
@@ -43,5 +54,84 @@ public enum ReactotronCurl {
         case "", "{}", "[]", "null": return nil
         default: return rendered
         }
+    }
+
+    // MARK: - Query params
+
+    /// The networking plugin reports `url` from `xhr.responseURL` — the *final*
+    /// URL after any redirect or gateway rewrite, which can arrive without the
+    /// query string the app actually sent — while the original query params ride
+    /// separately in the payload's `params` object. Append every param the URL
+    /// doesn't already carry so the copied command reproduces the request; when
+    /// the URL kept its query, this is a no-op.
+    static func urlMergingParams(_ url: String, params: JSONValue?) -> String {
+        guard let params = params?.objectValue, !params.isEmpty else { return url }
+        let existing = existingQueryKeys(url)
+        var merged = url
+        for (key, value) in params.sorted(by: { $0.key < $1.key }) {
+            guard !existing.contains(key) else { continue }
+            // query-string yields an array for a repeated key (?tag=a&tag=b).
+            let values = value.arrayValue ?? [value]
+            for item in values {
+                let separator = merged.contains("?") ? "&" : "?"
+                // A bare flag (?debug) parses to null — reproduce it value-less.
+                if item.isNull {
+                    merged += "\(separator)\(queryEscape(key))"
+                } else {
+                    let rendered = item.stringValue ?? item.jsonString
+                    merged += "\(separator)\(queryEscape(key))=\(queryEscape(rendered))"
+                }
+            }
+        }
+        return merged
+    }
+
+    /// The query keys already present in `url`, in both their raw and
+    /// percent-decoded spellings — the client decodes some param keys and not
+    /// others depending on its version, so match either form.
+    private static func existingQueryKeys(_ url: String) -> Set<String> {
+        guard let questionMark = url.firstIndex(of: "?") else { return [] }
+        var keys: Set<String> = []
+        let query = url[url.index(after: questionMark)...]
+        for pair in query.split(separator: "&") {
+            // A degenerate pair like "=" splits to nothing — skip it.
+            guard let rawKey = pair.split(separator: "=", maxSplits: 1).first else { continue }
+            let key = String(rawKey)
+            keys.insert(key)
+            if let decoded = key.removingPercentEncoding { keys.insert(decoded) }
+        }
+        return keys
+    }
+
+    /// RFC 3986 unreserved characters — everything else is percent-encoded so a
+    /// param value carrying `&`, `=`, or spaces survives the round trip.
+    private static let queryAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    private static func queryEscape(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: queryAllowed) ?? value
+    }
+
+    // MARK: - Multipart bodies
+
+    /// React Native's `FormData` reaches the wire as `{"_parts": [[name, value],
+    /// …]}` — attaching that JSON as `--data` reproduces nothing. Rebuild it as
+    /// `-F` fields instead: string values pass through; a file part (an object
+    /// with `uri`/`name`/`type`) renders as its JSON, since the file itself
+    /// lives on the device and can't ride a copied command.
+    static func formParts(_ data: JSONValue?) -> [(name: String, value: String)]? {
+        guard let object = data?.objectValue,
+              object.count == 1,
+              let parts = object["_parts"]?.arrayValue,
+              !parts.isEmpty else { return nil }
+        var fields: [(name: String, value: String)] = []
+        for part in parts {
+            guard let pair = part.arrayValue, pair.count >= 2 else { return nil }
+            let name = pair[0].stringValue ?? pair[0].jsonString
+            let value = pair[1].stringValue ?? pair[1].jsonString
+            fields.append((name: name, value: value))
+        }
+        return fields
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -82,6 +82,10 @@ public actor ReactotronServer {
     private let pingInterval: Duration
     private var listener: NWListener?
     private var connections: [Int: ConnectionBox] = [:]
+    /// Per-connection frame feeds — the ordered pipeline each socket's raw
+    /// frames ride to the actor (see `accept`). Finished when the connection
+    /// drops so its consumer drains what already arrived, then ends.
+    private var frameFeeds: [Int: AsyncStream<Data>.Continuation] = [:]
     /// The Reactotron clientId of each handshaken connection — an app reload
     /// reconnects with the same clientId, which is how the stale socket is
     /// recognized and dropped.
@@ -132,6 +136,11 @@ public actor ReactotronServer {
         }
         let webSocket = NWProtocolWebSocket.Options()
         webSocket.autoReplyPing = true
+        // Explicit, generous cap instead of the framework default: Android's
+        // RN WebSocket (OkHttp) queues up to 16 MiB outbound, so a single
+        // api.response/image frame can approach that — a too-small receive
+        // limit would fail the whole connection, not just the frame.
+        webSocket.maximumMessageSize = 64 * 1024 * 1024
         parameters.defaultProtocolStack.applicationProtocols.insert(webSocket, at: 0)
 
         let listener: NWListener
@@ -177,6 +186,8 @@ public actor ReactotronServer {
             box.connection.cancel()
         }
         connections.removeAll()
+        for feed in frameFeeds.values { feed.finish() }
+        frameFeeds.removeAll()
         clientIds.removeAll()
         listener?.cancel()
         listener = nil
@@ -235,6 +246,20 @@ public actor ReactotronServer {
         nextConnectionId += 1
         connections[id] = box
 
+        // Frames reach the actor through one stream and one consumer per
+        // connection, not a Task per frame: independent tasks have no FIFO
+        // guarantee on actor entry, so a burst could land timeline rows out
+        // of wire order. The socket callbacks run on a serial queue, so the
+        // yields — and therefore the events — keep the order the app sent.
+        let (frames, feed) = AsyncStream.makeStream(
+            of: Data.self, bufferingPolicy: .unbounded)
+        frameFeeds[id] = feed
+        Task { [weak self] in
+            for await data in frames {
+                await self?.handleFrame(connectionId: id, data: data)
+            }
+        }
+
         box.connection.stateUpdateHandler = { [weak self] state in
             switch state {
             case let .failed(error):
@@ -251,7 +276,7 @@ public actor ReactotronServer {
             }
         }
         box.connection.start(queue: Self.queue)
-        Self.receiveLoop(box, id: id, server: self)
+        Self.receiveLoop(box, id: id, server: self, feed: feed)
     }
 
     /// Drops the connection and reports why. Racing drop paths (close frame,
@@ -260,14 +285,20 @@ public actor ReactotronServer {
     private func dropConnection(_ id: Int, reason: DisconnectReason?) {
         guard let box = connections.removeValue(forKey: id) else { return }
         clientIds[id] = nil
+        // Finish (not cancel) the frame pipeline: frames that arrived before
+        // the close still drain into the timeline, then the consumer ends.
+        frameFeeds.removeValue(forKey: id)?.finish()
         box.connection.cancel()
         continuation?.yield(.disconnected(connectionId: id, reason: reason))
     }
 
     /// Recursive receive loop, off the actor (like `MirrorTransport.receiveLoop`).
-    /// Each WebSocket text frame is one Reactotron command; hop onto the actor to
-    /// decode and deliver it, then continue receiving.
-    private nonisolated static func receiveLoop(_ box: ConnectionBox, id: Int, server: ReactotronServer) {
+    /// Each WebSocket text frame is one Reactotron command; yield it into the
+    /// connection's ordered frame feed (see `accept`), then continue receiving.
+    private nonisolated static func receiveLoop(
+        _ box: ConnectionBox, id: Int, server: ReactotronServer,
+        feed: AsyncStream<Data>.Continuation
+    ) {
         box.connection.receiveMessage { content, context, _, error in
             if let context,
                let metadata = context.protocolMetadata(definition: NWProtocolWebSocket.definition)
@@ -276,7 +307,7 @@ public actor ReactotronServer {
                 case .text:
                     if let content {
                         NetworkTrafficMeter.shared.recordReceived(content.count)
-                        Task { await server.handleFrame(connectionId: id, data: content) }
+                        feed.yield(content)
                     }
                 case .close:
                     log.notice("connection #\(id): client sent WS close, code=\(String(describing: metadata.closeCode), privacy: .public)")
@@ -295,7 +326,7 @@ public actor ReactotronServer {
                 }
                 return
             }
-            receiveLoop(box, id: id, server: server)
+            receiveLoop(box, id: id, server: server, feed: feed)
         }
     }
 
@@ -347,6 +378,7 @@ public actor ReactotronServer {
         for (staleId, staleClientId) in clientIds
             where staleClientId == clientId && staleId != id {
             clientIds[staleId] = nil
+            frameFeeds.removeValue(forKey: staleId)?.finish()
             guard let stale = connections.removeValue(forKey: staleId) else { continue }
             continuation?.yield(.disconnected(connectionId: staleId, reason: nil))
             Task {

--- a/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
@@ -27,6 +27,86 @@ import Testing
         ])
     }
 
+    @Test func pullApkPullsEverySplitBaseFirst() async throws {
+        let runner = MockProcessRunner()
+        // pm path lists a split *before* base — the pull must still put
+        // base.apk at the user's chosen destination.
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "path"], stdout: """
+        package:/data/app/~~a==/com.x-1/split_config.arm64_v8a.apk
+        package:/data/app/~~a==/com.x-1/base.apk
+        package:/data/app/~~a==/com.x-1/split_config.en.apk
+        """)
+        runner.script(argsPrefix: ["-s", "S1", "pull"], stdout: "1 file pulled")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+        let dest = URL(fileURLWithPath: "/tmp/out/com.x.apk")
+
+        let saved = try await service.pullApk(serial: "S1", packageId: "com.x", to: dest)
+
+        #expect(saved.map(\.path) == [
+            "/tmp/out/com.x.apk",
+            "/tmp/out/com.x.split_config.arm64_v8a.apk",
+            "/tmp/out/com.x.split_config.en.apk",
+        ])
+        let pulls = runner.invocations.filter { $0.arguments.contains("pull") }.map(\.arguments)
+        #expect(pulls == [
+            ["-s", "S1", "pull", "/data/app/~~a==/com.x-1/base.apk", "/tmp/out/com.x.apk"],
+            ["-s", "S1", "pull", "/data/app/~~a==/com.x-1/split_config.arm64_v8a.apk",
+             "/tmp/out/com.x.split_config.arm64_v8a.apk"],
+            ["-s", "S1", "pull", "/data/app/~~a==/com.x-1/split_config.en.apk",
+             "/tmp/out/com.x.split_config.en.apk"],
+        ])
+    }
+
+    @Test func pullApkSingleApkLandsExactlyAtTheChosenDestination() async throws {
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["-s", "S1", "shell", "pm", "path"],
+            stdout: "package:/data/app/com.x-1/base.apk\n")
+        runner.script(argsPrefix: ["-s", "S1", "pull"], stdout: "1 file pulled")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+        let dest = URL(fileURLWithPath: "/tmp/out/renamed.apk")
+
+        let saved = try await service.pullApk(serial: "S1", packageId: "com.x", to: dest)
+
+        #expect(saved.map(\.path) == ["/tmp/out/renamed.apk"])
+        // The package reaches the device shell, so it must be quoted.
+        #expect(runner.invocations.first?.arguments == ["-s", "S1", "shell", "pm", "path", "'com.x'"])
+    }
+
+    @Test func pullApkWithNoInstalledPathsThrowsApkNotFound() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "path"], stdout: "")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+        await #expect(throws: AppInspectionService.PullError.self) {
+            _ = try await service.pullApk(
+                serial: "S1", packageId: "com.gone", to: URL(fileURLWithPath: "/tmp/x.apk"))
+        }
+    }
+
+    @Test func appInfoApkSizeSumsEverySplit() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "dumpsys"], stdout: """
+        Package [com.x] (abc):
+            versionName=1.0
+            versionCode=7
+        """)
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "path"], stdout: """
+        package:/a/base.apk
+        package:/a/split_config.en.apk
+        """)
+        runner.script(argsPrefix: ["-s", "S1", "shell", "stat"], stdout: "100\n40\n")
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+
+        let info = try await service.getAppInfo(serial: "S1", packageId: "com.x")
+
+        #expect(info.apkPath == "/a/base.apk")
+        #expect(info.apkSizeBytes == 140)
+        let stat = runner.invocations.first { $0.arguments.contains("stat") }
+        #expect(stat?.arguments == [
+            "-s", "S1", "shell", "stat", "-c", "%s", "'/a/base.apk'", "'/a/split_config.en.apk'",
+        ])
+    }
+
     @Test func sandboxPullPassesRawArgvBecauseExecOutDoesNotUseAShell() async throws {
         let runner = MockProcessRunner()
         runner.script(argsPrefix: ["-s"], stdout: "file bytes")

--- a/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
@@ -168,11 +168,23 @@ import Testing
         ])
         let curl = ReactotronCurl.command(method: "POST", url: "https://x.test/upload", request: request)
         #expect(curl.contains("-X POST"))
-        #expect(curl.contains("-F 'field=value'"))
-        #expect(curl.contains(#"-F 'photo={"name":"a.jpg","uri":"file:///a.jpg"}'"#))
+        #expect(curl.contains("--form-string 'field=value'"))
+        #expect(curl.contains(#"--form-string 'photo={"name":"a.jpg","uri":"file:///a.jpg"}'"#))
         #expect(curl.contains("-H 'accept: application/json'"))
         #expect(!curl.contains("content-type"))
         #expect(!curl.contains("--data"))
+    }
+
+    @Test func formValueStartingWithAtSignStaysLiteral() {
+        // -F would read "@token" as a local-file reference; --form-string
+        // must carry it verbatim.
+        let request = JSONValue.object([
+            "data": .object(["_parts": .array([
+                .array([.string("handle"), .string("@rohindh")]),
+            ])]),
+        ])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains("--form-string 'handle=@rohindh'"))
     }
 
     @Test func plainObjectBodyIsNotMistakenForFormData() {

--- a/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronCurlTests.swift
@@ -98,4 +98,132 @@ import Testing
         let curl = ReactotronCurl.command(method: "GET", url: "https://x.test", request: request)
         #expect(curl.contains("-H 'X-Retry: 3'"))
     }
+
+    // MARK: - params merging
+
+    @Test func paramsMissingFromURLAreAppended() {
+        // The networking plugin reports the URL from xhr.responseURL, which can
+        // lose the query string after a redirect/rewrite — the original params
+        // ride separately and must be restored into the copied command.
+        let request = JSONValue.object(["params": .object([
+            "store_id": .string("42"),
+            "postcode": .string("CB4 1AA"),
+        ])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/menu", request: request)
+        #expect(curl.contains("'https://x.test/menu?postcode=CB4%201AA&store_id=42'"))
+    }
+
+    @Test func paramsAlreadyInURLAreNotDuplicated() {
+        let request = JSONValue.object(["params": .object([
+            "a": .string("1"),
+            "b": .string("2"),
+        ])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/p?a=1", request: request)
+        #expect(curl.contains("'https://x.test/p?a=1&b=2'"))
+    }
+
+    @Test func paramValueCarryingMetacharactersIsPercentEncoded() {
+        let request = JSONValue.object(["params": .object(["q": .string("fish & chips=good")])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/s", request: request)
+        #expect(curl.contains("'https://x.test/s?q=fish%20%26%20chips%3Dgood'"))
+    }
+
+    @Test func repeatedParamKeyAppendsEveryValue() {
+        // query-string parses ?tag=a&tag=b into an array value.
+        let request = JSONValue.object(["params": .object([
+            "tag": .array([.string("a"), .string("b")]),
+        ])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/t", request: request)
+        #expect(curl.contains("'https://x.test/t?tag=a&tag=b'"))
+    }
+
+    @Test func bareFlagParamStaysValueless() {
+        // ?debug with no "=" parses to a null value.
+        let request = JSONValue.object(["params": .object(["debug": .null])])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/d", request: request)
+        #expect(curl.contains("'https://x.test/d?debug'"))
+    }
+
+    @Test func nullParamsFieldLeavesURLUntouched() {
+        let request = JSONValue.object(["params": .null, "data": .null])
+        let curl = ReactotronCurl.command(method: "GET", url: "https://x.test/plain", request: request)
+        #expect(curl.contains("'https://x.test/plain'"))
+    }
+
+    // MARK: - FormData bodies
+
+    @Test func formDataBodyRendersAsFormFields() {
+        // RN FormData reaches the wire as {"_parts": [[name, value], …]} —
+        // reproduce it as -F fields, and drop the captured multipart
+        // content-type so curl mints a fresh boundary.
+        let request = JSONValue.object([
+            "data": .object(["_parts": .array([
+                .array([.string("field"), .string("value")]),
+                .array([.string("photo"), .object(["uri": .string("file:///a.jpg"), "name": .string("a.jpg")])]),
+            ])]),
+            "headers": .object([
+                "content-type": .string("multipart/form-data; boundary=xyz"),
+                "accept": .string("application/json"),
+            ]),
+        ])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test/upload", request: request)
+        #expect(curl.contains("-X POST"))
+        #expect(curl.contains("-F 'field=value'"))
+        #expect(curl.contains(#"-F 'photo={"name":"a.jpg","uri":"file:///a.jpg"}'"#))
+        #expect(curl.contains("-H 'accept: application/json'"))
+        #expect(!curl.contains("content-type"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func plainObjectBodyIsNotMistakenForFormData() {
+        let request = JSONValue.object(["data": .object(["_parts": .string("just a field")])])
+        let curl = ReactotronCurl.command(method: "POST", url: "https://x.test", request: request)
+        #expect(curl.contains(#"--data '{"_parts":"just a field"}'"#))
+    }
+
+    // MARK: - Real wire frames (captured from reactotron-core-client 2.8.10)
+
+    @Test func realPostWireFrameProducesFullCurl() throws {
+        let frame = #"""
+        {"type":"api.response","payload":{"request":{"url":"https://api.example.test/consumer/order","method":"POST","data":"{\"user_id\":0,\"token\":null,\"filters\":{\"active\":false,\"promo\":\"\"},\"qty\":2}","headers":{"content-type":"application/json","accept":"application/json","x-app":"~~~ empty string ~~~"},"params":"~~~ null ~~~"},"response":{"body":{"status":"ok","data":"~~~ null ~~~"},"status":200,"headers":{"content-type":"application/json"}},"duration":123},"important":"~~~ false ~~~","date":"2026-07-15T07:20:58.991Z","deltaTime":490}
+        """#
+        let event = try ReactotronEvent(command: ReactotronCommand.decode(frame))
+        guard case let .apiResponse(method, url, _, _, request, _) = event else {
+            Issue.record("expected apiResponse, got \(event)")
+            return
+        }
+        let curl = ReactotronCurl.command(method: method, url: url, request: request)
+        #expect(curl.contains("-X POST"))
+        #expect(curl.contains("-H 'content-type: application/json'"))
+        #expect(curl.contains(#"--data '{"user_id":0,"token":null,"filters":{"active":false,"promo":""},"qty":2}'"#))
+    }
+
+    @Test func realGetWireFrameKeepsQueryParams() throws {
+        let frame = #"""
+        {"type":"api.response","payload":{"request":{"url":"https://api.example.test/menu?store_id=42&postcode=CB4+1AA&empty=&flag=0","method":"GET","data":"~~~ null ~~~","headers":{"accept":"application/json"},"params":{"store_id":"42","postcode":"CB4 1AA","empty":"~~~ empty string ~~~","flag":"0"}},"response":{"body":"~~~ skipped ~~~","status":200,"headers":{}},"duration":45},"important":"~~~ false ~~~","date":"2026-07-15T07:20:59.482Z","deltaTime":1}
+        """#
+        let event = try ReactotronEvent(command: ReactotronCommand.decode(frame))
+        guard case let .apiResponse(method, url, _, _, request, _) = event else {
+            Issue.record("expected apiResponse, got \(event)")
+            return
+        }
+        let curl = ReactotronCurl.command(method: method, url: url, request: request)
+        #expect(curl.contains("'https://api.example.test/menu?store_id=42&postcode=CB4+1AA&empty=&flag=0'"))
+        #expect(!curl.contains("--data"))
+    }
+
+    @Test func realFrameWhoseResponseURLLostTheQueryRegainsIt() throws {
+        // The plugin's url is xhr.responseURL — after a gateway rewrite it can
+        // arrive stripped of the query the app sent, while params keeps it.
+        let frame = #"""
+        {"type":"api.response","payload":{"request":{"url":"https://api.example.test/menu","method":"GET","data":"~~~ null ~~~","headers":{"accept":"application/json"},"params":{"store_id":"42","flag":"0"}},"response":{"body":"~~~ skipped ~~~","status":200,"headers":{}},"duration":45},"important":"~~~ false ~~~","date":"2026-07-15T07:20:59.482Z","deltaTime":1}
+        """#
+        let event = try ReactotronEvent(command: ReactotronCommand.decode(frame))
+        guard case let .apiResponse(method, url, _, _, request, _) = event else {
+            Issue.record("expected apiResponse, got \(event)")
+            return
+        }
+        let curl = ReactotronCurl.command(method: method, url: url, request: request)
+        #expect(curl.contains("'https://api.example.test/menu?flag=0&store_id=42'"))
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
@@ -124,6 +124,42 @@ import Testing
         }
     }
 
+    /// A burst of frames must reach the event stream in wire order — the
+    /// server pipes each connection's frames through one ordered consumer, so
+    /// timeline rows can't leapfrog each other under load.
+    @Test(.timeLimit(.minutes(1)))
+    func burstOfFramesArrivesInWireOrder() async throws {
+        let server = ReactotronServer(port: 0)
+        let stream = try await server.start()
+        defer { Task { await server.stop() } }
+        var iterator = stream.makeAsyncIterator()
+        let port = try await waitForListening(&iterator)
+
+        let url = try #require(URL(string: "ws://127.0.0.1:\(port)"))
+        let task = URLSession.shared.webSocketTask(with: url)
+        task.resume()
+        defer { task.cancel(with: .goingAway, reason: nil) }
+        try await task.send(.string(
+            #"{"type":"client.intro","payload":{"name":"BurstApp"},"important":false,"date":"d","deltaTime":0}"#
+        ))
+        guard case .connected = try await nextEvent(&iterator) else {
+            Issue.record("expected .connected"); return
+        }
+
+        let count = 100
+        for index in 0..<count {
+            try await task.send(.string(
+                #"{"type":"log","payload":{"level":"debug","message":"\#(index)"},"important":false,"date":"d","deltaTime":1}"#
+            ))
+        }
+        for index in 0..<count {
+            guard case let .command(_, command, _) = try await nextEvent(&iterator) else {
+                Issue.record("expected .command #\(index)"); return
+            }
+            #expect(command.payload?["message"]?.stringValue == "\(index)")
+        }
+    }
+
     private func waitForListening(_ iterator: inout Iterator) async throws -> UInt16 {
         while let event = await iterator.next() {
             if case let .listening(port) = event { return port }

--- a/App/Sources/FeatureDetail/Views/AppInfoView.swift
+++ b/App/Sources/FeatureDetail/Views/AppInfoView.swift
@@ -89,12 +89,21 @@ struct AppInfoView: View {
                     ) {
                         try await state.env.engine.inspection.pullApk(serial: serial, packageId: packageId, to: dest)
                     }
-                    state.showToast(Toast(message: "APK saved", ok: true, revealPath: saved.path))
+                    state.showToast(Toast(message: Self.pulledApkToast(saved), ok: true, revealPath: dest.path))
                 } catch {
                     state.showToast(Toast(message: error.localizedDescription, ok: false))
                 }
             }
             pulling = false
         }
+    }
+
+    /// "APK saved" for a single-file app; spells out the split count for an
+    /// App Bundle install so the extra files next to the chosen one aren't a
+    /// surprise. Shared with the Apps explorer's pull.
+    static func pulledApkToast(_ saved: [URL]) -> String {
+        let splits = saved.count - 1
+        guard splits > 0 else { return "APK saved" }
+        return "APK + \(splits) split\(splits == 1 ? "" : "s") saved"
     }
 }

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -514,7 +514,7 @@ private struct AppDetailPane: View {
                     ) {
                         try await state.env.engine.inspection.pullApk(serial: serial, packageId: packageId, to: dest)
                     }
-                    state.showToast(Toast(message: "APK saved", ok: true, revealPath: saved.path))
+                    state.showToast(Toast(message: AppInfoView.pulledApkToast(saved), ok: true, revealPath: dest.path))
                 } catch {
                     state.showToast(Toast(message: error.localizedDescription, ok: false))
                 }


### PR DESCRIPTION
## What

Three fixes to the Reactotron pipeline and one to APK pulls, found while auditing why a copied cURL could reproduce a request without its parameters.

### Copy as cURL (`ReactotronCurl`)
- Multipart bodies: React Native `FormData` reaches the wire as `{"_parts": [[name, value], …]}` and was attached verbatim as `--data` JSON — the server saw no fields at all. Rebuilt as `--form-string` fields (`-F` would read values starting with `@`/`<` as file references), dropping the captured multipart content-type so curl mints its own boundary.
- Query params: the networking plugin reports the URL from `xhr.responseURL` and carries the query params separately in `request.params`; the builder ignored that field. Params missing from the URL are now merged back in (percent-encoded, deduplicated, repeated keys and bare flags handled).

### Reactotron server
- Frames were handed to the actor via one `Task` per frame, which has no FIFO guarantee — a burst could land timeline rows out of wire order. Each connection's frames now flow through one ordered `AsyncStream` consumer; dropping a connection finishes the feed so already-received frames still drain.
- Explicit 64 MiB WebSocket `maximumMessageSize` instead of the framework default.

### Pull APK
- `pm path` lists one line per APK for App Bundle installs; the pull took only the first, producing a base.apk that looks complete but reinstalls with `INSTALL_FAILED_MISSING_SPLIT`. All splits are now pulled alongside the chosen file, and App Info's APK size sums them.

## Testing

- Wire-shaped unit tests captured from a real `reactotron-core-client` 2.8.10 session; 100-frame burst-order test over a real loopback WebSocket; arg-vector tests for split pulls. 788 tests green, build warning-free.
- Verified end to end against a live emulator: a real RN 0.86 + reactotron-react-native 5.2.0 app fired GET-with-query / redirect-stripped / JSON / form-urlencoded / multipart requests through the pipeline, and the copied cURLs were replayed against the origin server — received params, bodies, and multipart fields were identical to the originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)