### PR TITLE
Add custom background and text colors

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/BackgroundPalette.swift
+++ b/ADBKit/Sources/ADBKit/Features/BackgroundPalette.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Pure math for the user-chosen window background (Settings ▸ Appearance):
+/// parses the stored hex and derives the lifted surface, the hairline border,
+/// and the light/dark treatment from that one root color — mirroring the
+/// contrast steps between the stock `BgRoot`/`BgSurface`/`BorderSubtle`
+/// assets, so a custom palette keeps the same visual hierarchy.
+public enum BackgroundPalette {
+    /// sRGB components in 0…1.
+    public struct RGB: Equatable, Sendable {
+        public var red: Double
+        public var green: Double
+        public var blue: Double
+
+        public init(red: Double, green: Double, blue: Double) {
+            self.red = red
+            self.green = green
+            self.blue = blue
+        }
+    }
+
+    /// Parse "#RRGGBB" / "RRGGBB" (or the "#RGB" shorthand). nil on malformed
+    /// input, so a corrupt stored value falls back to the stock assets.
+    public static func parse(hex: String) -> RGB? {
+        var s = hex.trimmingCharacters(in: .whitespaces)
+        if s.hasPrefix("#") { s.removeFirst() }
+        if s.count == 3 { s = s.map { "\($0)\($0)" }.joined() }
+        guard s.count == 6, let value = UInt32(s, radix: 16) else { return nil }
+        return RGB(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255)
+    }
+
+    /// Rec. 709 weights on gamma-encoded sRGB — the same perceptual-luminance
+    /// heuristic the app's `contrastingForeground` uses.
+    public static func luminance(_ color: RGB) -> Double {
+        0.2126 * color.red + 0.7152 * color.green + 0.0722 * color.blue
+    }
+
+    /// Light backgrounds get dark text and the light (aqua) appearance — the
+    /// 0.35 threshold matches `contrastingForeground`.
+    public static func isLight(_ color: RGB) -> Bool {
+        luminance(color) > 0.35
+    }
+
+    /// One step lifted (sidebar, cards, bars): +9/255 per channel, clamped —
+    /// the stock dark step (#1A1A1A → #232323); a light root lands at white
+    /// just like the stock pair (#F5F6F7 → #FFFFFF).
+    public static func surface(for root: RGB) -> RGB {
+        shifted(root, by: 9.0 / 255)
+    }
+
+    /// Hairline dividers: dark roots go lighter (+25/255, the stock
+    /// #1A1A1A → #333333 step), light roots darker (−18/255, ≈the stock
+    /// #F5F6F7 → #E3E5E8 step).
+    public static func border(for root: RGB) -> RGB {
+        shifted(root, by: isLight(root) ? -18.0 / 255 : 25.0 / 255)
+    }
+
+    private static func shifted(_ color: RGB, by delta: Double) -> RGB {
+        RGB(
+            red: min(1, max(0, color.red + delta)),
+            green: min(1, max(0, color.green + delta)),
+            blue: min(1, max(0, color.blue + delta)))
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/TextPalette.swift
+++ b/ADBKit/Sources/ADBKit/Features/TextPalette.swift
@@ -27,4 +27,19 @@ public enum TextPalette {
             green: main.green * mutedOpacity + background.green * (1 - mutedOpacity),
             blue: main.blue * mutedOpacity + background.blue * (1 - mutedOpacity))
     }
+
+    /// A WCAG-style contrast ratio (1…21) between two colors, using the app's
+    /// gamma-encoded luminance approximation (`BackgroundPalette.luminance`, the
+    /// same one behind `isLight`) rather than a second, linearized model — so
+    /// the number lines up with the rest of the palette math.
+    public static func contrastRatio(_ a: RGB, _ b: RGB) -> Double {
+        let la = BackgroundPalette.luminance(a)
+        let lb = BackgroundPalette.luminance(b)
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+
+    /// Below this ratio a custom text color is likely hard to read on its
+    /// background, so Settings shows a non-blocking warning (it never prevents
+    /// applying the color). 3.0 is WCAG AA for large text / UI components.
+    public static let minComfortableContrast = 3.0
 }

--- a/ADBKit/Sources/ADBKit/Features/TextPalette.swift
+++ b/ADBKit/Sources/ADBKit/Features/TextPalette.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Pure math for the user-chosen text color (Settings ▸ Appearance ▸ Text):
+/// one picked color drives primary text, and the muted/subtitle tone is
+/// derived from it by the same primary→muted step as the stock palette, so the
+/// text hierarchy holds on whatever color the user picks.
+///
+/// Reuses `BackgroundPalette.RGB` for the component type.
+public enum TextPalette {
+    public typealias RGB = BackgroundPalette.RGB
+
+    /// The muted tone is the primary color composited at this opacity over the
+    /// surface behind it. It reproduces the stock primary→muted step in both
+    /// themes — dark `#ECECEC → #929292` (≈ ×0.62) and light `#181A1C` over
+    /// white `→ #6A6E73` (≈ ×0.63) — so the app applies it directly as a
+    /// SwiftUI opacity and lets it composite over whatever surface is actually
+    /// behind the text (root, card, or a custom background).
+    public static let mutedOpacity = 0.62
+
+    /// The muted tone as a concrete color: `main` alpha-composited at
+    /// `mutedOpacity` over `background`. The app renders muted text via the
+    /// opacity above (background-agnostic); this returns the equivalent solid
+    /// color and exists so the ratio is unit-tested against the stock pairs.
+    public static func muted(main: RGB, over background: RGB) -> RGB {
+        RGB(
+            red: main.red * mutedOpacity + background.red * (1 - mutedOpacity),
+            green: main.green * mutedOpacity + background.green * (1 - mutedOpacity),
+            blue: main.blue * mutedOpacity + background.blue * (1 - mutedOpacity))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/BackgroundPaletteTests.swift
+++ b/ADBKit/Tests/ADBKitTests/BackgroundPaletteTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import ADBKit
+
+/// The custom-background derivation: hex parsing, the light/dark decision,
+/// and the surface/border contrast steps that mirror the stock asset palette.
+@Suite struct BackgroundPaletteTests {
+    private func hexByte(_ v: Double) -> Int { Int((v * 255).rounded()) }
+
+    @Test func parsesLongShortAndBareHex() {
+        #expect(BackgroundPalette.parse(hex: "#1A1A1A") == BackgroundPalette.RGB(
+            red: 26.0 / 255, green: 26.0 / 255, blue: 26.0 / 255))
+        #expect(BackgroundPalette.parse(hex: "0D1B2A") != nil)
+        // #123 expands to #112233.
+        #expect(BackgroundPalette.parse(hex: "#123") == BackgroundPalette.parse(hex: "#112233"))
+        #expect(BackgroundPalette.parse(hex: "  #FFFFFF  ") != nil)
+    }
+
+    @Test func rejectsMalformedHex() {
+        #expect(BackgroundPalette.parse(hex: "") == nil)
+        #expect(BackgroundPalette.parse(hex: "#12345") == nil)
+        #expect(BackgroundPalette.parse(hex: "#GGGGGG") == nil)
+        #expect(BackgroundPalette.parse(hex: "not a color") == nil)
+    }
+
+    @Test func lightDecisionMatchesTheContrastHeuristic() {
+        #expect(!BackgroundPalette.isLight(BackgroundPalette.parse(hex: "#000000")!))
+        #expect(!BackgroundPalette.isLight(BackgroundPalette.parse(hex: "#1A1A1A")!))   // stock dark root
+        #expect(!BackgroundPalette.isLight(BackgroundPalette.parse(hex: "#0D1B2A")!))   // midnight blue
+        #expect(BackgroundPalette.isLight(BackgroundPalette.parse(hex: "#F5F6F7")!))    // stock light root
+        #expect(BackgroundPalette.isLight(BackgroundPalette.parse(hex: "#FFFFFF")!))
+    }
+
+    @Test func surfaceStepReproducesTheStockDarkPair() {
+        // #1A1A1A → #232323 (+9 per channel).
+        let surface = BackgroundPalette.surface(for: BackgroundPalette.parse(hex: "#1A1A1A")!)
+        #expect(hexByte(surface.red) == 0x23)
+        #expect(hexByte(surface.green) == 0x23)
+        #expect(hexByte(surface.blue) == 0x23)
+    }
+
+    @Test func surfaceOnALightRootClampsAtWhite() {
+        // #F5F6F7 → white-ish, clamped like the stock light pair (surface #FFFFFF).
+        let surface = BackgroundPalette.surface(for: BackgroundPalette.parse(hex: "#F5F6F7")!)
+        #expect(hexByte(surface.red) >= 0xFE)
+        #expect(hexByte(surface.green) == 0xFF)
+        #expect(hexByte(surface.blue) == 0xFF)
+    }
+
+    @Test func borderStepsFollowTheRootsSide() {
+        // Dark root lightens (+25): #1A1A1A → #333333.
+        let dark = BackgroundPalette.border(for: BackgroundPalette.parse(hex: "#1A1A1A")!)
+        #expect(hexByte(dark.red) == 0x33)
+        // Light root darkens (−18): #F5F6F7 → ≈#E3E4E5.
+        let light = BackgroundPalette.border(for: BackgroundPalette.parse(hex: "#F5F6F7")!)
+        #expect(hexByte(light.red) == 0xE3)
+        #expect(hexByte(light.green) == 0xE4)
+    }
+
+    @Test func extremesStayInRange() {
+        let onWhite = BackgroundPalette.surface(for: BackgroundPalette.parse(hex: "#FFFFFF")!)
+        #expect(onWhite.red <= 1 && onWhite.green <= 1 && onWhite.blue <= 1)
+        let onBlack = BackgroundPalette.border(for: BackgroundPalette.parse(hex: "#000000")!)
+        #expect(onBlack.red >= 0 && hexByte(onBlack.red) == 25)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TextPaletteTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TextPaletteTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import ADBKit
+
+/// The custom-text derivation: the muted tone derived from one chosen color
+/// must reproduce the stock primary→muted step in both themes.
+@Suite struct TextPaletteTests {
+    private func byte(_ v: Double) -> Int { Int((v * 255).rounded()) }
+
+    private func rgb(_ hex: String) -> TextPalette.RGB {
+        BackgroundPalette.parse(hex: hex)!
+    }
+
+    @Test func mutedReproducesStockDarkStep() {
+        // Dark: TextMain #ECECEC over the near-black root → TextMuted #929292.
+        let muted = TextPalette.muted(main: rgb("#ECECEC"), over: rgb("#000000"))
+        #expect(abs(byte(muted.red) - 0x92) <= 4)
+        #expect(abs(byte(muted.green) - 0x92) <= 4)
+        #expect(abs(byte(muted.blue) - 0x92) <= 4)
+    }
+
+    @Test func mutedReproducesStockLightStep() {
+        // Light: TextMain #181A1C over the white root → TextMuted #6A6E73.
+        let muted = TextPalette.muted(main: rgb("#181A1C"), over: rgb("#FFFFFF"))
+        #expect(abs(byte(muted.red) - 0x6A) <= 6)
+        #expect(abs(byte(muted.green) - 0x6E) <= 6)
+        #expect(abs(byte(muted.blue) - 0x73) <= 6)
+    }
+
+    @Test func mutedStaysBetweenMainAndBackground() {
+        // A blend never leaves the segment between the two endpoints, in
+        // whichever direction each channel runs.
+        let main = rgb("#FF8800")
+        let bg = rgb("#101010")
+        let muted = TextPalette.muted(main: main, over: bg)
+        #expect(muted.red >= min(main.red, bg.red) && muted.red <= max(main.red, bg.red))
+        #expect(muted.green >= min(main.green, bg.green) && muted.green <= max(main.green, bg.green))
+        #expect(muted.blue >= min(main.blue, bg.blue) && muted.blue <= max(main.blue, bg.blue))
+    }
+
+    @Test func mutedOpacityIsInUnitRange() {
+        #expect(TextPalette.mutedOpacity > 0 && TextPalette.mutedOpacity < 1)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TextPaletteTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TextPaletteTests.swift
@@ -40,4 +40,23 @@ import Testing
     @Test func mutedOpacityIsInUnitRange() {
         #expect(TextPalette.mutedOpacity > 0 && TextPalette.mutedOpacity < 1)
     }
+
+    @Test func contrastRatioSpansTheFullRange() {
+        // White on black is the maximum (~21); a color against itself is 1.
+        #expect(abs(TextPalette.contrastRatio(rgb("#FFFFFF"), rgb("#000000")) - 21) < 0.01)
+        #expect(abs(TextPalette.contrastRatio(rgb("#3A7BD5"), rgb("#3A7BD5")) - 1) < 0.001)
+        // Symmetric in its arguments.
+        #expect(
+            TextPalette.contrastRatio(rgb("#ECECEC"), rgb("#1A1A1A"))
+                == TextPalette.contrastRatio(rgb("#1A1A1A"), rgb("#ECECEC")))
+    }
+
+    @Test func lowContrastPairsFallBelowTheThreshold() {
+        // Readable choices clear the bar…
+        #expect(TextPalette.contrastRatio(rgb("#ECECEC"), rgb("#1A1A1A")) >= TextPalette.minComfortableContrast)
+        #expect(TextPalette.contrastRatio(rgb("#FFB000"), rgb("#1A1A1A")) >= TextPalette.minComfortableContrast)
+        // …a dark gray on the dark root, or a light text on a light background, does not.
+        #expect(TextPalette.contrastRatio(rgb("#444444"), rgb("#1A1A1A")) < TextPalette.minComfortableContrast)
+        #expect(TextPalette.contrastRatio(rgb("#F0F0F0"), rgb("#F7F3EC")) < TextPalette.minComfortableContrast)
+    }
 }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -166,11 +166,14 @@ struct ADTApp: App {
     /// `.brandAccent`, background token, and `Font.app` to re-resolve.
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
     @AppStorage(backgroundColorDefaultsKey) private var backgroundHex = ""
+    @AppStorage(textColorDefaultsKey) private var textHex = ""
     @AppStorage(appFontFamilyDefaultsKey) private var appFontFamily = ""
     @AppStorage(appFontSizeScaleDefaultsKey) private var appFontSizeScale = 1.0
 
     /// One key covering every appearance pref the view tree resolves statically.
-    private var appearanceKey: String { "\(accentHex)|\(backgroundHex)|\(appFontFamily)|\(appFontSizeScale)" }
+    private var appearanceKey: String {
+        "\(accentHex)|\(backgroundHex)|\(textHex)|\(appFontFamily)|\(appFontSizeScale)"
+    }
 
     /// ⌃1…⌃9 accelerators for jumping straight to a tab by position.
     private static let tabDigitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -161,15 +161,16 @@ struct ADTApp: App {
     @AppStorage("showMenuBarExtra") private var showMenuBarExtra = true
     @AppStorage("sidebarWidth") private var sidebarWidth = 300.0
     @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
-    /// The user-chosen accent and font. Read here so changing them re-renders
-    /// the scene and re-keys RootView (`.id`), forcing every `.brandAccent`
-    /// and `Font.app` to re-resolve.
+    /// The user-chosen accent, background, and font. Read here so changing
+    /// them re-renders the scene and re-keys RootView (`.id`), forcing every
+    /// `.brandAccent`, background token, and `Font.app` to re-resolve.
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
+    @AppStorage(backgroundColorDefaultsKey) private var backgroundHex = ""
     @AppStorage(appFontFamilyDefaultsKey) private var appFontFamily = ""
     @AppStorage(appFontSizeScaleDefaultsKey) private var appFontSizeScale = 1.0
 
     /// One key covering every appearance pref the view tree resolves statically.
-    private var appearanceKey: String { "\(accentHex)|\(appFontFamily)|\(appFontSizeScale)" }
+    private var appearanceKey: String { "\(accentHex)|\(backgroundHex)|\(appFontFamily)|\(appFontSizeScale)" }
 
     /// ⌃1…⌃9 accelerators for jumping straight to a tab by position.
     private static let tabDigitKeys: [KeyEquivalent] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -231,7 +231,7 @@ struct DeviceBarView: View {
     }
 
     private var deviceStatusColor: Color {
-        guard let device = selectedDevice else { return Color("TextMuted") }
+        guard let device = selectedDevice else { return .textMuted }
         // Ready rides the accent (it doubles as the bar's active marker);
         // trouble states keep their semaphore colors.
         if device.isReady { return .brandAccent }
@@ -254,7 +254,7 @@ struct DeviceBarView: View {
     }
 
     private var bundleIconColor: Color {
-        state.selectedBundle == nil ? Color("TextMuted") : .brandAccent
+        state.selectedBundle == nil ? .textMuted : .brandAccent
     }
 
     private var deviceStatusHelp: String {

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -59,7 +59,18 @@ struct RootView: View {
     ///
     /// `nil` / system pass-through for "auto" keeps both following the system
     /// appearance live.
+    /// A custom background overrides the theme picker: light/dark follows the
+    /// chosen color's luminance, so SwiftUI resolves asset colors (text,
+    /// icons, borders) for that color instead of the stored theme. Without
+    /// this, a light background keeps dark-mode light-gray text — invisible on
+    /// the light surface. Matches `applyStoredTheme`, which sets the *native*
+    /// appearance the same way.
+    private var backgroundScheme: ColorScheme? {
+        customBackgroundRGB.map { BackgroundPalette.isLight($0) ? .light : .dark }
+    }
+
     private var preferredScheme: ColorScheme? {
+        if let backgroundScheme { return backgroundScheme }
         switch theme {
         case "light": return .light
         case "dark": return .dark
@@ -68,6 +79,7 @@ struct RootView: View {
     }
 
     private var injectedColorScheme: ColorScheme {
+        if let backgroundScheme { return backgroundScheme }
         switch theme {
         case "light": return .light
         case "auto": return colorScheme

--- a/App/Sources/Root/ToastOverlay.swift
+++ b/App/Sources/Root/ToastOverlay.swift
@@ -141,7 +141,7 @@ enum ToastStyle {
     static func color(_ level: Toast.Level) -> Color {
         switch level {
         case .success: .brandAccent
-        case .info: Color("TextMuted")
+        case .info: .textMuted
         case .warning: .orange
         case .error: .red
         }

--- a/App/Sources/Root/WindowTranslucency.swift
+++ b/App/Sources/Root/WindowTranslucency.swift
@@ -132,7 +132,18 @@ private struct TranslucentListBackground: ViewModifier {
     @Environment(\.windowOpacity) private var opacity
 
     func body(content: Content) -> some View {
-        content.scrollContentBackground(WindowEffects.isTranslucent(opacity) ? .hidden : .automatic)
+        if WindowEffects.isTranslucent(opacity) {
+            // Glass: hide the scroll material; the single root wash behind
+            // shows through (a fill here would compound with it).
+            content.scrollContentBackground(.hidden)
+        } else if customBackgroundRGB != nil {
+            // Opaque with a custom background: the system scroll material
+            // ignores it, so hide it and paint the chosen root color the
+            // list would otherwise cover.
+            content.scrollContentBackground(.hidden).background(.bgRoot)
+        } else {
+            content.scrollContentBackground(.automatic)
+        }
     }
 }
 
@@ -140,6 +151,16 @@ private struct TranslucentFeedBackground: ViewModifier {
     @Environment(\.windowOpacity) private var opacity
 
     func body(content: Content) -> some View {
-        content.background(.background.opacity(WindowEffects.isTranslucent(opacity) ? 0 : 1))
+        if WindowEffects.isTranslucent(opacity) {
+            // Glass: drop the material so the single root wash behind shows
+            // through (a second fill here would compound and darken it).
+            content.background(.background.opacity(0))
+        } else if customBackgroundRGB != nil {
+            // Opaque with a custom background: the system `.background`
+            // material ignores it, so paint the chosen root color instead.
+            content.background(.bgRoot)
+        } else {
+            content.background(.background)
+        }
     }
 }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -321,6 +321,38 @@ struct AppearanceSettingsView: View {
             set: { textHex = $0.hexString ?? "" })
     }
 
+    /// The color the primary text actually sits on: the custom background if
+    /// one is set, else the stock root asset resolved for the effective
+    /// appearance. Used only to gauge text contrast.
+    private var effectiveBackgroundRGB: BackgroundPalette.RGB? {
+        if let custom = customBackgroundRGB { return custom }
+        let name: NSAppearance.Name =
+            theme == "light" ? .aqua
+            : theme == "dark" ? .darkAqua
+            : (NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) ?? .darkAqua)
+        guard let appearance = NSAppearance(named: name), let nc = NSColor(named: "BgRoot") else {
+            return nil
+        }
+        var rgb: BackgroundPalette.RGB?
+        appearance.performAsCurrentDrawingAppearance {
+            if let s = nc.usingColorSpace(.sRGB) {
+                rgb = BackgroundPalette.RGB(
+                    red: s.redComponent, green: s.greenComponent, blue: s.blueComponent)
+            }
+        }
+        return rgb
+    }
+
+    /// Non-blocking readability nudge: a custom text color whose contrast on the
+    /// effective background falls below the comfortable threshold. nil (no
+    /// warning) unless a custom text color is set and genuinely low-contrast.
+    private var textContrastWarning: String? {
+        guard let text = customTextRGB, let bg = effectiveBackgroundRGB,
+              TextPalette.contrastRatio(text, bg) < TextPalette.minComfortableContrast
+        else { return nil }
+        return "This color may be hard to read on your background — the contrast is low. It's still applied."
+    }
+
     /// One Window-section slider row: label, slider, live percent readout.
     private func effectSlider(
         _ label: String, value: Binding<Double>, in range: ClosedRange<Double>, percent: Double
@@ -459,6 +491,10 @@ struct AppearanceSettingsView: View {
                 }
                 if textHexInvalid {
                     Text("Enter a hex color like #ECECEC (or the short #EEE).")
+                        .font(.app(.footnote))
+                        .foregroundStyle(.orange)
+                } else if let warning = textContrastWarning {
+                    Label(warning, systemImage: "exclamationmark.triangle")
                         .font(.app(.footnote))
                         .foregroundStyle(.orange)
                 }

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -38,6 +38,13 @@ struct SettingsView: View {
 /// from view lifecycle (RootView/Settings onAppear), never from App.init().
 @MainActor
 func applyStoredTheme() {
+    // A custom background overrides the theme picker: the appearance follows
+    // the color's luminance, so text, controls, and system chrome resolve to
+    // the readable variant on any background the user picks.
+    if let rgb = customBackgroundRGB {
+        NSApp.appearance = NSAppearance(named: BackgroundPalette.isLight(rgb) ? .aqua : .darkAqua)
+        return
+    }
     switch UserDefaults.standard.string(forKey: "theme") {
     case "light": NSApp.appearance = NSAppearance(named: .aqua)
     case "auto": NSApp.appearance = nil
@@ -260,6 +267,7 @@ struct GeneralSettingsView: View {
 struct AppearanceSettingsView: View {
     @AppStorage("theme") private var theme = "dark"
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
+    @AppStorage(backgroundColorDefaultsKey) private var backgroundHex = ""
     @AppStorage(appFontFamilyDefaultsKey) private var fontFamily = ""
     @AppStorage(appFontSizeScaleDefaultsKey) private var fontSizeScale = 1.0
     @AppStorage(windowOpacityDefaultsKey) private var windowOpacity = 1.0
@@ -267,6 +275,8 @@ struct AppearanceSettingsView: View {
     @AppStorage(windowGrainDefaultsKey) private var windowGrain = 0.0
     @State private var hexDraft = ""
     @State private var hexInvalid = false
+    @State private var bgHexDraft = ""
+    @State private var bgHexInvalid = false
     #if DEBUG
     @AppStorage(DevMetrics.overlayEnabledKey) private var showDevMetrics = true
     #endif
@@ -278,12 +288,27 @@ struct AppearanceSettingsView: View {
         ("Red", "#FF453A"), ("Orange", "#FF9F0A"), ("Yellow", "#FFD60A"),
     ]
 
+    /// One-click background presets; the leading nil swatch is the stock
+    /// graphite/lab palette. Dark roots first, two light ones at the end.
+    private static let presetBackgrounds: [(name: String, hex: String)] = [
+        ("Slate", "#0F172A"), ("Midnight", "#0D1B2A"), ("Espresso", "#211A16"),
+        ("Forest", "#0C1F17"), ("Plum", "#1B1023"), ("Steel", "#1C2126"),
+        ("Paper", "#F7F3EC"), ("Mist", "#EEF1F5"),
+    ]
+
     /// The accent ColorPicker reads/writes the stored hex; an empty value shows
     /// (and resets to) the bundled default.
     private var accentBinding: Binding<Color> {
         Binding(
             get: { Color(hex: accentHex) ?? Color("BrandAccent") },
             set: { accentHex = $0.hexString ?? "" })
+    }
+
+    /// The background ColorPicker, same contract as the accent's.
+    private var backgroundBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: backgroundHex) ?? Color("BgRoot") },
+            set: { backgroundHex = $0.hexString ?? "" })
     }
 
     /// One Window-section slider row: label, slider, live percent readout.
@@ -311,7 +336,12 @@ struct AppearanceSettingsView: View {
                 }
                 .pickerStyle(.segmented)
                 .onChange(of: theme) { applyStoredTheme() }
-                if theme == "light" {
+                .disabled(!backgroundHex.isEmpty)
+                if !backgroundHex.isEmpty {
+                    Text("Overridden by your custom background below — light/dark follows that color. Reset the background to use the theme.")
+                        .font(.app(.footnote))
+                        .foregroundStyle(.textMuted)
+                } else if theme == "light" {
                     Text("Light mode is in beta — a few screens are still being tuned for it.")
                         .font(.app(.footnote))
                         .foregroundStyle(.textMuted)
@@ -346,6 +376,38 @@ struct AppearanceSettingsView: View {
                         .foregroundStyle(.orange)
                 }
                 Text("Recolors buttons, toggles, selection, and active icons across the app. Pick a preset, use the color well, or type a hex code and press ⏎.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+            }
+
+            Section("Background") {
+                LabeledContent("Presets") {
+                    HStack(spacing: 7) {
+                        backgroundSwatch(name: "Graphite (default)", hex: nil)
+                        ForEach(Self.presetBackgrounds, id: \.hex) { preset in
+                            backgroundSwatch(name: preset.name, hex: preset.hex)
+                        }
+                    }
+                }
+                LabeledContent("Custom") {
+                    HStack(spacing: 8) {
+                        ColorPicker("", selection: backgroundBinding, supportsOpacity: false).labelsHidden()
+                        TextField("Hex code", text: $bgHexDraft, prompt: Text("#0D1B2A"))
+                            .textFieldStyle(.roundedBorder)
+                            .labelsHidden()
+                            .frame(width: 110)
+                            .onSubmit { commitBackgroundHex() }
+                        if !backgroundHex.isEmpty {
+                            Button("Reset") { setBackground("") }
+                        }
+                    }
+                }
+                if bgHexInvalid {
+                    Text("Enter a hex color like #0D1B2A (or the short #123).")
+                        .font(.app(.footnote))
+                        .foregroundStyle(.orange)
+                }
+                Text("Repaints every pane, card, and bar; hairlines and the light/dark text treatment adapt to the color automatically. The Terminal and JS Console keep their console-dark surfaces, and the Window sliders below still turn it to glass.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
             }
@@ -404,10 +466,18 @@ struct AppearanceSettingsView: View {
             #endif
         }
         .formStyle(.grouped)
-        .onAppear { hexDraft = accentHex }
-        // Reflect swatch/color-well changes into the hex field so it always
-        // shows the effective value.
+        .onAppear {
+            hexDraft = accentHex
+            bgHexDraft = backgroundHex
+        }
+        // Reflect swatch/color-well changes into the hex fields so they always
+        // show the effective value; a background change also re-derives the
+        // appearance (light/dark follows the color).
         .onChange(of: accentHex) { hexDraft = accentHex }
+        .onChange(of: backgroundHex) {
+            bgHexDraft = backgroundHex
+            applyStoredTheme()
+        }
     }
 
     /// A one-click accent circle; nil hex is the bundled default. The selected
@@ -451,6 +521,48 @@ struct AppearanceSettingsView: View {
             return
         }
         setAccent(normalized)
+    }
+
+    /// A one-click background circle; nil hex is the stock palette. The
+    /// selected swatch carries a checkmark.
+    private func backgroundSwatch(name: String, hex: String?) -> some View {
+        let color = hex.flatMap { Color(hex: $0) } ?? Color("BgRoot")
+        let isSelected = backgroundHex == (hex ?? "")
+        return Button { setBackground(hex ?? "") } label: {
+            Circle()
+                .fill(color)
+                .frame(width: 18, height: 18)
+                .overlay {
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.app(size: 9, weight: .bold))
+                            .foregroundStyle(color.contrastingForeground)
+                    }
+                }
+                .overlay(Circle().strokeBorder(.primary.opacity(0.15), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help(name)
+    }
+
+    private func setBackground(_ hex: String) {
+        backgroundHex = hex
+        bgHexDraft = hex
+        bgHexInvalid = false
+    }
+
+    /// The background twin of `commitHex` — empty resets to the stock palette.
+    private func commitBackgroundHex() {
+        let trimmed = bgHexDraft.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            setBackground("")
+            return
+        }
+        guard let color = Color(hex: trimmed), let normalized = color.hexString else {
+            bgHexInvalid = true
+            return
+        }
+        setBackground(normalized)
     }
 }
 

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -268,6 +268,7 @@ struct AppearanceSettingsView: View {
     @AppStorage("theme") private var theme = "dark"
     @AppStorage(accentColorDefaultsKey) private var accentHex = ""
     @AppStorage(backgroundColorDefaultsKey) private var backgroundHex = ""
+    @AppStorage(textColorDefaultsKey) private var textHex = ""
     @AppStorage(appFontFamilyDefaultsKey) private var fontFamily = ""
     @AppStorage(appFontSizeScaleDefaultsKey) private var fontSizeScale = 1.0
     @AppStorage(windowOpacityDefaultsKey) private var windowOpacity = 1.0
@@ -277,6 +278,8 @@ struct AppearanceSettingsView: View {
     @State private var hexInvalid = false
     @State private var bgHexDraft = ""
     @State private var bgHexInvalid = false
+    @State private var textHexDraft = ""
+    @State private var textHexInvalid = false
     #if DEBUG
     @AppStorage(DevMetrics.overlayEnabledKey) private var showDevMetrics = true
     #endif
@@ -309,6 +312,13 @@ struct AppearanceSettingsView: View {
         Binding(
             get: { Color(hex: backgroundHex) ?? Color("BgRoot") },
             set: { backgroundHex = $0.hexString ?? "" })
+    }
+
+    /// The text-color ColorPicker, same contract as the accent's.
+    private var textBinding: Binding<Color> {
+        Binding(
+            get: { Color(hex: textHex) ?? Color("TextMain") },
+            set: { textHex = $0.hexString ?? "" })
     }
 
     /// One Window-section slider row: label, slider, live percent readout.
@@ -412,7 +422,7 @@ struct AppearanceSettingsView: View {
                     .foregroundStyle(.textMuted)
             }
 
-            Section("Font") {
+            Section("Text") {
                 Picker("Font", selection: $fontFamily) {
                     Text("System (San Francisco)").tag("")
                     if !FontCatalog.standardFamilies.isEmpty {
@@ -434,7 +444,25 @@ struct AppearanceSettingsView: View {
                     Text("Large").tag(1.1)
                     Text("Extra large").tag(1.25)
                 }
-                Text("Applies across the app — code and log views keep their monospaced font, and the terminal keeps its own. ⌘= / ⌘- additionally zoom the whole window.")
+                LabeledContent("Color") {
+                    HStack(spacing: 8) {
+                        ColorPicker("", selection: textBinding, supportsOpacity: false).labelsHidden()
+                        TextField("Hex code", text: $textHexDraft, prompt: Text("#ECECEC"))
+                            .textFieldStyle(.roundedBorder)
+                            .labelsHidden()
+                            .frame(width: 110)
+                            .onSubmit { commitTextHex() }
+                        if !textHex.isEmpty {
+                            Button("Reset") { setText("") }
+                        }
+                    }
+                }
+                if textHexInvalid {
+                    Text("Enter a hex color like #ECECEC (or the short #EEE).")
+                        .font(.app(.footnote))
+                        .foregroundStyle(.orange)
+                }
+                Text("Sets the primary text color; subtitles and muted labels are derived from it automatically. Font applies across the app — code and log views keep their monospaced font, and the terminal keeps its own. ⌘= / ⌘- additionally zoom the whole window.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
             }
@@ -469,6 +497,7 @@ struct AppearanceSettingsView: View {
         .onAppear {
             hexDraft = accentHex
             bgHexDraft = backgroundHex
+            textHexDraft = textHex
         }
         // Reflect swatch/color-well changes into the hex fields so they always
         // show the effective value; a background change also re-derives the
@@ -478,6 +507,7 @@ struct AppearanceSettingsView: View {
             bgHexDraft = backgroundHex
             applyStoredTheme()
         }
+        .onChange(of: textHex) { textHexDraft = textHex }
     }
 
     /// A one-click accent circle; nil hex is the bundled default. The selected
@@ -563,6 +593,26 @@ struct AppearanceSettingsView: View {
             return
         }
         setBackground(normalized)
+    }
+
+    private func setText(_ hex: String) {
+        textHex = hex
+        textHexDraft = hex
+        textHexInvalid = false
+    }
+
+    /// The text-color twin of `commitHex` — empty resets to the stock tokens.
+    private func commitTextHex() {
+        let trimmed = textHexDraft.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            setText("")
+            return
+        }
+        guard let color = Color(hex: trimmed), let normalized = color.hexString else {
+            textHexInvalid = true
+            return
+        }
+        setText(normalized)
     }
 }
 

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -66,9 +66,20 @@ extension ShapeStyle where Self == Color {
         return Color("BorderSubtle")
     }
     /// Primary reading text, header titles, active values, resting-action icons.
-    static var textMain: Color { Color("TextMain") }
-    /// Subtitles, timestamps, labels, and quiet navigation/input icons.
-    static var textMuted: Color { Color("TextMuted") }
+    /// Honors a user-chosen text color (Settings ▸ Appearance ▸ Text) when set,
+    /// read fresh per render (the root view keys on the stored hex).
+    static var textMain: Color {
+        if let rgb = customTextRGB { return Color(rgb: rgb) }
+        return Color("TextMain")
+    }
+    /// Subtitles, timestamps, labels, and quiet navigation/input icons. With a
+    /// custom text color, the muted tone is that color at `TextPalette`'s
+    /// primary→muted opacity, so it composites over the surface behind it the
+    /// same way the stock muted step does.
+    static var textMuted: Color {
+        if let rgb = customTextRGB { return Color(rgb: rgb).opacity(TextPalette.mutedOpacity) }
+        return Color("TextMuted")
+    }
     /// "The electricity" — CTAs, active toggles, selection, loaders, logo mark.
     /// Honors a user-chosen accent (Settings ▸ Appearance) when set, otherwise the
     /// bundled asset. A fixed color either way, so it doesn't desaturate on focus
@@ -98,6 +109,19 @@ let backgroundColorDefaultsKey = "backgroundColorHex"
 /// re-reads it. nil when unset or malformed → the stock assets.
 var customBackgroundRGB: BackgroundPalette.RGB? {
     guard let hex = UserDefaults.standard.string(forKey: backgroundColorDefaultsKey),
+          !hex.isEmpty else { return nil }
+    return BackgroundPalette.parse(hex: hex)
+}
+
+/// UserDefaults key for the user-chosen text color ("#RRGGBB"). Empty or unset
+/// → the bundled TextMain/TextMuted assets. When set, it drives primary text
+/// and the muted/subtitle tone is derived from it (`TextPalette`).
+let textColorDefaultsKey = "textColorHex"
+
+/// The stored custom text color, parsed fresh per render (the root view keys on
+/// the stored hex). nil when unset or malformed → the stock text assets.
+var customTextRGB: BackgroundPalette.RGB? {
+    guard let hex = UserDefaults.standard.string(forKey: textColorDefaultsKey),
           !hex.isEmpty else { return nil }
     return BackgroundPalette.parse(hex: hex)
 }
@@ -160,6 +184,13 @@ extension Color {
     /// white-on-white in light mode. Feeding the label a pre-resolved concrete
     /// color sidesteps that. Falls back to the dynamic asset if resolution fails.
     static func resolved(_ name: String, for scheme: ColorScheme) -> Color {
+        // A custom text color is already concrete (no light/dark variant to
+        // flatten), so hand it back directly — this is the path the device-bar
+        // pill title uses, which would otherwise keep the stock asset.
+        if name == "TextMain", let rgb = customTextRGB { return Color(rgb: rgb) }
+        if name == "TextMuted", let rgb = customTextRGB {
+            return Color(rgb: rgb).opacity(TextPalette.mutedOpacity)
+        }
         guard let appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua),
               let dynamic = NSColor(named: name) else { return Color(name) }
         var flat = dynamic

--- a/App/Sources/Theme.swift
+++ b/App/Sources/Theme.swift
@@ -26,19 +26,25 @@ extension EnvironmentValues {
 /// Deepest layer — the content background (the "graphite case"). Resolves
 /// against the window opacity environment, so every `.bgRoot` fill in the
 /// main window turns to glass with the translucency slider and stays fully
-/// opaque everywhere else (panels, Settings, sheets' own scenes).
+/// opaque everywhere else (panels, Settings, sheets' own scenes). Honors a
+/// user-chosen background (Settings ▸ Appearance) when set.
 struct RootFillStyle: ShapeStyle {
     func resolve(in environment: EnvironmentValues) -> some ShapeStyle {
-        Color("BgRoot").opacity(WindowEffects.clamped(environment.windowOpacity))
+        let base = customBackgroundRGB.map(Color.init(rgb:)) ?? Color("BgRoot")
+        return base.opacity(WindowEffects.clamped(environment.windowOpacity))
     }
 }
 
 /// Lifted surface — sidebar, cards, and bars sit one step above `bgRoot`.
 /// Stacked on the root wash, so under translucency it carries only the
 /// contrast step (`WindowEffects.cardAlpha`) instead of compounding solid.
+/// With a custom background, the surface is derived from it
+/// (`BackgroundPalette.surface`) so the lift step matches the stock palette.
 struct SurfaceFillStyle: ShapeStyle {
     func resolve(in environment: EnvironmentValues) -> some ShapeStyle {
-        Color("BgSurface").opacity(WindowEffects.cardAlpha(root: environment.windowOpacity))
+        let base = customBackgroundRGB.map { Color(rgb: BackgroundPalette.surface(for: $0)) }
+            ?? Color("BgSurface")
+        return base.opacity(WindowEffects.cardAlpha(root: environment.windowOpacity))
     }
 }
 
@@ -51,8 +57,14 @@ extension ShapeStyle where Self == SurfaceFillStyle {
 }
 
 extension ShapeStyle where Self == Color {
-    /// Thin dividers and borders.
-    static var borderSubtle: Color { Color("BorderSubtle") }
+    /// Thin dividers and borders — derived from a custom background when one
+    /// is set, so hairlines keep their contrast on any color.
+    static var borderSubtle: Color {
+        if let rgb = customBackgroundRGB {
+            return Color(rgb: BackgroundPalette.border(for: rgb))
+        }
+        return Color("BorderSubtle")
+    }
     /// Primary reading text, header titles, active values, resting-action icons.
     static var textMain: Color { Color("TextMain") }
     /// Subtitles, timestamps, labels, and quiet navigation/input icons.
@@ -74,6 +86,27 @@ extension ShapeStyle where Self == Color {
 /// UserDefaults key for the user-chosen accent (hex like "#34C759"). Empty or
 /// unset → the bundled BrandAccent asset.
 let accentColorDefaultsKey = "accentColorHex"
+
+/// UserDefaults key for the user-chosen window background ("#RRGGBB"). Empty
+/// or unset → the bundled BgRoot/BgSurface/BorderSubtle assets. While set,
+/// the app's appearance follows the color's luminance (see
+/// `applyStoredTheme`), so text and controls stay readable on any background.
+let backgroundColorDefaultsKey = "backgroundColorHex"
+
+/// The stored custom background, parsed fresh per render — the app keys its
+/// root view on the stored hex (like the accent), so a change rebuilds and
+/// re-reads it. nil when unset or malformed → the stock assets.
+var customBackgroundRGB: BackgroundPalette.RGB? {
+    guard let hex = UserDefaults.standard.string(forKey: backgroundColorDefaultsKey),
+          !hex.isEmpty else { return nil }
+    return BackgroundPalette.parse(hex: hex)
+}
+
+extension Color {
+    init(rgb: BackgroundPalette.RGB) {
+        self.init(.sRGB, red: rgb.red, green: rgb.green, blue: rgb.blue)
+    }
+}
 
 extension Color {
     /// Parse "#RRGGBB" / "RRGGBB" (or the "#RGB" shorthand) as sRGB. nil on


### PR DESCRIPTION
Like the accent color: Settings ▸ Appearance gains a **Background** section with eight presets (six dark, two light), a color well, and a hex field, stored as `#RRGGBB` in UserDefaults (`backgroundColorHex`, empty = stock palette).

## How it works

- The `.bgRoot` / `.bgSurface` tokens and `borderSubtle` resolve the custom color per render, and the root view re-keys on the stored hex (same mechanism as the accent), so **every pane, card, bar, sheet, and panel repaints** — nothing reads the stock assets directly outside `Theme.swift`.
- The lifted surface and hairline border are **derived** from the chosen root by the same contrast steps as the stock palette: `BackgroundPalette` in ADBKit (pure, 7 tests — hex parsing incl. `#RGB` shorthand and malformed fallback, the 0.35 luminance threshold shared with `contrastingForeground`, the +9/255 surface step reproducing `#1A1A1A → #232323`, the ±border steps, clamping at the extremes).
- While a custom background is set, **the appearance follows its luminance** — pick a light color and text/controls switch to the dark-on-light treatment automatically. The Theme picker is disabled with a note explaining the override; Reset restores it.
- Translucency stacks unchanged (the opacity/cardAlpha math applies to the custom color), and the Terminal and JS Console deliberately keep their console-dark surfaces.

## Verification

- `cd ADBKit && swift test` — 932 tests green (925 + 7 new)
- `make build` — zero warnings
- Live-verified on the running app: preset swatches repaint the sidebar, tab strip, device bar, Home cards, Reactotron panes (with a real RN client connected), and Settings itself; the theme-override note and Reset behave as described.
- Remaining hands-on checks: pick **Paper**/**Mist** and confirm the whole app flips to light treatment automatically; relaunch and confirm the background survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR (added after the original background work)

**Custom text color + "Font" section renamed to "Text".** One picked color drives primary text; the muted/subtitle tone is derived from it at `TextPalette.mutedOpacity` (0.62), reproducing the stock primary→muted step in both themes and compositing correctly over any surface. A **non-blocking** low-contrast warning appears when the chosen color reads poorly on the effective background (`TextPalette.contrastRatio` < 3.0) — it never prevents applying the color. `TextPalette` is pure ADBKit (6 tests).

**Fixes to the background feature:**
- Opaque feeds/lists (Reactotron, Logcat, iOS Logs, Frida, crash/files/apps/emulators/catalog/APK views) now honor the custom background at 100% opacity — they were falling back to the system material.
- The SwiftUI color scheme now follows the background's luminance, so a light background no longer leaves dark-mode light-gray text invisible (verified on cold launch).

938 ADBKit tests green; `make build` clean; verified live across dark/light custom backgrounds and custom text colors.
