### PR TITLE
Fix AAB-convert notification crash; restrict keystore picker

### DIFF
--- a/App/Sources/FeatureDetail/Views/SigningKeyForm.swift
+++ b/App/Sources/FeatureDetail/Views/SigningKeyForm.swift
@@ -1,6 +1,7 @@
 import ADBKit
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The signing-key choice shared by the APK signer and the AAB converter:
 /// the embedded debug key, an existing keystore, or a brand-new keystore
@@ -113,10 +114,16 @@ final class SigningKeyModel {
         createError = nil
     }
 
+    /// The only pickable keystore types. `.jks` stays in because the
+    /// "New keystore" flow (and keytool's default) writes `.jks` files.
+    static let keystoreTypes: [UTType] = ["keystore", "jks"]
+        .compactMap { UTType(filenameExtension: $0) }
+
     func chooseKeystore() {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
+        panel.allowedContentTypes = Self.keystoreTypes
         panel.message = "Choose a keystore (.jks / .keystore)"
         if panel.runModal() == .OK { keystoreURL = panel.url }
     }
@@ -124,6 +131,7 @@ final class SigningKeyModel {
     func chooseNewKeystoreLocation() {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "\(keyAlias.isEmpty ? "release" : keyAlias).jks"
+        panel.allowedContentTypes = Self.keystoreTypes
         panel.canCreateDirectories = true
         panel.directoryURL = try? ScreenCaptureService.ensureCaptureDir()
         if panel.runModal() == .OK { newKeystoreURL = panel.url }

--- a/App/Sources/State/SystemNotifier.swift
+++ b/App/Sources/State/SystemNotifier.swift
@@ -14,10 +14,16 @@ enum SystemNotifier {
     /// Ask for notification permission once per launch, at the moment it
     /// becomes relevant (a long task starting). A denial is respected
     /// silently — the in-app toasts still cover the foreground case.
+    /// Must stay on the async API: a completion closure formed here is
+    /// MainActor-isolated, UserNotifications invokes it on a background
+    /// queue, and the isolation check traps (DROIDECTIVE-MAC-3E).
     static func requestAuthorizationOnce() {
         guard !authorizationRequested else { return }
         authorizationRequested = true
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        Task {
+            _ = try? await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .sound])
+        }
     }
 
     /// True when an in-app toast can't be seen: background mode (accessory,


### PR DESCRIPTION
## Crash (Fixes DROIDECTIVE-MAC-3E)

Sentry: a production user on v3.4.0 (build 500) crashed 4 times using AAB to APK — EXC_BREAKPOINT, 'BUG IN CLIENT OF LIBDISPATCH: Block was expected to execute on queue com.apple.main-thread', culprit `closure in SystemNotifier.requestAuthorizationOnce`, tag `active_feature: aab-convert`, macOS 26.5.1.

Root cause: `requestAuthorizationOnce` passed a completion closure to `UNUserNotificationCenter.requestAuthorization`. `SystemNotifier` is `@MainActor`, so the closure is MainActor-isolated — but UserNotifications invokes completion handlers on a background queue, and the macOS 26 Swift runtime's isolation assertion (`dispatch_assert_queue`) traps fatally. The AAB converter's install step is what requests notification authorization in context, hence the feature correlation. `post()` in the same file already uses the async API correctly; `requestAuthorizationOnce` now does the same.

## Keystore picker

The signing keystore `NSOpenPanel` had no type restriction — any file was selectable. It now allows only `.keystore` / `.jks` (`.jks` stays because the app's own New-keystore flow and keytool write `.jks`), and the new-keystore save panel gets the same types. Shared `SigningKeyModel`, so this covers both the AAB converter's signing sheet and APK Studio's Sign tab.

## Verification

- `make build` clean (zero warnings, warnings-as-errors).
- The crash path needs a fresh notification-authorization prompt to exercise; the fix mirrors the already-working async pattern in `post()` two functions below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)