### PR TITLE
Redesign Send Text as two hub sections with one snippet list

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureNotes.swift
@@ -21,7 +21,7 @@ extension FeatureRegistry {
     }
 
     private static let notes: [String: String] = [
-        "send-text": "Types text into whatever field is focused on the device, via `adb shell input text`. Unicode and % need the ADBKeyboard app — you'll be offered a one-click install. Save named snippets from the ＋ tag or the bookmark menu — the five you use most sit under the box, and `{clipboard}` / `{ip}` fill in with the live value when inserted.",
+        "send-text": "Types text into whatever field is focused on the device, via `adb shell input text`. Unicode and % need the ADBKeyboard app — you'll be offered a one-click install. Save the text you send often as a named snippet — the list ranks by recent use, and `{clipboard}` / `{ip}` fill in with the live value when inserted.",
         "get-ip": "Reads the device's Wi-Fi IP (wlan0) and copies it — handy for wireless ADB or pointing the device at your local services.",
         "connection": "All the connection plumbing in one place — copy the device's Wi-Fi IP, reverse a port back to your Mac (Metro), drop a wireless connection, set Private DNS, and run the Android 11+ wireless ADB pairing flow. Wi-Fi, Network Speed, and Emulators stay on their own screens.",
         "reverse-port": "Maps a device port back to your Mac (`adb reverse`), so the device reaching localhost:8081 hits YOUR machine — essential for Metro/dev servers over USB.",

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -142,7 +142,9 @@ struct FeatureDetailView: View {
                 ComingSoonView(feature: feature)
             }
         case .formAction:
-            if FeatureEngine.implementedIDs.contains(feature.id) {
+            if feature.id == "send-text" {
+                SendTextView(feature: feature)
+            } else if FeatureEngine.implementedIDs.contains(feature.id) {
                 FormActionView(feature: feature)
             } else {
                 ComingSoonView(feature: feature)

--- a/App/Sources/FeatureDetail/FormActionView.swift
+++ b/App/Sources/FeatureDetail/FormActionView.swift
@@ -1,9 +1,9 @@
 import ADBKit
-import AppKit
 import SwiftUI
 
 /// Generic form generated from a feature's `[FieldDef]`. Field values are
 /// kept as strings/bools and converted to `FeatureValue` on submit.
+/// (Send Text renders through the bespoke `SendTextView` instead.)
 struct FormActionView: View {
     @Environment(AppState.self) private var state
     let feature: FeatureDef
@@ -12,22 +12,8 @@ struct FormActionView: View {
     @State private var boolValues: [String: Bool] = [:]
     @State private var sliderValues: [String: Double] = [:]
     @State private var presets = Presets()
-    /// Send Text: the Mac's LAN IP — the `{ip}` placeholder value, and (for
-    /// the React Native role) a quick insert in the snippets menu, since
-    /// Metro's "Debug server host" is `<mac-ip>:8081`.
-    @State private var macIP: String?
-    @State private var creatingSnippet = false
-    @State private var newSnippetName = ""
-    @State private var newSnippetText = ""
-    @State private var snippetSearch = ""
-    @State private var showAllSnippets = false
     @State private var confirmingRun = false
     @FocusState private var focusedField: String?
-    /// Send Text: wipe the field after a successful send, for firing a sequence
-    /// of inputs without hand-clearing between them. Persisted choice.
-    @AppStorage("sendTextClearAfterSend") private var clearAfterSend = false
-
-    private var isSendText: Bool { feature.id == "send-text" }
 
     var body: some View {
         Group {
@@ -67,20 +53,6 @@ struct FormActionView: View {
             }
             .padding(.top, 4)
 
-            if isSendText {
-                Toggle("Clear the text after sending", isOn: $clearAfterSend)
-                    .toggleStyle(.checkbox)
-                    .font(.app(.callout))
-            }
-
-            if isSendText, let textField = feature.fields.first(where: { $0.name == "text" }) {
-                VStack(alignment: .leading, spacing: 8) {
-                    newSnippetButton(for: textField)
-                    snippetLibrary(for: textField)
-                }
-                .padding(.top, 4)
-            }
-
             LastResultCard(featureID: feature.id)
         }
         .centeredCard()
@@ -105,9 +77,6 @@ struct FormActionView: View {
         }
         .task {
             presets = await state.env.stores.presets.load()
-            if isSendText {
-                macIP = HostNetwork.primaryIPv4()
-            }
         }
     }
 
@@ -190,16 +159,9 @@ struct FormActionView: View {
     private func control(for field: FieldDef) -> some View {
         switch field.control {
         case .text, .number, .bundle:
-            if isSendText, field.name == "text" {
-                // Quick inserts stay at the field; creating and browsing the
-                // full library live below the Run button (see formContent).
-                VStack(alignment: .leading, spacing: 8) {
-                    plainTextField(for: field)
-                    snippetTags(for: field)
-                }
-            } else {
-                plainTextField(for: field)
-            }
+            TextField("", text: binding(for: field), prompt: field.placeholder.map(Text.init))
+                .brandField()
+                .focused($focusedField, equals: field.name)
         case .preset:
             presetField(for: field)
         case .select:
@@ -218,274 +180,6 @@ struct FormActionView: View {
             VStack(alignment: .leading) {
                 Text("\(field.label): \(sliderValues[field.name] ?? defaultSlider(field), specifier: "%.2f")")
                 Slider(value: sliderBinding(for: field), in: range, step: field.step ?? 1)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func plainTextField(for field: FieldDef) -> some View {
-        TextField("", text: binding(for: field), prompt: field.placeholder.map(Text.init))
-            .brandField()
-            .focused($focusedField, equals: field.name)
-            .overlay(alignment: .trailing) {
-                if isSendText, field.name == "text", !(textValues[field.name] ?? "").isEmpty {
-                    Button {
-                        textValues[field.name] = ""
-                        focusedField = field.name
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.textMuted)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.trailing, 6)
-                    .help("Clear the text")
-                }
-            }
-    }
-
-    // MARK: - Send Text snippets
-
-    /// Tag row: at most 6 recent snippets. Library collapse: this many rows
-    /// before "Show more". Search appears once the library outgrows a glance.
-    private static let recentTagLimit = 6
-    private static let collapsedLibraryLimit = 8
-    private static let searchThreshold = 10
-
-    /// The recently used snippets as one-click tags under the field (top 6),
-    /// led by the Mac's IP for the React Native role (Metro's "Debug server
-    /// host" is `<mac-ip>:8081`).
-    @ViewBuilder
-    private func snippetTags(for field: FieldDef) -> some View {
-        let recents = presets.recentSnippets(limit: Self.recentTagLimit)
-        if !recents.isEmpty || (state.selectedRole == .reactNativeDeveloper && macIP != nil) {
-            SnippetTagFlow(spacing: 6) {
-                if state.selectedRole == .reactNativeDeveloper, let macIP {
-                    Button {
-                        textValues[field.name] = macIP
-                    } label: {
-                        Label("Mac IP", systemImage: "network")
-                            .font(.app(.caption))
-                            .lineLimit(1)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .background(.quaternary, in: Capsule())
-                            .contentShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
-                    .help("Insert this Mac's IP address — \(macIP)")
-                }
-                ForEach(recents) { snippet in
-                    snippetChip(snippet, field: field)
-                }
-            }
-        }
-    }
-
-    /// The one place a snippet gets created. Prefills with the typed text so
-    /// "save what I just sent" stays one click.
-    private func newSnippetButton(for field: FieldDef) -> some View {
-        Button {
-            beginCreatingSnippet(for: field)
-        } label: {
-            Label("New Snippet", systemImage: "plus")
-                .font(.app(.caption))
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-        .help("Save a snippet — supports {clipboard} and {ip}")
-        .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
-            newSnippetPopover(for: field)
-        }
-    }
-
-    /// Everything beyond the recent tags, under the New Snippet button:
-    /// alphabetical chips, collapsed behind "Show more" when long, with a
-    /// search over every snippet's name and text once the library is big
-    /// enough to need one.
-    @ViewBuilder
-    private func snippetLibrary(for field: FieldDef) -> some View {
-        let recentIDs = Set(presets.recentSnippets(limit: Self.recentTagLimit).map(\.id))
-        let query = snippetSearch.trimmingCharacters(in: .whitespaces)
-        let library = presets.sendTextSnippets
-            .filter { query.isEmpty ? !recentIDs.contains($0.id) : $0.matches(query) }
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-
-        if presets.sendTextSnippets.count > Self.searchThreshold {
-            TextField("Search snippets…", text: $snippetSearch)
-                .textFieldStyle(.roundedBorder)
-                .controlSize(.small)
-                .frame(maxWidth: 200)
-                .help("Find a snippet by its name or its text")
-        }
-
-        if !query.isEmpty && library.isEmpty {
-            Text("No snippets match “\(query)”.")
-                .font(.app(.caption))
-                .foregroundStyle(.textMuted)
-        } else if !library.isEmpty {
-            let shown = showAllSnippets || !query.isEmpty
-                ? library
-                : Array(library.prefix(Self.collapsedLibraryLimit))
-            VStack(spacing: 0) {
-                ForEach(shown) { snippet in
-                    snippetRow(snippet, field: field)
-                    if snippet.id != shown.last?.id { Divider() }
-                }
-                if query.isEmpty, library.count > Self.collapsedLibraryLimit {
-                    Divider()
-                    Button {
-                        showAllSnippets.toggle()
-                    } label: {
-                        Text(showAllSnippets
-                            ? "Show less"
-                            : "Show \(library.count - Self.collapsedLibraryLimit) more")
-                            .font(.app(.caption))
-                            .foregroundStyle(.textMuted)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 6)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .background(.bgSurface, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(.borderSubtle))
-            .frame(maxWidth: 380, alignment: .leading)
-        }
-    }
-
-    /// One library row: the name beside a muted preview of the text — click
-    /// inserts, right-click removes.
-    private func snippetRow(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
-        Button {
-            insert(snippet, into: field)
-        } label: {
-            HStack(spacing: 10) {
-                Text(snippet.name)
-                    .font(.app(.callout))
-                    .lineLimit(1)
-                Spacer(minLength: 12)
-                Text(snippet.text)
-                    .font(.app(.caption, design: .monospaced))
-                    .foregroundStyle(.textMuted)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help("Click to insert · right-click to remove")
-        .contextMenu {
-            Button("Remove Snippet", role: .destructive) {
-                presets.removeSnippet(named: snippet.name)
-                persistPresets()
-            }
-        }
-    }
-
-    /// One snippet as a click-to-insert tag; right-click removes it.
-    private func snippetChip(_ snippet: SendTextSnippet, field: FieldDef) -> some View {
-        Button {
-            insert(snippet, into: field)
-        } label: {
-            Text(snippet.name)
-                .font(.app(.caption))
-                .lineLimit(1)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(.quaternary, in: Capsule())
-                .contentShape(Capsule())
-        }
-        .buttonStyle(.plain)
-        .help("\(snippet.text)\n\nRight-click to remove")
-        .contextMenu {
-            Button("Remove Snippet", role: .destructive) {
-                presets.removeSnippet(named: snippet.name)
-                persistPresets()
-            }
-        }
-    }
-
-    private func newSnippetPopover(for field: FieldDef) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("New snippet")
-                .font(.app(.headline))
-            TextField("Name", text: $newSnippetName, prompt: Text("Name — shown on the tag"))
-                .textFieldStyle(.roundedBorder)
-                .onChange(of: newSnippetName) { _, value in
-                    if value.count > SendTextSnippet.nameLimit {
-                        newSnippetName = String(value.prefix(SendTextSnippet.nameLimit))
-                    }
-                }
-            TextField("Text", text: $newSnippetText, prompt: Text("Text to insert…"), axis: .vertical)
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(1...4)
-                .onSubmit { saveNewSnippet() }
-            Text("{clipboard} and {ip} fill in with the live value when inserted.")
-                .font(.app(.caption))
-                .foregroundStyle(.textMuted)
-            HStack {
-                Text("\(newSnippetName.count)/\(SendTextSnippet.nameLimit)")
-                    .font(.app(.caption2).monospacedDigit())
-                    .foregroundStyle(.tertiary)
-                Spacer()
-                Button("Cancel") { creatingSnippet = false }
-                    .keyboardShortcut(.cancelAction)
-                Button("Save") { saveNewSnippet() }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!canSaveNewSnippet)
-            }
-        }
-        .padding(14)
-        .frame(width: 300)
-    }
-
-    private var canSaveNewSnippet: Bool {
-        let name = newSnippetName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !name.isEmpty && !newSnippetText.isEmpty
-            && !presets.sendTextSnippets.contains { $0.name == name }
-    }
-
-    /// Prefill the text with what's already typed — "save what I just sent"
-    /// stays one click.
-    private func beginCreatingSnippet(for field: FieldDef) {
-        newSnippetName = ""
-        newSnippetText = textValues[field.name] ?? ""
-        creatingSnippet = true
-    }
-
-    private func saveNewSnippet() {
-        guard canSaveNewSnippet else { return }
-        presets.addSnippet(named: newSnippetName, text: newSnippetText)
-        persistPresets()
-        creatingSnippet = false
-    }
-
-    /// Insert a snippet: placeholders expand to their live values and the use
-    /// count behind the top-5 tags bumps.
-    private func insert(_ snippet: SendTextSnippet, into field: FieldDef) {
-        textValues[field.name] = SnippetPlaceholders.expand(snippet.text, values: placeholderValues())
-        presets.recordSnippetUse(named: snippet.name)
-        persistPresets()
-    }
-
-    private func placeholderValues() -> [String: String] {
-        var values: [String: String] = [:]
-        if let clipboard = NSPasteboard.general.string(forType: .string) { values["clipboard"] = clipboard }
-        if let macIP { values["ip"] = macIP }
-        return values
-    }
-
-    private func persistPresets() {
-        let updated = presets
-        Task {
-            do {
-                try await state.env.stores.presets.save(updated)
-            } catch {
-                state.showToast(Toast(message: "Couldn't save the snippet: \(error.localizedDescription)", ok: false))
             }
         }
     }
@@ -535,15 +229,7 @@ struct FormActionView: View {
             }
         }
         Task {
-            // Compare timestamps so a stale success (run() early-returns on
-            // no-device without touching lastResults) can't clear unsent text.
-            let previousResultAt = state.lastResults[feature.id]?.1
             await state.run(feature: feature, params: params)
-            if isSendText, clearAfterSend,
-               let (result, at) = state.lastResults[feature.id],
-               result.ok, at != previousResultAt {
-                textValues["text"] = ""
-            }
         }
     }
 
@@ -572,43 +258,4 @@ struct FormActionView: View {
         )
     }
 
-}
-
-/// Wraps the snippet tags onto new lines when they overflow the field width
-/// (same shape as ApkInspectorView's FlowChips).
-private struct SnippetTagFlow: Layout {
-    var spacing: CGFloat = 6
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
-        let maxWidth = proposal.width ?? .infinity
-        var x: CGFloat = 0, y: CGFloat = 0, rowHeight: CGFloat = 0
-        for view in subviews {
-            let size = view.sizeThatFits(.unspecified)
-            if x + size.width > maxWidth, x > 0 {
-                x = 0
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
-        return CGSize(width: maxWidth == .infinity ? x : maxWidth, height: y + rowHeight)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var rowHeight: CGFloat = 0
-        for view in subviews {
-            let size = view.sizeThatFits(.unspecified)
-            if x + size.width > bounds.maxX, x > bounds.minX {
-                x = bounds.minX
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
-    }
 }

--- a/App/Sources/FeatureDetail/Views/SendTextView.swift
+++ b/App/Sources/FeatureDetail/Views/SendTextView.swift
@@ -135,15 +135,16 @@ struct SendTextView: View {
         .frame(maxWidth: 460)
     }
 
-    /// The last send's outcome, right under the button that caused it — toasts
-    /// disappear, this stays (and carries the ADBKeyboard install offer).
+    /// Only a FAILED send stays visible under the button — it carries the
+    /// ADBKeyboard install offer and error text worth reading. A success
+    /// already announces itself via the toast, so it leaves no residue here.
     @ViewBuilder
     private var resultRow: some View {
-        if let entry = state.lastResults[feature.id] {
+        if let entry = state.lastResults[feature.id], !entry.result.ok {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Image(systemName: entry.result.ok ? "checkmark.circle.fill" : "xmark.circle.fill")
-                        .foregroundStyle(entry.result.ok ? .brandAccent : .red)
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
                     Text(entry.result.message)
                         .font(.app(.callout))
                         .textSelection(.enabled)
@@ -170,15 +171,19 @@ struct SendTextView: View {
     private var snippetsSection: some View {
         HubSection(
             "Snippets",
-            subtitle: "Click one to insert it — {clipboard} and {ip} fill in with the live value.",
-            accessory: { newSnippetButton }
+            subtitle: "Click one to insert it — {clipboard} and {ip} fill in with the live value."
         ) {
             VStack(alignment: .leading, spacing: 10) {
-                if presets.sendTextSnippets.count > Self.searchThreshold {
-                    SearchField(prompt: "Search snippets", text: $snippetSearch)
-                        .frame(maxWidth: 240)
-                        .help("Find a snippet by its name or its text")
+                HStack(spacing: 10) {
+                    newSnippetButton
+                    Spacer(minLength: 12)
+                    if presets.sendTextSnippets.count > Self.searchThreshold {
+                        SearchField(prompt: "Search snippets", text: $snippetSearch)
+                            .frame(maxWidth: 240)
+                            .help("Find a snippet by its name or its text")
+                    }
                 }
+                .frame(maxWidth: 520)
                 snippetList
             }
         }

--- a/App/Sources/FeatureDetail/Views/SendTextView.swift
+++ b/App/Sources/FeatureDetail/Views/SendTextView.swift
@@ -1,0 +1,434 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// Bespoke Send Text screen. Two sections instead of one flat column: the send
+/// flow (field → Send → its result, inline where the eyes are) and the snippet
+/// library (a single recency-ranked, searchable list). Replaces the old
+/// FormActionView special-case, whose recent-tags row duplicated the library
+/// and whose result card landed below the snippet list.
+struct SendTextView: View {
+    @Environment(AppState.self) private var state
+    let feature: FeatureDef
+
+    @State private var text = ""
+    @State private var presets = Presets()
+    /// The Mac's LAN IP — the `{ip}` placeholder value and, for the React
+    /// Native role, a pinned quick insert (Metro's "Debug server host" is
+    /// `<mac-ip>:8081`).
+    @State private var macIP: String?
+    @State private var creatingSnippet = false
+    @State private var newSnippetName = ""
+    @State private var newSnippetText = ""
+    @State private var snippetSearch = ""
+    @State private var showAllSnippets = false
+    @State private var snippetPendingRemoval: SendTextSnippet?
+    @FocusState private var textFocused: Bool
+    /// Wipe the field after a successful send, for firing a sequence of
+    /// inputs without hand-clearing between them. Persisted choice.
+    @AppStorage("sendTextClearAfterSend") private var clearAfterSend = false
+
+    /// Library collapse: this many rows before "Show more". Search appears
+    /// once the library outgrows a glance.
+    private static let collapsedLibraryLimit = 8
+    private static let searchThreshold = 10
+
+    var body: some View {
+        Group {
+            if state.targetSerials.isEmpty {
+                NoDeviceView(feature: feature)
+            } else {
+                HubColumn {
+                    sendSection
+                    snippetsSection
+                }
+            }
+        }
+        .task {
+            presets = await state.env.stores.presets.load()
+            macIP = HostNetwork.primaryIPv4()
+        }
+        .task {
+            // Put the cursor in the field so the user can type right away. The
+            // delay lets the field mount and the window become key first.
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled else { return }
+            textFocused = true
+        }
+        .confirmationDialog(
+            "Remove “\(snippetPendingRemoval?.name ?? "")”?",
+            isPresented: Binding(
+                get: { snippetPendingRemoval != nil },
+                set: { if !$0 { snippetPendingRemoval = nil } }
+            )
+        ) {
+            Button("Remove Snippet", role: .destructive) {
+                if let snippet = snippetPendingRemoval {
+                    presets.removeSnippet(named: snippet.name)
+                    persistPresets()
+                }
+                snippetPendingRemoval = nil
+            }
+            Button("Cancel", role: .cancel) { snippetPendingRemoval = nil }
+        }
+    }
+
+    // MARK: - Send section
+
+    private var sendSection: some View {
+        HubSection("Text", subtitle: "Types into whatever field is focused on the device.") {
+            VStack(alignment: .leading, spacing: 12) {
+                textField
+
+                HStack(spacing: 10) {
+                    Button {
+                        submit()
+                    } label: {
+                        Label("Send", systemImage: "paperplane.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(state.isRunningFeature || text.isEmpty)
+                    .keyboardShortcut(.return, modifiers: .command)
+
+                    Text("⏎ to send")
+                        .font(.app(.caption))
+                        .foregroundStyle(.tertiary)
+
+                    Spacer(minLength: 16)
+
+                    Toggle("Clear after sending", isOn: $clearAfterSend)
+                        .toggleStyle(.checkbox)
+                        .font(.app(.callout))
+                        .help("Empty the field after a successful send")
+                }
+                .frame(maxWidth: 460)
+
+                resultRow
+            }
+        }
+    }
+
+    private var textField: some View {
+        TextField(
+            "", text: $text,
+            prompt: feature.fields.first { $0.name == "text" }?.placeholder.map(Text.init)
+        )
+        .brandField()
+        .focused($textFocused)
+        .onSubmit { submit() }
+        .overlay(alignment: .trailing) {
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                    textFocused = true
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.textMuted)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 6)
+                .help("Clear the text")
+            }
+        }
+        .frame(maxWidth: 460)
+    }
+
+    /// The last send's outcome, right under the button that caused it — toasts
+    /// disappear, this stays (and carries the ADBKeyboard install offer).
+    @ViewBuilder
+    private var resultRow: some View {
+        if let entry = state.lastResults[feature.id] {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: entry.result.ok ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(entry.result.ok ? .brandAccent : .red)
+                    Text(entry.result.message)
+                        .font(.app(.callout))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 12)
+                    Text(entry.at, style: .time)
+                        .font(.app(.caption))
+                        .foregroundStyle(.tertiary)
+                }
+                if entry.result.needsAdbKeyboard {
+                    Button("Install ADBKeyboard") {
+                        state.installAdbKeyboard()
+                    }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .frame(maxWidth: 460, alignment: .leading)
+        }
+    }
+
+    // MARK: - Snippets section
+
+    private var snippetsSection: some View {
+        HubSection(
+            "Snippets",
+            subtitle: "Click one to insert it — {clipboard} and {ip} fill in with the live value.",
+            accessory: { newSnippetButton }
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                if presets.sendTextSnippets.count > Self.searchThreshold {
+                    SearchField(prompt: "Search snippets", text: $snippetSearch)
+                        .frame(maxWidth: 240)
+                        .help("Find a snippet by its name or its text")
+                }
+                snippetList
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var snippetList: some View {
+        let query = snippetSearch.trimmingCharacters(in: .whitespaces)
+        let ranked = presets.recentSnippets(limit: Int.max).filter { $0.matches(query) }
+        let pinnedIP = query.isEmpty && state.selectedRole == .reactNativeDeveloper ? macIP : nil
+
+        if !query.isEmpty, ranked.isEmpty {
+            Text("No snippets match “\(query)”.")
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+        } else if ranked.isEmpty, pinnedIP == nil {
+            Text("No snippets yet. Save the text you type often and it's one click from here.")
+                .font(.app(.callout))
+                .foregroundStyle(.textMuted)
+        } else {
+            let shown = showAllSnippets || !query.isEmpty
+                ? ranked
+                : Array(ranked.prefix(Self.collapsedLibraryLimit))
+            VStack(spacing: 0) {
+                if let pinnedIP {
+                    macIPRow(pinnedIP)
+                    if !shown.isEmpty { Divider() }
+                }
+                ForEach(shown) { snippet in
+                    SnippetRow(snippet: snippet) {
+                        insert(snippet)
+                    } onRemove: {
+                        snippetPendingRemoval = snippet
+                    }
+                    if snippet.id != shown.last?.id { Divider() }
+                }
+                if query.isEmpty, ranked.count > Self.collapsedLibraryLimit {
+                    Divider()
+                    Button {
+                        showAllSnippets.toggle()
+                    } label: {
+                        Text(showAllSnippets
+                            ? "Show less"
+                            : "Show \(ranked.count - Self.collapsedLibraryLimit) more")
+                            .font(.app(.caption))
+                            .foregroundStyle(.textMuted)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 6)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .background(.bgRoot, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(.borderSubtle))
+            .frame(maxWidth: 520, alignment: .leading)
+        }
+    }
+
+    /// Quick insert for the React Native role — not a saved snippet, so it
+    /// pins above the list and can't be removed.
+    private func macIPRow(_ ip: String) -> some View {
+        Button {
+            text = ip
+            textFocused = true
+        } label: {
+            HStack(spacing: 10) {
+                Label("Mac IP", systemImage: "network")
+                    .font(.app(.callout))
+                    .lineLimit(1)
+                Spacer(minLength: 12)
+                Text(ip)
+                    .font(.app(.caption, design: .monospaced))
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .modifier(HoverHighlight())
+        .help("Insert this Mac's IP address — Metro's Debug server host is \(ip):8081")
+    }
+
+    private var newSnippetButton: some View {
+        Button {
+            newSnippetName = ""
+            newSnippetText = text
+            creatingSnippet = true
+        } label: {
+            Label("New Snippet", systemImage: "plus")
+                .font(.app(.caption))
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .help("Save a snippet — supports {clipboard} and {ip}")
+        .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
+            newSnippetPopover
+        }
+    }
+
+    /// Prefilled with the typed text — "save what I just sent" stays one click.
+    private var newSnippetPopover: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("New snippet")
+                .font(.app(.headline))
+            TextField("Name", text: $newSnippetName, prompt: Text("Name — shown in the list"))
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: newSnippetName) { _, value in
+                    if value.count > SendTextSnippet.nameLimit {
+                        newSnippetName = String(value.prefix(SendTextSnippet.nameLimit))
+                    }
+                }
+            TextField("Text", text: $newSnippetText, prompt: Text("Text to insert…"), axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(1...4)
+                .onSubmit { saveNewSnippet() }
+            Text("{clipboard} and {ip} fill in with the live value when inserted.")
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+            HStack {
+                Text("\(newSnippetName.count)/\(SendTextSnippet.nameLimit)")
+                    .font(.app(.caption2).monospacedDigit())
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                Button("Cancel") { creatingSnippet = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") { saveNewSnippet() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSaveNewSnippet)
+            }
+        }
+        .padding(14)
+        .frame(width: 300)
+    }
+
+    private var canSaveNewSnippet: Bool {
+        let name = newSnippetName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !name.isEmpty && !newSnippetText.isEmpty
+            && !presets.sendTextSnippets.contains { $0.name == name }
+    }
+
+    private func saveNewSnippet() {
+        guard canSaveNewSnippet else { return }
+        presets.addSnippet(named: newSnippetName, text: newSnippetText)
+        persistPresets()
+        creatingSnippet = false
+    }
+
+    /// Insert a snippet: placeholders expand to their live values and the use
+    /// count behind the recency ranking bumps.
+    private func insert(_ snippet: SendTextSnippet) {
+        text = SnippetPlaceholders.expand(snippet.text, values: placeholderValues())
+        presets.recordSnippetUse(named: snippet.name)
+        persistPresets()
+        textFocused = true
+    }
+
+    private func placeholderValues() -> [String: String] {
+        var values: [String: String] = [:]
+        if let clipboard = NSPasteboard.general.string(forType: .string) {
+            values["clipboard"] = clipboard
+        }
+        if let macIP { values["ip"] = macIP }
+        return values
+    }
+
+    private func persistPresets() {
+        let updated = presets
+        Task {
+            do {
+                try await state.env.stores.presets.save(updated)
+            } catch {
+                state.showToast(Toast(
+                    message: "Couldn't save the snippet: \(error.localizedDescription)", ok: false))
+            }
+        }
+    }
+
+    private func submit() {
+        guard !text.isEmpty, !state.isRunningFeature else { return }
+        let params: [String: FeatureValue] = ["text": .string(text)]
+        Task {
+            // Compare timestamps so a stale success (run() early-returns on
+            // no-device without touching lastResults) can't clear unsent text.
+            let previousResultAt = state.lastResults[feature.id]?.1
+            await state.run(feature: feature, params: params)
+            if clearAfterSend, let (result, at) = state.lastResults[feature.id],
+               result.ok, at != previousResultAt {
+                text = ""
+            }
+        }
+    }
+}
+
+/// One library row: the name beside a muted preview of the text — click
+/// inserts, the hover-revealed trash (or right-click) removes. The trash keeps
+/// its layout slot when hidden so hovering never shifts the row.
+private struct SnippetRow: View {
+    let snippet: SendTextSnippet
+    let onInsert: () -> Void
+    let onRemove: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button(action: onInsert) {
+                HStack(spacing: 10) {
+                    Text(snippet.name)
+                        .font(.app(.callout))
+                        .lineLimit(1)
+                    Spacer(minLength: 12)
+                    Text(snippet.text)
+                        .font(.app(.caption, design: .monospaced))
+                        .foregroundStyle(.textMuted)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Click to insert\n\n\(snippet.text)")
+
+            Button(action: onRemove) {
+                Image(systemName: "trash")
+                    .foregroundStyle(.red)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(hovering ? 1 : 0)
+            .help("Remove this snippet")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(hovering ? Color.textMain.opacity(0.06) : .clear)
+        .onHover { hovering = $0 }
+        .contextMenu {
+            Button("Remove Snippet", role: .destructive, action: onRemove)
+        }
+    }
+}
+
+/// The quiet row-hover wash used across list-like rows.
+private struct HoverHighlight: ViewModifier {
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(hovering ? Color.textMain.opacity(0.06) : .clear)
+            .onHover { hovering = $0 }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/SendTextView.swift
+++ b/App/Sources/FeatureDetail/Views/SendTextView.swift
@@ -280,7 +280,7 @@ struct SendTextView: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
-        .help("Save a snippet — supports {clipboard} and {ip}")
+        .help("Save the text you send often as a reusable snippet")
         .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
             newSnippetPopover
         }
@@ -302,9 +302,15 @@ struct SendTextView: View {
                 .textFieldStyle(.roundedBorder)
                 .lineLimit(1...4)
                 .onSubmit { saveNewSnippet() }
-            Text("{clipboard} and {ip} fill in with the live value when inserted.")
-                .font(.app(.caption))
-                .foregroundStyle(.textMuted)
+            HStack(spacing: 6) {
+                Text("Add a live value:")
+                    .font(.app(.caption))
+                    .foregroundStyle(.textMuted)
+                placeholderChip("{clipboard}")
+                if state.selectedRole == .reactNativeDeveloper {
+                    placeholderChip("{ip}")
+                }
+            }
             HStack {
                 Text("\(newSnippetName.count)/\(SendTextSnippet.nameLimit)")
                     .font(.app(.caption2).monospacedDigit())
@@ -319,6 +325,24 @@ struct SendTextView: View {
         }
         .padding(14)
         .frame(width: 300)
+    }
+
+    /// A `{placeholder}` token as a click-to-append chip — it lands in the
+    /// snippet text and expands to the live value whenever the snippet is
+    /// inserted.
+    private func placeholderChip(_ token: String) -> some View {
+        Button {
+            newSnippetText += token
+        } label: {
+            Text(token)
+                .font(.app(.caption, design: .monospaced))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.quaternary, in: Capsule())
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("Adds \(token) to the text — it fills in with the live value when the snippet is inserted")
     }
 
     private var canSaveNewSnippet: Bool {


### PR DESCRIPTION
## What

Replaces the Send Text special-case inside `FormActionView` with a bespoke `SendTextView` built on the HubSection idiom.

**Text section** — the send flow only:
- brand field with the ⓧ clear, focused on open; Return in the field sends (⌘⏎ still works everywhere)
- a successful send announces itself via the toast only; a **failed** send stays inline under the Send button (error text, time, and the Install ADBKeyboard offer)
- "Clear after sending" sits beside the shortcut hint as a compact checkbox (same `sendTextClearAfterSend` key)

**Snippets section** — one list instead of two surfaces:
- the recent-tags chip row is gone; the library is a single list ranked by `Presets.recentSnippets` (recency → uses → save order), so the tags' job is served by row order
- a toolbar row directly above the list holds New Snippet (leading, still prefilled with the typed text) and the shared `SearchField` (appears past 10 snippets); collapse at 8 rows with "Show more"
- rows show name + monospaced text preview; click inserts, a hover-revealed trash (or right-click) removes behind a confirmation dialog
- `{clipboard}`/`{ip}` hints unchanged; empty-state hint when there are no snippets; the Mac IP quick insert stays for the React Native role as a pinned row

`FormActionView` returns to a purely generic renderer (snippet state, tag flow layout, and the send-text overlay are removed). The send-text how-it-works note is updated to match.

## Tests

- `cd ADBKit && swift test` — 910 tests green (snippet ranking/matching/placeholder logic lives in ADBKit and is already covered)
- `make build` — zero warnings
- Verified the Debug build launches with the new screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)