### PR TITLE
Resolve jar path to absolute before signing its natives

### DIFF
--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -57,6 +57,9 @@ ffmpeg="$APP/Contents/Resources/ffmpeg"
 if [[ "$SIGN_IDENTITY" != "-" ]]; then
   for jar in "$APP/Contents/Resources"/*.jar; do
     [[ -f "$jar" ]] || continue
+    # $APP is relative — resolve the jar to an absolute path so it survives
+    # the cd into the scratch directory below.
+    jar="$(cd "$(dirname "$jar")" && pwd)/$(basename "$jar")"
     natives="$(zipinfo -1 "$jar" | grep -E '\.(dylib|jnilib)$' || true)"
     [[ -n "$natives" ]] || continue
     jartmp="$(mktemp -d)"


### PR DESCRIPTION
The re-run of the v3.4.0 release failed earlier than before: the jar-natives signing loop from #176 cd's into a scratch directory, but $APP is a relative path (DerivedData/…), so unzip couldn't find the jar (exit 9). The local dry-run had used an absolute path, which masked it.

One-line fix: resolve the jar to an absolute path before the subshell. Re-tested from the repo root with a relative $APP exactly like CI — extract, sign, repack, and integrity check all pass, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)