### PR TITLE
Suspend the backdrop blur during live resizes

### DIFF
--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -507,12 +507,26 @@ struct RootView: View {
             .navigationTitle(activeTitle)
             // The deferred fixed-sidebar hide: fires when the drag ends
             // (splitDragFraction → nil); a fresh drag re-arms cleanly.
+            // Also: both seam drags redraw the window every frame — with a
+            // heavy backdrop blur that re-blurs per frame and turns the drag
+            // syrupy — so the blur rests while either drag is live.
             .onChange(of: splitDragFraction == nil) { _, dragEnded in
-                if dragEnded, pendingSidebarHide {
+                if dragEnded {
+                    WindowBlurSuspension.end(state)
+                    if pendingSidebarHide {
+                        pendingSidebarHide = false
+                        state.hideSidebarForSplitRoom()
+                    }
+                } else {
+                    WindowBlurSuspension.begin(state)
                     pendingSidebarHide = false
-                    state.hideSidebarForSplitRoom()
-                } else if !dragEnded {
-                    pendingSidebarHide = false
+                }
+            }
+            .onChange(of: sidebarDragWidth == nil) { _, ended in
+                if ended {
+                    WindowBlurSuspension.end(state)
+                } else {
+                    WindowBlurSuspension.begin(state)
                 }
             }
         }

--- a/App/Sources/Root/WindowTranslucency.swift
+++ b/App/Sources/Root/WindowTranslucency.swift
@@ -1,5 +1,6 @@
 import ADBKit
 import AppKit
+import Combine
 import SwiftUI
 
 /// The translucent-window appearance (Settings ▸ Appearance ▸ Window): the
@@ -59,10 +60,10 @@ private enum WindowServerBlur {
 }
 
 /// Everything RootView layers onto its content for the translucent window,
-/// as ONE chain link: the grain film, the `\.windowOpacity` environment, and
-/// the live re-application of window flags + blur radius on slider changes.
-/// (Kept out of RootView's `body` chain — its expression already sits near
-/// the type-checker's time limit on CI, and four more links pushed it over.)
+/// as ONE chain link: the grain film, the `\.windowOpacity` environment, the
+/// live re-application of window flags + blur radius on slider changes, and
+/// the live-resize blur suspension. (Kept out of RootView's `body` chain —
+/// its expression already sits near the type-checker's time limit on CI.)
 struct WindowTranslucencyModifier: ViewModifier {
     let state: AppState
     @AppStorage(windowOpacityDefaultsKey) private var windowOpacity = 1.0
@@ -88,6 +89,49 @@ struct WindowTranslucencyModifier: ViewModifier {
                     applyWindowTranslucency(window, opacity: windowOpacity, blurAmount: value)
                 }
             }
+            // Window-edge live resizes redraw every frame; at a large radius
+            // the window server re-blurs the whole backdrop each time and
+            // the drag turns syrupy. Suspend the blur for the duration.
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSWindow.willStartLiveResizeNotification)
+            ) { note in
+                if let window = note.object as? NSWindow, window === state.mainWindow {
+                    WindowBlurSuspension.begin(state)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSWindow.didEndLiveResizeNotification)
+            ) { note in
+                if let window = note.object as? NSWindow, window === state.mainWindow {
+                    WindowBlurSuspension.end(state)
+                }
+            }
+    }
+}
+
+/// Suspends the backdrop blur while a live resize is in flight (window edge,
+/// split divider, sidebar handle) and restores it when the last one ends —
+/// re-entrant, since a split drag can overlap a window resize. The frost
+/// vanishing during the drag is the visible trade for a fluid resize.
+@MainActor
+enum WindowBlurSuspension {
+    private static var active = 0
+
+    static func begin(_ state: AppState) {
+        active += 1
+        guard active == 1, let window = state.mainWindow else { return }
+        WindowServerBlur.apply(radius: 0, to: window)
+    }
+
+    static func end(_ state: AppState) {
+        guard active > 0 else { return }
+        active -= 1
+        guard active == 0, let window = state.mainWindow else { return }
+        let defaults = UserDefaults.standard
+        let opacity = defaults.object(forKey: windowOpacityDefaultsKey) as? Double ?? 1.0
+        let blur = defaults.object(forKey: windowBlurDefaultsKey) as? Double ?? 0.6
+        WindowServerBlur.apply(
+            radius: WindowEffects.blurRadius(amount: blur, root: opacity), to: window)
     }
 }
 


### PR DESCRIPTION
At a high Blur amount, the window server re-blurs the whole backdrop for every frame of a window-edge, split-divider, or sidebar-handle drag — resizing a translucent window turned syrupy.

The blur now rests for the duration of a live resize and snaps back on release (`WindowBlurSuspension`, re-entrant across overlapping drags). Opacity and grain stay as set — only the blur radius drops to 0 mid-drag.

This intentionally does NOT change any sidebar behavior: the split-overshoot sidebar hide stays deferred to mouse-up exactly as on main (the mid-drag-hide experiment was dropped — PR #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)