### PR TITLE
Fix terminal tab-strip clipping and reuse freed tab numbers

### DIFF
--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -28,7 +28,6 @@ final class TerminalManager {
     private(set) var layout = TerminalTabs()
     private var tabsByID: [UUID: Tab] = [:]
     var activeID: UUID?
-    private var counter = 0
     private var groupCounter = 0
 
     /// The rail's drag-in-flight state — which row/group is dragged and where
@@ -86,14 +85,13 @@ final class TerminalManager {
     /// `group` when given, else the active tab's group, else lands loose — a
     /// fresh rail has no groups.
     func newTab(inGroup group: UUID? = nil, name: String? = nil, initialCommand: String? = nil) {
-        counter += 1
         let paneID = UUID()
         let session = TerminalSession(
             startDirectory: activeSession?.currentDirectory,
             initialCommand: initialCommand
         )
         var tab = Tab(
-            name: name ?? "Terminal \(counter)",
+            name: name ?? nextAutoName(),
             splits: TerminalSplitTree(pane: paneID),
             activePaneID: paneID
         )
@@ -107,6 +105,21 @@ final class TerminalManager {
             layout.setCollapsed(groupID, false)
         }
         activeID = tab.id
+    }
+
+    /// The lowest "Terminal N" name not already in use, so a new tab reuses the
+    /// numbers freed by closed tabs instead of climbing forever (only Terminal 1
+    /// open ⇒ the next is Terminal 2, not Terminal 11). Names that aren't a plain
+    /// "Terminal <number>" — user-renamed tabs — are ignored.
+    private func nextAutoName() -> String {
+        let prefix = "Terminal "
+        let used = Set(tabsByID.values.compactMap { tab -> Int? in
+            guard tab.name.hasPrefix(prefix) else { return nil }
+            return Int(tab.name.dropFirst(prefix.count))
+        })
+        var n = 1
+        while used.contains(n) { n += 1 }
+        return "\(prefix)\(n)"
     }
 
     /// Kill every pane's shell and remove the tab. Focus falls to the neighbor
@@ -132,8 +145,9 @@ final class TerminalManager {
     }
 
     /// Kill every shell and clear the tabs — the Terminal feature tab was
-    /// closed, and background shells without a UI would be orphans. The name
-    /// counters reset so a reopened feature starts at "Terminal 1" again.
+    /// closed, and background shells without a UI would be orphans. With the
+    /// tabs cleared, the next new tab is "Terminal 1" again; only the group
+    /// counter needs an explicit reset.
     func killAll() {
         for tab in tabsByID.values {
             for session in tab.sessions.values {
@@ -143,7 +157,6 @@ final class TerminalManager {
         tabsByID.removeAll()
         layout = TerminalTabs()
         activeID = nil
-        counter = 0
         groupCounter = 0
     }
 

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -333,6 +333,10 @@ struct TerminalView: View {
     /// Where the tab list lives: a Chrome-style strip along the top (default)
     /// or a left rail.
     @AppStorage("terminalTabsOnTop") private var tabsOnTop = true
+    /// Live width of the top strip's scroll viewport, so its tab row can fill
+    /// the available space (the drop-at-end tail stretches to it) yet still
+    /// scroll once the tabs overflow instead of being clipped.
+    @State private var topStripWidth: CGFloat = 0
     @Environment(\.windowOpacity) private var windowOpacity
     private var terminals: TerminalManager { state.terminals }
 
@@ -661,22 +665,35 @@ struct TerminalView: View {
                     railButton("plus", help: "New terminal") {
                         terminals.newTab()
                     }
+
+                    // The strip's empty tail: dropping a drag here lands it at
+                    // the very end (loose), like the rail's bottom zone. It
+                    // lives inside the scroll content so the row can fill the
+                    // viewport (the `minWidth` below stretches it), and it
+                    // collapses to `minWidth` once the tabs overflow.
+                    Color.clear
+                        .frame(minWidth: 24, maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                        .overlay(alignment: .leading) {
+                            verticalGuideline(terminals.railDropSlot == .railEnd)
+                        }
+                        .onDrop(of: [.terminalRailItem], delegate: RailTailDropDelegate(
+                            terminals: terminals
+                        ))
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 5)
+                // Fill the viewport when the tabs are short so the tail's drop
+                // zone spans the empty space; grow past it (scrolling) when
+                // they overflow, instead of clipping the rightmost tabs.
+                .frame(minWidth: topStripWidth, alignment: .leading)
             }
-
-            // The strip's empty tail: dropping a drag here lands it at the
-            // very end (loose), like the rail's bottom zone.
-            Color.clear
-                .frame(minWidth: 24, maxWidth: .infinity, maxHeight: .infinity)
-                .contentShape(Rectangle())
-                .overlay(alignment: .leading) {
-                    verticalGuideline(terminals.railDropSlot == .railEnd)
-                }
-                .onDrop(of: [.terminalRailItem], delegate: RailTailDropDelegate(
-                    terminals: terminals
-                ))
+            // The scroll view is now the only greedy sibling, so it takes all
+            // width up to the trailing button; measure that width to feed the
+            // row's `minWidth` above.
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { width in
+                topStripWidth = width
+            }
 
             railButton("sidebar.left", help: "Move tabs to a sidebar") {
                 tabsOnTop = false


### PR DESCRIPTION
## What changed

Before :
<img width="1172" height="77" alt="Screenshot 2026-07-19 at 5 43 27 PM" src="https://github.com/user-attachments/assets/bc127032-a2a7-4086-9eb1-5c7b2f561d2d" />
<img width="562" height="72" alt="Screenshot 2026-07-19 at 6 12 58 PM" src="https://github.com/user-attachments/assets/a53f086c-dc3d-4361-a7dc-963dfd0d62b5" />

Two fixes to the Terminal feature's top tab strip:

- **Overflow no longer clips tabs.** With enough tabs open, the rightmost
  tab(s) were cut off / hidden behind the strip's trailing area instead of the
  strip scrolling. The strip now uses its full width and scrolls horizontally
  once the tabs overflow, so every tab stays reachable.
- **New tabs reuse freed numbers.** A new tab is named with the lowest unused
  "Terminal N" rather than an ever-increasing counter. With only "Terminal 1"
  open, the next tab is "Terminal 2" (not "Terminal 11"); closing a tab in the
  middle frees its number for reuse.

## Why

The top strip's drop-at-end tail was a greedy `maxWidth: .infinity` sibling of
the horizontal scroll view, so the `HStack` split the width between them and
the scroll region only got about half the strip — extra tabs overflowed behind
the tail and the sidebar toggle rather than scrolling, and the cutoff point
shifted with the window size. The tail now lives inside the scroll content and
the tab row is sized to the measured viewport width, so it fills the space when
tabs are few (the tail still spans the empty area for drop-to-end) and scrolls
when they overflow.

Tab names came from a monotonic counter that never reused numbers freed by
closed tabs, so the displayed numbers climbed indefinitely and looked wrong
after closing tabs.

## Impact area

- [x] None — isolated to one feature (Terminal)

Behaviour is otherwise unchanged: tab creation, split panes, sessions, closing,
focus, drag-reorder, groups, and the sidebar/top-strip toggle all work exactly
as before. User-renamed tabs are ignored by the numbering scan, so renaming is
unaffected. No ADBKit, registry, or persistence-schema changes.

## How verified

- [x] `make test` green (925 tests)
- [x] `make build` succeeds with **zero warnings**
- [x] Ran the app and verified live: opened many terminals until the strip
  overflowed (scrolls, nothing clipped, at several window sizes); closed tabs
  down to one and confirmed the next new tab reuses the lowest free number;
  checked drag-reorder, groups, `+`, and the sidebar toggle still work.

## Checklist

- [x] Logic lives in `ADBKit`, not in a SwiftUI view — the split-tree logic is
  already in ADBKit; this change is the App-layer tab strip layout plus a
  trivial name-picker on the existing `TerminalManager` view-model
- [x] New parsers / command construction are tested — N/A (none added)
- [x] New feature registered in `FeatureRegistry` — N/A (not a new feature)
- [x] `prek run` passes (gitleaks secret scan)
- [x] No secrets, no commented-out code, no relative `..` imports
