### PR TITLE
Fix sidebar two-click after split-resize; harden JS Console focus

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/SidebarVisibility.swift
+++ b/ADBKit/Sources/ADBKit/Features/SidebarVisibility.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Pure reconciliation of the sidebar's visibility, kept out of the view so the
+/// rules are tested and the call sites (the device-bar button, the Settings ▸
+/// Appearance toggle) can't drift.
+///
+/// The fixed (pinned) sidebar and the Dock-style auto-hide overlay have separate
+/// visibility flags, and only one is active per mode. A split-resize eviction
+/// (`hideSidebarForSplitRoom`) can leave the pinned sidebar hidden
+/// (`fixedVisible == false`) while still in fixed mode — the state that made the
+/// device-bar button's first click a dead no-op.
+public enum SidebarVisibility {
+    /// Visibility after a plain mode switch to `autoHide` (the Settings ▸
+    /// Appearance toggle). Entering auto-hide leaves the sidebar at rest —
+    /// hidden until a hover/⌘B peek — so the overlay stays down; leaving it
+    /// always restores the pinned sidebar. Neither direction strands the user
+    /// with both hidden.
+    public static func afterModeChange(autoHide: Bool, fixedVisible: Bool)
+        -> (fixedVisible: Bool, overlayShown: Bool)
+    {
+        (fixedVisible: autoHide ? fixedVisible : true, overlayShown: false)
+    }
+
+    /// The next state after the device-bar sidebar button is pressed. When the
+    /// pinned sidebar is hidden in fixed mode (a split-resize evicted it), the
+    /// click just brings it back — no mode change — so it's never a dead click.
+    /// Otherwise it flips the mode, reconciled for the new mode.
+    public static func afterButtonPress(autoHide: Bool, fixedVisible: Bool)
+        -> (autoHide: Bool, fixedVisible: Bool, overlayShown: Bool)
+    {
+        if !autoHide, !fixedVisible {
+            return (autoHide: false, fixedVisible: true, overlayShown: false)
+        }
+        let flipped = !autoHide
+        let next = afterModeChange(autoHide: flipped, fixedVisible: fixedVisible)
+        return (autoHide: flipped, fixedVisible: next.fixedVisible, overlayShown: next.overlayShown)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/SidebarVisibilityTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SidebarVisibilityTests.swift
@@ -1,0 +1,46 @@
+import Testing
+
+@testable import ADBKit
+
+@Suite struct SidebarVisibilityTests {
+    // MARK: Plain mode switch (Settings ▸ Appearance)
+
+    @Test func enteringAutoHideRestsWithTheOverlayHidden() {
+        // Auto-hide means hidden-until-peek, so switching it on never reveals the
+        // overlay — regardless of whether the pinned sidebar was showing.
+        #expect(SidebarVisibility.afterModeChange(autoHide: true, fixedVisible: true).overlayShown == false)
+        #expect(SidebarVisibility.afterModeChange(autoHide: true, fixedVisible: false).overlayShown == false)
+    }
+
+    @Test func leavingAutoHideAlwaysRestoresThePinnedSidebar() {
+        let next = SidebarVisibility.afterModeChange(autoHide: false, fixedVisible: false)
+        #expect(next.fixedVisible == true)
+        #expect(next.overlayShown == false)
+    }
+
+    // MARK: Device-bar button
+
+    @Test func buttonRevealsThePinnedSidebarWhenItWasEvicted() {
+        // The bug: a split-resize left the pinned sidebar hidden in fixed mode.
+        // The click brings it back and stays in fixed mode — no dead first click,
+        // no surprise mode flip.
+        let next = SidebarVisibility.afterButtonPress(autoHide: false, fixedVisible: false)
+        #expect(next == (autoHide: false, fixedVisible: true, overlayShown: false))
+    }
+
+    @Test func buttonSwitchesAVisiblePinnedSidebarToAutoHide() {
+        let next = SidebarVisibility.afterButtonPress(autoHide: false, fixedVisible: true)
+        #expect(next == (autoHide: true, fixedVisible: true, overlayShown: false))
+    }
+
+    @Test func buttonReturnsFromAutoHideToAShownPinnedSidebar() {
+        #expect(
+            SidebarVisibility.afterButtonPress(autoHide: true, fixedVisible: false)
+                == (autoHide: false, fixedVisible: true, overlayShown: false)
+        )
+        #expect(
+            SidebarVisibility.afterButtonPress(autoHide: true, fixedVisible: true)
+                == (autoHide: false, fixedVisible: true, overlayShown: false)
+        )
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -816,6 +816,10 @@ struct JSConsoleView: View {
     @State private var inputHeight: CGFloat = 26
     @State private var showLevels = false
     @FocusState private var findFocused: Bool
+    /// This tab stays mounted when the user switches away (see `TabHostView`).
+    /// The input is a bare `NSTextView`, which `installFocusRelease` can't
+    /// resign, so it hands this down to relinquish first responder when hidden.
+    @Environment(\.tabIsActive) private var tabIsActive
 
     private var session: JSConsoleSession { state.jsConsoleSession }
 
@@ -1258,6 +1262,7 @@ struct JSConsoleView: View {
                 JSCodeEditor(
                     text: $input,
                     height: $inputHeight,
+                    isActive: tabIsActive,
                     onSubmit: run,
                     historyUp: { session.historyUp(current: $0) },
                     historyDown: { session.historyDown() }
@@ -1763,6 +1768,7 @@ private struct StackView: View {
 private struct JSCodeEditor: NSViewRepresentable {
     @Binding var text: String
     @Binding var height: CGFloat
+    var isActive: Bool
     var onSubmit: () -> Void
     var historyUp: (String) -> String?
     var historyDown: () -> String?
@@ -1805,6 +1811,16 @@ private struct JSCodeEditor: NSViewRepresentable {
         if textView.string != text {
             textView.string = text
             context.coordinator.recalculateHeight()
+        }
+        // The tab went to the background but stays mounted (TabHostView), and a
+        // standalone NSTextView isn't a field editor, so nothing else resigns it
+        // — leaving it first responder means every keystroke lands in this hidden
+        // input while the visible pane looks keyboard-dead. Hand focus back to the
+        // window. Deferred so we never touch first responder during a view update.
+        if !isActive, let window = textView.window, window.firstResponder === textView {
+            Task { @MainActor in
+                if window.firstResponder === textView { window.makeFirstResponder(nil) }
+            }
         }
     }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -457,14 +457,11 @@ struct RootView: View {
             }
         }
         // The Settings ▸ Appearance toggle flips the mode without going
-        // through toggleSidebarMode — apply the same safeguard here: never
-        // leave BOTH the fixed sidebar and the overlay hidden (turning
-        // auto-hide off after ⌘B would silently vanish the sidebar).
+        // through toggleSidebarMode — reconcile here too so both paths keep
+        // every flip visible (never leave BOTH the fixed sidebar and the
+        // overlay hidden, in either direction).
         .onChange(of: sidebarAutoHide) { _, autoHide in
-            state.sidebarOverlayShown = false
-            if !autoHide, !state.sidebarVisible {
-                withAnimation(.easeInOut(duration: 0.18)) { state.sidebarVisible = true }
-            }
+            withAnimation(.easeInOut(duration: 0.18)) { state.reconcileSidebarVisibility(autoHide: autoHide) }
         }
         // The stationary ancestor space both seam drags measure in — a drag
         // measured in the handle's own space feeds back on itself as the

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -271,17 +271,32 @@ final class AppState {
         }
     }
 
-    /// The device bar's sidebar button: switches between the fixed sidebar
-    /// and Dock-style auto-hide. Returning to fixed always shows the sidebar —
-    /// a mode flip that leaves everything hidden would read as a dead button.
+    /// The device bar's sidebar button. When a split-resize has evicted the
+    /// pinned sidebar (fixed mode, `sidebarVisible == false`), the click just
+    /// brings it back — it used to be a dead no-op that only worked on the
+    /// second press. Otherwise it switches between the fixed sidebar and
+    /// Dock-style auto-hide.
     func toggleSidebarMode() {
         let defaults = UserDefaults.standard
-        let autoHide = !defaults.bool(forKey: sidebarAutoHideDefaultsKey)
+        let current = defaults.bool(forKey: sidebarAutoHideDefaultsKey)
+        let next = SidebarVisibility.afterButtonPress(autoHide: current, fixedVisible: sidebarVisible)
         withAnimation(.easeInOut(duration: 0.18)) {
-            defaults.set(autoHide, forKey: sidebarAutoHideDefaultsKey)
-            sidebarOverlayShown = false
-            if !autoHide { sidebarVisible = true }
+            if next.autoHide != current {
+                defaults.set(next.autoHide, forKey: sidebarAutoHideDefaultsKey)
+            }
+            sidebarVisible = next.fixedVisible
+            sidebarOverlayShown = next.overlayShown
         }
+    }
+
+    /// Reconcile the live flags to a mode the Settings ▸ Appearance toggle just
+    /// set (RootView observes the persisted flag and calls this), so that path
+    /// and `toggleSidebarMode` can't drift. Idempotent — the button's own flip
+    /// re-runs it harmlessly.
+    func reconcileSidebarVisibility(autoHide: Bool) {
+        let next = SidebarVisibility.afterModeChange(autoHide: autoHide, fixedVisible: sidebarVisible)
+        sidebarVisible = next.fixedVisible
+        sidebarOverlayShown = next.overlayShown
     }
 
     // MARK: - Font scaling (⌘= / ⌘- / ⌘0)


### PR DESCRIPTION
Two fixes from user bug reports.

## Sidebar button no-op after a split-resize (fixed)

Dragging the split divider past its floor evicts the pinned sidebar
(`sidebarVisible == false`, still fixed mode). The device-bar sidebar button
then flipped straight to auto-hide with nothing shown, so the first click did
nothing and the sidebar only came back on the second click.

The button now brings the pinned sidebar back (staying in fixed mode) when it
was hidden, and only toggles auto-hide when the sidebar is visible. The button
decision and the Settings ▸ Appearance reconcile both go through a pure,
tested `SidebarVisibility` helper (ADBKit) so the two paths stay in sync. Turning
auto-hide on from Settings now leaves the sidebar at rest (hidden until a
hover/⌘B peek) as expected.

| Starting state | Click result |
|---|---|
| Hidden + fixed | Pinned sidebar returns, stays fixed |
| Visible + fixed | Switches to auto-hide |
| Auto-hide | Switches to fixed, shown |

5 unit tests cover every path.

## JS Console input focus (defensive hardening)

The JS Console input is a bare `NSTextView`. Open tabs stay mounted
(`TabHostView` hides inactive ones with opacity 0 / `allowsHitTesting(false)`),
and `installFocusRelease` only resigns field editors — so the input could keep
first responder after you leave the tab, delivering keystrokes to the hidden
input while the visible pane looks keyboard-dead. It now resigns first responder
when its tab goes background, via the existing `tabIsActive` environment value.

This addresses a user report of keyboard-dead-after-JS-reload, but the symptom
is **not reproduced** by the reporter's steps or ours, so this is defensive
hardening of a latent first-responder issue rather than a verified fix.

## Testing

`swift test` green (929 tests, +5 new); `make build` warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)