### PR TITLE
Fix React Native hub greying every quick action while one runs

### DIFF
--- a/App/Sources/FeatureDetail/Views/ReactNativeView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactNativeView.swift
@@ -10,6 +10,11 @@ struct ReactNativeView: View {
     @Environment(AppState.self) private var state
     @AppStorage("rnDevHost") private var devHost = ""
     @State private var metroPort = "8081"
+    /// The single action currently running, keyed by feature id. Only that
+    /// button shows the running/disabled state — the shared global
+    /// `state.isRunningFeature` would grey out every button on this screen at
+    /// once, so we track the running one here instead.
+    @State private var runningID: String?
 
     private let actionColumns = [GridItem(.adaptive(minimum: 220), spacing: 10)]
 
@@ -21,19 +26,19 @@ struct ReactNativeView: View {
                         title: "Reload JS", detail: "Reload the JS bundle — like pressing R twice",
                         icon: "arrow.clockwise", prominent: true,
                         help: "Sends R·R (keycode 46) — needs an RN dev build with the app in front",
-                        disabled: actionsDisabled
+                        disabled: isDisabled("reload-js"), running: runningID == "reload-js"
                     ) { run("reload-js") }
                     RNActionCard(
                         title: "Dev Menu", detail: "Open the in-app developer menu",
                         icon: "filemenu.and.selection",
                         help: "Sends keycode 82 — needs an RN dev build with the app in front",
-                        disabled: actionsDisabled
+                        disabled: isDisabled("open-dev-menu"), running: runningID == "open-dev-menu"
                     ) { run("open-dev-menu") }
                     RNActionCard(
                         title: "Process Death", detail: "Background, then kill the app to test state restore",
                         icon: "xmark.octagon",
                         help: "Backgrounds then kills the selected bundle — or the app in front when none is chosen",
-                        disabled: actionsDisabled
+                        disabled: isDisabled("process-death"), running: runningID == "process-death"
                     ) { run("process-death") }
                 }
                 if state.targetSerials.isEmpty {
@@ -59,7 +64,7 @@ struct ReactNativeView: View {
                         run("reverse-port", ["port": .string(metroPort.trimmingCharacters(in: .whitespaces))])
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(actionsDisabled || metroPort.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(isDisabled("reverse-port") || metroPort.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
 
                 Divider()
@@ -77,7 +82,7 @@ struct ReactNativeView: View {
                         run("rn-dev-host", ["host": .string(devHost.trimmingCharacters(in: .whitespaces))])
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(actionsDisabled || devHost.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(isDisabled("rn-dev-host") || devHost.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
 
@@ -95,8 +100,10 @@ struct ReactNativeView: View {
         }
     }
 
-    private var actionsDisabled: Bool {
-        state.targetSerials.isEmpty || state.isRunningFeature
+    /// A button is disabled when no device is connected, or while *its own*
+    /// action is in flight — never because a different button is running.
+    private func isDisabled(_ id: String) -> Bool {
+        state.targetSerials.isEmpty || runningID == id
     }
 
     /// One Metro transport path: an eyebrow naming the transport, what the
@@ -148,7 +155,13 @@ struct ReactNativeView: View {
 
     private func run(_ id: String, _ params: [String: FeatureValue] = [:]) {
         guard let feature = FeatureRegistry.byID[id] else { return }
-        Task { await state.run(feature: feature, params: params) }
+        runningID = id
+        Task {
+            await state.run(feature: feature, params: params)
+            // Clear only if this same action is still the one showing as
+            // running — a newer click on another button owns the state now.
+            if runningID == id { runningID = nil }
+        }
     }
 }
 
@@ -163,20 +176,31 @@ private struct RNActionCard: View {
     var prominent = false
     var help = ""
     var disabled = false
+    /// This card's own action is in flight — shows a spinner in place of the
+    /// icon. Set independently per card so one running action never spins the
+    /// others.
+    var running = false
     let action: () -> Void
     @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
             HStack(alignment: .top, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.app(.body).weight(.medium))
-                    .foregroundStyle(prominent ? Color.brandAccent.contrastingForeground : .brandAccent)
-                    .frame(width: 30, height: 30)
-                    .background(
-                        prominent ? Color.brandAccent : Color.brandAccent.opacity(0.12),
-                        in: RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    )
+                Group {
+                    if running {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: icon)
+                            .font(.app(.body).weight(.medium))
+                            .foregroundStyle(prominent ? Color.brandAccent.contrastingForeground : .brandAccent)
+                    }
+                }
+                .frame(width: 30, height: 30)
+                .background(
+                    prominent ? Color.brandAccent : Color.brandAccent.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+                )
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
                         .font(.app(.headline))


### PR DESCRIPTION
## What changed

In the React Native hub, clicking any one Quick Action button no longer greys
out the rest of the screen. Only the button whose action is running shows the
running state (a spinner on its card); the other Quick Action cards (Reload JS,
Dev Menu, Process Death) and the Metro **Forward** / **Set** buttons stay active
and untouched.

## Why

All of those controls shared a single disabled condition:

```swift
state.targetSerials.isEmpty || state.isRunningFeature
```

`state.isRunningFeature` is one global flag on `AppState` that flips `true` for
the duration of *any* run. Because every button read it, running one action
(e.g. Process Death) disabled and greyed out **all** of them at once, so it
looked like every button — including the Metro Forward button — had been
triggered. It wasn't a re-render bug; it was shared global state driving every
button's enabled/greyed appearance.

## How

- Track the in-flight action locally with `@State private var runningID: String?`
  (keyed by feature id), set when a button is tapped and cleared when its run
  finishes.
- Replace the shared `actionsDisabled` with `isDisabled(_ id:)`: a button is
  disabled only when no device is connected, or while **its own** action is in
  flight — never because a different button is running.
- `RNActionCard` gains an independent `running` flag and shows a spinner in
  place of its icon while its own action runs.

The actions themselves are unchanged — same feature ids, same params, same
`state.run(feature:params:)` path.

## Impact area

- [x] None — isolated to one feature (React Native hub)

No ADBKit, registry, or persistence-schema changes. `state.isRunningFeature` is
still set/cleared by `AppState.run` and still consumed by the other screens that
use it (instant/form action views, Send Text, Bug Report); this change only
stops the RN hub from binding every button's appearance to it. Behaviour with
no device connected is unchanged (all buttons disabled, "Connect a device"
hint shown).

## How verified

- [x] `make test` green (925 tests)
- [x] `make build` succeeds with **zero warnings**
- [x] Ran the app and exercised the RN hub live: clicking Process Death spins /
  dims only Process Death while Reload JS, Dev Menu, and the Metro Forward/Set
  buttons stay active; confirmed each action still fires and the no-device
  state still disables everything with the hint.

## Checklist

- [x] Logic lives in `ADBKit`, not in a SwiftUI view — N/A (view-only state fix;
  no adb/parsing logic added)
- [x] New parsers / command construction are tested — N/A (none added)
- [x] New feature registered in `FeatureRegistry` — N/A (not a new feature)
- [x] `prek run` passes (gitleaks secret scan)
- [x] No secrets, no commented-out code, no relative `..` imports
