### PR TITLE
Shield pane content from feature drop regions during tab drags

### DIFF
--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -659,18 +659,22 @@ private struct EditorPane: View {
             TabStripView(group: index)
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .onDrop(of: [.workspaceTab], delegate: TabPaneDrop(
-                    state: state,
-                    onDrop: { id in
-                        if state.isSplit {
-                            state.moveTab(id, toGroup: index)
-                        } else {
-                            state.splitTab(id)
-                        }
-                        state.draggingTabID = nil
-                    },
-                    onTargetedChange: { contentTargeted = $0 }
-                ))
+                .onDrop(of: [.workspaceTab], delegate: paneDrop)
+                .overlay {
+                    // Drops route to the deepest region under the cursor even
+                    // when its types don't match (see CLAUDE.md) — a feature's
+                    // own full-pane dropDestination (AAB to APK, opened APK)
+                    // swallows a dragged tab, killing drop-to-split whenever
+                    // such a tab is merely open. While a tab drag is live,
+                    // shield the content with a topmost workspaceTab target;
+                    // it vanishes with the drag, so feature drops (APKs from
+                    // Finder…) are untouched otherwise.
+                    if state.draggingTabID != nil {
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .onDrop(of: [.workspaceTab], delegate: paneDrop)
+                    }
+                }
                 .overlay(alignment: .trailing) {
                     // Only promise a split the model will honor: `split()`
                     // requires >1 tab (something must stay behind), so a
@@ -680,6 +684,21 @@ private struct EditorPane: View {
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var paneDrop: TabPaneDrop {
+        TabPaneDrop(
+            state: state,
+            onDrop: { id in
+                if state.isSplit {
+                    state.moveTab(id, toGroup: index)
+                } else {
+                    state.splitTab(id)
+                }
+                state.draggingTabID = nil
+            },
+            onTargetedChange: { contentTargeted = $0 }
+        )
     }
 
     /// Non-interactive right-half wash showing where the new split pane will land


### PR DESCRIPTION
Drag-to-split/move died whenever an AAB to APK or opened-APK tab was open: both screens attach a full-pane URL dropDestination, drops route to the deepest region under the cursor even when its types don't match, and hidden keep-alive tabs keep their regions — the same failure the Terminal's catch-all caused in v2.8.1.

While a tab drag is live (`AppState.draggingTabID`), `EditorPane` overlays the content with a topmost `workspaceTab` drop target. It vanishes when the drag ends, so Finder APK/AAB drops behave as before.

Verified by hand on a live build (synthetic drags can't initiate SwiftUI drag sessions): tab drop-to-split and cross-pane moves work with the AAB tab open; Finder drops still land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)