### PR TITLE
ui issues fixed

### DIFF
--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -139,6 +139,12 @@ struct NotificationBell: View {
                         Text(state.unreadNotifications > 99 ? "99+" : "\(state.unreadNotifications)")
                             .font(.app(size: 9, weight: .bold))
                             .foregroundStyle(.white)
+                            // The badge is an overlay sized to the bell (~16pt),
+                            // so a tight layout pass would propose the count too
+                            // little width and it truncated to "…"; hug the
+                            // content so the number always renders in full.
+                            .lineLimit(1)
+                            .fixedSize()
                             .padding(.horizontal, 3)
                             .frame(minWidth: 9)
                             .padding(.vertical, 1)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -631,7 +631,13 @@ private struct EditorPane: View {
     @State private var contentTargeted = false
 
     var body: some View {
-        VStack(spacing: 0) {
+        // Leading alignment, not the VStack default of center: a hidden tab
+        // whose content can't compress (a wide toolbar, the catalog grid)
+        // widens this VStack past the pane, and a centered tab strip then
+        // shifts right until the pane's clip eats its trailing scroll arrow.
+        // Pinning leading keeps the strip flush at x=0 so both ‹ › arrows stay
+        // inside the clipped pane regardless of how many tabs are open.
+        VStack(alignment: .leading, spacing: 0) {
             TabStripView(group: index)
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION

UI Issues 
<img width="133" height="94" alt="Screenshot 2026-07-16 at 10 51 57 PM" src="https://github.com/user-attachments/assets/be0ec020-5d92-4fc3-819a-fd5a7b5b932a" />

Right arrow key to scroll the horizontal sidebar and + button was cropped
<img width="472" height="41" alt="Screenshot 2026-07-16 at 10 45 19 PM" src="https://github.com/user-attachments/assets/44749e68-140b-4180-9c8a-ecd13687a4cb" />

<!--
PR guidelines: docs/PULL_REQUESTS.md
Describe what the code does NOW — not discarded approaches. Plain, factual
language. No AI attribution (no co-author trailer, no "Generated with…").
-->

## What changed

<!-- One or two sentences. What does the code do now? -->

## Why

<!-- The problem or motivation. Closes #NN if applicable. -->

## Impact area

<!-- What else could this affect? Delete the lines that don't apply. -->

- [ ] Shared `ADBKit` service used by other features
- [ ] `FeatureRegistry` / `FeatureNotes` / hub membership
- [ ] Persisted state schema (`Persistence/`, `~/Library/Application Support/Droidective/`)
- [ ] Bundled tools / release / signing / appcast
- [ ] None — isolated to one feature

## How verified

<!-- swift test + build, and what you exercised live. Screenshots/GIF for UI. -->

- [ ] `make test` green
- [ ] `make build` succeeds with **zero warnings**
- [ ] Ran the app and verified live (device/emulator + Android version): …

## Checklist

- [ ] Logic lives in `ADBKit`, not in a SwiftUI view
- [ ] New parsers / command construction are tested
- [ ] New feature registered in `FeatureRegistry` **and** has a `FeatureNotes` entry
- [ ] `prek run` passes (gitleaks secret scan)
- [ ] No secrets, no commented-out code, no relative `..` imports, no AI attribution
