### PR TITLE
Fix tab drops, auto-connect wireless pairing, rework Send Text snippets

### DIFF
--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -314,11 +314,11 @@ public struct LayoutState: Codable, Sendable, Equatable {
     }
 }
 
-/// A saved Send Text snippet: a short display name (what the tag chips and
-/// menu show) over the text that gets inserted. `uses` ranks the top-5
-/// quick-insert tags under the text field; the text may hold
-/// `{clipboard}`/`{ip}` placeholders expanded by `SnippetPlaceholders` at
-/// insert time.
+/// A saved Send Text snippet: a short display name (what the tag chips show)
+/// over the text that gets inserted. `lastUsedAt` (epoch seconds) ranks the
+/// recently-used tags under the text field — `uses` breaks ties and ranks
+/// never-used snippets; the text may hold `{clipboard}`/`{ip}` placeholders
+/// expanded by `SnippetPlaceholders` at insert time.
 public struct SendTextSnippet: Codable, Sendable, Equatable, Identifiable {
     /// Names longer than this are clamped — chips and menu rows stay short.
     public static let nameLimit = 24
@@ -326,13 +326,26 @@ public struct SendTextSnippet: Codable, Sendable, Equatable, Identifiable {
     public var name: String
     public var text: String
     public var uses: Int
+    /// Epoch seconds of the last insert (or creation). Optional so files
+    /// written before the field existed still decode; nil sorts last.
+    public var lastUsedAt: Double?
 
     public var id: String { name }
 
-    public init(name: String, text: String, uses: Int = 0) {
+    public init(name: String, text: String, uses: Int = 0, lastUsedAt: Double? = nil) {
         self.name = String(name.prefix(Self.nameLimit))
         self.text = text
         self.uses = uses
+        self.lastUsedAt = lastUsedAt
+    }
+
+    /// Case-insensitive match on the name (the tag's title) or the inserted
+    /// text — what the snippet search box filters by.
+    public func matches(_ query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return true }
+        return name.localizedCaseInsensitiveContains(trimmed)
+            || text.localizedCaseInsensitiveContains(trimmed)
     }
 }
 
@@ -363,14 +376,18 @@ public struct Presets: Codable, Sendable, Equatable {
 
     /// Adds a snippet with a trimmed, length-clamped name; false (and no
     /// change) when the name or text is empty or the name is already taken.
+    /// A new snippet is stamped as just-used so it leads the recent tags —
+    /// the thing you just saved is the thing you're about to insert.
     @discardableResult
-    public mutating func addSnippet(named name: String, text: String) -> Bool {
+    public mutating func addSnippet(
+        named name: String, text: String, at date: Double = Date().timeIntervalSince1970
+    ) -> Bool {
         let trimmedName = String(
             name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(SendTextSnippet.nameLimit))
         guard !trimmedName.isEmpty, !text.isEmpty,
               !sendTextSnippets.contains(where: { $0.name == trimmedName })
         else { return false }
-        sendTextSnippets.append(SendTextSnippet(name: trimmedName, text: text))
+        sendTextSnippets.append(SendTextSnippet(name: trimmedName, text: text, lastUsedAt: date))
         return true
     }
 
@@ -378,18 +395,29 @@ public struct Presets: Codable, Sendable, Equatable {
         sendTextSnippets.removeAll { $0.name == name }
     }
 
-    /// Bumps the use count that ranks the quick-insert tags.
-    public mutating func recordSnippetUse(named name: String) {
+    /// Bumps the use count and freshness that rank the quick-insert tags.
+    public mutating func recordSnippetUse(
+        named name: String, at date: Double = Date().timeIntervalSince1970
+    ) {
         guard let index = sendTextSnippets.firstIndex(where: { $0.name == name }) else { return }
         sendTextSnippets[index].uses += 1
+        sendTextSnippets[index].lastUsedAt = date
     }
 
-    /// The most-used snippets, ties kept in the order they were saved.
-    public func topSnippets(limit: Int) -> [SendTextSnippet] {
+    /// The most recently used snippets — the quick-insert tag row. Never-used
+    /// snippets (files from before `lastUsedAt` existed) follow, ranked by
+    /// use count, ties kept in the order they were saved.
+    public func recentSnippets(limit: Int) -> [SendTextSnippet] {
         sendTextSnippets.enumerated()
             .sorted { lhs, rhs in
-                if lhs.element.uses != rhs.element.uses { return lhs.element.uses > rhs.element.uses }
-                return lhs.offset < rhs.offset
+                switch (lhs.element.lastUsedAt, rhs.element.lastUsedAt) {
+                case (let left?, let right?) where left != right: return left > right
+                case (.some, .none): return true
+                case (.none, .some): return false
+                default:
+                    if lhs.element.uses != rhs.element.uses { return lhs.element.uses > rhs.element.uses }
+                    return lhs.offset < rhs.offset
+                }
             }
             .prefix(limit)
             .map(\.element)

--- a/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ConnectionService.swift
@@ -75,6 +75,55 @@ public struct ConnectionService: Sendable {
         return FeatureResult(ok: false, message: reason.isEmpty ? "Connection failed." : reason)
     }
 
+    /// One row of `adb mdns services` output: instance name, service type,
+    /// and the advertised endpoint.
+    public struct MdnsService: Equatable, Sendable {
+        public let name: String
+        public let type: String
+        public let endpoint: WirelessEndpoint
+    }
+
+    /// The wireless-debugging connect endpoint a freshly paired device
+    /// advertises over mDNS (`_adb-tls-connect._tcp`), or nil when nothing
+    /// matching `host` shows up. The advertisement can lag the pairing
+    /// handshake by a beat, so this retries; every failure mode (mdns
+    /// disabled in this adb, no matching host) is a nil — the caller falls
+    /// back to asking for the port.
+    public func discoverConnectEndpoint(
+        host: String, attempts: Int = 3, delay: Duration = .seconds(1)
+    ) async -> WirelessEndpoint? {
+        for attempt in 0..<max(1, attempts) {
+            guard !Task.isCancelled else { return nil }
+            if attempt > 0 { try? await Task.sleep(for: delay) }
+            guard let result = try? await client.run(["mdns", "services"], timeout: .seconds(5))
+            else { return nil }
+            let match = Self.parseMdnsServices(result.stdout).first { service in
+                service.type.hasPrefix("_adb-tls-connect") && service.endpoint.host == host
+            }
+            if let match { return match.endpoint }
+        }
+        return nil
+    }
+
+    /// Pure parse of `adb mdns services` output:
+    ///
+    ///     List of discovered mdns services
+    ///     adb-R58M4-xyz	_adb-tls-connect._tcp	192.168.1.42:40913
+    ///
+    /// Columns are whitespace-separated; the service type always leads with
+    /// an underscore (which also skips the header line), and the endpoint
+    /// must parse with a port.
+    public static func parseMdnsServices(_ text: String) -> [MdnsService] {
+        var services: [MdnsService] = []
+        for line in text.components(separatedBy: .newlines) {
+            let fields = line.split(whereSeparator: { $0 == "\t" || $0 == " " }).map(String.init)
+            guard fields.count >= 3, fields[1].hasPrefix("_") else { continue }
+            guard let endpoint = parseEndpoint(fields[2]), endpoint.port != nil else { continue }
+            services.append(MdnsService(name: fields[0], type: fields[1], endpoint: endpoint))
+        }
+        return services
+    }
+
     /// adb's default connect port — what `adb connect <host>` assumes.
     public static let defaultConnectPort = "5555"
 

--- a/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConnectionServiceTests.swift
@@ -170,4 +170,92 @@ import Testing
         #expect(!result.ok)
         #expect(result.message == "failed to connect to 192.168.1.42:5555")
     }
+
+    @Test func discoverQueriesMdnsServicesAndMatchesTheHost() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout: """
+        List of discovered mdns services
+        adb-R58M4-pair\t_adb-tls-pairing._tcp\t192.168.1.42:37123
+        adb-OTHER-conn\t_adb-tls-connect._tcp\t192.168.1.99:41000
+        adb-R58M4-conn\t_adb-tls-connect._tcp\t192.168.1.42:40913
+        """)
+        let service = await makeService(runner: runner)
+
+        let endpoint = await service.discoverConnectEndpoint(host: "192.168.1.42")
+        #expect(endpoint == WirelessEndpoint(host: "192.168.1.42", port: "40913"))
+        #expect(runner.invocations.contains { $0.arguments == ["mdns", "services"] })
+        // The pairing service and the other device's endpoint never match.
+        #expect(endpoint?.port != "37123")
+    }
+
+    @Test func discoverRetriesThenGivesUpQuietly() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout: "List of discovered mdns services\n")
+        let service = await makeService(runner: runner)
+
+        let endpoint = await service.discoverConnectEndpoint(
+            host: "192.168.1.42", attempts: 3, delay: .milliseconds(1))
+        #expect(endpoint == nil)
+        #expect(runner.invocations.filter { $0.arguments == ["mdns", "services"] }.count == 3)
+    }
+
+    @Test func discoverTreatsMdnsUnsupportedAsNotFound() async {
+        // Older adb: "mdns" is an unknown command on stderr, non-zero exit.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stderr: "adb: unknown command mdns", exitCode: 1)
+        let service = await makeService(runner: runner)
+
+        let endpoint = await service.discoverConnectEndpoint(
+            host: "192.168.1.42", attempts: 2, delay: .milliseconds(1))
+        #expect(endpoint == nil)
+    }
+}
+
+@Suite struct MdnsServicesParserTests {
+    @Test func parsesTabSeparatedRowsAndSkipsTheHeader() {
+        let output = """
+        List of discovered mdns services
+        adb-R58M4-pair\t_adb-tls-pairing._tcp\t192.168.1.42:37123
+        adb-R58M4-conn\t_adb-tls-connect._tcp\t192.168.1.42:40913
+        """
+        let services = ConnectionService.parseMdnsServices(output)
+        #expect(services == [
+            ConnectionService.MdnsService(
+                name: "adb-R58M4-pair", type: "_adb-tls-pairing._tcp",
+                endpoint: WirelessEndpoint(host: "192.168.1.42", port: "37123")),
+            ConnectionService.MdnsService(
+                name: "adb-R58M4-conn", type: "_adb-tls-connect._tcp",
+                endpoint: WirelessEndpoint(host: "192.168.1.42", port: "40913")),
+        ])
+    }
+
+    @Test func toleratesSpaceSeparationAndTrailingTypeDot() {
+        let services = ConnectionService.parseMdnsServices(
+            "adb-X   _adb-tls-connect._tcp.   10.0.0.7:39001")
+        #expect(services.count == 1)
+        #expect(services.first?.type == "_adb-tls-connect._tcp.")
+        #expect(services.first?.endpoint == WirelessEndpoint(host: "10.0.0.7", port: "39001"))
+    }
+
+    @Test func crlfSplitsCleanly() {
+        let services = ConnectionService.parseMdnsServices(
+            "adb-A\t_adb-tls-connect._tcp\t10.0.0.1:40000\r\nadb-B\t_adb-tls-connect._tcp\t10.0.0.2:40001")
+        #expect(services.count == 2)
+    }
+
+    @Test func skipsMalformedRows() {
+        let output = """
+        adb-A\t_adb-tls-connect._tcp\tnot-an-endpoint:99999999
+        adb-B\t_adb-tls-connect._tcp
+        just one field
+        adb-C\t_adb-tls-connect._tcp\t10.0.0.3
+        """
+        // A giant port, a missing column, and a portless endpoint all drop.
+        #expect(ConnectionService.parseMdnsServices(output).isEmpty)
+    }
+
+    @Test func emptyInputYieldsNothing() {
+        #expect(ConnectionService.parseMdnsServices("").isEmpty)
+        #expect(ConnectionService.parseMdnsServices("List of discovered mdns services\n").isEmpty)
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONStoreTests.swift
@@ -113,16 +113,16 @@ import Testing
         let dir = try tempDir()
         let store = JSONStore(filename: "presets.json", default: Presets(), directory: dir)
         try await store.update {
-            $0.addSnippet(named: "Login email", text: "user@example.com")
-            $0.addSnippet(named: "Metro host", text: "{ip}:8081")
-            $0.recordSnippetUse(named: "Metro host")
+            $0.addSnippet(named: "Login email", text: "user@example.com", at: 100)
+            $0.addSnippet(named: "Metro host", text: "{ip}:8081", at: 200)
+            $0.recordSnippetUse(named: "Metro host", at: 300)
         }
 
         let fresh = JSONStore(filename: "presets.json", default: Presets(), directory: dir)
         let loaded = await fresh.load()
         #expect(loaded.sendTextSnippets == [
-            SendTextSnippet(name: "Login email", text: "user@example.com", uses: 0),
-            SendTextSnippet(name: "Metro host", text: "{ip}:8081", uses: 1),
+            SendTextSnippet(name: "Login email", text: "user@example.com", uses: 0, lastUsedAt: 100),
+            SendTextSnippet(name: "Metro host", text: "{ip}:8081", uses: 1, lastUsedAt: 300),
         ])
     }
 

