### PR TITLE
Skippable welcome tour; bare connect IP defaults to port 5555

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
@@ -75,10 +75,6 @@ public struct ConnectionService: Sendable {
         return FeatureResult(ok: false, message: reason.isEmpty ? "Connection failed." : reason)
     }
 
-    /// Parse a pasted endpoint — the "IP address & Port" string the phone
-    /// displays — tolerating stray whitespace, a bare host, and IPv6 (bracketed
-    /// or not). Returns nil when the text isn't a plausible endpoint (empty,
-    /// inner spaces, or a non-numeric port).
     /// adb's default connect port — what `adb connect <host>` assumes.
     public static let defaultConnectPort = "5555"
 
@@ -93,12 +89,17 @@ public struct ConnectionService: Sendable {
         return WirelessEndpoint(host: endpoint.host, port: defaultConnectPort)
     }
 
+    /// Parse a pasted endpoint — the "IP address & Port" string the phone
+    /// displays — tolerating stray whitespace, a bare host, and IPv6 (bracketed
+    /// or not). Returns nil when the text isn't a plausible endpoint: empty,
+    /// inner spaces, a non-numeric port, or an implausible host (a truncated
+    /// IPv4 like "1.1.1", a non-parsing IPv6, a malformed hostname).
     public static func parseEndpoint(_ text: String) -> WirelessEndpoint? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else { return nil }
 
         func validated(host: String, port: String?) -> WirelessEndpoint? {
-            guard !host.isEmpty else { return nil }
+            guard isValidHost(host) else { return nil }
             if let port {
                 guard (1...5).contains(port.count), port.allSatisfy(\.isNumber) else { return nil }
             }
@@ -125,6 +126,46 @@ public struct ConnectionService: Sendable {
         default:
             // Bare IPv6 with no port — bracket it for adb.
             return validated(host: "[\(trimmed)]", port: nil)
+        }
+    }
+
+    /// A plausible adb host: a complete IPv4 address, a bracketed IPv6
+    /// literal, or a DNS hostname. Digits-and-dots input that isn't valid
+    /// IPv4 ("1.1.1", "256.1.1.1") is a truncated IP, not a hostname —
+    /// rejected so the sheet's buttons don't enable on it.
+    private static func isValidHost(_ host: String) -> Bool {
+        if host.hasPrefix("[") {
+            guard host.hasSuffix("]") else { return false }
+            return isIPv6(String(host.dropFirst().dropLast()))
+        }
+        if host.allSatisfy({ $0.isNumber || $0 == "." }) { return isIPv4(host) }
+        return isHostname(host)
+    }
+
+    private static func isIPv4(_ text: String) -> Bool {
+        let octets = text.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+        // `Int(_:)` also rejects non-ASCII digits that `isNumber` lets through.
+        return octets.allSatisfy { octet in
+            (1...3).contains(octet.count) && (Int(octet).map { $0 <= 255 } ?? false)
+        }
+    }
+
+    private static func isIPv6(_ text: String) -> Bool {
+        // A zone index ("fe80::1%en0") rides after the address proper.
+        let address = String(text.prefix { $0 != "%" })
+        guard !address.isEmpty else { return false }
+        var parsed = in6_addr()
+        return inet_pton(AF_INET6, address, &parsed) == 1
+    }
+
+    private static func isHostname(_ text: String) -> Bool {
+        guard text.count <= 253 else { return false }
+        let labels = text.split(separator: ".", omittingEmptySubsequences: false)
+        return labels.allSatisfy { label in
+            (1...63).contains(label.count)
+                && label.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" }
+                && label.first != "-" && label.last != "-"
         }
     }
 

