### PR TITLE
Sign jar-embedded macOS natives so notarization passes

### DIFF
--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -22,11 +22,24 @@ DMG="${1:?dmg path required}"
 }
 
 echo "Submitting $DMG for notarization (waiting for Apple)…"
-xcrun notarytool submit "$DMG" \
+# `submit --wait` exits 0 even when Apple rejects the build, so read the final
+# status from the JSON result and dump the notary log on anything but Accepted.
+result="$(xcrun notarytool submit "$DMG" \
   --key "$AC_API_KEY_PATH" \
   --key-id "$AC_API_KEY_ID" \
   --issuer "$AC_API_ISSUER_ID" \
-  --wait
+  --wait --output-format json)"
+echo "$result"
+status="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' <<<"$result")"
+if [[ "$status" != "Accepted" ]]; then
+  submission_id="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' <<<"$result")"
+  echo "Notarization status: ${status:-unknown} — notary log follows" >&2
+  xcrun notarytool log "$submission_id" \
+    --key "$AC_API_KEY_PATH" \
+    --key-id "$AC_API_KEY_ID" \
+    --issuer "$AC_API_ISSUER_ID" >&2 || true
+  exit 1
+fi
 
 echo "Stapling notarization ticket…"
 xcrun stapler staple "$DMG"

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -50,6 +50,30 @@ fi
 ffmpeg="$APP/Contents/Resources/ffmpeg"
 [[ -f "$ffmpeg" ]] && codesign "${opts[@]}" "$ffmpeg"
 
+# Notarization unpacks jar archives and rejects any unsigned Mach-O inside them
+# — bundletool-all.jar ships JNA's darwin libjnidispatch.jnilib. Extract each
+# bundled jar's macOS natives, sign them, and repack in place (seeding doesn't
+# digest-check the bundled jars, so the changed hash is fine).
+if [[ "$SIGN_IDENTITY" != "-" ]]; then
+  for jar in "$APP/Contents/Resources"/*.jar; do
+    [[ -f "$jar" ]] || continue
+    natives="$(zipinfo -1 "$jar" | grep -E '\.(dylib|jnilib)$' || true)"
+    [[ -n "$natives" ]] || continue
+    jartmp="$(mktemp -d)"
+    while IFS= read -r entry; do
+      (
+        cd "$jartmp"
+        unzip -qo "$jar" "$entry"
+        codesign "${opts[@]}" "$entry"
+        zip -q "$jar" "$entry"
+      )
+    done <<<"$natives"
+    rm -rf "$jartmp"
+    echo "signed jar natives in $(basename "$jar"):"
+    echo "$natives"
+  done
+fi
+
 codesign "${opts[@]}" "$APP"
 codesign --verify --deep --strict "$APP"
 


### PR DESCRIPTION
The v3.4.0 release run failed notarization with status Invalid. Cause: bundletool-all.jar (bundled since #165) contains JNA's com/sun/jna/darwin/libjnidispatch.jnilib, an unsigned Mach-O dylib — Apple's notary service unpacks jar archives and rejects any unsigned Mach-O inside.

## Changes

- scripts/package-dmg.sh: before sealing the app, scan each bundled jar for .dylib/.jnilib entries, extract, sign with the release identity (hardened runtime + timestamp), and repack in place. Skipped for ad-hoc builds. Seeding doesn't digest-check the bundled jars, so the changed hash is fine.
- scripts/notarize.sh: notarytool submit --wait exits 0 even on Invalid (the release job only died later, at stapling). The script now parses the JSON status, prints Apple's notary log on anything but Accepted, and exits 1 there.

## Verification

- The extract → sign → repack cycle was run locally against a copy of bundletool-all.jar (ad-hoc identity): the jar passes unzip -t, the re-extracted jnilib carries the signature, and java -jar … version still prints 1.18.3.
- shellcheck clean on both scripts.
- Real proof is the re-run: after merging, the v3.4.0 tag will be moved to include this fix and re-pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)