--- a/ADBKit/Tests/ADBKitTests/SendTextSnippetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SendTextSnippetTests.swift
@@ -35,30 +35,57 @@ import Testing
         #expect(presets.sendTextSnippets.map(\.name) == ["b"])
     }
 
-    @Test func recordUseBumpsOnlyTheMatch() {
+    @Test func recordUseBumpsAndStampsOnlyTheMatch() {
         var presets = Presets(sendTextSnippets: [
             SendTextSnippet(name: "a", text: "1"), SendTextSnippet(name: "b", text: "2"),
         ])
-        presets.recordSnippetUse(named: "b")
-        presets.recordSnippetUse(named: "b")
-        presets.recordSnippetUse(named: "missing")
+        presets.recordSnippetUse(named: "b", at: 100)
+        presets.recordSnippetUse(named: "b", at: 200)
+        presets.recordSnippetUse(named: "missing", at: 300)
         #expect(presets.sendTextSnippets == [
             SendTextSnippet(name: "a", text: "1", uses: 0),
-            SendTextSnippet(name: "b", text: "2", uses: 2),
+            SendTextSnippet(name: "b", text: "2", uses: 2, lastUsedAt: 200),
         ])
     }
 
-    @Test func topSnippetsRanksByUsesThenSaveOrder() {
+    @Test func addStampsANewSnippetAsJustUsed() {
+        var presets = Presets()
+        presets.addSnippet(named: "fresh", text: "x", at: 42)
+        #expect(presets.sendTextSnippets.first?.lastUsedAt == 42)
+    }
+
+    @Test func recentSnippetsRankByFreshnessThenUsesThenSaveOrder() {
         let presets = Presets(sendTextSnippets: [
             SendTextSnippet(name: "old-tie", text: "1", uses: 1),
-            SendTextSnippet(name: "hot", text: "2", uses: 5),
+            SendTextSnippet(name: "yesterday", text: "2", uses: 1, lastUsedAt: 1000),
             SendTextSnippet(name: "new-tie", text: "3", uses: 1),
-            SendTextSnippet(name: "cold", text: "4", uses: 0),
-            SendTextSnippet(name: "warm", text: "5", uses: 3),
-            SendTextSnippet(name: "mild", text: "6", uses: 2),
+            SendTextSnippet(name: "just-now", text: "4", uses: 0, lastUsedAt: 3000),
+            SendTextSnippet(name: "this-morning", text: "5", uses: 9, lastUsedAt: 2000),
+            SendTextSnippet(name: "much-used", text: "6", uses: 5),
         ])
-        // The quick-insert row shows at most the top 5.
-        #expect(presets.topSnippets(limit: 5).map(\.name) == ["hot", "warm", "mild", "old-tie", "new-tie"])
+        // Freshness first; never-used snippets (pre-lastUsedAt files) follow
+        // by use count, ties in save order.
+        #expect(presets.recentSnippets(limit: 6).map(\.name) == [
+            "just-now", "this-morning", "yesterday", "much-used", "old-tie", "new-tie",
+        ])
+        #expect(presets.recentSnippets(limit: 2).map(\.name) == ["just-now", "this-morning"])
+    }
+
+    @Test func snippetsWithoutLastUsedAtStillDecode() throws {
+        // Files written before the field existed carry no lastUsedAt key.
+        let old = Data(#"{"name":"a","text":"1","uses":3}"#.utf8)
+        let snippet = try JSONDecoder().decode(SendTextSnippet.self, from: old)
+        #expect(snippet == SendTextSnippet(name: "a", text: "1", uses: 3, lastUsedAt: nil))
+    }
+
+    @Test func matchesSearchesNameAndTextCaseInsensitively() {
+        let snippet = SendTextSnippet(name: "Metro host", text: "{ip}:8081")
+        #expect(snippet.matches("metro"))
+        #expect(snippet.matches("8081"))
+        #expect(snippet.matches("{IP}"))
+        #expect(snippet.matches("  metro "))
+        #expect(snippet.matches(""))
+        #expect(!snippet.matches("logcat"))
     }
 
     // MARK: - Placeholder expansion

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -73,6 +73,14 @@ struct FormActionView: View {
                     .font(.app(.callout))
             }
 
+            if isSendText, let textField = feature.fields.first(where: { $0.name == "text" }) {
+                VStack(alignment: .leading, spacing: 8) {
+                    newSnippetButton(for: textField)
+                    snippetLibrary(for: textField)
+                }
+                .padding(.top, 4)
+            }
+
             LastResultCard(featureID: feature.id)
         }
         .centeredCard()