--- a/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
@@ -79,6 +79,20 @@ public struct ConnectionService: Sendable {
     /// displays — tolerating stray whitespace, a bare host, and IPv6 (bracketed
     /// or not). Returns nil when the text isn't a plausible endpoint (empty,
     /// inner spaces, or a non-numeric port).
+    /// adb's default connect port — what `adb connect <host>` assumes.
+    public static let defaultConnectPort = "5555"
+
+    /// `parseEndpoint` for *connect* inputs: a bare host gets adb's default
+    /// port 5555 ("10.158.128.7" → "10.158.128.7:5555"), so the returned
+    /// endpoint always carries a port. Never use this for pairing — the
+    /// Android 11+ pairing port is random per session, so a default would
+    /// silently target the wrong port.
+    public static func parseConnectEndpoint(_ text: String) -> WirelessEndpoint? {
+        guard let endpoint = parseEndpoint(text) else { return nil }
+        guard endpoint.port == nil else { return endpoint }
+        return WirelessEndpoint(host: endpoint.host, port: defaultConnectPort)
+    }
+
     public static func parseEndpoint(_ text: String) -> WirelessEndpoint? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else { return nil }

--- a/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
@@ -92,8 +92,9 @@ public struct ConnectionService: Sendable {
     /// Parse a pasted endpoint — the "IP address & Port" string the phone
     /// displays — tolerating stray whitespace, a bare host, and IPv6 (bracketed
     /// or not). Returns nil when the text isn't a plausible endpoint: empty,
-    /// inner spaces, a non-numeric port, or an implausible host (a truncated
-    /// IPv4 like "1.1.1", a non-parsing IPv6, a malformed hostname).
+    /// inner spaces, a non-numeric or out-of-range port, or an implausible
+    /// host (a truncated IPv4 like "1.1.1", a non-parsing IPv6, a malformed
+    /// hostname).
     public static func parseEndpoint(_ text: String) -> WirelessEndpoint? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !trimmed.contains(where: \.isWhitespace) else { return nil }
@@ -101,7 +102,10 @@ public struct ConnectionService: Sendable {
         func validated(host: String, port: String?) -> WirelessEndpoint? {
             guard isValidHost(host) else { return nil }
             if let port {
-                guard (1...5).contains(port.count), port.allSatisfy(\.isNumber) else { return nil }
+                // `Int(_:)` rejects the non-ASCII digits `isNumber` lets through.
+                guard (1...5).contains(port.count), port.allSatisfy(\.isNumber),
+                      let value = Int(port), (1...65535).contains(value)
+                else { return nil }
             }
             return WirelessEndpoint(host: host, port: port)
         }

--- a/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
@@ -51,6 +51,9 @@ import Testing
         #expect(
             ConnectionService.parseConnectEndpoint("fe80::aa:1")
                 == WirelessEndpoint(host: "[fe80::aa:1]", port: "5555"))
+        #expect(
+            ConnectionService.parseConnectEndpoint("[fe80::1]")
+                == WirelessEndpoint(host: "[fe80::1]", port: "5555"))
     }
 
     @Test func connectParseKeepsAnExplicitPort() {
@@ -79,6 +82,22 @@ import Testing
         #expect(ConnectionService.parseEndpoint("[not-an-address]:5555") == nil)
         #expect(ConnectionService.parseEndpoint("-bad-.local:5555") == nil)
         #expect(ConnectionService.parseEndpoint("a..b:5555") == nil)
+    }
+
+    @Test func rejectsOutOfRangePorts() {
+        #expect(ConnectionService.parseEndpoint("192.168.1.42:0") == nil)
+        #expect(ConnectionService.parseEndpoint("192.168.1.42:65536") == nil)
+        #expect(ConnectionService.parseEndpoint("192.168.1.42:99999") == nil)
+        #expect(ConnectionService.parseConnectEndpoint("192.168.1.42:0") == nil)
+        #expect(
+            ConnectionService.parseEndpoint("192.168.1.42:65535")
+                == WirelessEndpoint(host: "192.168.1.42", port: "65535"))
+    }
+
+    @Test func rejectsURLPastes() {
+        #expect(ConnectionService.parseEndpoint("http://1.2.3.4:5555") == nil)
+        #expect(ConnectionService.parseEndpoint("http://x") == nil)
+        #expect(ConnectionService.parseConnectEndpoint("http://1.2.3.4:5555") == nil)
     }
 
     @Test func acceptsZonedIPv6() {

--- a/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
@@ -41,6 +41,33 @@ import Testing
                 == WirelessEndpoint(host: "[fe80::aa:1]", port: nil))
     }
 
