### PR TITLE
Route ⌘F to the active tab's find or filter

### DIFF
--- a/App/Sources/FeatureDetail/LogFindBar.swift
+++ b/App/Sources/FeatureDetail/LogFindBar.swift
@@ -11,6 +11,12 @@ struct LogFindBar: View {
     let onNext: () -> Void
     let onPrevious: () -> Void
     let onClose: () -> Void
+    /// Bump to re-focus the field — ⌘F pressed while the bar is already open.
+    var focusToken = 0
+    /// Attach the ⌘G/⇧⌘G shortcuts only while the owning tab is the active
+    /// one — keep-alive hidden tabs stay mounted, and a hidden bar's
+    /// shortcuts steal the keys from the visible one.
+    var shortcutsActive = true
     @FocusState private var focused: Bool
 
     var body: some View {
@@ -38,13 +44,13 @@ struct LogFindBar: View {
             }
             .buttonStyle(IconButtonStyle())
             .help("Previous match (⇧⌘G)")
-            .keyboardShortcut("g", modifiers: [.command, .shift])
+            .keyboardShortcut(shortcutsActive ? KeyboardShortcut("g", modifiers: [.command, .shift]) : nil)
             Button(action: onNext) {
                 Image(systemName: "chevron.down")
             }
             .buttonStyle(IconButtonStyle())
             .help("Next match (⌘G)")
-            .keyboardShortcut("g", modifiers: .command)
+            .keyboardShortcut(shortcutsActive ? KeyboardShortcut("g", modifiers: .command) : nil)
             Button(action: onClose) {
                 Image(systemName: "xmark")
             }
@@ -56,5 +62,10 @@ struct LogFindBar: View {
         .padding(.vertical, 5)
         .background(.yellow.opacity(0.08))
         .onAppear { focused = true }
+        // Deferred: a synchronous @FocusState write doesn't take while
+        // another field (e.g. the sidebar search) still holds focus.
+        .onChange(of: focusToken) { _, _ in
+            Task { @MainActor in focused = true }
+        }
     }
 }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1011,10 +1011,21 @@ struct JSConsoleView: View {
             }
             Spacer(minLength: 8)
             levelFilter
-            Button { session.openFind() } label: { Image(systemName: "text.magnifyingglass") }
+            Button {
+                session.openFind()
+                // Re-focus when the bar is already open — the onChange
+                // focuser only fires on the closed→open transition. Deferred:
+                // a synchronous @FocusState write doesn't take while another
+                // field (e.g. the sidebar search) still holds focus.
+                Task { @MainActor in findFocused = true }
+            } label: { Image(systemName: "text.magnifyingglass") }
                 .buttonStyle(IconButtonStyle())
                 .help("Find & highlight in console (⌘F)")
-                .keyboardShortcut("f", modifiers: .command)
+                // Active-tab only — a hidden keep-alive tab winning ⌘F sends
+                // the focus request into an invisible view and it falls
+                // through to the sidebar search.
+                .keyboardShortcut(state.activeTabID == "js-console"
+                    ? KeyboardShortcut("f", modifiers: .command) : nil)
             Button { session.newestFirst.toggle() } label: { Image(systemName: "arrow.up.arrow.down") }
                 .buttonStyle(IconButtonStyle())
                 .help(session.newestFirst

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -26,6 +26,7 @@ struct LogcatView: View {
     @State private var findInput = ""
     @State private var find = ""
     @State private var currentFindID: UUID?
+    @State private var findFocusToken = 0
     @State private var waitingForPackage: String?
     @State private var streamingPid: Int?
     /// One-shot: the App filter is seeded from the device bar's chosen bundle
@@ -129,12 +130,17 @@ struct LogcatView: View {
 
             Button {
                 findVisible = true
+                findFocusToken += 1
             } label: {
                 Image(systemName: "text.magnifyingglass")
             }
             .buttonStyle(IconButtonStyle())
             .help("Find & highlight in the log without hiding lines (⌘F)")
-            .keyboardShortcut("f", modifiers: .command)
+            // Registered only while this is the focused pane's tab —
+            // keep-alive hidden tabs stay mounted, and a hidden tab winning
+            // ⌘F opens an invisible find bar whose focus request lands on the
+            // sidebar search.
+            .keyboardShortcut(isActiveTab ? KeyboardShortcut("f", modifiers: .command) : nil)
 
             Button {
                 newestFirst.toggle()
@@ -178,13 +184,17 @@ struct LogcatView: View {
 
     // MARK: - Find bar
 
+    private var isActiveTab: Bool { state.activeTabID == "logcat" }
+
     private func findBar(matches: [UUID]) -> some View {
         LogFindBar(
             text: $findInput,
             countLabel: findCountLabel(matches: matches),
             onNext: { currentFindID = LogLineFilter.advance(from: currentFindID, in: matches, forward: true) },
             onPrevious: { currentFindID = LogLineFilter.advance(from: currentFindID, in: matches, forward: false) },
-            onClose: closeFind
+            onClose: closeFind,
+            focusToken: findFocusToken,
+            shortcutsActive: isActiveTab
         )
         .task(id: findInput) {
             if !find.isEmpty || !findInput.isEmpty {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -679,6 +679,8 @@ final class ReactotronSession {
 /// follow-to-bottom. A second tab drives the client's custom commands.
 struct ReactotronView: View {
     @Environment(AppState.self) private var state
+    /// Bumped by ⌘F; the primary timeline pane focuses its search on change.
+    @State private var findFocusToken = 0
     @Environment(\.tabIsActive) private var tabIsActive
 
     // View-local UI only — drafts and the active tab/split. Everything that must
@@ -923,14 +925,30 @@ struct ReactotronView: View {
 
     @ViewBuilder
     private var timelineBody: some View {
-        if split {
-            HStack(spacing: 0) {
-                pane(showOnboarding: true)
-                Divider()
-                pane(showOnboarding: false)
+        Group {
+            if split {
+                HStack(spacing: 0) {
+                    pane(showOnboarding: true, findToken: findFocusToken)
+                    Divider()
+                    pane(showOnboarding: false)
+                }
+            } else {
+                pane(
+                    showOnboarding: true, trailing: AnyView(paneGlobalControls),
+                    findToken: findFocusToken
+                )
             }
-        } else {
-            pane(showOnboarding: true, trailing: AnyView(paneGlobalControls))
+        }
+        // ⌘F focuses the (first) timeline's search — Reactotron's only text
+        // filter, so that's what "find" means here. A zero-opacity button
+        // carries the shortcut, registered only while this is the focused
+        // pane's tab (hidden keep-alive tabs must not steal ⌘F).
+        .background {
+            Button("") { findFocusToken += 1 }
+                .keyboardShortcut(state.activeTabID == "reactotron"
+                    ? KeyboardShortcut("f", modifiers: .command) : nil)
+                .opacity(0)
+                .accessibilityHidden(true)
         }
     }
 
@@ -958,7 +976,9 @@ struct ReactotronView: View {
         }
     }
 
-    private func pane(showOnboarding: Bool, trailing: AnyView? = nil) -> some View {
+    private func pane(
+        showOnboarding: Bool, trailing: AnyView? = nil, findToken: Int = 0
+    ) -> some View {
         TimelinePane(
             items: session.displayedItems,
             targetEmpty: state.targetSerials.isEmpty,
@@ -966,6 +986,7 @@ struct ReactotronView: View {
             showOnboarding: showOnboarding,
             minContentWidth: session.maxRowWidth,
             trailing: trailing,
+            findToken: findToken,
             onExport: { session.export($0) },
             onRetry: { Task { await session.start(serials: readySerials) } }
         )
@@ -1421,6 +1442,9 @@ private struct TimelinePane: View {
     /// Extra trailing toolbar content — the global timeline controls when the
     /// pane is the only one on screen (no dedicated strip above it).
     let trailing: AnyView?
+    /// Bumped by the tab-level ⌘F to focus this pane's search (the primary
+    /// pane in a split; the second pane always gets the never-firing 0).
+    var findToken = 0
     let onExport: ([RtItem]) -> Void
     let onRetry: () -> Void
 
@@ -1469,7 +1493,7 @@ private struct TimelinePane: View {
             .help("Filter the timeline by event type")
             .sheet(isPresented: $showFilterSheet) { filterSheet }
 
-            SearchField(prompt: "Search…", text: $search)
+            SearchField(prompt: "Search…", text: $search, focusToken: findToken)
                 .frame(maxWidth: 200)
 
             Spacer()

--- a/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
@@ -39,6 +39,7 @@ struct SimulatorLogsView: View {
     @State private var findInput = ""
     @State private var find = ""
     @State private var currentFindID: UUID?
+    @State private var findFocusToken = 0
     /// The row parked at the viewport's bottom edge. Written to pin the tail;
     /// read back to detect the user returning to it.
     @State private var scrolledID: UUID?
@@ -176,12 +177,16 @@ struct SimulatorLogsView: View {
 
             Button {
                 findVisible = true
+                findFocusToken += 1
             } label: {
                 Image(systemName: "text.magnifyingglass")
             }
             .buttonStyle(IconButtonStyle())
             .help("Find & highlight in the log without hiding lines (⌘F)")
-            .keyboardShortcut("f", modifiers: .command)
+            // Active-tab only — a hidden keep-alive tab winning ⌘F opens an
+            // invisible find bar and the focus request falls through to the
+            // sidebar search.
+            .keyboardShortcut(isActiveTab ? KeyboardShortcut("f", modifiers: .command) : nil)
 
             Button {
                 paused.toggle()
@@ -287,13 +292,17 @@ struct SimulatorLogsView: View {
 
     // MARK: - Find bar
 
+    private var isActiveTab: Bool { state.activeTabID == "ios-logs" }
+
     private func findBar(matches: [UUID]) -> some View {
         LogFindBar(
             text: $findInput,
             countLabel: findCountLabel(matches: matches),
             onNext: { stepFind(in: matches, forward: true) },
             onPrevious: { stepFind(in: matches, forward: false) },
-            onClose: closeFind
+            onClose: closeFind,
+            focusToken: findFocusToken,
+            shortcutsActive: isActiveTab
         )
         .task(id: findInput) {
             if !find.isEmpty || !findInput.isEmpty {

--- a/App/Sources/SearchField.swift
+++ b/App/Sources/SearchField.swift
@@ -6,6 +6,9 @@ import SwiftUI
 struct SearchField: View {
     let prompt: String
     @Binding var text: String
+    /// Bump to focus the field programmatically (e.g. a ⌘F routed to the
+    /// pane that owns this search). The default never fires.
+    var focusToken = 0
     @FocusState private var focused: Bool
     @Environment(\.controlActiveState) private var controlActive
 
@@ -39,5 +42,10 @@ struct SearchField: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { focused = true }
+        // Deferred: a synchronous @FocusState write doesn't take while
+        // another field elsewhere still holds focus.
+        .onChange(of: focusToken) { _, _ in
+            Task { @MainActor in focused = true }
+        }
     }
 }


### PR DESCRIPTION
Fixes ⌘F focusing the sidebar search instead of the active feature's find bar.

**Root cause:** the find buttons in logcat, iOS Logs, and JS Console each carried an unconditional `keyboardShortcut("f")`. Keep-alive hidden tabs stay mounted, so SwiftUI could hand ⌘F to an *invisible* tab's button — its find bar opened where nobody could see it, and the focus request fell through to the first focusable field in the window: the sidebar search. A second layer: a synchronous `@FocusState` write doesn't take while another field still holds focus (exactly the state after using the ⌘T palette), so even the right tab could fail to focus its already-open bar.

**Changes:**
- The ⌘F shortcuts (and the find bar's ⌘G/⇧⌘G) register only while their feature is the focused pane's active tab.
- Re-focus requests (`LogFindBar`/`SearchField` focus tokens, JS Console's re-open) are deferred one runloop turn so they reliably take focus away from whichever field holds it.
- **Reactotron** gains ⌘F: it focuses the timeline's Search field — its only text filter (the primary pane in a split).
- The sidebar search is only ever focused by ⌘T or a click — unchanged, but no longer stolen into.

**Verified live** with logcat, iOS Logs, JS Console, and Reactotron tabs all open simultaneously (the collision scenario): ⌘F on logcat types into its find bar; ⌘F on Reactotron focuses its Search and live-filters; the sidebar search stayed empty throughout. JS Console was disconnected from Metro at test time, but the reported sidebar steal is verified gone and it shares the same deferred-focus path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)