### PR TITLE
Release v3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ needs a new UI layer.
 
 ## Features
 
-A searchable palette (`⌘T`) of 56 tools, organised by category and
+A searchable palette (`⌘T`) of 57 tools, organised by category and
 gathered into focused hubs (React Native, Simulate, Connection, APK Studio) so
 the sidebar stays short. Every action is on by default; hide the ones you don't want from
 the in-app catalog.
@@ -61,10 +61,13 @@ the in-app catalog.
   and sign — including creating a keystore) and **Frida** setup (arch-matched
   frida-server / frida-gadget). jadx, apktool, and a Java runtime download on
   demand and are managed in Settings.
-- **Logs & diagnostics** — live logcat (level/app/tag/text filters,
-  follow-to-bottom, export), crash catcher with Slack/Jira formatting, one-click
-  bug-report zip, and a **performance monitor** (per-core CPU, RAM, FPS, network,
-  and per-process usage charted live, recorded, and exported to JSON/CSV).
+- **Logs & diagnostics** — live logcat (level/app/tag/text filters, a ⌘F find
+  bar that highlights and steps through matches without hiding lines,
+  follow-to-bottom, export), **iOS Logs** (the same pane streaming a booted
+  iOS Simulator's unified log), crash catcher with Slack/Jira formatting,
+  one-click bug-report zip, and a **performance monitor** (per-core CPU, RAM,
+  FPS, network, and per-process usage charted live, recorded, and exported to
+  JSON/CSV).
 - **Tool UX** — a multi-tab **Terminal** (real PTY login shells with the
   selected device exported as `ANDROID_SERIAL`), custom command macros with
   `{bundleId}`/`{serial}` placeholders (typed as full command lines — even
@@ -128,7 +131,7 @@ through Sparkle (and `brew upgrade` defers to that).
 ADBKit/   Swift package — all logic, zero UI dependencies (swift test)
   Exec/         adb process execution, tool location, scoped command log
   Devices/      discovery (2s polling), getprop, hardware/usage overview
-  Features/     declarative 56-feature registry + runners + how-to notes
+  Features/     declarative 57-feature registry + runners + how-to notes
   Services/     logcat streaming, overrides, file/apps explorers, capture,
                 screen record, crash, bug report, wireless, emulators,
                 performance + network monitors, APK inspect/sign/decompile,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,73 @@
+## Droidective v3.3.0
+
+A JS console that stays connected, a screen mirror that no longer eats CPU
+after you leave it, logcat search split into separate Filter and Find, and a
+first iOS feature: streaming a simulator's native logs.
+
+### Logcat: Filter vs Find
+
+- **Filter and Find are now separate** — the toolbar field *filters* (shows
+  only matching lines, as before); a new find bar (⌘F) *finds*: it highlights
+  matches and steps through them with ⌘G/⇧⌘G and a "2 of 7" counter without
+  hiding anything.
+- **One app selector** — the App menu inside logcat now does everything the
+  bar's bundle pill did (pick a saved bundle, add from the device's installed
+  apps, grab the app on screen, manage), and the bundle pill no longer
+  doubles up above it.
+
+### iOS Logs (new)
+
+- **Stream a simulator's unified log** — the new iOS Logs feature tails a
+  booted iOS Simulator's native logs (`log stream`) in the same pane logcat
+  uses: level picker, text filter, the ⌘F find bar, export, and right-click
+  to filter by process.
+
+### JS Console stays connected
+
+- **No more idle disconnects** — a silent keepalive satisfies React Native's
+  inspector-proxy heartbeat, which a plain WebSocket ping doesn't.
+- **Reconnects survive app relaunches, phone sleep, and Metro restarts** —
+  auto-reconnect no longer strands itself on a stale device id.
+- **Plays nice with React Native DevTools** — when another debugger takes
+  over (RN ≤ 0.84 allows one), the console stands down with a notice instead
+  of fighting for the session; on RN 0.85+ both attach side by side.
+- **No duplicate logs on reconnect** — Hermes' replayed console history is
+  deduplicated, so the feed no longer doubles after each reconnect.
+
+### Screen mirror
+
+- **Fixed: runaway CPU after using the mirror** — switching away from the
+  mirror while it was still connecting could leak a session that kept
+  streaming and decoding until the app quit (the reported 500%+ CPU). Leaked
+  sessions and stray adb tunnels are gone.
+- **Lower latency** — frames render as they decode, touch input isn't
+  batched by the TCP stack, and the slow-motion catch-up after opening the
+  mirror is gone.
+- **Device audio is now opt-in** — the mirror starts video-only; the Audio
+  switch streams device audio too (Android 11+). The choice persists.
+
+### Improvements
+
+- **Device dropdown refreshes itself** — opening it re-scans for devices;
+  the separate refresh button appears only when nothing is connected.
+- **Smooth resizing** — dragging the sidebar edge and the split-pane divider
+  no longer jitters.
+- **Newest-first logs** — Logcat, JS Console, and Reactotron can flip to
+  newest-at-top.
+- **Beta update channel** — Settings ▸ General ▸ Updates gains an opt-in
+  beta channel; opting out never downgrades.
+- Reactotron's Copy as cURL keeps query params and form fields, timeline
+  frames stay in wire order, and large frames no longer truncate.
+- Pulling an app's APK grabs every split APK, not just base.apk.
+- Device platforms, features, and the Emulators screen scope to your role.
+
+### Install
+
+Download `Droidective-v3.3.0.dmg` below, or `brew install --cask
+rohindh-r/tap/droidective`. Existing installs update in place via Sparkle.
+
+---
+
 ## Droidective v3.3.0-beta.2
 
 This beta fixes the runaway-CPU reports traced to the screen mirror and cuts

--- a/project.yml
+++ b/project.yml
@@ -102,7 +102,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
-        MARKETING_VERSION: "3.2.0"
+        MARKETING_VERSION: "3.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete

--- a/site/for-android-developers.html
+++ b/site/for-android-developers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-ios-developers.html
+++ b/site/for-ios-developers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="/for-android-developers.html">For Android developers →</a>
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-qa-and-testers.html
+++ b/site/for-qa-and-testers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-android-developers.html">For Android developers →</a>
         <a href="/for-support-teams.html">For support teams →</a>
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-security-testers.html
+++ b/site/for-security-testers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-android-developers.html">For Android developers →</a>
         <a href="/react-native-debugger.html">React Native debugger →</a>
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-support-teams.html
+++ b/site/for-support-teams.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
         <a href="/for-android-developers.html">For Android developers →</a>
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
       </div>
     </div>
   </main>

--- a/site/react-native-debugger.html
+++ b/site/react-native-debugger.html
@@ -127,7 +127,7 @@
       <h2>Debug React Native without the terminal</h2>
       <a class="btn btn-primary" data-dl="rn" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
       <div class="related">
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
         <a href="/scrcpy-gui-mac.html">scrcpy GUI for Mac →</a>
         <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
       </div>

--- a/site/scrcpy-gui-mac.html
+++ b/site/scrcpy-gui-mac.html
@@ -127,7 +127,7 @@
       <h2>Mirror and record Android on your Mac</h2>
       <a class="btn btn-primary" data-dl="scrcpy" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
       <div class="related">
-        <a href="/">All 56 tools →</a>
+        <a href="/">All 57 tools →</a>
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Droidective — All-in-One Android &amp; React Native Debugging Tool for macOS</title>
-  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 56 tools in all, no terminal required." />
+  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 57 tools in all, no terminal required." />
   <meta name="keywords" content="adb tool, android debugging tool, all in one android dev tool, react native debugger, scrcpy gui mac, android developer tool macos, logcat viewer mac, adb gui, mobile dev tool, android emulator manager, react native debugging" />
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
@@ -20,14 +20,14 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 56 tools, one keystroke away." />
+  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 57 tools, one keystroke away." />
   <meta property="og:url" content="https://droidective.com/" />
   <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 56 tools, one keystroke away. Free & open source." />
+  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 57 tools, one keystroke away. Free & open source." />
   <meta name="twitter:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -41,7 +41,7 @@
     "name": "Droidective",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS 14.0 or later",
-    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 56 tools in all.",
+    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 57 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
     "softwareVersion": "3.0.0",

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -21,7 +21,7 @@ export const RELEASES_URL = `${GITHUB_URL}/releases`
 // stable-named Droidective.dmg (see ci.yml), so this always serves the
 // newest version — no appcast fetch, nothing cached to go stale.
 export const DOWNLOAD_URL = `${GITHUB_URL}/releases/latest/download/Droidective.dmg`
-export const APP_VERSION = "v3.2.0"
+export const APP_VERSION = "v3.3.0"
 
 export interface PaletteCommand {
   icon: LucideIcon
@@ -96,7 +96,7 @@ export const showcases: Showcase[] = [
   {
     eyebrow: "the palette",
     title: "One keystroke to everything",
-    body: "Hit ⌘T from any screen and fuzzy-search all 56 tools. The device bar follows you, so every command targets the device you mean.",
+    body: "Hit ⌘T from any screen and fuzzy-search all 57 tools. The device bar follows you, so every command targets the device you mean.",
     ticks: [
       { lead: "Pin favorites", rest: " and bind global hotkeys" },
       { lead: "Target one device", rest: " or fan out to all of them" },
@@ -197,11 +197,12 @@ export const galleryShots = [
   { image: "/assets/screenshot-device.webp", alt: "Droidective device info showing RAM, storage, battery health and CPU for the connected device", title: "Device info", caption: "RAM, storage, battery health, CPU, and every getprop — searchable." },
   { image: "/assets/screenshot-hotkeys.webp", alt: "Droidective hotkeys settings — record a global shortcut to show the app, and a per-feature shortcut for any tool", title: "Global hotkeys", caption: "Bind a global shortcut to summon the app, and one per feature." },
   { image: "/assets/screenshot-tabs.webp", alt: "Droidective home screen with a multi-tab strip across the top — File Explorer, Device Info, Connection, Performance Monitor, Apps, and Terminal behind a permanent Home icon", title: "Tabbed home", caption: "Your most-used tools front and center, each a tab away." },
-  { image: "/assets/screenshot-catalog.webp", alt: "Droidective feature catalog listing all 56 tools with on/off toggles", title: "Feature catalog", caption: "Toggle, reorder, and pin any of the 56 tools." },
+  { image: "/assets/screenshot-catalog.webp", alt: "Droidective feature catalog listing all 57 tools with on/off toggles", title: "Feature catalog", caption: "Toggle, reorder, and pin any of the 57 tools." },
 ]
 
 export const releases: { version: string; date: string; latest?: boolean; html: string }[] = [
-  { version: "v3.2.0", date: "Jul 2026", latest: true, html: "<b>Pair &amp; connect over Wi-Fi from the device dropdown</b> — the device menu gains a Wireless debugging section opening a guided sheet with three paths: Android 11+ pairing with a code (numbered steps that mirror the phone's pairing dialog, with the connection-vs-pairing port difference explained), a direct <code>ip:port</code> connect for already-paired devices, and a one-click USB→Wi-Fi switch. Address fields take the exact string the phone shows — paste and go — and a successful connection selects the new device automatically." },
+  { version: "v3.3.0", date: "Jul 2026", latest: true, html: "<b>A JS console that stays connected</b> — a keepalive satisfies React Native's inspector-proxy heartbeat, reconnects survive app relaunches, phone sleep, and Metro restarts, and logs no longer duplicate after each reconnect. The <b>screen mirror's runaway CPU is fixed</b> (leaked background sessions), its latency drops, and device audio becomes opt-in. <b>Logcat splits Filter and Find</b>: the field hides non-matching lines while <kbd>⌘F</kbd> highlights and steps through matches with a counter — and the new <b>iOS Logs</b> feature streams a booted simulator's native logs in the same pane. The device dropdown refreshes itself on open, and sidebar &amp; split-pane resizing is smooth." },
+  { version: "v3.2.0", date: "Jul 2026", html: "<b>Pair &amp; connect over Wi-Fi from the device dropdown</b> — the device menu gains a Wireless debugging section opening a guided sheet with three paths: Android 11+ pairing with a code (numbered steps that mirror the phone's pairing dialog, with the connection-vs-pairing port difference explained), a direct <code>ip:port</code> connect for already-paired devices, and a one-click USB→Wi-Fi switch. Address fields take the exact string the phone shows — paste and go — and a successful connection selects the new device automatically." },
   { version: "v3.1.0", date: "Jul 2026", html: "<b>Custom commands, reworked</b> — one box for full command lines exactly as you'd type them in a terminal (multi-line supported), <kbd>adb</kbd> lines detected automatically, and each command can open Droidective's Terminal or your Mac's default terminal. The <b>Quick Actions panel is now yours to curate</b>: pin custom commands with <kbd>⌘P</kbd>, hide actions you don't use, and a <code>{bundleId}</code> command with no app selected asks you to pick one instead of erroring. Updates check twice a day and a dismissed update returns as a notification until installed. Apps gain a one-click <b>Restart</b> everywhere they're managed, launching works on devices with a broken <code>monkey</code>, the app no longer installs tools via Homebrew (it links to the official sources), and the welcome tour ends by pressing your new Quick Actions hotkey — confetti included." },
   { version: "v3.0.1", date: "Jul 2026", html: "<b>Bug-fix release</b> — Uninstall and Monkey Test now confirm before running, Logcat streams as soon as a device authorizes, and the APK tools (Studio, Inspector, Sign, Decompile) and Reactotron open without an Android device selected. Frida and Change Locale give honest status messages, Screen Record and Performance recordings survive a mid-capture disconnect, and anonymous analytics no longer include the device model or OS version. Bundled developer tools now install pinned, known-good versions." },
   { version: "v3.0.0", date: "Jul 2026", html: "<b>Terminal split panes</b> — <kbd>⌘D</kbd> splits the shell side by side, <kbd>⇧⌘D</kbd> stacks it, and new tabs and panes open in the focused shell's working directory — no shell config needed — with the tab list dockable as a left rail or a Chrome-style top strip. The <b>onboarding tour is rebuilt</b> around recordings of the real app, the <b>React Native and Connection hubs are redesigned</b> (described action cards, a Metro port field, your device's live Wi-Fi network and IP), <b>custom commands run in your login shell</b> — aliases work, optionally in a Terminal tab — and the JS Console gains <b>Reload JS and Restart app</b>." },


### PR DESCRIPTION
Prepares the v3.3.0 stable release, ending the v3.3.0 beta cycle. Release notes cover everything since v3.2.0: the JS console connection fixes (beta.1), the screen-mirror CPU/latency fixes and opt-in audio (beta.2), and the logcat Filter/Find split, iOS Logs feature, device-refresh rework, and seam-resize fixes (#154).

### Prepare (on the feature branch)

- [x] `cd ADBKit && swift test` is green — 812 tests, no skips.
- [x] `make build` is clean — zero warnings.
- [x] App runs and the changed features are verified live against an emulator (iOS Logs live-streaming still unexercised — no simulator was booted).
- [x] Bump `MARKETING_VERSION` in `project.yml` to 3.3.0.
- [x] `## Droidective v3.3.0` section added to the top of `RELEASE_NOTES.md`.
- [x] `APP_VERSION` bumped and the release added to `releases` in `website/src/lib/content.ts` (site builds clean).
- [x] Feature counts 56 → 57 in `README.md`, `CLAUDE.md`, `website/src/lib/content.ts`, `website/index.html`, and the `site/*.html` SEO subpages.
- [ ] Screenshots refreshed — **not done**: the sidebar now shows iOS Logs and the logcat toolbar changed, so `screenshot-home`/`screenshot-catalog`/`screenshot-logcat` are stale. Needs a clean default-layout capture (1512×948 @2×, Dock hidden).
- [x] `README.md` and `CLAUDE.md` updated for the new feature.
- [x] Diff re-read; nothing agent-only committed.

### Land

- [x] Branch pushed; PR opened against `main`.
- [ ] PR reviewed and merged to `main`.

### Release (CI does the build — triggered by the tag)

- [ ] Tag from `main` and push: `git tag v3.3.0 && git push origin v3.3.0`.
- [ ] The Actions `release` job succeeds (build, sign, notarize, DMG, appcast commit, Homebrew cask).
- [ ] The follow-up `pages` run deploys the site + appcast.

### Verify (post-release)

- [ ] GitHub release page shows v3.3.0 with notes and a DMG.
- [ ] Fresh DMG passes `spctl` (Notarized Developer ID) and launches cleanly.
- [ ] `brew install --cask rohindh-r/tap/droidective` installs 3.3.0.
- [ ] `https://droidective.com/appcast.xml` lists v3.3.0 (stable-only — the beta cycle ends) with a valid `sparkle:edSignature`.
- [ ] A beta install offers and applies the stable update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)