+    @Test func connectParseDefaultsBareHostToPort5555() {
+        #expect(
+            ConnectionService.parseConnectEndpoint("10.158.128.7")
+                == WirelessEndpoint(host: "10.158.128.7", port: "5555"))
+        #expect(
+            ConnectionService.parseConnectEndpoint("pixel.local")
+                == WirelessEndpoint(host: "pixel.local", port: "5555"))
+        #expect(
+            ConnectionService.parseConnectEndpoint("fe80::aa:1")
+                == WirelessEndpoint(host: "[fe80::aa:1]", port: "5555"))
+    }
+
+    @Test func connectParseKeepsAnExplicitPort() {
+        #expect(
+            ConnectionService.parseConnectEndpoint("192.168.1.42:40913")
+                == WirelessEndpoint(host: "192.168.1.42", port: "40913"))
+        #expect(
+            ConnectionService.parseConnectEndpoint("[fe80::1]:37123")
+                == WirelessEndpoint(host: "[fe80::1]", port: "37123"))
+    }
+
+    @Test func connectParseStillRejectsGarbage() {
+        #expect(ConnectionService.parseConnectEndpoint("") == nil)
+        #expect(ConnectionService.parseConnectEndpoint("192.168.1.42:") == nil)
+        #expect(ConnectionService.parseConnectEndpoint("192.168.1.42 :5555") == nil)
+    }
+
     @Test func rejectsGarbage() {
         #expect(ConnectionService.parseEndpoint("") == nil)
         #expect(ConnectionService.parseEndpoint("   ") == nil)

--- a/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
@@ -68,6 +68,25 @@ import Testing
         #expect(ConnectionService.parseConnectEndpoint("192.168.1.42 :5555") == nil)
     }
 
+    @Test func rejectsImplausibleHosts() {
+        #expect(ConnectionService.parseEndpoint("1.1.1") == nil)
+        #expect(ConnectionService.parseEndpoint("1.1.1.") == nil)
+        #expect(ConnectionService.parseEndpoint("1.1.1.1.1") == nil)
+        #expect(ConnectionService.parseEndpoint("256.1.1.1:5555") == nil)
+        #expect(ConnectionService.parseEndpoint("192.168.1:5555") == nil)
+        #expect(ConnectionService.parseEndpoint("1234.1.1.1") == nil)
+        #expect(ConnectionService.parseConnectEndpoint("1.1.1") == nil)
+        #expect(ConnectionService.parseEndpoint("[not-an-address]:5555") == nil)
+        #expect(ConnectionService.parseEndpoint("-bad-.local:5555") == nil)
+        #expect(ConnectionService.parseEndpoint("a..b:5555") == nil)
+    }
+
+    @Test func acceptsZonedIPv6() {
+        #expect(
+            ConnectionService.parseEndpoint("[fe80::1%en0]:5555")
+                == WirelessEndpoint(host: "[fe80::1%en0]", port: "5555"))
+    }
+
     @Test func rejectsGarbage() {
         #expect(ConnectionService.parseEndpoint("") == nil)
         #expect(ConnectionService.parseEndpoint("   ") == nil)

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -258,7 +258,6 @@ struct TourView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
     }
-
 }
 
 /// The try-it page's stage: the user's own hotkey drawn as oversized keycaps

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -7,11 +7,11 @@ import SwiftUI
 /// the sidebar, tabs & split panes, roles, settings & hotkeys, then the two
 /// Quick Actions steps: *pick the hotkey* (recorder inline; Next stays
 /// disabled until one is set) and *try it*, whose stage is the user's own
