### PR TITLE
Add ADBKit portability conventions for the Windows/Linux port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,30 @@ pane per feature. Swift 6 + SwiftUI, macOS 14+.
 ## Architecture (the load-bearing rule)
 
 Two layers, strictly separated so a second **Apple** UI (iPad/visionOS) could
-reuse ADBKit almost as-is. Note the honest scope: a Linux/Windows port re-does
-the UI **plus** the macOS-bound seams inside ADBKit — the Mirror media stack
-(CoreMedia/VideoToolbox/AVFoundation), the Network.framework socket servers,
-`ToolLocator`'s macOS install/SDK paths + `zsh -lc`, and `.lzma`/`tar` extraction;
-an iOS companion can't run `Process` at all, so it would need a remote-host
-protocol, not just a UI swap. Keep the existing seams (`ProcessRunning`,
-injected directories) and don't pre-abstract the rest until a port is scheduled.
+reuse ADBKit almost as-is. A Windows/Linux port is staged on
+`feat/cross-platform-core`: a portable ADBKit core first (the full
+mock-driven suite runs on Linux there; Windows compiles), then a
+`droidectived` local daemon over ADBKit and a Tauri/React UI — the strategy
+lives in that branch's `docs/cross-platform.md`. An iOS companion can't run
+`Process` at all, so it would ride the same daemon protocol. Main doesn't
+carry the port, but new ADBKit code must stay easy to absorb there:
+
+- **No new Apple-only framework imports in ADBKit** (Network, CoreMedia,
+  AVFoundation, VideoToolbox, CryptoKit, os, Darwin) outside the already
+  Apple-bound subsystems — the Mirror pipeline + ScreenRecorder, the
+  Reactotron server, `ConsoleLinkDetector`, `ProcessStats`. A feature that
+  genuinely needs one goes in its own small file so the port can gate it
+  wholesale with `#if canImport`.
+- **Avoid the corelibs-Foundation traps** in new ADBKit code:
+  `NSDataDetector`, `FileHandle.bytes`, `FileManager.replaceItemAt`,
+  `OSAllocatedUnfairLock`, raw `posix_spawn`, and `readabilityHandler` as an
+  EOF signal. Each already has a portable pattern on the port branch; a
+  Darwin-only spelling in new code becomes a rebase conflict there.
+- **No hardcoded host facts**: avoid new `/usr/bin/...` and `/bin/zsh`
+  literals, and mock-driven tests must not stat the real filesystem (e.g.
+  assume `/usr/bin/xcrun` exists) — after the port merges, the same suite
+  runs on a Linux CI host with none of that present.
+- Keep the existing seams (`ProcessRunning`, injected directories) intact.
 
 - **`ADBKit/`** — a SwiftPM package holding *all* logic. Zero UI imports
   (feature icons are SF Symbol *name strings*). Actors for stateful services,


### PR DESCRIPTION
Heads-up PR: Windows/Linux support is in flight on `feat/cross-platform-core` — a portable ADBKit core (the full mock-driven suite runs on Linux there, Windows compiles; Apple-only subsystems `#if canImport`-gated), to be followed by a `droidectived` local daemon and a Tauri/React UI. The strategy doc (`docs/cross-platform.md`) rides that branch.

This PR only updates CLAUDE.md's architecture note so work on main cooperates with the port instead of colliding with it:

- no new Apple-only framework imports in ADBKit outside the already Apple-bound subsystems (a feature that needs one goes in its own small file so the port can gate it wholesale)
- avoid the corelibs-Foundation traps in new ADBKit code (`NSDataDetector`, `FileHandle.bytes`, `FileManager.replaceItemAt`, `OSAllocatedUnfairLock`, raw `posix_spawn`, `readabilityHandler` as an EOF signal) — each has a portable pattern on the port branch
- no hardcoded host facts in code or tests (`/usr/bin/...`, `/bin/zsh`, "xcrun exists") — the same suite runs on a Linux CI host once the port merges

Main is not being asked to support Windows/Linux — these rules just keep new features cheap to absorb on the port branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)