### PR TITLE
Add a Quick Actions setting to close the panel after a run

### DIFF
--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -9,6 +9,12 @@ let keepRunningInBackgroundKey = "keepRunningInBackground"
 /// its session for resume; 0 disables resume. Defaults to 5.
 let quickPanelResumeMinutesKey = "quickPanelResumeMinutes"
 
+/// UserDefaults key for Settings ▸ General ▸ Quick Actions ▸ "Close the panel
+/// after running an action". Off by default: the panel stays up showing the
+/// result. A failed action always keeps the panel open so the error is
+/// readable.
+let quickPanelCloseAfterRunKey = "quickPanelCloseAfterRun"
+
 /// Routes APKs opened from Finder (double-click / "Open With") into the install
 /// inbox, which surfaces the device picker once the UI is ready.
 final class AppDelegate: NSObject, NSApplicationDelegate {

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -180,6 +180,9 @@ struct QuickActionsView: View {
     @State private var emulatorsLoading = false
     /// Outcome of the last action run from the panel, shown in the footer.
     @State private var lastRun: QuickRunOutcome?
+    /// Settings ▸ General ▸ Quick Actions: dismiss the panel once an action
+    /// completes successfully (failures always stay open).
+    @AppStorage(quickPanelCloseAfterRunKey) private var closeAfterRun = false
     @FocusState private var searchFocused: Bool
 
     @MainActor init(onClose: @escaping () -> Void) {
@@ -377,7 +380,7 @@ struct QuickActionsView: View {
             QuickActionFormView(
                 feature: feature,
                 targetsProvider: { explicitTargets(for: $0) },
-                onFinish: finish
+                onFinish: { finish($0) }
             )
         } else if isRoot {
             Divider()
@@ -1417,7 +1420,8 @@ struct QuickActionsView: View {
             state.requestDevice(serial)
             syncMemory()
             if !stack.isEmpty { pop() }
-            finish(QuickRunOutcome(message: "Now targeting \(label)", ok: true))
+            // Retargeting isn't an action — never auto-close on it.
+            finish(QuickRunOutcome(message: "Now targeting \(label)", ok: true), allowsAutoClose: false)
         case .chooseDevice(let serial, _):
             pickedSerial = serial
             approvedAllSerials = nil
@@ -1644,8 +1648,19 @@ struct QuickActionsView: View {
 
     /// Show the outcome in the footer. The panel stays up — chain more
     /// actions, use the result's Reveal/Copy, and leave with Esc.
-    private func finish(_ outcome: QuickRunOutcome) {
+    /// Every action path lands here with its final outcome. With the
+    /// Settings ▸ Quick Actions auto-close on, a successful run dismisses the
+    /// panel after a beat — long enough for the footer result to register —
+    /// while a failure always stays open so the error is readable.
+    /// `allowsAutoClose: false` is for outcomes that aren't really actions
+    /// (switching the target device).
+    private func finish(_ outcome: QuickRunOutcome, allowsAutoClose: Bool = true) {
         runningRowID = nil
         lastRun = outcome
+        guard closeAfterRun, allowsAutoClose, outcome.ok else { return }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(450))
+            onClose()
+        }
     }
 }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -51,6 +51,7 @@ struct GeneralSettingsView: View {
     @AppStorage("showMenuBarExtra") private var showMenuBar = true
     @AppStorage(keepRunningInBackgroundKey) private var keepRunningInBackground = true
     @AppStorage(quickPanelResumeMinutesKey) private var quickPanelResumeMinutes = 5
+    @AppStorage(quickPanelCloseAfterRunKey) private var closePanelAfterRun = false
     @State private var openAtLoginOn = false
     @State private var showMenuItems = false
     @State private var showQuickActionToggles = false
@@ -136,6 +137,10 @@ struct GeneralSettingsView: View {
                     Text("For 1 hour").tag(60)
                 }
                 Text("Reopening the panel within this window returns to the screen and device you had — after that it starts fresh. Open the panel with its global hotkey (record one in the Hotkeys tab) or from the menu bar icon.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                Toggle("Close the panel after running an action", isOn: $closePanelAfterRun)
+                Text("A successful action dismisses the panel right after its result shows; a failed one keeps it open so you can read the error.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
                 DisclosureGroup(isExpanded: $showQuickActionToggles) {


### PR DESCRIPTION
Settings ▸ General ▸ Quick Actions gains **"Close the panel after running an action"** (off by default, so nothing changes until opted in).

With it on:
- A successful action dismisses the panel ~450 ms after its footer result appears, so the outcome still registers.
- A failed action always keeps the panel open so the error is readable.
- Switching the target device ("Now targeting …") is not treated as an action and never auto-closes.

Every action path — instant/toggle features, in-panel forms, custom commands, app verbs, and APK installs — already funnels through the panel's single `finish` handler, so the hook covers them all in one place.

Testing: `make build` clean with warnings-as-errors; no ADBKit changes. The Settings toggle renders in the Quick Actions section. Worth one manual pass: enable the setting, run an instant action from the panel (it should flash the result and close), then run a failing one (it should stay open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)