-/// hotkey drawn as keycaps pressing themselves. The try page is the only
-/// exit and it can't be skipped: pressing the hotkey for real — building the
-/// muscle memory, no button shortcut — opens Quick Actions, completes the
-/// tour, marks it seen, and fires the confetti celebration
-/// (`AppState.noteQuickActionsOpened`).
+/// hotkey drawn as keycaps pressing themselves. Pressing the hotkey for real
+/// on the try page opens Quick Actions, completes the tour, and fires the
+/// confetti celebration (`AppState.noteQuickActionsOpened`) — but nothing is
+/// mandatory: Skip, the try page's Finish button, and Esc all end the tour
+/// too (`AppState.endTour`, seen-marked, just without confetti).
 struct TourView: View {
     @Environment(AppState.self) private var state
     @State private var index = 0
@@ -59,9 +59,6 @@ struct TourView: View {
             controls
         }
         .frame(width: 780, height: 700)
-        // Non-skippable: no Esc / click-away dismissal — the tour ends by
-        // trying Quick Actions on the last page.
-        .interactiveDismissDisabled()
         .onAppear { quickActionsShortcut = KeyboardShortcuts.getShortcut(for: .quickActions) }
         .onChange(of: HotkeyRecording.shared.active) {
             quickActionsShortcut = KeyboardShortcuts.getShortcut(for: .quickActions)
@@ -71,7 +68,9 @@ struct TourView: View {
         .onChange(of: index, initial: true) { _, new in
             state.awaitingQuickActionsTry = new == Self.pages.count - 1
         }
-        .onDisappear { state.awaitingQuickActionsTry = false }
+        // Any dismissal counts as seen — an Esc'd tour must not re-present on
+        // the next launch. Idempotent after a hotkey-press finish.
+        .onDisappear { state.endTour() }
     }
 
     private var content: some View {
@@ -182,7 +181,7 @@ struct TourView: View {
     /// The last step's walkthrough: pressing the hotkey to open the panel is
     /// the tour's finish line (confetti included), so spell out exactly how —
     /// plus the menu-bar fallback, because a hotkey another app already owns
-    /// silently never fires and this page has no other way out.
+    /// silently never fires.
     private var tryGuide: some View {
         VStack(alignment: .leading, spacing: 6) {
             guideRow(1, "Press \(shortcutHint) — it works anywhere, even with this window closed.")
@@ -214,9 +213,8 @@ struct TourView: View {
 
     private var controls: some View {
         HStack {
-            // Skip only fast-forwards to the last page — the try-it step
-            // itself has no skip; opening the panel is the tour's one exit.
-            Button("Skip") { skip() }
+            // Skip ends the tour outright; the last page trades it for Finish.
+            Button("Skip") { state.endTour() }
                 .buttonStyle(.plain)
                 .foregroundStyle(.textMuted)
                 // A quiet, secondary action — suppress the accent-colored
@@ -242,31 +240,25 @@ struct TourView: View {
                     // On the try page this returns to the pick-hotkey page.
                     Button("Back") { withAnimation { index -= 1 } }
                 }
-                if !isLast {
+                if isLast {
+                    // Pressing the hotkey is the celebrated finish (confetti
+                    // via `noteQuickActionsOpened`), but it's an invitation,
+                    // not a gate — Finish ends the tour without it.
+                    Button("Finish") { state.endTour() }
+                        .keyboardShortcut(.defaultAction)
+                } else {
                     // The try page needs a hotkey to press, so the pick page
                     // holds the gate.
                     Button("Next") { withAnimation { index += 1 } }
                         .keyboardShortcut(.defaultAction)
                         .disabled(isHotkeyPage && quickActionsShortcut == nil)
                 }
-                // The try page adds no forward control on purpose: the finish
-                // line is *pressing the hotkey* — the muscle memory the panel
-                // lives on. The open completes the tour
-                // (`noteQuickActionsOpened`) and pops confetti.
             }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)
     }
 
-    /// Skipping mid-tour jumps to the tour's payoff: the try-it finale, via
-    /// the pick-hotkey page when none is recorded yet (the finale needs a
-    /// hotkey to press).
-    private func skip() {
-        withAnimation {
-            index = quickActionsShortcut == nil ? Self.pages.count - 2 : Self.pages.count - 1
-        }
-    }
 }
 
 /// The try-it page's stage: the user's own hotkey drawn as oversized keycaps

--- a/App/Sources/Root/WirelessConnectSheet.swift
+++ b/App/Sources/Root/WirelessConnectSheet.swift
@@ -128,7 +128,7 @@ struct WirelessConnectSheet: View {
                     HubField("IP address & port", prompt: "192.168.1.42:40913", text: $pairConnectEndpoint)
                     Button("Connect") { runConnect(pairConnectEndpoint) }
                         .buttonStyle(.borderedProminent)
-                        .disabled(busy || completeEndpoint(pairConnectEndpoint) == nil)
+                        .disabled(busy || ConnectionService.parseConnectEndpoint(pairConnectEndpoint) == nil)
                 }
             }
         }
@@ -146,7 +146,7 @@ struct WirelessConnectSheet: View {
                 HubField("IP address & port", prompt: "192.168.1.42:5555", text: $connectEndpoint)
                 Button("Connect") { runConnect(connectEndpoint) }
                     .buttonStyle(.borderedProminent)
-                    .disabled(busy || completeEndpoint(connectEndpoint) == nil)
+                    .disabled(busy || ConnectionService.parseConnectEndpoint(connectEndpoint) == nil)
             }
         }
     }
@@ -213,8 +213,8 @@ struct WirelessConnectSheet: View {
         return (endpoint.host, endpoint.port ?? "", code)
     }
 
-    /// An endpoint that parses *and* carries a port — both adb commands here
-    /// need one.
+    /// The pairing endpoint must parse *and* carry an explicit port — the
+    /// pairing port is random per session, so nothing sensible to default to.
     private func completeEndpoint(_ text: String) -> WirelessEndpoint? {
         guard let endpoint = ConnectionService.parseEndpoint(text), endpoint.port != nil else { return nil }
         return endpoint
@@ -231,8 +231,10 @@ struct WirelessConnectSheet: View {
         }
     }
 
+    /// Connect fields take a bare IP too — it defaults to adb's port 5555.
     private func runConnect(_ endpointText: String) {
-        guard let endpoint = completeEndpoint(endpointText), let port = endpoint.port else { return }
+        guard let endpoint = ConnectionService.parseConnectEndpoint(endpointText),
+              let port = endpoint.port else { return }
         let connection = state.env.engine.connection
         run({ try await connection.connect(host: endpoint.host, port: port) }) { result in
             finishConnected(result, address: "\(endpoint.host):\(port)")

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -150,7 +150,7 @@ final class AppState {
     /// Drives the first-launch / replayable welcome tour sheet.
     var presentTour = false
     /// True while the tour's final "try Quick Actions" page is on screen —
-    /// opening the panel is the tour's only exit (see TourView).
+    /// pressing the hotkey there finishes the tour with confetti (see TourView).
     var awaitingQuickActionsTry = false
     /// Bumped to fire a confetti burst over the main window (see
     /// `ConfettiCelebration` in RootView).
@@ -166,6 +166,15 @@ final class AppState {
         UserDefaults.standard.set(true, forKey: "hasSeenTour")
         presentTour = false
         confettiTrigger += 1
+    }
+
+    /// Ends the tour without the Quick Actions try — Skip, Finish, or an Esc
+    /// dismissal. Marks it seen so it never re-presents; no confetti (that's
+    /// the reward for pressing the hotkey for real).
+    func endTour() {
+        awaitingQuickActionsTry = false
+        UserDefaults.standard.set(true, forKey: "hasSeenTour")
+        presentTour = false
     }
     /// Drives the first-launch role picker (a full-window takeover) and the
     /// "Change role" flow. Picking a role seeds a curated feature set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,10 +311,11 @@ platforms annotation without a runner.
   mistaken for a window close). The app stays resident for the menu bar, the
   per-feature hotkeys, and `QuickActionsPanel` — a **non-activating**
   `FloatingPanelController` panel (global hotkey in Settings ▸ Hotkeys; the
-  welcome tour ends on two mandatory pages — record the hotkey (Next gated
+  welcome tour ends on two Quick Actions pages — record the hotkey (Next gated
   until one is set, ⇧⌘Space recommended), then a try-it finale whose keycap
-  animation waits for the real press: opening the panel is the tour's only
-  exit and fires the confetti, `AppState.noteQuickActionsOpened`) that is
+  animation invites the real press: opening the panel fires the confetti,
+  `AppState.noteQuickActionsOpened`, but Skip/Finish/Esc also end the tour,
+  `AppState.endTour`) that is
   a small push-navigation mini app. The root is a *grid* of everything
   runnable in place — saved custom commands (pinnable, stored on the
   command), every *enabled* implemented


### PR DESCRIPTION
## What

**Skippable welcome tour.** The tour previously had one exit: pressing the Quick Actions hotkey on the final page. Now:
- Skip ends the tour (it used to fast-forward to the finale).
- The try-it page has a Finish button (⏎).
- Esc / click-away dismisses the sheet.
- Every exit routes through `AppState.endTour`, which marks the tour seen so it never re-presents. Pressing the hotkey for real still completes with confetti.
- The pick-hotkey page's Next gate is unchanged (the finale needs a recorded hotkey); Skip is available there.

**Bare connect IP defaults to port 5555.** `ConnectionService.parseConnectEndpoint` (new) fills adb's default port when the input has no port, so the wireless sheet's Connect buttons accept `10.158.128.7` and target `10.158.128.7:5555`. Hostnames and bare IPv6 included. The pairing field still requires an explicit port — the Android 11+ pairing port is random per session.

## Tests

- 3 new parser tests (default applied, explicit port kept, garbage rejected); 824 ADBKit tests green.
- Tour driven live via AX: Skip verified from page 1 and the pick-hotkey page, Finish renders on the finale, Next stays disabled without a hotkey, and any dismissal sets `hasSeenTour`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)