@@ -183,11 +191,11 @@ struct FormActionView: View {
         switch field.control {
         case .text, .number, .bundle:
             if isSendText, field.name == "text" {
+                // Quick inserts stay at the field; creating and browsing the
+                // full library live below the Run button (see formContent).
                 VStack(alignment: .leading, spacing: 8) {
                     plainTextField(for: field)
                     snippetTags(for: field)
-                    newSnippetButton(for: field)
-                    snippetLibrary(for: field)
                 }
             } else {
                 plainTextField(for: field)

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -327,11 +327,13 @@ struct FormActionView: View {
             let shown = showAllSnippets || !query.isEmpty
                 ? library
                 : Array(library.prefix(Self.collapsedLibraryLimit))
-            SnippetTagFlow(spacing: 6) {
+            VStack(spacing: 0) {
                 ForEach(shown) { snippet in
-                    snippetChip(snippet, field: field)
+                    snippetRow(snippet, field: field)
+                    if snippet.id != shown.last?.id { Divider() }
                 }
                 if query.isEmpty, library.count > Self.collapsedLibraryLimit {
+                    Divider()
                     Button {
                         showAllSnippets.toggle()
                     } label: {
@@ -339,14 +341,47 @@ struct FormActionView: View {
                             ? "Show less"
                             : "Show \(library.count - Self.collapsedLibraryLimit) more")
                             .font(.app(.caption))
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .overlay(Capsule().strokeBorder(.borderSubtle))
-                            .contentShape(Capsule())
+                            .foregroundStyle(.textMuted)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 6)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(.textMuted)
                 }
+            }
+            .background(.bgSurface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(.borderSubtle))
+            .frame(maxWidth: 380, alignment: .leading)
+        }
+    }
+
+    /// One library row: the name beside a muted preview of the text — click
+    /// inserts, right-click removes.
+    private func snippetRow(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
+        Button {
+            insert(snippet, into: field)
+        } label: {
+            HStack(spacing: 10) {
+                Text(snippet.name)
+                    .font(.app(.callout))
+                    .lineLimit(1)
+                Spacer(minLength: 12)
+                Text(snippet.text)
+                    .font(.app(.caption, design: .monospaced))
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Click to insert · right-click to remove")
+        .contextMenu {
+            Button("Remove Snippet", role: .destructive) {
+                presets.removeSnippet(named: snippet.name)
+                persistPresets()
             }
         }
     }

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -19,6 +19,8 @@ struct FormActionView: View {
     @State private var creatingSnippet = false
     @State private var newSnippetName = ""
     @State private var newSnippetText = ""
+    @State private var snippetSearch = ""
+    @State private var showAllSnippets = false
     @State private var confirmingRun = false
     @FocusState private var focusedField: String?
     /// Send Text: wipe the field after a successful send, for firing a sequence
@@ -181,12 +183,11 @@ struct FormActionView: View {
         switch field.control {
         case .text, .number, .bundle:
             if isSendText, field.name == "text" {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 4) {
-                        plainTextField(for: field)
-                        snippetsMenu(for: field)
-                    }
+                VStack(alignment: .leading, spacing: 8) {
+                    plainTextField(for: field)
                     snippetTags(for: field)
+                    newSnippetButton(for: field)
+                    snippetLibrary(for: field)
                 }
             } else {
                 plainTextField(for: field)
@@ -237,82 +238,130 @@ struct FormActionView: View {
 
     // MARK: - Send Text snippets
 
-    /// The full snippet list plus management: every saved snippet by name,
-    /// the Mac's IP as a quick insert for the React Native role, New
-    /// Snippet…, and removal. The top-5 tags below the field cover the
-    /// everyday inserts; this menu is the complete library.
-    private func snippetsMenu(for field: FieldDef) -> some View {
-        Menu {
-            if state.selectedRole == .reactNativeDeveloper, let macIP {
-                Section("This Mac") {
-                    Button("IP address — \(macIP)") { textValues[field.name] = macIP }
-                }
-            }
-            if !presets.sendTextSnippets.isEmpty {
-                Section("Snippets") {
-                    ForEach(presets.sendTextSnippets) { snippet in
-                        Button(snippet.name) { insert(snippet, into: field) }
+    /// Tag row: at most 6 recent snippets. Library collapse: this many rows
+    /// before "Show more". Search appears once the library outgrows a glance.
+    private static let recentTagLimit = 6
+    private static let collapsedLibraryLimit = 8
+    private static let searchThreshold = 10
+
+    /// The recently used snippets as one-click tags under the field (top 6),
+    /// led by the Mac's IP for the React Native role (Metro's "Debug server
+    /// host" is `<mac-ip>:8081`).
+    @ViewBuilder
+    private func snippetTags(for field: FieldDef) -> some View {
+        let recents = presets.recentSnippets(limit: Self.recentTagLimit)
+        if !recents.isEmpty || (state.selectedRole == .reactNativeDeveloper && macIP != nil) {
+            SnippetTagFlow(spacing: 6) {
+                if state.selectedRole == .reactNativeDeveloper, let macIP {
+                    Button {
+                        textValues[field.name] = macIP
+                    } label: {
+                        Label("Mac IP", systemImage: "network")
+                            .font(.app(.caption))
+                            .lineLimit(1)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(.quaternary, in: Capsule())
+                            .contentShape(Capsule())
                     }
+                    .buttonStyle(.plain)
+                    .help("Insert this Mac's IP address — \(macIP)")
+                }
+                ForEach(recents) { snippet in
+                    snippetChip(snippet, field: field)
                 }
             }
-            Section {
-                Button("New Snippet…") { beginCreatingSnippet(for: field) }
-                if !presets.sendTextSnippets.isEmpty {
-                    Menu("Remove Snippet") {
-                        ForEach(presets.sendTextSnippets) { snippet in
-                            Button(snippet.name) {
-                                presets.removeSnippet(named: snippet.name)
-                                persistPresets()
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: "bookmark")
-                .foregroundStyle(.textMuted)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help("Snippets — insert a saved text")
     }
 
-    /// The most-used snippets as one-click tags under the field, capped at 5,
-    /// ending with the ＋ chip that creates a new snippet in a popover.
-    private func snippetTags(for field: FieldDef) -> some View {
-        SnippetTagFlow(spacing: 6) {
-            ForEach(presets.topSnippets(limit: 5)) { snippet in
-                Button {
-                    insert(snippet, into: field)
-                } label: {
-                    Text(snippet.name)
-                        .font(.app(.caption))
-                        .lineLimit(1)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(.quaternary, in: Capsule())
-                        .contentShape(Capsule())
+    /// The one place a snippet gets created. Prefills with the typed text so
+    /// "save what I just sent" stays one click.
+    private func newSnippetButton(for field: FieldDef) -> some View {
+        Button {
+            beginCreatingSnippet(for: field)
+        } label: {
+            Label("New Snippet", systemImage: "plus")
+                .font(.app(.caption))
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help("Save a snippet — supports {clipboard} and {ip}")
+        .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
+            newSnippetPopover(for: field)
+        }
+    }
+
+    /// Everything beyond the recent tags, under the New Snippet button:
+    /// alphabetical chips, collapsed behind "Show more" when long, with a
+    /// search over every snippet's name and text once the library is big
+    /// enough to need one.
+    @ViewBuilder
+    private func snippetLibrary(for field: FieldDef) -> some View {
+        let recentIDs = Set(presets.recentSnippets(limit: Self.recentTagLimit).map(\.id))
+        let query = snippetSearch.trimmingCharacters(in: .whitespaces)
+        let library = presets.sendTextSnippets
+            .filter { query.isEmpty ? !recentIDs.contains($0.id) : $0.matches(query) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        if presets.sendTextSnippets.count > Self.searchThreshold {
+            TextField("Search snippets…", text: $snippetSearch)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: 200)
+                .help("Find a snippet by its name or its text")
+        }
+
+        if !query.isEmpty && library.isEmpty {
+            Text("No snippets match “\(query)”.")
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+        } else if !library.isEmpty {
+            let shown = showAllSnippets || !query.isEmpty
+                ? library
+                : Array(library.prefix(Self.collapsedLibraryLimit))
+            SnippetTagFlow(spacing: 6) {
+                ForEach(shown) { snippet in
+                    snippetChip(snippet, field: field)
                 }
-                .buttonStyle(.plain)
-                .help(snippet.text)
+                if query.isEmpty, library.count > Self.collapsedLibraryLimit {
+                    Button {
+                        showAllSnippets.toggle()
+                    } label: {
+                        Text(showAllSnippets
+                            ? "Show less"
+                            : "Show \(library.count - Self.collapsedLibraryLimit) more")
+                            .font(.app(.caption))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .overlay(Capsule().strokeBorder(.borderSubtle))
+                            .contentShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.textMuted)
+                }
             }
-            Button {
-                beginCreatingSnippet(for: field)
-            } label: {
-                Label("New", systemImage: "plus")
-                    .font(.app(.caption))
-                    .labelStyle(.titleAndIcon)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .overlay(Capsule().strokeBorder(.borderSubtle))
-                    .contentShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.textMuted)
-            .help("Save a snippet — supports {clipboard} and {ip}")
-            .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
-                newSnippetPopover(for: field)
+        }
+    }
+
+    /// One snippet as a click-to-insert tag; right-click removes it.
+    private func snippetChip(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
+        Button {
+            insert(snippet, into: field)
+        } label: {
+            Text(snippet.name)
+                .font(.app(.caption))
+                .lineLimit(1)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.quaternary, in: Capsule())
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("\(snippet.text)\n\nRight-click to remove")
+        .contextMenu {
+            Button("Remove Snippet", role: .destructive) {
+                presets.removeSnippet(named: snippet.name)
+                persistPresets()
             }
         }
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -659,18 +659,22 @@ private struct EditorPane: View {
             TabStripView(group: index)
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .onDrop(of: [.workspaceTab], delegate: TabPaneDrop(
-                    state: state,
-                    onDrop: { id in
-                        if state.isSplit {
-                            state.moveTab(id, toGroup: index)
-                        } else {
-                            state.splitTab(id)
-                        }
-                        state.draggingTabID = nil
-                    },
-                    onTargetedChange: { contentTargeted = $0 }
-                ))
+                .onDrop(of: [.workspaceTab], delegate: paneDrop)
+                .overlay {
+                    // Drops route to the deepest region under the cursor even
+                    // when its types don't match (see CLAUDE.md) — a feature's
+                    // own full-pane dropDestination (AAB to APK, opened APK)
+                    // swallows a dragged tab, killing drop-to-split whenever
+                    // such a tab is merely open. While a tab drag is live,
+                    // shield the content with a topmost workspaceTab target;
+                    // it vanishes with the drag, so feature drops (APKs from
+                    // Finder…) are untouched otherwise.
+                    if state.draggingTabID != nil {
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .onDrop(of: [.workspaceTab], delegate: paneDrop)
+                    }
+                }
                 .overlay(alignment: .trailing) {
                     // Only promise a split the model will honor: `split()`
                     // requires >1 tab (something must stay behind), so a
@@ -680,6 +684,21 @@ private struct EditorPane: View {
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var paneDrop: TabPaneDrop {
+        TabPaneDrop(
+            state: state,
+            onDrop: { id in
+                if state.isSplit {
+                    state.moveTab(id, toGroup: index)
+                } else {
+                    state.splitTab(id)
+                }
+                state.draggingTabID = nil
+            },
+            onTargetedChange: { contentTargeted = $0 }
+        )
     }
 
     /// Non-interactive right-half wash showing where the new split pane will land

--- a/App/Sources/Root/WirelessConnectSheet.swift
+++ b/App/Sources/Root/WirelessConnectSheet.swift
@@ -120,7 +120,7 @@ struct WirelessConnectSheet: View {
             }
 
             StepRow(number: 3, title: "Connect", done: paired) {
-                Text("Use the port on the main Wireless debugging screen — it differs from the pairing port.")
+                Text("After pairing, Droidective looks up the connect port and connects by itself. If it can't, use the port on the main Wireless debugging screen — it differs from the pairing port.")
                     .font(.app(.callout))
                     .foregroundStyle(.textMuted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -220,14 +220,47 @@ struct WirelessConnectSheet: View {
         return endpoint
     }
 
+    /// Pair, then finish the job when possible: a paired device advertises
+    /// its connect port over mDNS (`_adb-tls-connect._tcp`), so on success we
+    /// look it up and connect without asking for the port. When discovery
+    /// comes up empty (older adb, mDNS off, different subnet), fall back to
+    /// prefilling "ip:" so the user only types the port from the Wireless
+    /// debugging screen.
     private func runPair() {
         guard let input = pairInput else { return }
         let connection = state.env.engine.connection
-        run({ try await connection.pair(host: input.host, port: input.port, code: input.code) }) { _ in
-            paired = true
-            if pairConnectEndpoint.isEmpty {
-                pairConnectEndpoint = "\(input.host):"
+        busy = true
+        status = nil
+        Task {
+            await CommandLog.userInitiated {
+                do {
+                    let result = try await connection.pair(
+                        host: input.host, port: input.port, code: input.code)
+                    status = Status(ok: result.ok, message: result.message)
+                    guard result.ok else { return }
+                    paired = true
+                    if pairConnectEndpoint.isEmpty {
+                        pairConnectEndpoint = "\(input.host):"
+                    }
+                    status = Status(ok: true, message: "Paired — looking up the connect port…")
+                    guard let endpoint = await connection.discoverConnectEndpoint(host: input.host),
+                          let port = endpoint.port else {
+                        status = Status(
+                            ok: true,
+                            message: "Paired — enter the port from the Wireless debugging screen to connect.")
+                        return
+                    }
+                    pairConnectEndpoint = "\(endpoint.host):\(port)"
+                    let connected = try await connection.connect(host: endpoint.host, port: port)
+                    status = Status(ok: connected.ok, message: connected.message)
+                    if connected.ok {
+                        finishConnected(connected, address: "\(endpoint.host):\(port)")
+                    }
+                } catch {
+                    status = Status(ok: false, message: error.localizedDescription)
+                }
             }
+            busy = false
         }
     }
 


### PR DESCRIPTION
Combines three changes (replaces #170, #171, #172).

## Drop-to-split fix
Drag-to-split/move died whenever an AAB to APK or opened-APK tab was open: both attach a full-pane URL `dropDestination`, drops route to the deepest region under the cursor even on a type mismatch, and hidden keep-alive tabs keep their regions (the v2.8.1 Terminal failure again). While a tab drag is live, `EditorPane` overlays the content with a topmost `workspaceTab` target; it vanishes with the drag, so Finder APK/AAB drops are untouched. Verified by hand on a live build.

## Wireless pairing auto-connects
After a successful Android 11+ pair, the sheet looks up the device's advertised `_adb-tls-connect._tcp` endpoint (`adb mdns services` — pure `parseMdnsServices` + retrying `discoverConnectEndpoint`) and connects without asking for the port; discovery coming up empty falls back to prefilling `ip:`. Needs one live pass with a physical Android 11+ device before merge (emulators don't support wireless pairing).

## Send Text snippets reworked
One "＋ New Snippet" button replaces the bookmark menu and the ＋ chip. The 6 most recently used snippets sit under the field as tags (`SendTextSnippet.lastUsedAt`, stamped on insert/creation; older files decode with nil and rank by use count). Below the Run button: the create button, a search field past 10 snippets (matches names and text), and the rest of the library as a list — name beside a muted text preview, click to insert, right-click to remove, "Show N more" past 8. UI verified live with a seeded 16-snippet library.

## Tests
910 green (mDNS parser/discovery, snippet ranking/stamping/decode/matching); builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)