### PR TITLE
Rework Send Text snippets: one creator, recent tags, searchable library

### DIFF
--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -314,11 +314,11 @@ public struct LayoutState: Codable, Sendable, Equatable {
     }
 }
 
-/// A saved Send Text snippet: a short display name (what the tag chips and
-/// menu show) over the text that gets inserted. `uses` ranks the top-5
-/// quick-insert tags under the text field; the text may hold
-/// `{clipboard}`/`{ip}` placeholders expanded by `SnippetPlaceholders` at
-/// insert time.
+/// A saved Send Text snippet: a short display name (what the tag chips show)
+/// over the text that gets inserted. `lastUsedAt` (epoch seconds) ranks the
+/// recently-used tags under the text field — `uses` breaks ties and ranks
+/// never-used snippets; the text may hold `{clipboard}`/`{ip}` placeholders
+/// expanded by `SnippetPlaceholders` at insert time.
 public struct SendTextSnippet: Codable, Sendable, Equatable, Identifiable {
     /// Names longer than this are clamped — chips and menu rows stay short.
     public static let nameLimit = 24
@@ -326,13 +326,26 @@ public struct SendTextSnippet: Codable, Sendable, Equatable, Identifiable {
     public var name: String
     public var text: String
     public var uses: Int
+    /// Epoch seconds of the last insert (or creation). Optional so files
+    /// written before the field existed still decode; nil sorts last.
+    public var lastUsedAt: Double?
 
     public var id: String { name }
 
-    public init(name: String, text: String, uses: Int = 0) {
+    public init(name: String, text: String, uses: Int = 0, lastUsedAt: Double? = nil) {
         self.name = String(name.prefix(Self.nameLimit))
         self.text = text
         self.uses = uses
+        self.lastUsedAt = lastUsedAt
+    }
+
+    /// Case-insensitive match on the name (the tag's title) or the inserted
+    /// text — what the snippet search box filters by.
+    public func matches(_ query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return true }
+        return name.localizedCaseInsensitiveContains(trimmed)
+            || text.localizedCaseInsensitiveContains(trimmed)
     }
 }
 
@@ -363,14 +376,18 @@ public struct Presets: Codable, Sendable, Equatable {
 
     /// Adds a snippet with a trimmed, length-clamped name; false (and no
     /// change) when the name or text is empty or the name is already taken.
+    /// A new snippet is stamped as just-used so it leads the recent tags —
+    /// the thing you just saved is the thing you're about to insert.
     @discardableResult
-    public mutating func addSnippet(named name: String, text: String) -> Bool {
+    public mutating func addSnippet(
+        named name: String, text: String, at date: Double = Date().timeIntervalSince1970
+    ) -> Bool {
         let trimmedName = String(
             name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(SendTextSnippet.nameLimit))
         guard !trimmedName.isEmpty, !text.isEmpty,
               !sendTextSnippets.contains(where: { $0.name == trimmedName })
         else { return false }
-        sendTextSnippets.append(SendTextSnippet(name: trimmedName, text: text))
+        sendTextSnippets.append(SendTextSnippet(name: trimmedName, text: text, lastUsedAt: date))
         return true
     }
 
@@ -378,18 +395,29 @@ public struct Presets: Codable, Sendable, Equatable {
         sendTextSnippets.removeAll { $0.name == name }
     }
 
-    /// Bumps the use count that ranks the quick-insert tags.
-    public mutating func recordSnippetUse(named name: String) {
+    /// Bumps the use count and freshness that rank the quick-insert tags.
+    public mutating func recordSnippetUse(
+        named name: String, at date: Double = Date().timeIntervalSince1970
+    ) {
         guard let index = sendTextSnippets.firstIndex(where: { $0.name == name }) else { return }
         sendTextSnippets[index].uses += 1
+        sendTextSnippets[index].lastUsedAt = date
     }
 
-    /// The most-used snippets, ties kept in the order they were saved.
-    public func topSnippets(limit: Int) -> [SendTextSnippet] {
+    /// The most recently used snippets — the quick-insert tag row. Never-used
+    /// snippets (files from before `lastUsedAt` existed) follow, ranked by
+    /// use count, ties kept in the order they were saved.
+    public func recentSnippets(limit: Int) -> [SendTextSnippet] {
         sendTextSnippets.enumerated()
             .sorted { lhs, rhs in
-                if lhs.element.uses != rhs.element.uses { return lhs.element.uses > rhs.element.uses }
-                return lhs.offset < rhs.offset
+                switch (lhs.element.lastUsedAt, rhs.element.lastUsedAt) {
+                case (let left?, let right?) where left != right: return left > right
+                case (.some, .none): return true
+                case (.none, .some): return false
+                default:
+                    if lhs.element.uses != rhs.element.uses { return lhs.element.uses > rhs.element.uses }
+                    return lhs.offset < rhs.offset
+                }
             }
             .prefix(limit)
             .map(\.element)

--- a/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
@@ -113,16 +113,16 @@ import Testing
         let dir = try tempDir()
         let store = JSONStore(filename: "presets.json", default: Presets(), directory: dir)
         try await store.update {
-            $0.addSnippet(named: "Login email", text: "user@example.com")
-            $0.addSnippet(named: "Metro host", text: "{ip}:8081")
-            $0.recordSnippetUse(named: "Metro host")
+            $0.addSnippet(named: "Login email", text: "user@example.com", at: 100)
+            $0.addSnippet(named: "Metro host", text: "{ip}:8081", at: 200)
+            $0.recordSnippetUse(named: "Metro host", at: 300)
         }
 
         let fresh = JSONStore(filename: "presets.json", default: Presets(), directory: dir)
         let loaded = await fresh.load()
         #expect(loaded.sendTextSnippets == [
-            SendTextSnippet(name: "Login email", text: "user@example.com", uses: 0),
-            SendTextSnippet(name: "Metro host", text: "{ip}:8081", uses: 1),
+            SendTextSnippet(name: "Login email", text: "user@example.com", uses: 0, lastUsedAt: 100),
+            SendTextSnippet(name: "Metro host", text: "{ip}:8081", uses: 1, lastUsedAt: 300),
         ])
     }
 

--- a/ADBKit/Tests/ADBKitTests/SendTextSnippetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SendTextSnippetTests.swift
@@ -35,30 +35,57 @@ import Testing
         #expect(presets.sendTextSnippets.map(\.name) == ["b"])
     }
 
-    @Test func recordUseBumpsOnlyTheMatch() {
+    @Test func recordUseBumpsAndStampsOnlyTheMatch() {
         var presets = Presets(sendTextSnippets: [
             SendTextSnippet(name: "a", text: "1"), SendTextSnippet(name: "b", text: "2"),
         ])
-        presets.recordSnippetUse(named: "b")
-        presets.recordSnippetUse(named: "b")
-        presets.recordSnippetUse(named: "missing")
+        presets.recordSnippetUse(named: "b", at: 100)
+        presets.recordSnippetUse(named: "b", at: 200)
+        presets.recordSnippetUse(named: "missing", at: 300)
         #expect(presets.sendTextSnippets == [
             SendTextSnippet(name: "a", text: "1", uses: 0),
-            SendTextSnippet(name: "b", text: "2", uses: 2),
+            SendTextSnippet(name: "b", text: "2", uses: 2, lastUsedAt: 200),
         ])
     }
 
-    @Test func topSnippetsRanksByUsesThenSaveOrder() {
+    @Test func addStampsANewSnippetAsJustUsed() {
+        var presets = Presets()
+        presets.addSnippet(named: "fresh", text: "x", at: 42)
+        #expect(presets.sendTextSnippets.first?.lastUsedAt == 42)
+    }
+
+    @Test func recentSnippetsRankByFreshnessThenUsesThenSaveOrder() {
         let presets = Presets(sendTextSnippets: [
             SendTextSnippet(name: "old-tie", text: "1", uses: 1),
-            SendTextSnippet(name: "hot", text: "2", uses: 5),
+            SendTextSnippet(name: "yesterday", text: "2", uses: 1, lastUsedAt: 1000),
             SendTextSnippet(name: "new-tie", text: "3", uses: 1),
-            SendTextSnippet(name: "cold", text: "4", uses: 0),
-            SendTextSnippet(name: "warm", text: "5", uses: 3),
-            SendTextSnippet(name: "mild", text: "6", uses: 2),
+            SendTextSnippet(name: "just-now", text: "4", uses: 0, lastUsedAt: 3000),
+            SendTextSnippet(name: "this-morning", text: "5", uses: 9, lastUsedAt: 2000),
+            SendTextSnippet(name: "much-used", text: "6", uses: 5),
         ])
-        // The quick-insert row shows at most the top 5.
-        #expect(presets.topSnippets(limit: 5).map(\.name) == ["hot", "warm", "mild", "old-tie", "new-tie"])
+        // Freshness first; never-used snippets (pre-lastUsedAt files) follow
+        // by use count, ties in save order.
+        #expect(presets.recentSnippets(limit: 6).map(\.name) == [
+            "just-now", "this-morning", "yesterday", "much-used", "old-tie", "new-tie",
+        ])
+        #expect(presets.recentSnippets(limit: 2).map(\.name) == ["just-now", "this-morning"])
+    }
+
+    @Test func snippetsWithoutLastUsedAtStillDecode() throws {
+        // Files written before the field existed carry no lastUsedAt key.
+        let old = Data(#"{"name":"a","text":"1","uses":3}"#.utf8)
+        let snippet = try JSONDecoder().decode(SendTextSnippet.self, from: old)
+        #expect(snippet == SendTextSnippet(name: "a", text: "1", uses: 3, lastUsedAt: nil))
+    }
+
+    @Test func matchesSearchesNameAndTextCaseInsensitively() {
+        let snippet = SendTextSnippet(name: "Metro host", text: "{ip}:8081")
+        #expect(snippet.matches("metro"))
+        #expect(snippet.matches("8081"))
+        #expect(snippet.matches("{IP}"))
+        #expect(snippet.matches("  metro "))
+        #expect(snippet.matches(""))
+        #expect(!snippet.matches("logcat"))
     }
 
     // MARK: - Placeholder expansion

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -73,6 +73,14 @@ struct FormActionView: View {
                     .font(.app(.callout))
             }
 
+            if isSendText, let textField = feature.fields.first(where: { $0.name == "text" }) {
+                VStack(alignment: .leading, spacing: 8) {
+                    newSnippetButton(for: textField)
+                    snippetLibrary(for: textField)
+                }
+                .padding(.top, 4)
+            }
+
             LastResultCard(featureID: feature.id)
         }
         .centeredCard()
@@ -183,11 +191,11 @@ struct FormActionView: View {
         switch field.control {
         case .text, .number, .bundle:
             if isSendText, field.name == "text" {
+                // Quick inserts stay at the field; creating and browsing the
+                // full library live below the Run button (see formContent).
                 VStack(alignment: .leading, spacing: 8) {
                     plainTextField(for: field)
                     snippetTags(for: field)
-                    newSnippetButton(for: field)
-                    snippetLibrary(for: field)
                 }
             } else {
                 plainTextField(for: field)

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -327,11 +327,13 @@ struct FormActionView: View {
             let shown = showAllSnippets || !query.isEmpty
                 ? library
                 : Array(library.prefix(Self.collapsedLibraryLimit))
-            SnippetTagFlow(spacing: 6) {
+            VStack(spacing: 0) {
                 ForEach(shown) { snippet in
-                    snippetChip(snippet, field: field)
+                    snippetRow(snippet, field: field)
+                    if snippet.id != shown.last?.id { Divider() }
                 }
                 if query.isEmpty, library.count > Self.collapsedLibraryLimit {
+                    Divider()
                     Button {
                         showAllSnippets.toggle()
                     } label: {
@@ -339,14 +341,47 @@ struct FormActionView: View {
                             ? "Show less"
                             : "Show \(library.count - Self.collapsedLibraryLimit) more")
                             .font(.app(.caption))
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .overlay(Capsule().strokeBorder(.borderSubtle))
-                            .contentShape(Capsule())
+                            .foregroundStyle(.textMuted)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 6)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(.textMuted)
                 }
+            }
+            .background(.bgSurface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(.borderSubtle))
+            .frame(maxWidth: 380, alignment: .leading)
+        }
+    }
+
+    /// One library row: the name beside a muted preview of the text — click
+    /// inserts, right-click removes.
+    private func snippetRow(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
+        Button {
+            insert(snippet, into: field)
+        } label: {
+            HStack(spacing: 10) {
+                Text(snippet.name)
+                    .font(.app(.callout))
+                    .lineLimit(1)
+                Spacer(minLength: 12)
+                Text(snippet.text)
+                    .font(.app(.caption, design: .monospaced))
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Click to insert · right-click to remove")
+        .contextMenu {
+            Button("Remove Snippet", role: .destructive) {
+                presets.removeSnippet(named: snippet.name)
+                persistPresets()
             }
         }
     }

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -19,6 +19,8 @@ struct FormActionView: View {
     @State private var creatingSnippet = false
     @State private var newSnippetName = ""
     @State private var newSnippetText = ""
+    @State private var snippetSearch = ""
+    @State private var showAllSnippets = false
     @State private var confirmingRun = false
     @FocusState private var focusedField: String?
     /// Send Text: wipe the field after a successful send, for firing a sequence
@@ -181,12 +183,11 @@ struct FormActionView: View {
         switch field.control {
         case .text, .number, .bundle:
             if isSendText, field.name == "text" {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 4) {
-                        plainTextField(for: field)
-                        snippetsMenu(for: field)
-                    }
+                VStack(alignment: .leading, spacing: 8) {
+                    plainTextField(for: field)
                     snippetTags(for: field)
+                    newSnippetButton(for: field)
+                    snippetLibrary(for: field)
                 }
             } else {
                 plainTextField(for: field)
@@ -237,82 +238,130 @@ struct FormActionView: View {
 
     // MARK: - Send Text snippets
 
-    /// The full snippet list plus management: every saved snippet by name,
-    /// the Mac's IP as a quick insert for the React Native role, New
-    /// Snippet…, and removal. The top-5 tags below the field cover the
-    /// everyday inserts; this menu is the complete library.
-    private func snippetsMenu(for field: FieldDef) -> some View {
-        Menu {
-            if state.selectedRole == .reactNativeDeveloper, let macIP {
-                Section("This Mac") {
-                    Button("IP address — \(macIP)") { textValues[field.name] = macIP }
-                }
-            }
-            if !presets.sendTextSnippets.isEmpty {
-                Section("Snippets") {
-                    ForEach(presets.sendTextSnippets) { snippet in
-                        Button(snippet.name) { insert(snippet, into: field) }
+    /// Tag row: at most 6 recent snippets. Library collapse: this many rows
+    /// before "Show more". Search appears once the library outgrows a glance.
+    private static let recentTagLimit = 6
+    private static let collapsedLibraryLimit = 8
+    private static let searchThreshold = 10
+
+    /// The recently used snippets as one-click tags under the field (top 6),
+    /// led by the Mac's IP for the React Native role (Metro's "Debug server
+    /// host" is `<mac-ip>:8081`).
+    @ViewBuilder
+    private func snippetTags(for field: FieldDef) -> some View {
+        let recents = presets.recentSnippets(limit: Self.recentTagLimit)
+        if !recents.isEmpty || (state.selectedRole == .reactNativeDeveloper && macIP != nil) {
+            SnippetTagFlow(spacing: 6) {
+                if state.selectedRole == .reactNativeDeveloper, let macIP {
+                    Button {
+                        textValues[field.name] = macIP
+                    } label: {
+                        Label("Mac IP", systemImage: "network")
+                            .font(.app(.caption))
+                            .lineLimit(1)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(.quaternary, in: Capsule())
+                            .contentShape(Capsule())
                     }
+                    .buttonStyle(.plain)
+                    .help("Insert this Mac's IP address — \(macIP)")
+                }
+                ForEach(recents) { snippet in
+                    snippetChip(snippet, field: field)
                 }
             }
-            Section {
-                Button("New Snippet…") { beginCreatingSnippet(for: field) }
-                if !presets.sendTextSnippets.isEmpty {
-                    Menu("Remove Snippet") {
-                        ForEach(presets.sendTextSnippets) { snippet in
-                            Button(snippet.name) {
-                                presets.removeSnippet(named: snippet.name)
-                                persistPresets()
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: "bookmark")
-                .foregroundStyle(.textMuted)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help("Snippets — insert a saved text")
     }
 
-    /// The most-used snippets as one-click tags under the field, capped at 5,
-    /// ending with the ＋ chip that creates a new snippet in a popover.
-    private func snippetTags(for field: FieldDef) -> some View {
-        SnippetTagFlow(spacing: 6) {
-            ForEach(presets.topSnippets(limit: 5)) { snippet in
-                Button {
-                    insert(snippet, into: field)
-                } label: {
-                    Text(snippet.name)
-                        .font(.app(.caption))
-                        .lineLimit(1)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(.quaternary, in: Capsule())
-                        .contentShape(Capsule())
+    /// The one place a snippet gets created. Prefills with the typed text so
+    /// "save what I just sent" stays one click.
+    private func newSnippetButton(for field: FieldDef) -> some View {
+        Button {
+            beginCreatingSnippet(for: field)
+        } label: {
+            Label("New Snippet", systemImage: "plus")
+                .font(.app(.caption))
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help("Save a snippet — supports {clipboard} and {ip}")
+        .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
+            newSnippetPopover(for: field)
+        }
+    }
+
+    /// Everything beyond the recent tags, under the New Snippet button:
+    /// alphabetical chips, collapsed behind "Show more" when long, with a
+    /// search over every snippet's name and text once the library is big
+    /// enough to need one.
+    @ViewBuilder
+    private func snippetLibrary(for field: FieldDef) -> some View {
+        let recentIDs = Set(presets.recentSnippets(limit: Self.recentTagLimit).map(\.id))
+        let query = snippetSearch.trimmingCharacters(in: .whitespaces)
+        let library = presets.sendTextSnippets
+            .filter { query.isEmpty ? !recentIDs.contains($0.id) : $0.matches(query) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        if presets.sendTextSnippets.count > Self.searchThreshold {
+            TextField("Search snippets…", text: $snippetSearch)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: 200)
+                .help("Find a snippet by its name or its text")
+        }
+
+        if !query.isEmpty && library.isEmpty {
+            Text("No snippets match “\(query)”.")
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+        } else if !library.isEmpty {
+            let shown = showAllSnippets || !query.isEmpty
+                ? library
+                : Array(library.prefix(Self.collapsedLibraryLimit))
+            SnippetTagFlow(spacing: 6) {
+                ForEach(shown) { snippet in
+                    snippetChip(snippet, field: field)
                 }
-                .buttonStyle(.plain)
-                .help(snippet.text)
+                if query.isEmpty, library.count > Self.collapsedLibraryLimit {
+                    Button {
+                        showAllSnippets.toggle()
+                    } label: {
+                        Text(showAllSnippets
+                            ? "Show less"
+                            : "Show \(library.count - Self.collapsedLibraryLimit) more")
+                            .font(.app(.caption))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .overlay(Capsule().strokeBorder(.borderSubtle))
+                            .contentShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.textMuted)
+                }
             }
-            Button {
-                beginCreatingSnippet(for: field)
-            } label: {
-                Label("New", systemImage: "plus")
-                    .font(.app(.caption))
-                    .labelStyle(.titleAndIcon)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .overlay(Capsule().strokeBorder(.borderSubtle))
-                    .contentShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.textMuted)
-            .help("Save a snippet — supports {clipboard} and {ip}")
-            .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
-                newSnippetPopover(for: field)
+        }
+    }
+
+    /// One snippet as a click-to-insert tag; right-click removes it.
+    private func snippetChip(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
+        Button {
+            insert(snippet, into: field)
+        } label: {
+            Text(snippet.name)
+                .font(.app(.caption))
+                .lineLimit(1)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.quaternary, in: Capsule())
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("\(snippet.text)\n\nRight-click to remove")
+        .contextMenu {
+            Button("Remove Snippet", role: .destructive) {
+                presets.removeSnippet(named: snippet.name)
+                persistPresets()
             }
         }
     }


### PR DESCRIPTION
Send Text had two ways to create a snippet (the bookmark menu's "New Snippet…" and the ＋ chip). Now there's one:

- **Tags**: the 6 most recently used snippets sit under the text field as one-click tags. `SendTextSnippet` gains `lastUsedAt` (stamped on insert and creation; older files decode with nil and rank by use count instead).
- **One "＋ New Snippet" button** under the tags — same prefilled popover as before.
- **Library**: every other snippet sits under the button as alphabetical chips, collapsed behind "Show N more" past 8, with a search field (matches snippet names and text, case-insensitive) once the library passes 10.
- Right-click any chip to remove it; the Mac IP quick insert for the React Native role is now a leading tag. The bookmark menu is gone.

ADBKit: `recentSnippets(limit:)` replaces `topSnippets(limit:)`, `recordSnippetUse`/`addSnippet` take an injectable timestamp, `SendTextSnippet.matches(_:)` backs the search. Tests cover ranking, stamping, old-file decoding, and matching; 902 green, build warning-free. UI verified live with a seeded 16-snippet library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)