### PR TITLE
JS console & Reactotron rework, columnar logcat, and device-list polish

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -81,7 +81,7 @@ public enum UserRole: String, Sendable, Codable, CaseIterable, Identifiable {
     public var blurb: String {
         switch self {
         case .androidDeveloper: return "Logs, app internals, files, and device connection."
-        case .reactNativeDeveloper: return "Metro reload, dev menu, logs, and performance."
+        case .reactNativeDeveloper: return "Metro reload, dev menu, logs, and performance — Android & iOS."
         case .iosDeveloper: return "Simulators, push testing, capture, and deep links."
         case .qaTester: return "Capture, recording, crash hunting, and state simulation."
         case .supportTriage: return "Device diagnostics, connection, and quick checks."

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -635,13 +635,16 @@ public enum FeatureRegistry {
             "emulators", "connection",
             "terminal", "custom-commands",
         ],
-        // RN-specific tools first, then the shared debug loop (logs, crash,
-        // perf, network), app management, and device/capture.
+        // RN-specific tools first, then the shared debug loop (logs — both
+        // platforms' — crash, perf, network), app management, device/capture
+        // with state simulation, and infra. RN apps ship on Android AND iOS,
+        // so the iOS Simulator tools (ios-logs, the Simulate hub with its
+        // push tester) ride along and the role sees both platforms.
         .reactNativeDeveloper: [
             "react-native", "reactotron", "js-console",
-            "logcat", "crash-catcher", "performance", "network-speed",
+            "logcat", "ios-logs", "crash-catcher", "performance", "network-speed",
             "apps", "install-app", "apk-studio", "aab-convert",
-            "device-info", "scrcpy", "screenshot", "send-text",
+            "device-info", "simulate", "scrcpy", "screenshot", "send-text",
             "emulators", "connection",
             "terminal", "custom-commands",
         ],
@@ -695,25 +698,28 @@ public enum FeatureRegistry {
 
     /// The device platforms a role works with. The device bar, the virtual-
     /// device launch lists, and the Emulators screen show only these; `nil`
-    /// ("all features") shows both. The iOS Developer role is simulator-only,
-    /// every other role is Android-only.
+    /// ("all features") shows both. iOS Developer is simulator-only, React
+    /// Native spans both (RN apps ship on Android and iOS), every other role
+    /// is Android-only.
     public static func visiblePlatforms(for role: UserRole?) -> Set<DevicePlatform> {
         switch role {
         case .iosDeveloper: return [.iosSimulator]
-        case nil: return [.android, .iosSimulator]
+        case .reactNativeDeveloper, nil: return [.android, .iosSimulator]
         default: return [.android]
         }
     }
 
     /// The def as `role` presents it: the emulators screen renames itself to
-    /// the platform(s) the role can see ("Simulators" for iOS Developer,
-    /// "Emulators" for the Android-only roles, the combined title with no
-    /// role). Only display strings change — id, kind, icon, and behavior
-    /// don't, so ids stay a stable contract.
+    /// the platform(s) the role can see ("Simulators" for a simulator-only
+    /// role, "Emulators" for the Android-only ones, the combined title when
+    /// both platforms are visible). Only display strings change — id, kind,
+    /// icon, and behavior don't, so ids stay a stable contract.
     public static func presented(_ def: FeatureDef, for role: UserRole?) -> FeatureDef {
         guard def.id == "emulators", let role else { return def }
+        let platforms = visiblePlatforms(for: role)
+        guard platforms != [.android, .iosSimulator] else { return def }
         var adapted = def
-        if role == .iosDeveloper {
+        if platforms == [.iosSimulator] {
             adapted.title = "Simulators"
             adapted.subtitle = "Boot and shut down iOS Simulators"
         } else {

--- a/ADBKit/Sources/ADBKit/Features/WindowEffects.swift
+++ b/ADBKit/Sources/ADBKit/Features/WindowEffects.swift
@@ -57,10 +57,11 @@ public enum WindowEffects {
         return Int((clampedAmount(amount) * maximumBlurRadius).rounded())
     }
 
-    /// The grain film's alpha for a slider amount — zero whenever the window
-    /// is opaque, so the film never sits over a solid background.
-    public static func grainOpacity(root opacity: Double, amount: Double) -> Double {
-        guard isTranslucent(opacity) else { return 0 }
-        return clampedAmount(amount) * maximumGrainAlpha
+    /// The grain film's alpha for a slider amount. Deliberately independent
+    /// of the window opacity: the film reads as texture over a solid window
+    /// just as well as over glass. (Blur, by contrast, needs something
+    /// showing through, so it stays opacity-gated above.)
+    public static func grainOpacity(amount: Double) -> Double {
+        clampedAmount(amount) * maximumGrainAlpha
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleExport.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleExport.swift
@@ -38,14 +38,16 @@ public enum ConsoleExport {
 
     /// A pretty-printed JSON array of the entries, in the order given (the
     /// caller passes them in display/chronological order). `level` is omitted
-    /// for entries that have none.
-    public static func json(_ entries: [ConsoleExportEntry]) -> String {
+    /// for entries that have none. Returns nil if encoding fails so the caller
+    /// surfaces the failure instead of shipping an empty artifact with a
+    /// success message.
+    public static func json(_ entries: [ConsoleExportEntry]) -> String? {
         let lines = entries.map {
             Line(timestamp: stamp($0.at), type: $0.type, level: $0.level, text: $0.text)
         }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-        guard let data = try? encoder.encode(lines) else { return "[]" }
+        guard let data = try? encoder.encode(lines) else { return nil }
         return String(decoding: data, as: UTF8.self)
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleExport.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleExport.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// One console line flattened for export — the view maps its feed entries
+/// (already filtered by the active level/text filter) into these.
+public struct ConsoleExportEntry: Sendable, Equatable {
+    public let at: Date
+    /// `log` · `input` · `result` · `error` · `notice`.
+    public let type: String
+    /// The console level for `log` entries; nil otherwise (omitted from JSON).
+    public let level: String?
+    public let text: String
+
+    public init(at: Date, type: String, level: String? = nil, text: String) {
+        self.at = at
+        self.type = type
+        self.level = level
+        self.text = text
+    }
+}
+
+/// Serializes a console feed for the Export button — one deterministic JSON
+/// shape shared by "save as file" and "copy to clipboard".
+public enum ConsoleExport {
+    private struct Line: Encodable {
+        let timestamp: String
+        let type: String
+        let level: String?
+        let text: String
+    }
+
+    /// ISO 8601 with fractional seconds — console bursts land several entries
+    /// in the same second, so whole-second stamps would read as ties.
+    private static func stamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    /// A pretty-printed JSON array of the entries, in the order given (the
+    /// caller passes them in display/chronological order). `level` is omitted
+    /// for entries that have none.
+    public static func json(_ entries: [ConsoleExportEntry]) -> String {
+        let lines = entries.map {
+            Line(timestamp: stamp($0.at), type: $0.type, level: $0.level, text: $0.text)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(lines) else { return "[]" }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNode.swift
@@ -41,17 +41,4 @@ public struct SnapNode: Sendable, Decodable, Equatable {
         guard let data = json.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(SnapNode.self, from: data)
     }
-
-    /// Whether this node — or any descendant — matches `query` (already
-    /// lowercased) in a key or a primitive value, so a search within an object
-    /// can keep matching branches and prune the rest. `key` is this node's own
-    /// key (nil for array items and the root). An empty query matches everything.
-    public func matches(_ query: String, key: String? = nil) -> Bool {
-        if query.isEmpty { return true }
-        if let key, key.lowercased().contains(query) { return true }
-        if let text, text.lowercased().contains(query) { return true }
-        if let entries { return entries.contains { $0.node.matches(query, key: $0.name) } }
-        if let items { return items.contains { $0.matches(query) } }
-        return false
-    }
 }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/TargetStability.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/TargetStability.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Gates the JS console's auto-connect on target *stability*: a target must be
+/// listed in two consecutive discovery passes before it's attached to.
+///
+/// Attaching the instant a target first appears crashed the app under debug —
+/// the runtime was still booting when the debugger connected and Hermes's
+/// attach-time replay hit it mid-init (its debugger serialization is fragile
+/// on 0.84–0.86; see the upstream crash notes). One extra ~2s pass lets the
+/// app settle. A *relaunched* app registers with a fresh target id, so it is
+/// re-gated automatically; a target that merely reconnects (JS reload, socket
+/// drop) has been listed all along and passes immediately. The user's manual
+/// pick never goes through this gate.
+public struct TargetStabilityTracker: Sendable, Equatable {
+    private var seenLastPass: Set<String> = []
+    private var stable: Set<String> = []
+
+    public init() {}
+
+    /// Record one discovery pass's target ids. A target becomes stable on its
+    /// second consecutive sighting and stays stable while it remains listed;
+    /// vanishing from a pass resets it (the next appearance is a fresh boot).
+    public mutating func recordPass(ids: some Sequence<String>) {
+        let current = Set(ids)
+        stable = current.intersection(seenLastPass.union(stable))
+        seenLastPass = current
+    }
+
+    /// Whether this target has been listed in at least the last two passes.
+    public func isStable(_ id: String) -> Bool {
+        stable.contains(id)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/TreeSearch.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/TreeSearch.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// One hit from a find inside an expanded value tree (the JS console's object
+/// snapshots and Reactotron's JSON payloads). The view renders these as a
+/// clickable result list; clicking one expands the tree along `path` and
+/// highlights the node.
+public struct TreeMatch: Sendable, Equatable {
+    /// Ordinal child indices from the root to the matched node, in the exact
+    /// order the tree view renders children — the view derives its expansion
+    /// keys from these.
+    public let path: [Int]
+    /// Human-readable location, e.g. `user.addresses[0].city`.
+    public let displayPath: String
+    /// The matched node's value text, or a container summary like `Array(3)`.
+    public let preview: String
+    public let isContainer: Bool
+
+    public init(path: [Int], displayPath: String, preview: String, isContainer: Bool) {
+        self.path = path
+        self.displayPath = displayPath
+        self.preview = preview
+        self.isContainer = isContainer
+    }
+}
+
+public extension SnapNode {
+    /// Collapsed one-liner for a container node, e.g. `Array(200)`, `{3}`,
+    /// `Map {2}` — shared by the tree rows and the find-result previews.
+    var containerSummary: String {
+        if type == "array" {
+            return "Array(\(length ?? items?.count ?? 0))"
+        }
+        let count = entries?.count ?? 0
+        let ctor = ctor ?? "Object"
+        return ctor == "Object" ? "{\(count)}" : "\(ctor) {\(count)}"
+    }
+
+    /// Display text for a primitive node (strings quoted, like the tree rows).
+    var primitivePreview: String {
+        let text = text ?? "—"
+        return type == "string" ? "\"\(text)\"" : text
+    }
+
+    /// Every descendant whose own key or primitive value contains `query`
+    /// (case-insensitive), in render order, capped at `limit`. The root itself
+    /// is never a match — it has no key of its own.
+    func findMatches(query: String, limit: Int = 200) -> [TreeMatch] {
+        let query = query.lowercased()
+        guard !query.isEmpty else { return [] }
+        var out: [TreeMatch] = []
+
+        func matchesSelf(_ node: SnapNode, key: String?) -> Bool {
+            if let key, key.lowercased().contains(query) { return true }
+            if let text = node.text, text.lowercased().contains(query) { return true }
+            return false
+        }
+
+        func walk(_ node: SnapNode, key: String?, path: [Int], displayPath: String) {
+            guard out.count < limit else { return }
+            if !path.isEmpty, matchesSelf(node, key: key) {
+                out.append(TreeMatch(
+                    path: path,
+                    displayPath: displayPath,
+                    preview: node.isContainer ? node.containerSummary : node.primitivePreview,
+                    isContainer: node.isContainer
+                ))
+            }
+            if let entries = node.entries {
+                for (index, entry) in entries.enumerated() {
+                    let child = displayPath.isEmpty ? entry.name : "\(displayPath).\(entry.name)"
+                    walk(entry.node, key: entry.name, path: path + [index], displayPath: child)
+                }
+            } else if let items = node.items {
+                for (index, item) in items.enumerated() {
+                    walk(item, key: nil, path: path + [index], displayPath: "\(displayPath)[\(index)]")
+                }
+            }
+        }
+
+        walk(self, key: nil, path: [], displayPath: "")
+        return out
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -5,19 +5,30 @@ public struct LogLine: Sendable, Equatable, Identifiable {
     public let raw: String
     public let time: String
     public let pid: String
+    /// The emitting thread id (threadtime format); empty for sources that
+    /// don't carry one (unparsed lines, the simulator log).
+    public let tid: String
     public let level: String
     public let tag: String
     public let message: String
+    /// The process name behind `pid`, stamped at ingest from a `ps` snapshot
+    /// (see `LogcatStreamer.processNames`); nil renders as "?" like the pid
+    /// map does for a process that already exited.
+    public var processName: String?
     /// `raw` lowercased once at ingest, so the search filter is a plain
     /// substring check per line instead of a locale-aware case-insensitive
     /// scan re-done for the full buffer on every streamed batch.
     public let searchKey: String
 
-    public init(raw: String, time: String, pid: String, level: String, tag: String, message: String) {
+    public init(
+        raw: String, time: String, pid: String, tid: String = "",
+        level: String, tag: String, message: String
+    ) {
         self.id = UUID()
         self.raw = raw
         self.time = time
         self.pid = pid
+        self.tid = tid
         self.level = level
         self.tag = tag
         self.message = message
@@ -65,10 +76,24 @@ public enum LogcatLineParser {
             raw: raw,
             time: String(match.1),
             pid: String(match.2),
+            tid: String(match.3),
             level: String(match.4),
             tag: String(match.5),
             message: String(match.6)
         )
+    }
+
+    /// Parse `ps -A -o PID,NAME` output into pid → process name, for the log
+    /// pane's process column. Tolerates the header row, CRLF, and ragged
+    /// whitespace; rows that don't lead with a number are skipped.
+    public static func parseProcessNames(_ output: String) -> [String: String] {
+        var names: [String: String] = [:]
+        for row in output.components(separatedBy: .newlines) {
+            let fields = row.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+            guard fields.count == 2, fields[0].allSatisfy(\.isNumber) else { continue }
+            names[String(fields[0])] = fields[1].trimmingCharacters(in: .whitespaces)
+        }
+        return names
     }
 
     public static func buildArgs(serial: String, filters: LogcatFilters) -> [String] {
@@ -105,6 +130,16 @@ public actor LogcatStreamer {
 
     public init(client: AdbClient) {
         self.client = client
+    }
+
+    /// A snapshot of the device's running processes (pid → name), for the
+    /// log pane's process column. Best-effort: an error reads as an empty
+    /// map and the column shows "?".
+    public func processNames(serial: String) async -> [String: String] {
+        guard let result = try? await client.run(on: serial, ["shell", "ps", "-A", "-o", "PID,NAME"]) else {
+            return [:]
+        }
+        return LogcatLineParser.parseProcessNames(result.stdout)
     }
 
     /// Resolve a package's running PID, or nil if it isn't running.

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/JSONSearch.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/JSONSearch.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Find inside a `JSONValue` tree (Reactotron payloads, the store browser).
+/// Returns `TreeMatch`es whose ordinal paths follow the tree view's render
+/// order — object children sorted by key, array items in order — so the view
+/// can expand straight to a clicked result.
+public enum JSONSearch {
+    /// Every node whose own key or scalar value contains `query`
+    /// (case-insensitive), in render order. Bounded by `limit` results and
+    /// `maxVisited` visited nodes so a pathological payload can't stall a
+    /// keystroke.
+    public static func matches(
+        in root: JSONValue, query: String, limit: Int = 200, maxVisited: Int = 40_000
+    ) -> [TreeMatch] {
+        let query = query.lowercased()
+        guard !query.isEmpty else { return [] }
+        var out: [TreeMatch] = []
+        var visited = 0
+
+        func matchesSelf(_ value: JSONValue, key: String) -> Bool {
+            if key.lowercased().contains(query) { return true }
+            switch value {
+            case let .string(text): return text.lowercased().contains(query)
+            case let .number(number): return preview(.number(number)).contains(query)
+            case let .bool(flag): return (flag ? "true" : "false").contains(query)
+            case .null, .object, .array: return false
+            }
+        }
+
+        func walk(_ value: JSONValue, key: String, path: [Int], displayPath: String) {
+            guard out.count < limit, visited < maxVisited else { return }
+            visited += 1
+            if !path.isEmpty, matchesSelf(value, key: key) {
+                let isContainer = value.objectValue != nil || value.arrayValue != nil
+                out.append(TreeMatch(
+                    path: path, displayPath: displayPath,
+                    preview: preview(value), isContainer: isContainer
+                ))
+            }
+            switch value {
+            case let .object(dict):
+                // Sorted by key — the same order the tree view renders, so the
+                // ordinal path lands on the right row.
+                for (index, entry) in dict.sorted(by: { $0.key < $1.key }).enumerated() {
+                    let child = displayPath.isEmpty ? entry.key : "\(displayPath).\(entry.key)"
+                    walk(entry.value, key: entry.key, path: path + [index], displayPath: child)
+                }
+            case let .array(items):
+                for (index, item) in items.enumerated() {
+                    walk(item, key: "[\(index)]", path: path + [index], displayPath: "\(displayPath)[\(index)]")
+                }
+            case .null, .bool, .number, .string:
+                break
+            }
+        }
+
+        walk(root, key: "", path: [], displayPath: "")
+        return out
+    }
+
+    /// One-line value preview matching the tree rows: containers summarize,
+    /// strings quote, whole numbers drop the decimal point.
+    public static func preview(_ value: JSONValue) -> String {
+        switch value {
+        case let .object(dict): return "{ \(dict.count) }"
+        case let .array(items): return "[ \(items.count) ]"
+        case let .string(text): return "\"\(text)\""
+        case let .number(number):
+            return number.truncatingRemainder(dividingBy: 1) == 0 && abs(number) < 9e15
+                ? String(Int(number)) : String(number)
+        case let .bool(flag): return flag ? "true" : "false"
+        case .null: return "null"
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
@@ -149,6 +149,18 @@ import Testing
         #expect(!result.ok)
     }
 
+    @Test func clearCacheUsesCacheOnlyAndQuotesPackage() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "Success")
+        let service = await makeService(runner)
+
+        let result = try await service.control(serial: "S1", packageId: "a'b", action: .clearCache)
+        #expect(result.ok)
+        #expect(runner.invocations.last?.arguments == [
+            "-s", "S1", "shell", "pm", "clear", "--cache-only", "'a'\\''b'",
+        ])
+    }
+
     @Test func clearCacheReportsFailureWhenNoSuccessText() async throws {
         // Older devices print nothing (no --cache-only support) and exit 0.
         let runner = MockProcessRunner()

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -33,22 +33,6 @@ import Testing
     @Test func malformedJSONReturnsNil() {
         #expect(SnapNode.parse("not json") == nil)
     }
-
-    @Test func matchesFindsKeysAndValuesInDescendants() {
-        let json = """
-        {"type":"object","entries":[
-          {"name":"userId","node":{"type":"number","text":"7"}},
-          {"name":"profile","node":{"type":"object","entries":[
-            {"name":"city","node":{"type":"string","text":"Berlin"}}]}}
-        ]}
-        """
-        let node = SnapNode.parse(json)!
-        #expect(node.matches("berlin"))          // nested value
-        #expect(node.matches("city"))            // nested key
-        #expect(node.matches("userid"))          // top-level key, case-insensitive
-        #expect(!node.matches("london"))         // absent
-        #expect(node.matches(""))                // empty query matches everything
-    }
 }
 
 /// Pure tests for the CDP framing: request shapes and decoding of the replies

--- a/ADBKit/Tests/ADBKitTests/ConsoleExportTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleExportTests.swift
@@ -8,16 +8,17 @@ struct ConsoleExportTests {
     }
 
     @Test func emptyFeedExportsEmptyArray() throws {
-        let data = try #require(ConsoleExport.json([]).data(using: .utf8))
+        let json = try #require(ConsoleExport.json([]))
+        let data = try #require(json.data(using: .utf8))
         let decoded = try #require(try JSONSerialization.jsonObject(with: data) as? [Any])
         #expect(decoded.isEmpty)
     }
 
     @Test func exportsEntriesInGivenOrderWithISOTimestamps() throws {
-        let json = ConsoleExport.json([
+        let json = try #require(ConsoleExport.json([
             ConsoleExportEntry(at: date(0), type: "log", level: "error", text: "boom"),
             ConsoleExportEntry(at: date(1.5), type: "input", text: "1 + 1"),
-        ])
+        ]))
         let data = try #require(json.data(using: .utf8))
         let decoded = try #require(
             try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
@@ -33,16 +34,16 @@ struct ConsoleExportTests {
     }
 
     @Test func levelIsOmittedWhenAbsent() throws {
-        let json = ConsoleExport.json([
+        let json = try #require(ConsoleExport.json([
             ConsoleExportEntry(at: date(0), type: "notice", text: "connected"),
-        ])
+        ]))
         #expect(!json.contains("\"level\""))
     }
 
     @Test func escapesQuotesAndNewlines() throws {
-        let json = ConsoleExport.json([
+        let json = try #require(ConsoleExport.json([
             ConsoleExportEntry(at: date(0), type: "log", level: "log", text: "a \"quoted\"\nline"),
-        ])
+        ]))
         let data = try #require(json.data(using: .utf8))
         let decoded = try #require(
             try JSONSerialization.jsonObject(with: data) as? [[String: Any]]

--- a/ADBKit/Tests/ADBKitTests/ConsoleExportTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleExportTests.swift
@@ -1,0 +1,52 @@
+@testable import ADBKit
+import Foundation
+import Testing
+
+struct ConsoleExportTests {
+    private func date(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: seconds)
+    }
+
+    @Test func emptyFeedExportsEmptyArray() throws {
+        let data = try #require(ConsoleExport.json([]).data(using: .utf8))
+        let decoded = try #require(try JSONSerialization.jsonObject(with: data) as? [Any])
+        #expect(decoded.isEmpty)
+    }
+
+    @Test func exportsEntriesInGivenOrderWithISOTimestamps() throws {
+        let json = ConsoleExport.json([
+            ConsoleExportEntry(at: date(0), type: "log", level: "error", text: "boom"),
+            ConsoleExportEntry(at: date(1.5), type: "input", text: "1 + 1"),
+        ])
+        let data = try #require(json.data(using: .utf8))
+        let decoded = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        )
+        #expect(decoded.count == 2)
+        #expect(decoded[0]["timestamp"] as? String == "1970-01-01T00:00:00.000Z")
+        #expect(decoded[0]["type"] as? String == "log")
+        #expect(decoded[0]["level"] as? String == "error")
+        #expect(decoded[0]["text"] as? String == "boom")
+        // Fractional seconds survive — bursts land several entries per second.
+        #expect(decoded[1]["timestamp"] as? String == "1970-01-01T00:00:01.500Z")
+        #expect(decoded[1]["type"] as? String == "input")
+    }
+
+    @Test func levelIsOmittedWhenAbsent() throws {
+        let json = ConsoleExport.json([
+            ConsoleExportEntry(at: date(0), type: "notice", text: "connected"),
+        ])
+        #expect(!json.contains("\"level\""))
+    }
+
+    @Test func escapesQuotesAndNewlines() throws {
+        let json = ConsoleExport.json([
+            ConsoleExportEntry(at: date(0), type: "log", level: "log", text: "a \"quoted\"\nline"),
+        ])
+        let data = try #require(json.data(using: .utf8))
+        let decoded = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        )
+        #expect(decoded[0]["text"] as? String == "a \"quoted\"\nline")
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/LogcatParserTests.swift
+++ b/ADBKit/Tests/ADBKitTests/LogcatParserTests.swift
@@ -8,12 +8,40 @@ import Testing
         )
         #expect(line.time == "06-12 14:03:22.123")
         #expect(line.pid == "1234")
+        #expect(line.tid == "5678")
         #expect(line.level == "E")
         #expect(line.tag == "ReactNativeJS")
         #expect(line.message == "TypeError: undefined is not a function")
         // The cached search key backs the view's per-keystroke filter — it
         // must be the lowercased raw line.
         #expect(line.searchKey == line.raw.lowercased())
+    }
+
+    @Test func malformedLineHasNoTid() {
+        #expect(LogcatLineParser.parse("not a log line").tid == "")
+    }
+
+    @Test func parsesProcessNameTable() {
+        let output = """
+        PID NAME
+            1 init
+          813 system_server
+         3011 com.google.android.gms
+        30246 com.google.android.webview:sandboxed_process0:org.chromium.content.app.SandboxedProcessService0:0
+        garbage row
+        """
+        let names = LogcatLineParser.parseProcessNames(output)
+        #expect(names["1"] == "init")
+        #expect(names["813"] == "system_server")
+        #expect(names["3011"] == "com.google.android.gms")
+        #expect(names["30246"]?.hasPrefix("com.google.android.webview:sandboxed") == true)
+        #expect(names["PID"] == nil)
+        #expect(names.count == 4)
+    }
+
+    @Test func processNameTableHandlesCRLFAndEmpty() {
+        #expect(LogcatLineParser.parseProcessNames("PID NAME\r\n  42 my.app\r\n")["42"] == "my.app")
+        #expect(LogcatLineParser.parseProcessNames("").isEmpty)
     }
 
     @Test func parsesEmptyMessage() {

--- a/ADBKit/Tests/ADBKitTests/RolePresentationTests.swift
+++ b/ADBKit/Tests/ADBKitTests/RolePresentationTests.swift
@@ -12,10 +12,24 @@ import Testing
         #expect(FeatureRegistry.visiblePlatforms(for: nil) == [.android, .iosSimulator])
     }
 
+    /// React Native apps ship on Android and iOS, so the role spans both —
+    /// booted simulators join the device bar and the launch lists.
+    @Test func reactNativeSeesBothPlatforms() {
+        #expect(FeatureRegistry.visiblePlatforms(for: .reactNativeDeveloper) == [.android, .iosSimulator])
+    }
+
+    /// The RN role curates the iOS-side tools too: the simulator log stream
+    /// and the Simulate hub (which carries the iOS-only push tester).
+    @Test func reactNativeCuratesIOSTools() {
+        let ids = FeatureRegistry.featureIDs(for: .reactNativeDeveloper)
+        #expect(ids.contains("ios-logs"))
+        #expect(ids.contains("simulate"))
+    }
+
     @Test(arguments: [
-        UserRole.androidDeveloper, .reactNativeDeveloper, .qaTester, .supportTriage, .securityTester,
+        UserRole.androidDeveloper, .qaTester, .supportTriage, .securityTester,
     ])
-    func everyNonIOSRoleSeesOnlyAndroid(role: UserRole) {
+    func androidOnlyRolesSeeOnlyAndroid(role: UserRole) {
         #expect(FeatureRegistry.visiblePlatforms(for: role) == [.android])
     }
 
@@ -23,7 +37,9 @@ import Testing
         let emulators = try #require(FeatureRegistry.byID["emulators"])
         #expect(FeatureRegistry.presented(emulators, for: nil).title == "Emulators & Simulators")
         #expect(FeatureRegistry.presented(emulators, for: .iosDeveloper).title == "Simulators")
-        for role in UserRole.allCases where role != .iosDeveloper {
+        // Both platforms visible → the combined default title stands.
+        #expect(FeatureRegistry.presented(emulators, for: .reactNativeDeveloper).title == "Emulators & Simulators")
+        for role in UserRole.allCases where role != .iosDeveloper && role != .reactNativeDeveloper {
             #expect(FeatureRegistry.presented(emulators, for: role).title == "Emulators")
         }
     }

--- a/ADBKit/Tests/ADBKitTests/TargetStabilityTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TargetStabilityTests.swift
@@ -1,0 +1,53 @@
+@testable import ADBKit
+import Testing
+
+struct TargetStabilityTests {
+    @Test func firstSightingIsNotStable() {
+        var tracker = TargetStabilityTracker()
+        tracker.recordPass(ids: ["a"])
+        #expect(!tracker.isStable("a"))
+    }
+
+    @Test func secondConsecutiveSightingBecomesStable() {
+        var tracker = TargetStabilityTracker()
+        tracker.recordPass(ids: ["a"])
+        tracker.recordPass(ids: ["a"])
+        #expect(tracker.isStable("a"))
+    }
+
+    @Test func stayingListedKeepsStability() {
+        var tracker = TargetStabilityTracker()
+        for _ in 0 ..< 5 { tracker.recordPass(ids: ["a"]) }
+        #expect(tracker.isStable("a"))
+    }
+
+    @Test func vanishingResetsAndReappearanceIsRegated() {
+        var tracker = TargetStabilityTracker()
+        tracker.recordPass(ids: ["a"])
+        tracker.recordPass(ids: ["a"])
+        // App relaunch: gone for a pass (even if the id were reused).
+        tracker.recordPass(ids: [])
+        #expect(!tracker.isStable("a"))
+        tracker.recordPass(ids: ["a"])
+        #expect(!tracker.isStable("a"))
+        tracker.recordPass(ids: ["a"])
+        #expect(tracker.isStable("a"))
+    }
+
+    @Test func targetsAreTrackedIndependently() {
+        var tracker = TargetStabilityTracker()
+        tracker.recordPass(ids: ["old"])
+        tracker.recordPass(ids: ["old", "new"])
+        #expect(tracker.isStable("old"))
+        #expect(!tracker.isStable("new"))
+        tracker.recordPass(ids: ["old", "new"])
+        #expect(tracker.isStable("new"))
+    }
+
+    @Test func unknownIdIsNeverStable() {
+        var tracker = TargetStabilityTracker()
+        tracker.recordPass(ids: ["a"])
+        tracker.recordPass(ids: ["a"])
+        #expect(!tracker.isStable("b"))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
@@ -60,6 +60,21 @@ struct SnapNodeFindMatchesTests {
         // matches come from keys and primitive values.
         #expect(root.findMatches(query: "object").isEmpty)
     }
+
+    @Test func containerSummariesCoverObjectMapAndArray() {
+        let map = SnapNode.parse(
+            #"{"type":"object","ctor":"Map","entries":[{"name":"a","node":{"type":"number","text":"1"}},{"name":"b","node":{"type":"number","text":"2"}}]}"#
+        )
+        #expect(map?.containerSummary == "Map {2}")
+
+        let plain = SnapNode.parse(
+            #"{"type":"object","entries":[{"name":"a","node":{"type":"number","text":"1"}}]}"#
+        )
+        #expect(plain?.containerSummary == "{1}")
+
+        let array = SnapNode.parse(#"{"type":"array","length":3,"items":[]}"#)
+        #expect(array?.containerSummary == "Array(3)")
+    }
 }
 
 /// `JSONSearch` — Reactotron's find-in-payload result list.
@@ -120,5 +135,23 @@ struct JSONSearchTests {
 
     @Test func emptyQueryReturnsNothing() {
         #expect(JSONSearch.matches(in: root, query: "").isEmpty)
+    }
+
+    @Test func sortOrderIsCaseSensitiveASCIIMatchingTheTree() {
+        // The Reactotron tree view sorts object keys with `<` (ASCII,
+        // uppercase first). JSONSearch must index the identical order or a
+        // clicked result reveals the wrong row — this locks the contract.
+        let mixed = JSONValue.object(["a": .number(2), "B": .number(1)])
+        let matches = JSONSearch.matches(in: mixed, query: "1")
+        #expect(matches.map(\.path) == [[0]]) // "B" sorts before "a"
+        #expect(matches[0].displayPath == "B")
+    }
+
+    @Test func numberPreviewsHandleBoundariesAndNegatives() {
+        #expect(JSONSearch.preview(.number(-3)) == "-3")
+        // At and beyond the 9e15 integer-safety cutoff the raw Double form
+        // is kept rather than a lossy Int conversion.
+        #expect(JSONSearch.preview(.number(1e16)) == "1e+16")
+        #expect(JSONSearch.preview(.number(-1e16)) == "-1e+16")
     }
 }

--- a/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
@@ -1,0 +1,124 @@
+@testable import ADBKit
+import Foundation
+import Testing
+
+/// `SnapNode.findMatches` — the JS console's find-in-object result list.
+struct SnapNodeFindMatchesTests {
+    /// { user: { name: "Ada", tags: ["math", "code"] }, count: 2 }
+    private var root: SnapNode {
+        let json = """
+        {"type":"object","entries":[
+          {"name":"user","node":{"type":"object","entries":[
+            {"name":"name","node":{"type":"string","text":"Ada"}},
+            {"name":"tags","node":{"type":"array","length":2,"items":[
+              {"type":"string","text":"math"},
+              {"type":"string","text":"code"}
+            ]}}
+          ]}},
+          {"name":"count","node":{"type":"number","text":"2"}}
+        ]}
+        """
+        guard let node = SnapNode.parse(json) else {
+            Issue.record("fixture failed to parse")
+            return SnapNode.parse(#"{"type":"object","entries":[]}"#)!
+        }
+        return node
+    }
+
+    @Test func matchesValueWithOrdinalPathAndDisplayPath() {
+        let matches = root.findMatches(query: "ada")
+        #expect(matches.count == 1)
+        #expect(matches[0].path == [0, 0])
+        #expect(matches[0].displayPath == "user.name")
+        #expect(matches[0].preview == "\"Ada\"")
+        #expect(matches[0].isContainer == false)
+    }
+
+    @Test func matchesKeysAndArrayItems() {
+        let byKey = root.findMatches(query: "tags")
+        #expect(byKey.map(\.path) == [[0, 1]])
+        #expect(byKey[0].isContainer == true)
+        #expect(byKey[0].preview == "Array(2)")
+
+        let inArray = root.findMatches(query: "code")
+        #expect(inArray.map(\.path) == [[0, 1, 1]])
+        #expect(inArray[0].displayPath == "user.tags[1]")
+    }
+
+    @Test func matchingIsCaseInsensitiveAndEmptyQueryReturnsNothing() {
+        #expect(root.findMatches(query: "ADA").count == 1)
+        #expect(root.findMatches(query: "").isEmpty)
+    }
+
+    @Test func limitCapsResults() {
+        let matches = root.findMatches(query: "a", limit: 1)
+        #expect(matches.count == 1)
+    }
+
+    @Test func rootItselfNeverMatches() {
+        // A query matching only container summaries/ctor text finds nothing —
+        // matches come from keys and primitive values.
+        #expect(root.findMatches(query: "object").isEmpty)
+    }
+}
+
+/// `JSONSearch` — Reactotron's find-in-payload result list.
+struct JSONSearchTests {
+    /// Object keys deliberately unsorted in source: render order is sorted.
+    private var root: JSONValue {
+        .object([
+            "zeta": .string("last"),
+            "alpha": .object([
+                "flag": .bool(true),
+                "count": .number(42),
+            ]),
+            "items": .array([.string("one"), .number(2.5)]),
+        ])
+    }
+
+    @Test func ordinalPathsFollowSortedKeyOrder() {
+        // Sorted top-level order: alpha(0), items(1), zeta(2).
+        let matches = JSONSearch.matches(in: root, query: "last")
+        #expect(matches.map(\.path) == [[2]])
+        #expect(matches[0].displayPath == "zeta")
+        #expect(matches[0].preview == "\"last\"")
+    }
+
+    @Test func nestedKeysAndValuesMatch() {
+        // "count" the key and 42 the value under alpha (sorted: count=0, flag=1).
+        let byKey = JSONSearch.matches(in: root, query: "count")
+        #expect(byKey.map(\.path) == [[0, 0]])
+        #expect(byKey[0].displayPath == "alpha.count")
+        #expect(byKey[0].preview == "42")
+
+        let byBool = JSONSearch.matches(in: root, query: "true")
+        #expect(byBool.map(\.path) == [[0, 1]])
+    }
+
+    @Test func arrayItemsMatchWithBracketPaths() {
+        let matches = JSONSearch.matches(in: root, query: "2.5")
+        #expect(matches.map(\.path) == [[1, 1]])
+        #expect(matches[0].displayPath == "items[1]")
+        #expect(matches[0].preview == "2.5")
+    }
+
+    @Test func containerMatchesByKeyOnly() {
+        let matches = JSONSearch.matches(in: root, query: "alpha")
+        #expect(matches.count == 1)
+        #expect(matches[0].isContainer == true)
+        #expect(matches[0].preview == "{ 2 }")
+    }
+
+    @Test func capsResultsAndVisits() {
+        let wide = JSONValue.array((0 ..< 500).map { .string("hit\($0)") })
+        #expect(JSONSearch.matches(in: wide, query: "hit", limit: 10).count == 10)
+        // A visit cap smaller than the tree still returns what it saw.
+        let capped = JSONSearch.matches(in: wide, query: "hit", maxVisited: 50)
+        #expect(capped.count < 500)
+        #expect(!capped.isEmpty)
+    }
+
+    @Test func emptyQueryReturnsNothing() {
+        #expect(JSONSearch.matches(in: root, query: "").isEmpty)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/WindowEffectsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WindowEffectsTests.swift
@@ -49,10 +49,12 @@ import Testing
         #expect(WindowEffects.blurRadius(amount: 2, root: 0.5) == 40)
     }
 
-    @Test func grainScalesWithTheSliderAndDiesWhenOpaque() {
-        #expect(WindowEffects.grainOpacity(root: 0.5, amount: 1) == WindowEffects.maximumGrainAlpha)
-        #expect(WindowEffects.grainOpacity(root: 0.5, amount: 0.5) == WindowEffects.maximumGrainAlpha / 2)
-        #expect(WindowEffects.grainOpacity(root: 0.5, amount: 0) == 0)
-        #expect(WindowEffects.grainOpacity(root: 1.0, amount: 1) == 0)
+    @Test func grainScalesWithTheSliderIndependentOfOpacity() {
+        #expect(WindowEffects.grainOpacity(amount: 1) == WindowEffects.maximumGrainAlpha)
+        #expect(WindowEffects.grainOpacity(amount: 0.5) == WindowEffects.maximumGrainAlpha / 2)
+        #expect(WindowEffects.grainOpacity(amount: 0) == 0)
+        // Out-of-range and non-finite amounts clamp like the other sliders.
+        #expect(WindowEffects.grainOpacity(amount: 2) == WindowEffects.maximumGrainAlpha)
+        #expect(WindowEffects.grainOpacity(amount: .nan) == 0)
     }
 }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -470,7 +470,7 @@ struct MenuBarView: View {
 
     var body: some View {
         if let device = state.selectedDevice {
-            Text(device.label)
+            Text(state.deviceDisplayName(device))
         } else {
             Text("No device")
         }

--- a/App/Sources/FeatureDetail/SelectableLogView.swift
+++ b/App/Sources/FeatureDetail/SelectableLogView.swift
@@ -23,6 +23,8 @@ struct SelectableLogView: NSViewRepresentable {
     /// Display order: false reads oldest-top/newest-bottom (terminal style),
     /// true flips the feed so new lines land at the top.
     let newestFirst: Bool
+    /// Whether rows lead with the time column (the toolbar's clock toggle).
+    let showTime: Bool
     /// Which ends the viewport touches and whether it can scroll at all — the
     /// caller feeds this to the shared `LogJumpControls`. While parked at the
     /// newest edge the view follows new lines; scrolling away pauses that.
@@ -65,7 +67,7 @@ struct SelectableLogView: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.onFilterTag = onFilterTag
-        context.coordinator.update(lines: lines, find: find, newestFirst: newestFirst)
+        context.coordinator.update(lines: lines, find: find, newestFirst: newestFirst, showTime: showTime)
         context.coordinator.showFindCurrent(currentFindID)
         context.coordinator.handleJump(jump)
     }
@@ -88,7 +90,15 @@ struct SelectableLogView: NSViewRepresentable {
         private var lineLengths: [Int] = []
         private var renderedFind = ""
         private var renderedNewestFirst = false
+        private var renderedShowTime = true
         private var lastJumpToken: Int?
+        /// Clicking (or right-clicking) a line means the user is reading it —
+        /// hold the tail-follow so streaming lines can't scroll the selection
+        /// away even while the viewport sits at the newest edge. The
+        /// jump-to-newest button (which appears as soon as new lines land
+        /// beyond the held viewport) resumes following; clearing the buffer
+        /// resets it too.
+        private var holdFollow = false
         /// The Find match line currently painted (via temporary attributes) —
         /// scroll-to fires only when this changes, so streamed batches don't
         /// keep yanking the viewport back to the match.
@@ -106,6 +116,9 @@ struct SelectableLogView: NSViewRepresentable {
             }
             textView.filterTag = { [weak self] tag in
                 self?.onFilterTag?(tag)
+            }
+            textView.onUserClick = { [weak self] in
+                self?.holdFollow = true
             }
             scrollView.contentView.postsBoundsChangedNotifications = true
             NotificationCenter.default.addObserver(
@@ -152,6 +165,10 @@ struct SelectableLogView: NSViewRepresentable {
         func handleJump(_ request: LogJumpRequest?) {
             guard let request, request.token != lastJumpToken else { return }
             lastJumpToken = request.token
+            // Jumping to the newest edge is the explicit "resume following"
+            // gesture — it lifts a click-hold. Jumping into scrollback keeps it.
+            let newestEdge: VerticalEdge = renderedNewestFirst ? .top : .bottom
+            if request.edge == newestEdge { holdFollow = false }
             switch request.edge {
             case .top: scrollToTop()
             case .bottom: scrollToBottom()
@@ -165,12 +182,16 @@ struct SelectableLogView: NSViewRepresentable {
         /// (prepend + tail-trim) when the display order is newest-first;
         /// anything else (filter change, clear, search change, an order flip)
         /// rebuilds.
-        func update(lines: [LogLine], find: String, newestFirst: Bool) {
+        func update(lines: [LogLine], find: String, newestFirst: Bool, showTime: Bool) {
             guard let storage = textView?.textStorage else { return }
+            // A cleared buffer starts a fresh tail — a hold from the old
+            // content has nothing left to protect.
+            if lines.isEmpty { holdFollow = false }
             // Judged against the *rendered* orientation, so flipping the order
             // while parked on the newest line keeps following it at the other
-            // edge.
-            let wasTailing = renderedLines.isEmpty || isAtNewestEdge(newestFirst: renderedNewestFirst)
+            // edge. A click-hold suspends following even at the edge.
+            let wasTailing = renderedLines.isEmpty
+                || (!holdFollow && isAtNewestEdge(newestFirst: renderedNewestFirst))
 
             defer {
                 if wasTailing { newestFirst ? scrollToTop() : scrollToBottom() }
@@ -180,9 +201,10 @@ struct SelectableLogView: NSViewRepresentable {
                 syncEdges()
             }
 
-            if find != renderedFind || newestFirst != renderedNewestFirst {
+            if find != renderedFind || newestFirst != renderedNewestFirst || showTime != renderedShowTime {
                 renderedFind = find
                 renderedNewestFirst = newestFirst
+                renderedShowTime = showTime
                 rebuild(lines, in: storage)
                 return
             }
@@ -196,6 +218,16 @@ struct SelectableLogView: NSViewRepresentable {
             case .rebuild:
                 rebuild(lines, in: storage)
             case .edit(let dropHead, let appendFrom):
+                // While tailing, run the ring trim and the append as ONE
+                // editing transaction: layout and display coalesce, and the
+                // follow-scroll in the defer lands in the same frame. Without
+                // this, once the buffer hit its line cap every batch painted
+                // an intermediate frame — content clamped upward by the trim
+                // before the append + re-pin caught up — and the feed visibly
+                // bounced. Scrollback paths stay unbatched: their scroll-place
+                // compensation measures layout between the edits.
+                let batchable = wasTailing
+                if batchable { storage.beginEditing() }
                 if newestFirst {
                     // Mirrored: the stream's head-trim is the *bottom* of the
                     // display, its tail-append the *top*.
@@ -213,6 +245,7 @@ struct SelectableLogView: NSViewRepresentable {
                         append(Array(lines[appendFrom...]), to: storage)
                     }
                 }
+                if batchable { storage.endEditing() }
             }
         }
 
@@ -269,7 +302,7 @@ struct SelectableLogView: NSViewRepresentable {
             guard !lines.isEmpty else { return }
             let batch = NSMutableAttributedString()
             for line in lines {
-                let attributed = Self.attributedLine(line, find: renderedFind)
+                let attributed = Self.attributedLine(line, find: renderedFind, showTime: renderedShowTime)
                 lineLengths.append(attributed.length)
                 batch.append(attributed)
             }
@@ -288,7 +321,7 @@ struct SelectableLogView: NSViewRepresentable {
             let batch = NSMutableAttributedString()
             var batchLengths: [Int] = []
             for line in displayLines {
-                let attributed = Self.attributedLine(line, find: renderedFind)
+                let attributed = Self.attributedLine(line, find: renderedFind, showTime: renderedShowTime)
                 batchLengths.append(attributed.length)
                 batch.append(attributed)
             }
@@ -330,7 +363,15 @@ struct SelectableLogView: NSViewRepresentable {
 
         // MARK: Rendering
 
+        // Columnar rows (the Android-log-viewer convention): time, pid–tid,
+        // process name, a colored level chip, the tag in a stable per-tag
+        // color, then the message tinted by severity. Widths are fixed so the
+        // monospaced columns align down the feed.
         private static let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        private static let chipFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
+        private static let pidWidth = 11
+        private static let processWidth = 20
+        private static let tagWidth = 22
 
         private static func color(for level: String) -> NSColor {
             switch level {
@@ -341,22 +382,72 @@ struct SelectableLogView: NSViewRepresentable {
             }
         }
 
-        static func display(_ line: LogLine) -> String {
-            line.level.isEmpty
-                ? line.raw
-                : "\(line.time)  \(line.pid)  \(line.level)/\(line.tag): \(line.message)"
+        /// The level badge: a filled block behind the letter, like the I/W/E
+        /// chips in desktop log viewers.
+        private static func chipColors(for level: String) -> (bg: NSColor, fg: NSColor) {
+            switch level {
+            case "V": return (.systemGray, .white)
+            case "D": return (.systemBlue, .white)
+            case "I": return (.systemGreen, .black)
+            case "W": return (.systemOrange, .black)
+            case "E": return (.systemRed, .white)
+            case "F": return (.systemPurple, .white)
+            default: return (.tertiaryLabelColor, .labelColor)
+            }
         }
 
-        /// One rendered line (newline included), with every Find match
-        /// highlighted.
-        static func attributedLine(_ line: LogLine, find: String) -> NSAttributedString {
-            let text = display(line) + "\n"
-            let attributed = NSMutableAttributedString(string: text, attributes: [
-                .font: font,
-                .foregroundColor: color(for: line.level),
-            ])
+        /// A stable per-tag hue so one tag reads as one color across the feed
+        /// and across launches (djb2 — String.hashValue reseeds per launch).
+        private static let tagPalette: [NSColor] = [
+            .systemTeal, .systemOrange, .systemPurple, .systemPink,
+            .systemBlue, .systemCyan, .systemMint, .systemIndigo,
+            .systemBrown, .systemYellow,
+        ]
+
+        private static func tagColor(_ tag: String) -> NSColor {
+            var hash: UInt64 = 5381
+            for byte in tag.utf8 { hash = hash &* 33 &+ UInt64(byte) }
+            return tagPalette[Int(hash % UInt64(tagPalette.count))]
+        }
+
+        /// Fixed-width cell: pads short values, mid-ellipsizes long ones so
+        /// the trailing discriminator (`:process0`, numbered tags) survives.
+        private static func pad(_ text: String, to width: Int) -> String {
+            let count = text.count
+            if count <= width {
+                return text + String(repeating: " ", count: width - count)
+            }
+            let head = (width - 1) / 2
+            let tail = width - 1 - head
+            return text.prefix(head) + "…" + text.suffix(tail)
+        }
+
+        /// One rendered line (newline included): the aligned columns above,
+        /// with every Find match highlighted. Lines that didn't parse (buffer
+        /// separators) stay raw and muted.
+        static func attributedLine(_ line: LogLine, find: String, showTime: Bool) -> NSAttributedString {
+            let attributed = NSMutableAttributedString()
+            func run(_ text: String, _ color: NSColor, font: NSFont = font, background: NSColor? = nil) {
+                var attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: color]
+                if let background { attributes[.backgroundColor] = background }
+                attributed.append(NSAttributedString(string: text, attributes: attributes))
+            }
+            if line.level.isEmpty {
+                run(line.raw, .secondaryLabelColor)
+            } else {
+                let chip = chipColors(for: line.level)
+                let pidTid = line.tid.isEmpty ? line.pid : "\(line.pid)-\(line.tid)"
+                if showTime { run(line.time + "  ", .tertiaryLabelColor) }
+                run(pad(pidTid, to: pidWidth) + " ", .secondaryLabelColor)
+                run(pad(line.processName ?? "?", to: processWidth) + " ", .secondaryLabelColor)
+                run(" \(line.level) ", chip.fg, font: chipFont, background: chip.bg)
+                run("  ", .labelColor)
+                run(pad(line.tag, to: tagWidth) + " ", tagColor(line.tag))
+                run(line.message, color(for: line.level))
+            }
+            run("\n", .labelColor)
             guard !find.isEmpty else { return attributed }
-            let haystack = text as NSString
+            let haystack = attributed.string as NSString
             var location = 0
             while location < haystack.length {
                 let range = haystack.range(
@@ -408,9 +499,18 @@ struct SelectableLogView: NSViewRepresentable {
 final class LogTextView: NSTextView {
     var lineAt: ((Int) -> LogLine?)?
     var filterTag: ((String) -> Void)?
+    /// Fired on any click into the log (left or right) — the coordinator
+    /// holds tail-follow so the line being read/selected stays put.
+    var onUserClick: (() -> Void)?
     private var menuLine: LogLine?
 
+    override func mouseDown(with event: NSEvent) {
+        onUserClick?()
+        super.mouseDown(with: event)
+    }
+
     override func menu(for event: NSEvent) -> NSMenu? {
+        onUserClick?()
         let point = convert(event.locationInWindow, from: nil)
         menuLine = lineAt?(characterIndexForInsertion(at: point))
         let menu = NSMenu()

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -221,11 +221,14 @@ final class JSConsoleSession {
     /// device keep reaching Metro. Keyed by port so changing the port and
     /// re-reversing doesn't orphan the earlier binding.
     @ObservationIgnored private var reversedTunnels: [Int: Set<String>] = [:]
-    /// port → serials automatic discovery already tried to reverse, so the 2s
-    /// loop doesn't respawn adb forever for a device that keeps failing. A
-    /// serial that leaves the device list is forgotten (a replug drops the
-    /// binding device-side, so it must be re-attempted).
-    @ObservationIgnored private var autoReverseAttempted: [Int: Set<String>] = [:]
+    /// port → per-serial auto-reverse try count, capped at `autoReverseTryLimit`
+    /// so the 2s loop doesn't respawn adb forever for a device that keeps
+    /// failing — while a transient failure still gets retried instead of
+    /// stranding the device on its first bad pass. A serial that leaves the
+    /// device list is forgotten (a replug drops the binding device-side, so it
+    /// must be re-attempted).
+    @ObservationIgnored private var autoReverseAttempts: [Int: [String: Int]] = [:]
+    private let autoReverseTryLimit = 3
     weak var app: AppState?
 
     var isConnected: Bool { connectedTarget != nil }
@@ -368,7 +371,9 @@ final class JSConsoleSession {
         // reverse re-attempted — replugging drops the binding device-side.
         let removed = Set(self.serials).subtracting(serials)
         if !removed.isEmpty {
-            for key in autoReverseAttempted.keys { autoReverseAttempted[key]?.subtract(removed) }
+            for key in autoReverseAttempts.keys {
+                for serial in removed { autoReverseAttempts[key]?[serial] = nil }
+            }
             for key in reversedTunnels.keys { reversedTunnels[key]?.subtract(removed) }
         }
         self.serials = serials
@@ -378,19 +383,24 @@ final class JSConsoleSession {
     /// a USB device can register with Metro without the user knowing to click
     /// "adb reverse" first (`react-native run-android` does the same on every
     /// launch — its absence was why the console often found no target until
-    /// the feature was poked). Once per device+port; the manual button stays
-    /// as the retry path. Background work, so deliberately not
-    /// CommandLog-wrapped.
+    /// the feature was poked). A failed reverse stays eligible on later scan
+    /// passes, up to a few tries per device+port — a transient adb hiccup
+    /// shouldn't strand the device; the manual button stays as the fallback.
+    /// Background work, so deliberately not CommandLog-wrapped.
     private func autoReverse() async {
         let metroPort = port
-        let missing = serials.filter { !autoReverseAttempted[metroPort, default: []].contains($0) }
-        guard !missing.isEmpty else { return }
-        autoReverseAttempted[metroPort, default: []].formUnion(missing)
+        let eligible = serials.filter {
+            autoReverseAttempts[metroPort, default: [:]][$0, default: 0] < autoReverseTryLimit
+        }
+        guard !eligible.isEmpty else { return }
         var reversed: Set<String> = []
-        for serial in missing where !Task.isCancelled {
+        for serial in eligible where !Task.isCancelled {
             if let result = try? await adb.run(on: serial, ["reverse", "tcp:\(metroPort)", "tcp:\(metroPort)"]),
                result.succeeded {
+                autoReverseAttempts[metroPort, default: [:]][serial] = autoReverseTryLimit
                 reversed.insert(serial)
+            } else {
+                autoReverseAttempts[metroPort, default: [:]][serial, default: 0] += 1
             }
         }
         if !reversed.isEmpty { reversedTunnels[metroPort, default: []].formUnion(reversed) }
@@ -1233,7 +1243,7 @@ struct JSConsoleView: View {
 
     /// What Export writes: exactly the rows the feed is showing — the level
     /// and text filters apply, in display (chronological) order.
-    private var exportJSON: String {
+    private var exportJSON: String? {
         ConsoleExport.json(session.filteredEntries.map { entry in
             let (type, level): (String, String?) = switch entry.kind {
             case .input: ("input", nil)
@@ -1251,8 +1261,12 @@ struct JSConsoleView: View {
         guard let file = state.askSaveLocation(
             suggestedName: "js-console_\(ScreenCaptureService.stamp()).json"
         ) else { return }
+        guard let json = exportJSON else {
+            state.showToast(Toast(message: "Export failed: entries couldn't be encoded", ok: false))
+            return
+        }
         do {
-            try Data(exportJSON.utf8).write(to: file)
+            try Data(json.utf8).write(to: file)
             state.showToast(Toast(message: "Exported \(count) entries", ok: true, revealPath: file.path))
         } catch {
             state.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
@@ -1261,7 +1275,11 @@ struct JSConsoleView: View {
 
     private func exportToClipboard() {
         let count = session.filteredEntries.count
-        copyToPasteboard(exportJSON)
+        guard let json = exportJSON else {
+            state.showToast(Toast(message: "Copy failed: entries couldn't be encoded", ok: false))
+            return
+        }
+        copyToPasteboard(json)
         state.showToast(Toast(message: "Copied \(count) entries as JSON", ok: true))
     }
 
@@ -1844,6 +1862,11 @@ private struct ExpandedTree: View {
             } else {
                 SnapMatchList(matches: node.findMatches(query: query), onSelect: reveal)
             }
+        }
+        // A newly typed query drops the previous reveal's tint (reveal itself
+        // clears the field, so its own highlight survives this).
+        .onChange(of: search) { _, newValue in
+            if !newValue.trimmingCharacters(in: .whitespaces).isEmpty { highlightedPath = nil }
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -207,6 +207,10 @@ final class JSConsoleSession {
     /// Drops the re-replayed console history on reconnects to the same app so
     /// the persistent feed doesn't duplicate.
     @ObservationIgnored private var replayGate = ConsoleReplayGate()
+    /// Auto-connect waits for a target to survive two discovery passes —
+    /// attaching the instant it first registered crashed Hermes mid-boot
+    /// (`TargetStabilityTracker`). Manual picks bypass this.
+    @ObservationIgnored private var targetStability = TargetStabilityTracker()
     /// Whether the "connected" notice was posted for the current app — an
     /// auto-reconnect to the same app doesn't repeat the welcome.
     private var hasWelcomed = false
@@ -217,6 +221,11 @@ final class JSConsoleSession {
     /// device keep reaching Metro. Keyed by port so changing the port and
     /// re-reversing doesn't orphan the earlier binding.
     @ObservationIgnored private var reversedTunnels: [Int: Set<String>] = [:]
+    /// port → serials automatic discovery already tried to reverse, so the 2s
+    /// loop doesn't respawn adb forever for a device that keeps failing. A
+    /// serial that leaves the device list is forgotten (a replug drops the
+    /// binding device-side, so it must be re-attempted).
+    @ObservationIgnored private var autoReverseAttempted: [Int: Set<String>] = [:]
     weak var app: AppState?
 
     var isConnected: Bool { connectedTarget != nil }
@@ -261,6 +270,35 @@ final class JSConsoleSession {
         discoveryTask = nil
     }
 
+    // MARK: View attach/detach
+
+    /// Views currently showing this session. Moving the tab between split
+    /// panes REMOUNTS the view, and SwiftUI may fire the new pane's onAppear
+    /// before the old pane's onDisappear — a hard `stop()` there killed the
+    /// live connection and dropped the chosen target. So the view lifecycle
+    /// counts attachments and only stops once no view has claimed the session
+    /// for a beat; the direct `start`/`stop` remain for AppState's explicit
+    /// paths (tab close, window close, reopen).
+    @ObservationIgnored private var attachedViews = 0
+
+    func viewAppeared(serials: [String]) {
+        attachedViews += 1
+        start(serials: serials)
+    }
+
+    func viewDisappeared() {
+        attachedViews = max(0, attachedViews - 1)
+        guard attachedViews == 0 else { return }
+        // Deferred: on a pane move the replacement view attaches within the
+        // same UI beat (in either onAppear/onDisappear order) and vetoes the
+        // stop. Only a real teardown leaves the count at zero.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard let self, self.attachedViews == 0 else { return }
+            self.stop()
+        }
+    }
+
     /// Run discovery + connection until cancelled; tears the connection down on
     /// the way out.
     private func activate(serials: [String]) async {
@@ -270,11 +308,22 @@ final class JSConsoleSession {
         autoReconnectSuspended = false
         if !isConnected { phase = .searching }
         while !Task.isCancelled {
+            // Self-heal a half-dead connection: the socket is gone but its
+            // close event was never consumed (a torn-down consumer during a
+            // reconnect race) — without this, discovery idles forever
+            // believing it's connected while the status shows a green dot
+            // over a silent feed. Restarting the feature used to be the fix.
+            if connectedTarget != nil, !(await cdp.isConnected) {
+                connectedTarget = nil
+                phase = .searching
+            }
+            if connectedTarget == nil { await autoReverse() }
             let scannedPort = port
             let found = (try? await MetroInspector(port: scannedPort).listTargets()) ?? []
             // Drop a pass whose port changed mid-fetch — its results are stale.
             if !Task.isCancelled, scannedPort == port {
                 targets = found
+                targetStability.recordPass(ids: found.map(\.id))
                 // A takeover stand-down holds while any target is still
                 // listed; once the list is empty there's no debugger left to
                 // kick off and discovery should self-heal again.
@@ -283,11 +332,17 @@ final class JSConsoleSession {
                     phase = .searching
                 }
                 if connectedTarget == nil, !autoReconnectSuspended {
+                    // Auto-connect only once the candidate has survived two
+                    // consecutive scans: attaching the instant an app first
+                    // registers hit Hermes mid-boot and crashed it. A booting
+                    // app waits one extra pass; a long-listed target (JS
+                    // reload, socket drop) reconnects immediately; the user's
+                    // pick from the target menu skips the gate entirely.
                     if let candidate = MetroInspector.autoConnectCandidate(
                         from: found,
                         preferredDeviceId: preferredLogicalDeviceId,
                         preferredAppId: preferredAppId
-                    ) {
+                    ), targetStability.isStable(candidate.id) {
                         await connect(to: candidate)
                     } else if phase != .connecting {
                         phase = found.isEmpty ? .searching : .targetsAvailable
@@ -308,7 +363,38 @@ final class JSConsoleSession {
         phase = .searching
     }
 
-    func updateSerials(_ serials: [String]) { self.serials = serials }
+    func updateSerials(_ serials: [String]) {
+        // A serial that vanished is forgotten so a replugged device gets its
+        // reverse re-attempted — replugging drops the binding device-side.
+        let removed = Set(self.serials).subtracting(serials)
+        if !removed.isEmpty {
+            for key in autoReverseAttempted.keys { autoReverseAttempted[key]?.subtract(removed) }
+            for key in reversedTunnels.keys { reversedTunnels[key]?.subtract(removed) }
+        }
+        self.serials = serials
+    }
+
+    /// Install the device→Mac Metro binding automatically while searching, so
+    /// a USB device can register with Metro without the user knowing to click
+    /// "adb reverse" first (`react-native run-android` does the same on every
+    /// launch — its absence was why the console often found no target until
+    /// the feature was poked). Once per device+port; the manual button stays
+    /// as the retry path. Background work, so deliberately not
+    /// CommandLog-wrapped.
+    private func autoReverse() async {
+        let metroPort = port
+        let missing = serials.filter { !autoReverseAttempted[metroPort, default: []].contains($0) }
+        guard !missing.isEmpty else { return }
+        autoReverseAttempted[metroPort, default: []].formUnion(missing)
+        var reversed: Set<String> = []
+        for serial in missing where !Task.isCancelled {
+            if let result = try? await adb.run(on: serial, ["reverse", "tcp:\(metroPort)", "tcp:\(metroPort)"]),
+               result.succeeded {
+                reversed.insert(serial)
+            }
+        }
+        if !reversed.isEmpty { reversedTunnels[metroPort, default: []].formUnion(reversed) }
+    }
 
     func connect(to target: CDPTarget) async {
         guard let url = URL(string: target.webSocketDebuggerUrl),
@@ -534,6 +620,8 @@ final class JSConsoleSession {
         autoReconnectSuspended = false
         resetWelcome()
         targets = []
+        // Sightings from the old port say nothing about the new one.
+        targetStability = TargetStabilityTracker()
         phase = .searching
         Task { [weak self] in await self?.cdp.disconnect() }
     }
@@ -600,8 +688,8 @@ final class JSConsoleSession {
     /// else the selected bundle. Disconnected — or when detection/relaunch
     /// fails — the installed-apps picker opens instead. Discovery reconnects
     /// by logical-device id once the app is back.
-    func restartApp() {
-        Task { [weak self] in await self?.performRestart() }
+    func restartApp(clearCache: Bool = false) {
+        Task { [weak self] in await self?.performRestart(clearCache: clearCache) }
     }
 
     /// Drives the fallback installed-apps picker sheet.
@@ -609,8 +697,12 @@ final class JSConsoleSession {
     /// The user's manual pick from the restart sheet, reused on later restarts
     /// whenever the connected target doesn't report its own `appId`.
     private var manualRestartPackage: String?
+    /// Whether the restart currently in flight (including one waiting on the
+    /// fallback picker) should clear the app's cache first.
+    private var pendingClearCache = false
 
-    private func performRestart() async {
+    private func performRestart(clearCache: Bool) async {
+        pendingClearCache = clearCache
         guard !serials.isEmpty else {
             app?.showToast(Toast(message: "Can't restart — no device selected.", ok: false))
             return
@@ -620,16 +712,17 @@ final class JSConsoleSession {
         let detected: String? = isConnected
             ? connectedTarget?.appId ?? manualRestartPackage ?? app?.selectedBundle?.packageId
             : nil
-        if let detected, await restart(package: detected) { return }
+        if let detected, await restart(package: detected, clearCache: clearCache) { return }
         restartPickerVisible = true
     }
 
     /// A pick from the fallback sheet: restart it and remember the choice.
     func restartPicked(_ package: String) {
         manualRestartPackage = package
+        let clearCache = pendingClearCache
         Task { [weak self] in
             guard let self else { return }
-            if !(await restart(package: package)) {
+            if !(await restart(package: package, clearCache: clearCache)) {
                 app?.showToast(Toast(
                     message: "Couldn't relaunch \(package) — is it installed on the selected device?",
                     ok: false
@@ -639,24 +732,55 @@ final class JSConsoleSession {
     }
 
     /// Force-stop + relaunch on every target device (the service's `.restart`
-    /// verb); true when any relaunch worked (the toast reports success;
+    /// verb), optionally clearing the app's cache first (`pm clear
+    /// --cache-only`, Android 14+ — best-effort, the restart proceeds either
+    /// way); true when any relaunch worked (the toast reports success;
     /// failures fall back to the picker).
-    private func restart(package: String) async -> Bool {
+    private func restart(package: String, clearCache: Bool) async -> Bool {
         let serials = serials
         let control = AppControlService(client: adb)
-        let relaunched = await CommandLog.userInitiated {
+        let (relaunched, cacheCleared) = await CommandLog.userInitiated {
             var relaunched = 0
+            var cacheCleared = true
             for serial in serials {
+                if clearCache, !(await Self.clearCacheBounded(control, serial: serial, package: package)) {
+                    cacheCleared = false
+                }
                 if let result = try? await control.control(serial: serial, packageId: package, action: .restart),
                    result.ok {
                     relaunched += 1
                 }
             }
-            return relaunched
+            return (relaunched, cacheCleared)
         }
         guard relaunched > 0 else { return false }
-        app?.showToast(Toast(message: "Restarting \(package)…", ok: true))
+        let message = if !clearCache {
+            "Restarting \(package)…"
+        } else if cacheCleared {
+            "Cleared cache — restarting \(package)…"
+        } else {
+            "Cache clear didn't finish — restarting \(package)…"
+        }
+        app?.showToast(Toast(message: message, ok: true))
         return true
+    }
+
+    /// `pm clear --cache-only` never returns on some images (observed live on
+    /// the API 36 emulator), so the clear gets a bounded window — cancelling
+    /// the task kills the adb child — and the restart proceeds either way.
+    private static func clearCacheBounded(
+        _ control: AppControlService, serial: String, package: String
+    ) async -> Bool {
+        let clear = Task {
+            (try? await control.control(serial: serial, packageId: package, action: .clearCache))?.ok == true
+        }
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(10))
+            clear.cancel()
+        }
+        let ok = await clear.value
+        watchdog.cancel()
+        return ok
     }
 
     /// Remove the `adb reverse` bindings this console installed. Called when the
@@ -851,11 +975,12 @@ struct JSConsoleView: View {
             inputBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { session.start(serials: state.targetSerials) }
-        // A real unmount (tab closed) — keep-alive tab switches never fire
-        // this. AppState also stops the session on tab/window close; both
-        // paths are idempotent.
-        .onDisappear { session.stop() }
+        .onAppear { session.viewAppeared(serials: state.targetSerials) }
+        // Fires on a real unmount: tab closed, or the tab MOVED between split
+        // panes (a remount — the attach count and its deferred zero-check in
+        // the session keep the connection alive through that). AppState also
+        // stops the session on tab/window close; every path is idempotent.
+        .onDisappear { session.viewDisappeared() }
         .onChange(of: state.targetSerials) { _, serials in session.updateSerials(serials) }
         .onAppear { portText = String(session.port) }
         .onChange(of: session.port) { _, newPort in portText = String(newPort) }
@@ -947,9 +1072,20 @@ struct JSConsoleView: View {
             .help("Reload the JS bundle — what ⌘R in React Native DevTools does")
         }
         if !state.targetSerials.isEmpty {
-            Button { session.restartApp() } label: {
+            // A split button: the primary click restarts, the chevron reveals
+            // the cache-clearing variant (pm clear --cache-only, then relaunch).
+            Menu {
+                Button {
+                    session.restartApp(clearCache: true)
+                } label: {
+                    Label("Clear cache and restart", systemImage: "arrow.triangle.2.circlepath")
+                }
+            } label: {
                 Label("Restart app", systemImage: "restart.circle")
+            } primaryAction: {
+                session.restartApp()
             }
+            .fixedSize()
             .help(session.isConnected
                 ? "Force-stop and relaunch the connected app on the device"
                 : "Pick an app to force-stop and relaunch")
@@ -1074,12 +1210,59 @@ struct JSConsoleView: View {
                 .help(session.newestFirst
                     ? "Newest at top — click to show newest at bottom"
                     : "Newest at bottom — click to show newest at top")
+            Menu {
+                Button("Save as JSON…") { exportToFile() }
+                Button("Copy to Clipboard") { exportToClipboard() }
+            } label: {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .buttonStyle(IconButtonStyle())
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Export the filtered console — save as a JSON file or copy to the clipboard")
+            .disabled(session.filteredEntries.isEmpty)
             Button { session.clear() } label: { Image(systemName: "trash") }
                 .buttonStyle(IconButtonStyle())
                 .help("Clear the console")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+    }
+
+    // MARK: Export
+
+    /// What Export writes: exactly the rows the feed is showing — the level
+    /// and text filters apply, in display (chronological) order.
+    private var exportJSON: String {
+        ConsoleExport.json(session.filteredEntries.map { entry in
+            let (type, level): (String, String?) = switch entry.kind {
+            case .input: ("input", nil)
+            case .result: ("result", nil)
+            case .evalError: ("error", nil)
+            case .notice: ("notice", nil)
+            case let .log(logLevel, _, _): ("log", logLevel.rawValue)
+            }
+            return ConsoleExportEntry(at: entry.at, type: type, level: level, text: jsEntryPlainText(entry.kind))
+        })
+    }
+
+    private func exportToFile() {
+        let count = session.filteredEntries.count
+        guard let file = state.askSaveLocation(
+            suggestedName: "js-console_\(ScreenCaptureService.stamp()).json"
+        ) else { return }
+        do {
+            try Data(exportJSON.utf8).write(to: file)
+            state.showToast(Toast(message: "Exported \(count) entries", ok: true, revealPath: file.path))
+        } catch {
+            state.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
+        }
+    }
+
+    private func exportToClipboard() {
+        let count = session.filteredEntries.count
+        copyToPasteboard(exportJSON)
+        state.showToast(Toast(message: "Copied \(count) entries as JSON", ok: true))
     }
 
     /// Multi-select level filter: one dropdown that toggles several levels at
@@ -1238,8 +1421,8 @@ struct JSConsoleView: View {
         }
         return """
         Open a dev build running Hermes with Metro on port \(session.port). \
-        The app must be connected to Metro — for a USB device, tap “adb reverse” so it can reach the dev server. \
-        Targets appear automatically.
+        Droidective routes the device's port to Metro automatically (adb reverse); \
+        the button below retries it. Targets appear automatically.
         """
     }
 
@@ -1290,6 +1473,12 @@ struct JSConsoleView: View {
 private struct JSEntryRow: View {
     let entry: JSEntry
     let session: JSConsoleSession
+    @State private var hovering = false
+    @State private var copied = false
+    /// Bumped by a click anywhere on the row; the primary expandable value
+    /// observes it and toggles, so the whole row is the disclosure target —
+    /// not just the value's own summary line.
+    @State private var rowToggleToken = 0
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
     private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
@@ -1299,11 +1488,26 @@ private struct JSEntryRow: View {
             glyph
             content
                 .frame(maxWidth: .infinity, alignment: .leading)
+            // Always in the layout — hidden, not removed, when idle — so
+            // hovering can't change the row's width and reflow its text.
+            copyButton
+                .opacity(hovering || copied ? 1 : 0)
+                .allowsHitTesting(hovering || copied)
             Text(entry.at, format: .dateTime.hour().minute().second())
                 .font(.app(.caption2).monospacedDigit())
                 .foregroundStyle(JSConsoleTheme.muted)
                 .padding(.top, 1)
         }
+        .contentShape(Rectangle())
+        // Whitespace, glyph, and timestamp clicks toggle the row's expandable
+        // value too (the value's own header still works). Text keeps its
+        // selection gesture — this only catches clicks nothing else claims.
+        .onTapGesture {
+            if primaryObjectID != nil { rowToggleToken += 1 }
+        }
+        .onHover { hovering = $0 }
+        // Hovering the row is what reveals its URLs' underlines.
+        .environment(\.consoleLinkUnderline, hovering)
         .contextMenu {
             Button("Copy") { copyToPasteboard(jsEntryPlainText(entry.kind)) }
             if let objectID = primaryObjectID {
@@ -1315,6 +1519,27 @@ private struct JSEntryRow: View {
                 }
             }
         }
+    }
+
+    /// Hover copy affordance (the Reactotron rows' pattern): copies the row's
+    /// plain text with a checkmark flash; the right-click menu keeps the
+    /// deep "Copy as JSON".
+    private var copyButton: some View {
+        Button {
+            copyToPasteboard(jsEntryPlainText(entry.kind))
+            copied = true
+            Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.app(.caption))
+                .foregroundStyle(copied ? .green : JSConsoleTheme.muted)
+                // Fixed footprint for both glyphs, so neither hover nor the
+                // copy→checkmark swap nudges the layout.
+                .frame(width: 14)
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 1)
+        .help("Copy this entry (right-click for JSON)")
     }
 
     /// The object handle to deep-copy as JSON (result value, or the first
@@ -1355,7 +1580,7 @@ private struct JSEntryRow: View {
         case let .input(text):
             line(text, base: JSConsoleTheme.muted)
         case let .result(object):
-            JSValueView(object: object, session: session, scrollTargetID: entry.id)
+            JSValueView(object: object, session: session, scrollTargetID: entry.id, toggleToken: rowToggleToken)
         case let .evalError(details):
             errorContent(details)
         case let .log(level, args, stack):
@@ -1366,7 +1591,7 @@ private struct JSEntryRow: View {
     }
 
     private func line(_ text: String, base: Color) -> some View {
-        highlightedText(text, query: query, base: base, current: isCurrentFind)
+        highlightedText(text, query: query, base: base, current: isCurrentFind, underlineLinks: hovering)
             .font(.app(.callout, design: .monospaced))
             .lineSpacing(2)
             .textSelection(.enabled)
@@ -1374,26 +1599,33 @@ private struct JSEntryRow: View {
     }
 
     private func logContent(level: JSLevel, args: [RemoteObject], stack: CDPStackTrace?) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
+        let rows = argRows(args)
+        // The row-level click toggles the first expandable object — the one
+        // "Copy as JSON" also targets.
+        let primaryRowID = rows.first { if case .object = $0.kind { true } else { false } }?.id
+        return VStack(alignment: .leading, spacing: 3) {
             // Each expandable object renders exactly once, as its own disclosure
             // row in argument order — it used to appear twice (inline in the
             // message line AND repeated below), which doubled every logged object.
             // Scalar runs keep the level tint for errors/warnings and VSCode-style
             // syntax colors otherwise.
-            ForEach(argRows(args)) { row in
+            ForEach(rows) { row in
                 switch row.kind {
                 case let .scalars(text, tokens):
                     if level == .error || level == .warning {
                         line(text, base: level.consoleTextColor)
                     } else {
-                        coloredTokenText(tokens, query: query, current: isCurrentFind)
+                        coloredTokenText(tokens, query: query, current: isCurrentFind, underlineLinks: hovering)
                             .font(.app(.callout, design: .monospaced))
                             .lineSpacing(2)
                             .textSelection(.enabled)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 case let .object(arg):
-                    JSValueView(object: arg, session: session, scrollTargetID: entry.id)
+                    JSValueView(
+                        object: arg, session: session, scrollTargetID: entry.id,
+                        toggleToken: row.id == primaryRowID ? rowToggleToken : 0
+                    )
                 }
             }
             if level == .error, let stack { StackView(stack: stack) }
@@ -1459,8 +1691,12 @@ private struct JSValueView: View {
     /// scrolls that row's header into view instead of leaving the viewport at
     /// the object's end (the flipped-layout jump).
     var scrollTargetID: AnyHashable?
+    /// Bumped by the owning row when the user clicks anywhere on it — the
+    /// whole log row acts as this value's disclosure toggle.
+    var toggleToken = 0
     @Environment(\.logTailScrollToHeader) private var scrollToHeader
     @Environment(\.logTailPauseFollow) private var pauseFollow
+    @Environment(\.consoleLinkUnderline) private var underlineLinks
     @State private var expanded = false
     @State private var snapshot: SnapNode?
     @State private var failed = false
@@ -1476,15 +1712,7 @@ private struct JSValueView: View {
             // whole object — expanding is how you read the rest.
             VStack(alignment: .leading, spacing: 2) {
                 Button {
-                    expanded.toggle()
-                    if expanded {
-                        // Expanding means the user is reading — pause
-                        // tail-follow so streaming lines can't scroll the
-                        // object away (same affordances as Reactotron:
-                        // the jump button or scrolling back resumes).
-                        pauseFollow()
-                        if snapshot == nil, !loading { load() } else { scrollHeaderToTop() }
-                    }
+                    toggleExpanded()
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Image(systemName: expanded ? "chevron.down" : "chevron.right")
@@ -1502,6 +1730,7 @@ private struct JSValueView: View {
                 if expanded { expandedChildren.padding(.leading, 18) }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .onChange(of: toggleToken) { _, _ in toggleExpanded() }
         } else {
             summaryText
                 .fixedSize(horizontal: false, vertical: true)
@@ -1510,8 +1739,19 @@ private struct JSValueView: View {
         }
     }
 
+    private func toggleExpanded() {
+        expanded.toggle()
+        if expanded {
+            // Expanding means the user is reading — pause tail-follow so
+            // streaming lines can't scroll the object away (same affordances
+            // as Reactotron: the jump button or scrolling back resumes).
+            pauseFollow()
+            if snapshot == nil, !loading { load() } else { scrollHeaderToTop() }
+        }
+    }
+
     private var summaryText: some View {
-        coloredTokenText(object.tokens, query: query, current: false)
+        coloredTokenText(object.tokens, query: query, current: false, underlineLinks: underlineLinks)
             .font(.app(.callout, design: .monospaced))
             .textSelection(.enabled)
     }
@@ -1574,75 +1814,138 @@ private struct JSValueView: View {
 
 // MARK: - Snapshot tree (client-side, no getProperties)
 
-/// An expanded object/array: an optional "search in object" field over the
-/// tree, rendered inline (the feed grows to fit — no nested scroll). The scroll
-/// jump on expand is handled by the owning row scrolling its header into view.
+/// An expanded object/array: a "find in object" field over the tree, rendered
+/// inline (the feed grows to fit — no nested scroll). Typing shows a clickable
+/// result list (`SnapNode.findMatches`, pure in ADBKit); clicking a result
+/// expands the tree along its path and highlights the node in place. The
+/// scroll jump on expand is handled by the owning row scrolling its header
+/// into view.
 private struct ExpandedTree: View {
     let node: SnapNode
     let session: JSConsoleSession
     @State private var search = ""
-
-    /// Only worth an in-object search box once there are enough children.
-    private var searchable: Bool {
-        (node.entries?.count ?? node.items?.count ?? 0) >= 8
-    }
+    /// Ordinal paths ("0/3/1") of the containers currently open — hoisted here
+    /// so a clicked find result can expand its whole ancestor chain.
+    @State private var expandedPaths: Set<String> = []
+    /// The last revealed find result, tinted until the next find/reveal.
+    @State private var highlightedPath: String?
 
     var body: some View {
         let query = search.trimmingCharacters(in: .whitespaces).lowercased()
         VStack(alignment: .leading, spacing: 4) {
-            if searchable {
-                SearchField(prompt: "Search in object…", text: $search)
-                    .controlSize(.small)
-                    .frame(maxWidth: 260)
+            SearchField(prompt: "Find in object…", text: $search)
+                .controlSize(.small)
+                .frame(maxWidth: 260)
+            if query.isEmpty {
+                SnapChildrenView(
+                    node: node, session: session, path: "",
+                    expandedPaths: $expandedPaths, highlightedPath: highlightedPath
+                )
+            } else {
+                SnapMatchList(matches: node.findMatches(query: query), onSelect: reveal)
             }
-            SnapChildrenView(node: node, session: session, query: query)
         }
+    }
+
+    /// Open every container down to the match, mark it, and swap back to the
+    /// tree so the user lands on the node.
+    private func reveal(_ match: TreeMatch) {
+        var path = ""
+        for index in match.path {
+            path = path.isEmpty ? String(index) : "\(path)/\(index)"
+            expandedPaths.insert(path)
+        }
+        highlightedPath = path
+        search = ""
+    }
+}
+
+/// The clickable results of a find inside one object — location, then value.
+private struct SnapMatchList: View {
+    let matches: [TreeMatch]
+    let onSelect: (TreeMatch) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if matches.isEmpty {
+                Text("No matches").font(.app(.caption)).foregroundStyle(.tertiary)
+            }
+            ForEach(Array(matches.enumerated()), id: \.offset) { _, match in
+                Button {
+                    onSelect(match)
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: "arrow.turn.down.right")
+                            .font(.app(size: 10))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 14)
+                        Text("\(match.displayPath):")
+                            .font(.app(.callout, design: .monospaced))
+                            .foregroundStyle(jsColor(.key))
+                        Text(match.preview)
+                            .font(.app(.callout, design: .monospaced))
+                            .foregroundStyle(jsColor(match.isContainer ? .className : .plain))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Reveal in the tree")
+            }
+            if matches.count >= 200 {
+                Text("…first 200 matches — narrow the search")
+                    .font(.app(.caption)).foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
 /// The ordered child rows of a container `SnapNode` — array items with index
-/// labels, or object entries with key labels. `query` (lowercased) prunes to
-/// matching branches for the in-object search.
+/// labels, or object entries with key labels. `path` is the container's own
+/// ordinal path; expansion state lives in the owning `ExpandedTree` so find
+/// results can drive it.
 private struct SnapChildrenView: View {
     let node: SnapNode
     let session: JSConsoleSession
-    var query: String = ""
-
-    /// Rows shown per level while an in-object search is active. The search
-    /// auto-expands every matching container, and the rows are not lazy — an
-    /// uncapped broad query over a big snapshot (the device allows up to
-    /// 20 000 nodes) laid out tens of thousands of views in one pass.
-    private static let maxSearchRows = 100
+    let path: String
+    @Binding var expandedPaths: Set<String>
+    let highlightedPath: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             if node.type == "array", let items = node.items {
-                let matched = items.enumerated().filter { query.isEmpty || $0.element.matches(query) }
-                let shown = query.isEmpty ? matched : Array(matched.prefix(Self.maxSearchRows))
-                if shown.isEmpty { emptyRow }
-                ForEach(shown, id: \.offset) { index, child in
-                    SnapValueView(label: String(index), node: child, session: session, query: query)
+                if items.isEmpty { emptyRow }
+                ForEach(Array(items.enumerated()), id: \.offset) { index, child in
+                    SnapValueView(
+                        label: String(index), node: child, session: session,
+                        path: childPath(index), expandedPaths: $expandedPaths,
+                        highlightedPath: highlightedPath
+                    )
                 }
-                if query.isEmpty, let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
-                if matched.count > shown.count { moreRow("…(+\(matched.count - shown.count) more matches — narrow the search)") }
+                if let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
             } else if let entries = node.entries {
-                let matched = entries.enumerated().filter { query.isEmpty || $0.element.node.matches(query, key: $0.element.name) }
-                let shown = query.isEmpty ? matched : Array(matched.prefix(Self.maxSearchRows))
-                if shown.isEmpty { emptyRow }
-                ForEach(shown, id: \.offset) { _, entry in
-                    SnapValueView(label: entry.name, node: entry.node, session: session, query: query)
+                if entries.isEmpty { emptyRow }
+                ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
+                    SnapValueView(
+                        label: entry.name, node: entry.node, session: session,
+                        path: childPath(index), expandedPaths: $expandedPaths,
+                        highlightedPath: highlightedPath
+                    )
                 }
-                if query.isEmpty, node.truncated == true { moreRow("…(more)") }
-                if matched.count > shown.count { moreRow("…(+\(matched.count - shown.count) more matches — narrow the search)") }
+                if node.truncated == true { moreRow("…(more)") }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private func childPath(_ index: Int) -> String {
+        path.isEmpty ? String(index) : "\(path)/\(index)"
+    }
+
     private var emptyRow: some View {
-        Text(query.isEmpty
-            ? (node.type == "array" ? "(empty array)" : "(no enumerable properties)")
-            : "No matches")
+        Text(node.type == "array" ? "(empty array)" : "(no enumerable properties)")
             .font(.app(.caption)).foregroundStyle(.tertiary)
     }
 
@@ -1653,30 +1956,34 @@ private struct SnapChildrenView: View {
 
 /// One row in the snapshot tree: a primitive `key: value`, or a collapsible
 /// container header whose children (another `SnapChildrenView`) indent below.
-/// A non-empty `query` auto-expands containers so matches are revealed, and
-/// highlights the matched text.
+/// The row revealed by a find result carries a highlight tint.
 private struct SnapValueView: View {
     let label: String?
     let node: SnapNode
     let session: JSConsoleSession
-    var query: String = ""
+    let path: String
+    @Binding var expandedPaths: Set<String>
+    let highlightedPath: String?
     @Environment(\.logTailPauseFollow) private var pauseFollow
-    @State private var expanded = false
+    @Environment(\.consoleLinkUnderline) private var underlineLinks
 
-    /// Text highlighted in rows: the in-object search when active, else the ⌘F find.
-    private var highlight: String {
-        query.isEmpty ? session.findText.trimmingCharacters(in: .whitespaces) : query
-    }
-    private var isOpen: Bool { expanded || !query.isEmpty }
+    /// Text highlighted in rows: the ⌘F find query.
+    private var highlight: String { session.findText.trimmingCharacters(in: .whitespaces) }
+    private var isOpen: Bool { expandedPaths.contains(path) }
+    private var isRevealed: Bool { path == highlightedPath }
 
     var body: some View {
         if node.isContainer {
             VStack(alignment: .leading, spacing: 2) {
                 Button {
-                    expanded.toggle()
-                    // Reading a nested node is still reading — keep the feed
-                    // from scrolling it away.
-                    if expanded { pauseFollow() }
+                    if isOpen {
+                        expandedPaths.remove(path)
+                    } else {
+                        expandedPaths.insert(path)
+                        // Reading a nested node is still reading — keep the
+                        // feed from scrolling it away.
+                        pauseFollow()
+                    }
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         Image(systemName: isOpen ? "chevron.down" : "chevron.right")
@@ -1684,26 +1991,40 @@ private struct SnapValueView: View {
                             .foregroundStyle(.secondary)
                             .frame(width: 14)
                         labelText
-                        highlightedText(summary, query: highlight, base: jsColor(.className))
+                        highlightedText(node.containerSummary, query: highlight, base: jsColor(.className))
                             .font(.app(.callout, design: .monospaced))
                     }
                     .contentShape(Rectangle())
+                    .background(revealTint)
                 }
                 .buttonStyle(.plain)
-                .disabled(!query.isEmpty)   // search drives expansion; manual toggle resumes when cleared
                 if isOpen {
-                    SnapChildrenView(node: node, session: session, query: query).padding(.leading, 18)
+                    SnapChildrenView(
+                        node: node, session: session, path: path,
+                        expandedPaths: $expandedPaths, highlightedPath: highlightedPath
+                    )
+                    .padding(.leading, 18)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 labelText
-                highlightedText(primitiveText, query: highlight, base: jsColor(kind))
-                    .font(.app(.callout, design: .monospaced))
-                    .textSelection(.enabled)
+                highlightedText(
+                    node.primitivePreview, query: highlight, base: jsColor(kind),
+                    underlineLinks: underlineLinks
+                )
+                .font(.app(.callout, design: .monospaced))
+                .textSelection(.enabled)
             }
+            .background(revealTint)
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder private var revealTint: some View {
+        if isRevealed {
+            RoundedRectangle(cornerRadius: 3).fill(JSConsoleTheme.findMatch.opacity(0.22))
         }
     }
 
@@ -1713,21 +2034,6 @@ private struct SnapValueView: View {
                 .font(.app(.callout, design: .monospaced))
                 .fixedSize(horizontal: false, vertical: true)
         }
-    }
-
-    /// Collapsed one-liner for a container, e.g. `Array(200)`, `{3}`, `Map {2}`.
-    private var summary: String {
-        if node.type == "array" {
-            return "Array(\(node.length ?? node.items?.count ?? 0))"
-        }
-        let count = node.entries?.count ?? 0
-        let ctor = node.ctor ?? "Object"
-        return ctor == "Object" ? "{\(count)}" : "\(ctor) {\(count)}"
-    }
-
-    private var primitiveText: String {
-        let text = node.text ?? "—"
-        return node.type == "string" ? "\"\(text)\"" : text
     }
 
     private var kind: JSTokenKind {
@@ -1921,9 +2227,22 @@ private func jsTruncationNote(hiddenCharacters: Int) -> AttributedString {
     return note
 }
 
+/// Whether detected URLs in console text draw their underline — set true by
+/// the hovered row, so links read as plain text until pointed at.
+private struct ConsoleLinkUnderlineKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    fileprivate var consoleLinkUnderline: Bool {
+        get { self[ConsoleLinkUnderlineKey.self] }
+        set { self[ConsoleLinkUnderlineKey.self] = newValue }
+    }
+}
+
 /// Syntax-colored `Text` for a value's tokens, with find matches highlighted
 /// and http(s) URLs linkified. Bounded to `jsDisplayCharacterLimit` characters.
-func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool) -> Text {
+func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool, underlineLinks: Bool = false) -> Text {
     var attr = AttributedString()
     var remaining = jsDisplayCharacterLimit
     var hidden = 0
@@ -1944,14 +2263,16 @@ func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool) -> Text
         attr += jsTruncationNote(hiddenCharacters: hidden)
     }
     applyFindHighlight(&attr, query: query, current: current)
-    applyLinkAttributes(&attr)
+    applyLinkAttributes(&attr, underlined: underlineLinks)
     return Text(attr)
 }
 
 /// A single-color `Text` (input/notice/error lines) with find matches
 /// highlighted and http(s) URLs linkified. Bounded to
 /// `jsDisplayCharacterLimit` characters.
-func highlightedText(_ string: String, query: String, base: Color, current: Bool = false) -> Text {
+func highlightedText(
+    _ string: String, query: String, base: Color, current: Bool = false, underlineLinks: Bool = false
+) -> Text {
     var attr = AttributedString(String(string.prefix(jsDisplayCharacterLimit)))
     attr.foregroundColor = base
     let hidden = string.utf8.count - jsDisplayCharacterLimit
@@ -1960,22 +2281,26 @@ func highlightedText(_ string: String, query: String, base: Color, current: Bool
         attr += jsTruncationNote(hiddenCharacters: hidden)
     }
     applyFindHighlight(&attr, query: query, current: current)
-    applyLinkAttributes(&attr)
+    applyLinkAttributes(&attr, underlined: underlineLinks)
     return Text(attr)
 }
 
-/// Underline http(s) URLs and attach `.link`, so the console's ⌘-click
-/// `openURL` gate can send them to the browser. Detection — including the
-/// explicit-scheme guard and the UTF-16 → Character offset mapping — is
-/// `ConsoleLinkDetector` (pure, tested in ADBKit); this only applies the
-/// SwiftUI attributes at the returned offsets.
-func applyLinkAttributes(_ attr: inout AttributedString) {
+/// Attach `.link` to http(s) URLs — underlined only while the owning row is
+/// hovered (`underlined`), so a URL-heavy feed doesn't read as a wall of
+/// underlines — letting the console's ⌘-click `openURL` gate send them to the
+/// browser. Detection — including the explicit-scheme guard and the
+/// UTF-16 → Character offset mapping — is `ConsoleLinkDetector` (pure, tested
+/// in ADBKit); this only applies the SwiftUI attributes at the returned
+/// offsets.
+func applyLinkAttributes(_ attr: inout AttributedString, underlined: Bool) {
     let plain = String(attr.characters)
     for span in ConsoleLinkDetector.linkSpans(in: plain) {
         let lower = attr.index(attr.startIndex, offsetByCharacters: span.start)
         let upper = attr.index(lower, offsetByCharacters: span.count)
         attr[lower ..< upper].link = span.url
-        attr[lower ..< upper].swiftUI.underlineStyle = .single
+        if underlined {
+            attr[lower ..< upper].swiftUI.underlineStyle = .single
+        }
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -32,6 +32,8 @@ struct LogcatView: View {
     @State private var findFocusToken = 0
     @State private var waitingForPackage: String?
     @State private var streamingPid: Int?
+    /// pid → process name (a periodic `ps` snapshot) for the process column.
+    @State private var processNames: [String: String] = [:]
     /// One-shot: the App filter is seeded from the device bar's chosen bundle
     /// the first time the view appears, then left to the user.
     @State private var seededPackageFilter = false
@@ -47,6 +49,9 @@ struct LogcatView: View {
     /// Reversed feed: newest lines at the top instead of the terminal-style
     /// newest-at-bottom. Persisted per feature.
     @AppStorage("logcatNewestFirst") private var newestFirst = false
+    /// Show the leading time column. Hiding it buys the message ~20 columns
+    /// in narrow panes. Persisted per feature.
+    @AppStorage("logcatShowTime") private var showTime = true
 
     private static let levels: [(value: String, label: String)] = [
         ("All", "All levels"), ("V", "Verbose"), ("D", "Debug"),
@@ -188,6 +193,14 @@ struct LogcatView: View {
         // ⌘F opens an invisible find bar whose focus request lands on the
         // sidebar search.
         .keyboardShortcut(isActiveTab ? KeyboardShortcut("f", modifiers: .command) : nil)
+
+        Button {
+            showTime.toggle()
+        } label: {
+            Image(systemName: showTime ? "clock" : "clock.badge.xmark")
+        }
+        .buttonStyle(IconButtonStyle())
+        .help(showTime ? "Hide the time column" : "Show the time column")
 
         Button {
             newestFirst.toggle()
@@ -409,6 +422,7 @@ struct LogcatView: View {
             find: find,
             currentFindID: currentFindID,
             newestFirst: newestFirst,
+            showTime: showTime,
             edges: $edges,
             jump: jump,
             onFilterTag: { tagFilter = $0 }
@@ -475,7 +489,19 @@ struct LogcatView: View {
         guard let serial = state.targetSerials.first else { return }
 
         let streamer = LogcatStreamer(client: state.env.client)
+        // The process-name column: a ps snapshot up front so the initial tail
+        // is named, then refreshed on a slow cadence for processes that spawn
+        // mid-stream. Background polling — deliberately not CommandLog-wrapped.
+        processNames = await streamer.processNames(serial: serial)
+        let nameRefresher = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                if Task.isCancelled { return }
+                processNames = await streamer.processNames(serial: serial)
+            }
+        }
         defer {
+            nameRefresher.cancel()
             Task { await streamer.stop() }
             waitingForPackage = nil
             streamingPid = nil
@@ -533,8 +559,18 @@ struct LogcatView: View {
             for await batch in stream {
                 if Task.isCancelled { break }
                 if paused { continue }
-                lines.append(contentsOf: batch)
-                if lines.count > Self.maxLines {
+                // Stamp each line's process name at ingest — rendered rows are
+                // immutable, so resolving lazily at render would never fill in.
+                lines.append(contentsOf: batch.map { line in
+                    var stamped = line
+                    stamped.processName = processNames[line.pid]
+                    return stamped
+                })
+                // Hysteresis: once at the cap, trimming exactly per batch
+                // meant a head-trim text edit every flush (~120ms). Letting
+                // the buffer float a little above the cap turns that into one
+                // chunked trim per ~250 lines.
+                if lines.count > Self.maxLines + 250 {
                     lines.removeFirst(lines.count - Self.maxLines)
                 }
             }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -497,7 +497,10 @@ struct LogcatView: View {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(5))
                 if Task.isCancelled { return }
-                processNames = await streamer.processNames(serial: serial)
+                let refreshed = await streamer.processNames(serial: serial)
+                // A transient ps failure comes back empty — keep the last good
+                // map rather than blanking the process column for a cycle.
+                if !Task.isCancelled, !refreshed.isEmpty { processNames = refreshed }
             }
         }
         defer {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -440,18 +440,32 @@ final class ReactotronSession {
         Self.discardInBackground(previous)
     }
 
+    /// The export payload: the raw wire commands of the given (already
+    /// filtered) items, pretty-printed — one shape for file and clipboard.
+    private func exportJSON(_ itemsToExport: [RtItem]) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try? encoder.encode(itemsToExport.map(\.command))
+    }
+
     fileprivate func export(_ itemsToExport: [RtItem]) {
         guard let file = app?.askSaveLocation(
             suggestedName: "reactotron_\(ScreenCaptureService.stamp()).json"
         ) else { return }
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-            try encoder.encode(itemsToExport.map(\.command)).write(to: file)
+            guard let data = exportJSON(itemsToExport) else { return }
+            try data.write(to: file)
             app?.showToast(Toast(message: "Exported \(itemsToExport.count) events", ok: true, revealPath: file.path))
         } catch {
             app?.showToast(Toast(message: "Export failed: \(error.localizedDescription)", ok: false))
         }
+    }
+
+    fileprivate func copyExport(_ itemsToExport: [RtItem]) {
+        guard let data = exportJSON(itemsToExport) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(String(decoding: data, as: UTF8.self), forType: .string)
+        app?.showToast(Toast(message: "Copied \(itemsToExport.count) events as JSON", ok: true))
     }
 
     // MARK: - Inbound
@@ -1079,6 +1093,7 @@ struct ReactotronView: View {
             trailing: trailing,
             findToken: findToken,
             onExport: { session.export($0) },
+            onCopyExport: { session.copyExport($0) },
             onRetry: { Task { await session.start(serials: readySerials) } },
             onClear: split ? { session.clearPane(index) } : nil
         )
@@ -1810,6 +1825,7 @@ private struct TimelinePane: View {
     /// pane in a split; the second pane always gets the never-firing 0).
     let findToken: Int
     let onExport: ([RtItem]) -> Void
+    let onCopyExport: ([RtItem]) -> Void
     let onRetry: () -> Void
     /// Clears just this pane (split mode only — the single pane's trash in the
     /// trailing controls clears the whole timeline). nil hides the button.
@@ -1840,6 +1856,7 @@ private struct TimelinePane: View {
         trailing: AnyView?,
         findToken: Int = 0,
         onExport: @escaping ([RtItem]) -> Void,
+        onCopyExport: @escaping ([RtItem]) -> Void,
         onRetry: @escaping () -> Void,
         onClear: (() -> Void)? = nil
     ) {
@@ -1852,6 +1869,7 @@ private struct TimelinePane: View {
         self.trailing = trailing
         self.findToken = findToken
         self.onExport = onExport
+        self.onCopyExport = onCopyExport
         self.onRetry = onRetry
         self.onClear = onClear
         _search = AppStorage(wrappedValue: "", "reactotronPane\(pane)Search")
@@ -1937,13 +1955,16 @@ private struct TimelinePane: View {
                 ? "Newest at top — click to show newest at bottom"
                 : "Newest at bottom — click to show newest at top")
 
-            Button {
-                onExport(visible)
+            Menu {
+                Button("Save as JSON…") { onExport(visible) }
+                Button("Copy to Clipboard") { onCopyExport(visible) }
             } label: {
                 Image(systemName: "square.and.arrow.up")
             }
             .buttonStyle(IconButtonStyle())
-            .help("Export this pane's filtered timeline to JSON")
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Export this pane's filtered timeline — save as a JSON file or copy to the clipboard")
             .disabled(visible.isEmpty)
 
             if let onClear {
@@ -2524,6 +2545,9 @@ private struct JSONTreeView: View {
     var showSearch: Bool = true
     @State private var expanded: Set<String> = []
     @State private var search = ""
+    /// The last find result revealed by a click, tinted in the tree until the
+    /// next search.
+    @State private var highlightedPath: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -2543,21 +2567,33 @@ private struct JSONTreeView: View {
                 }
             }
             LazyVStack(alignment: .leading, spacing: 1) {
-                let nodes = rows
-                ForEach(nodes) { node in
-                    rowView(node)
-                }
-                if nodes.isEmpty {
-                    Text(search.isEmpty ? "(empty)" : "No matches")
-                        .font(.app(size: 11))
-                        .foregroundStyle(.tertiary)
+                if search.isEmpty {
+                    let nodes = collapsedRows()
+                    ForEach(nodes) { node in
+                        rowView(node)
+                    }
+                    if nodes.isEmpty {
+                        emptyRow("(empty)")
+                    }
+                } else {
+                    // Clickable results (JSONSearch, pure in ADBKit): clicking
+                    // one expands the tree along its path and highlights the
+                    // node in place.
+                    let matches = JSONSearch.matches(in: root, query: search)
+                    ForEach(Array(matches.enumerated()), id: \.offset) { _, match in
+                        matchRow(match)
+                    }
+                    if matches.isEmpty { emptyRow("No matches") }
+                    if matches.count >= 200 { emptyRow("…first 200 matches — narrow the search") }
                 }
             }
         }
     }
 
-    private var rows: [JSONNode] {
-        search.isEmpty ? collapsedRows() : matchRows(search.lowercased())
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .font(.app(size: 11))
+            .foregroundStyle(.tertiary)
     }
 
     private func collapsedRows() -> [JSONNode] {
@@ -2571,26 +2607,52 @@ private struct JSONTreeView: View {
         return out
     }
 
-    private func matchRows(_ query: String) -> [JSONNode] {
-        var out: [JSONNode] = []
-        var visited = 0
-        func walk(_ node: JSONNode) {
-            if out.count >= 800 || visited >= 40_000 { return }
-            visited += 1
-            if node.matches(query) { out.append(JSONNode(path: node.path, key: node.key, value: node.value, depth: 0)) }
-            for child in node.children { walk(child) }
+    /// One find result: its dot-path and value; clicking reveals it in the tree.
+    private func matchRow(_ match: TreeMatch) -> some View {
+        Button {
+            reveal(match)
+        } label: {
+            HStack(alignment: .top, spacing: 4) {
+                Image(systemName: "arrow.turn.down.right")
+                    .font(.app(size: 9))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 14)
+                Text(match.displayPath)
+                    .font(.app(size: 11, design: .monospaced))
+                    .foregroundStyle(.rtKey)
+                Text(":")
+                    .font(.app(size: 11, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                Text(match.preview)
+                    .font(.app(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 2)
+            .contentShape(Rectangle())
         }
-        for child in JSONNode(path: "", key: "", value: root, depth: -1).children { walk(child) }
-        return out
+        .buttonStyle(.plain)
+        .help("Reveal in the tree")
+    }
+
+    /// Open every container down to the match, mark it, and swap back to the
+    /// tree so the clicked result is visible in place.
+    private func reveal(_ match: TreeMatch) {
+        var path = ""
+        for index in match.path {
+            path += ".\(index)"
+            expanded.insert(path)
+        }
+        highlightedPath = path
+        search = ""
     }
 
     @ViewBuilder
     private func rowView(_ node: JSONNode) -> some View {
         HStack(alignment: .top, spacing: 4) {
-            if search.isEmpty {
-                Color.clear.frame(width: CGFloat(max(0, node.depth)) * 12, height: 1)
-            }
-            if node.isContainer, search.isEmpty {
+            Color.clear.frame(width: CGFloat(max(0, node.depth)) * 12, height: 1)
+            if node.isContainer {
                 Image(systemName: expanded.contains(node.path) ? "chevron.down" : "chevron.right")
                     .font(.app(size: 10, weight: .bold))
                     .foregroundStyle(.secondary)
@@ -2616,8 +2678,13 @@ private struct JSONTreeView: View {
         // Rows were 13pt slivers — give container rows a real click target.
         .padding(.vertical, 2)
         .contentShape(Rectangle())
+        .background {
+            if node.path == highlightedPath {
+                RoundedRectangle(cornerRadius: 3).fill(Color.brandAccent.opacity(0.14))
+            }
+        }
         .onTapGesture {
-            if node.isContainer, search.isEmpty { toggle(node.path) }
+            if node.isContainer { toggle(node.path) }
         }
         .contextMenu {
             Button("Copy value") {
@@ -2661,16 +2728,6 @@ private struct JSONNode: Identifiable {
             }
         default:
             return []
-        }
-    }
-
-    func matches(_ query: String) -> Bool {
-        if key.lowercased().contains(query) { return true }
-        switch value {
-        case let .string(text): return text.lowercased().contains(query)
-        case let .number(number): return "\(number)".contains(query)
-        case let .bool(flag): return "\(flag)".contains(query)
-        default: return false
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -452,8 +452,11 @@ final class ReactotronSession {
         guard let file = app?.askSaveLocation(
             suggestedName: "reactotron_\(ScreenCaptureService.stamp()).json"
         ) else { return }
+        guard let data = exportJSON(itemsToExport) else {
+            app?.showToast(Toast(message: "Export failed: events couldn't be encoded", ok: false))
+            return
+        }
         do {
-            guard let data = exportJSON(itemsToExport) else { return }
             try data.write(to: file)
             app?.showToast(Toast(message: "Exported \(itemsToExport.count) events", ok: true, revealPath: file.path))
         } catch {
@@ -462,7 +465,10 @@ final class ReactotronSession {
     }
 
     fileprivate func copyExport(_ itemsToExport: [RtItem]) {
-        guard let data = exportJSON(itemsToExport) else { return }
+        guard let data = exportJSON(itemsToExport) else {
+            app?.showToast(Toast(message: "Copy failed: events couldn't be encoded", ok: false))
+            return
+        }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(String(decoding: data, as: UTF8.self), forType: .string)
         app?.showToast(Toast(message: "Copied \(itemsToExport.count) events as JSON", ok: true))
@@ -2587,6 +2593,11 @@ private struct JSONTreeView: View {
                     if matches.count >= 200 { emptyRow("…first 200 matches — narrow the search") }
                 }
             }
+        }
+        // A newly typed query drops the previous reveal's tint (reveal itself
+        // clears the field, so its own highlight survives this).
+        .onChange(of: search) { _, newValue in
+            if !newValue.isEmpty { highlightedPath = nil }
         }
     }
 

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -53,6 +53,9 @@ struct DeviceBarView: View {
                 if let device = selectedDevice, device.isWireless {
                     disconnectControl(device)
                 }
+                if mirrorButtonVisible {
+                    mirrorButton
+                }
             }
 
             // Only when the selected feature actually works with an app bundle.
@@ -118,6 +121,27 @@ struct DeviceBarView: View {
 
     private var selectedDevice: Device? {
         state.devices.first { $0.serial == state.selectedSerial }
+    }
+
+    // MARK: - Mirror shortcut
+
+    /// Quick jump to Mirror Screen for the selected device. Android only
+    /// (scrcpy can't mirror an iOS Simulator), and hidden while the mirror is
+    /// already on screen — as the focused tab or in either split pane
+    /// (`activeTabIDs` is the active tab of every visible pane).
+    private var mirrorButtonVisible: Bool {
+        selectedDevice?.platform == .android && !state.activeTabIDs.contains("scrcpy")
+    }
+
+    private var mirrorButton: some View {
+        Button {
+            state.requestFeature("scrcpy")
+        } label: {
+            Image(systemName: "display")
+        }
+        .buttonStyle(IconButtonStyle())
+        .help("Mirror this device's screen (scrcpy)")
+        .accessibilityLabel("Mirror screen")
     }
 
     // MARK: - Device pill

--- a/App/Sources/Root/QuickActionsView.swift
+++ b/App/Sources/Root/QuickActionsView.swift
@@ -801,9 +801,9 @@ struct QuickActionsView: View {
             QuickRow(
                 id: "pick:\(device.serial)",
                 icon: device.platform == .iosSimulator ? "iphone" : "iphone.gen3",
-                title: device.label,
+                title: state.deviceDisplayName(device),
                 subtitle: state.deviceTitle(device),
-                action: .chooseDevice(serial: device.serial, label: device.label)
+                action: .chooseDevice(serial: device.serial, label: state.deviceDisplayName(device))
             )
         }
     }
@@ -1514,7 +1514,8 @@ struct QuickActionsView: View {
                 lastResult = result
                 // Mirror the Custom Commands screen: results land in the
                 // notifications history too, not just this transient footer.
-                let label = state.devices.first { $0.serial == serial }?.label
+                let label = state.devices.first { $0.serial == serial }
+                    .map { state.deviceDisplayName($0) }
                 state.showToast(Toast(
                     message: targets.count > 1 ? "\(label ?? serial): \(result.message)" : result.message,
                     ok: result.ok

--- a/App/Sources/Root/WindowTranslucency.swift
+++ b/App/Sources/Root/WindowTranslucency.swift
@@ -74,8 +74,7 @@ struct WindowTranslucencyModifier: ViewModifier {
             // Outside RootView's zoom scaleEffect, so ⌘= never magnifies
             // the specks.
             .overlay {
-                GrainOverlay(
-                    strength: WindowEffects.grainOpacity(root: windowOpacity, amount: windowGrain))
+                GrainOverlay(strength: WindowEffects.grainOpacity(amount: windowGrain))
             }
             .environment(\.windowOpacity, WindowEffects.clamped(windowOpacity))
             .onChange(of: windowOpacity) { _, value in

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -514,8 +514,7 @@ struct AppearanceSettingsView: View {
                 effectSlider(
                     "Grain", value: $windowGrain, in: 0...1,
                     percent: WindowEffects.clampedAmount(windowGrain))
-                    .disabled(!WindowEffects.isTranslucent(windowOpacity))
-                Text("Below 100% opacity the main window turns to glass — what's behind shows through every pane, softened by Blur and textured by Grain.")
+                Text("Below 100% opacity the main window turns to glass — what's behind shows through every pane, softened by Blur. Grain films the window with texture at any opacity.")
                     .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
             }

--- a/App/Sources/State/AppState+Install.swift
+++ b/App/Sources/State/AppState+Install.swift
@@ -122,6 +122,15 @@ extension AppState {
     private func finishInstallJob(_ id: UUID, result: FeatureResult) {
         guard let index = installJobs.firstIndex(where: { $0.id == id }) else { return }
         installJobs[index].status = result.ok ? .succeeded : .failed(result.message)
+        // A success row has said its piece after a few seconds — drop it so
+        // the install screens don't carry a stale green check forever.
+        // Failures stay: the user needs the reason until a retry replaces it.
+        if result.ok {
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(5))
+                self?.installJobs.removeAll { $0.id == id }
+            }
+        }
     }
 
     /// A short install headline for the toast; on failure the full adb output is

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -656,15 +656,27 @@ final class AppState {
         )
     }
 
+    /// The device's human name: a running emulator shows its AVD name
+    /// ("Medium Tablet") — every emulator otherwise carries the same generic
+    /// system-image model ("sdk gphone64 arm64") — and everything else keeps
+    /// its adb label.
+    func deviceDisplayName(_ device: Device) -> String {
+        if device.serial.hasPrefix("emulator-"),
+           let avd = availableAvds.first(where: { $0.runningSerial == device.serial }) {
+            return avd.displayName
+        }
+        return device.label
+    }
+
     /// Picker label with enrichment: "Pixel 7 (005F) · Android 14 · 82%",
     /// or "iPhone 16 Pro · iOS 18.2 · Simulator" for a booted simulator.
     func deviceTitle(_ device: Device) -> String {
         guard device.isReady else {
             return device.state == "unauthorized"
-                ? "\(device.label) — accept the prompt on the device"
-                : "\(device.label) — \(device.state)"
+                ? "\(deviceDisplayName(device)) — accept the prompt on the device"
+                : "\(deviceDisplayName(device)) — \(device.state)"
         }
-        var parts = [device.label]
+        var parts = [deviceDisplayName(device)]
         switch device.platform {
         case .android:
             if let details = deviceDetails[device.serial] {
@@ -1078,6 +1090,13 @@ final class AppState {
     func setQuickPanelOpen(_ open: Bool) {
         quickPanelOpen = open
         applyPollInterval()
+        // The panel's device rows name emulators by their AVD
+        // (`deviceDisplayName`) — refresh the AVD↔serial mapping on open, so
+        // it's right even when the main window (whose device bar usually
+        // keeps it fresh) has been closed all along.
+        if open {
+            Task { await refreshAvds() }
+        }
     }
 
     private func applyPollInterval() {

--- a/App/Sources/Updates/WhatsNewView.swift
+++ b/App/Sources/Updates/WhatsNewView.swift
@@ -11,20 +11,8 @@ struct WhatsNewView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("What's new in Droidective \(whatsNew.version)")
-                        .font(.app(.title2).weight(.semibold))
-                    Text("You're now on the latest version.")
-                        .font(.app(.footnote))
-                        .foregroundStyle(.textMuted)
-                }
-                Spacer()
-            }
-            .padding(20)
-
+            header
             Divider()
-
             if let notes = whatsNew.notesHTML {
                 ReleaseNotesHTMLView(html: notes)
             } else {
@@ -40,17 +28,58 @@ struct WhatsNewView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-
             Divider()
-
-            HStack {
-                Spacer()
-                Button("Continue") { dismiss() }
-                    .keyboardShortcut(.defaultAction)
-            }
-            .padding(16)
+            footer
         }
-        .frame(width: 560, height: 480)
+        .frame(width: 600, height: 540)
+        .background(.bgRoot)
+    }
+
+    /// Accent-badged masthead: eyebrow + version title, with an "up to date"
+    /// seal on the trailing edge.
+    private var header: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(LinearGradient(
+                        colors: [Color.brandAccent, Color.brandAccent.opacity(0.55)],
+                        startPoint: .topLeading, endPoint: .bottomTrailing))
+                    .frame(width: 46, height: 46)
+                Image(systemName: "sparkles")
+                    .font(.system(size: 21, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text("WHAT'S NEW")
+                    .font(.app(size: 10, weight: .bold))
+                    .kerning(1.2)
+                    .foregroundStyle(Color.brandAccent)
+                Text("Droidective \(whatsNew.version)")
+                    .font(.app(.title2).weight(.bold))
+            }
+            Spacer(minLength: 12)
+            Label("Up to date", systemImage: "checkmark.seal.fill")
+                .font(.app(.caption).weight(.medium))
+                .foregroundStyle(.green)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(Color.green.opacity(0.12), in: Capsule())
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Continue") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .tint(.brandAccent)
+                .controlSize(.large)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
     }
 }
 
@@ -75,7 +104,10 @@ struct WhatsNewPresenter: ViewModifier {
 }
 
 /// Renders the appcast item's embedded HTML notes. Links open in the
-/// browser; the page itself never navigates.
+/// browser; the page itself never navigates. The notes ship a base style in
+/// the appcast; `styled` layers app-side CSS over it so the sheet reads like
+/// the app — the user's accent on links/markers, sectioned headings, and a
+/// transparent canvas over the sheet background.
 private struct ReleaseNotesHTMLView: NSViewRepresentable {
     let html: String
 
@@ -89,10 +121,34 @@ private struct ReleaseNotesHTMLView: NSViewRepresentable {
         configuration.defaultWebpagePreferences.allowsContentJavaScript = false
         let view = WKWebView(frame: .zero, configuration: configuration)
         view.navigationDelegate = context.coordinator
-        // The appcast notes declare `color-scheme: light dark`, so the page
-        // canvas follows the app's appearance on its own.
-        view.loadHTMLString(html, baseURL: nil)
+        // Let the sheet's own background show through instead of the page
+        // canvas painting a second, slightly-off surface.
+        view.underPageBackgroundColor = .clear
+        view.setValue(false, forKey: "drawsBackground")
+        // The appcast notes declare `color-scheme: light dark`, so the text
+        // follows the app's appearance on its own.
+        view.loadHTMLString(Self.styled(html), baseURL: nil)
         return view
+    }
+
+    /// Append an app-side style layer — later rules win at equal specificity,
+    /// so this restyles the appcast's baseline without the release pipeline
+    /// changing.
+    static func styled(_ notes: String) -> String {
+        let accent = UserDefaults.standard.string(forKey: accentColorDefaultsKey)
+            .flatMap { $0.isEmpty ? nil : $0 } ?? "#2f9e44"
+        return notes + """
+        <style>
+        html, body { background: transparent; }
+        body { padding: 16px 22px 24px; }
+        body > p:first-of-type { font-size: 1.06em; color: color-mix(in srgb, currentColor 75%, transparent); margin-bottom: 1em; }
+        h2, h3 { font-weight: 700; }
+        h3 { margin: 1.5em 0 .45em; padding-bottom: .35em; border-bottom: 1px solid color-mix(in srgb, currentColor 14%, transparent); }
+        li { margin: .38em 0; }
+        li::marker { color: \(accent); }
+        a { color: \(accent); }
+        </style>
+        """
     }
 
     func updateNSView(_ view: WKWebView, context: Context) {}


### PR DESCRIPTION
## JS Console

- **Export menu** (share icon in the filter bar): save the *filtered* feed as a JSON file or copy it to the clipboard — `{timestamp, type, level, text}` per line (`ConsoleExport`, pure + tested).
- **Find in object with clickable results**: typing in an expanded object's find field lists `path: value` matches; clicking one expands the tree along the path and highlights the node (`SnapNode.findMatches` → `TreeMatch`, tested; expansion state hoisted so results can drive it).
- **URLs underline on hover only** (⌘-click to open unchanged); the hovered row is what reveals its links.
- **Whole-row expand**: clicking anywhere on a log row toggles its primary object, not just the object's summary line. Text selection is preserved.
- **Hover copy button** with permanently reserved space, so hovering never reflows the row; right-click keeps Copy as JSON.
- **Restart app is a split button** with *Clear cache and restart* (`pm clear --cache-only` + relaunch). The cache step is bounded to 10s — it hangs forever on some images (observed live on the API 36 emulator) — and the toast reports honestly when it didn't finish.
- **Connection robustness**:
  - discovery installs `adb reverse tcp:<port>` automatically while searching (once per device+port; the manual button stays as retry) — a USB device can now register with Metro without knowing to click anything;
  - a half-dead connection (socket gone, close event unconsumed) self-heals instead of wedging until the feature is restarted;
  - moving the tab between split panes no longer drops the chosen target (the remount race is absorbed by view refcounting with a deferred stop);
  - **auto-connect waits for target stability** — a target must survive two discovery scans before attaching (`TargetStabilityTracker`, tested), because attaching the instant an app registers hit Hermes mid-boot and crashed it. Reconnects stay instant; manual picks bypass the gate.

## Reactotron

- The pane export button becomes the same **Save as JSON… / Copy to Clipboard** menu, still filter-aware per pane.
- The JSON tree search shows **clickable results that reveal the node in place** (`JSONSearch`, tested — ordinal paths match the tree's render order).

## Logcat

- **Columnar rows**: time · PID–TID · process name · filled level chip (V/D/I/W/E/F) · tag in a stable hashed color · severity-tinted message. The parser now captures the TID, and a `ps -A` snapshot (pure parser, tested) names each pid — fetched before streaming, refreshed every 5s, stamped at ingest.
- **Time column toggle** in the toolbar (persisted).
- **Click holds the tail**: clicking/selecting a line suspends follow so streaming can't scroll the selection away; the jump-to-newest button resumes.
- **No more bouncing at the 5,000-line cap**: the ring trim + append run as one editing transaction (single layout/display pass) and trims are chunked (~250 lines) instead of per-flush.

## Device lists

- Running emulators are named by their **AVD** ("Medium Tablet") instead of the shared system-image model, in the device dropdown/pill, Quick Actions pick-a-device rows and run-on-all toasts, and the menu-bar header. Opening the Quick Actions panel refreshes the AVD↔serial mapping so names hold with the main window closed.
- A **Mirror Screen shortcut** sits next to the device pill — Android devices only, hidden while the mirror is already the focused tab or in a split pane.

## Roles

- The **React Native role spans Android and iOS Simulators**: booted simulators join the device bar and launch lists, the role curates `ios-logs` and the Simulate hub, and the emulators screen title derives from visible platforms (RN keeps "Emulators & Simulators").

## Smaller fixes

- **Grain is independent of window opacity** (slider enabled at 100%); blur keeps its opacity gate.
- **What's New sheet redesigned**: accent masthead, transparent notes canvas with app-side CSS over the appcast HTML (user accent on links/markers, sectioned headings), prominent Continue.
- **Succeeded install rows auto-hide after 5s** on all three install screens; failures stay until retried.

## Testing

- ADBKit: 968 tests green (43 new — export shape, tree search ordinals, target stability, grain math, tid + `ps` parsing, RN role invariants).
- Zero-warning build.
- Verified live against the StreamLab rig (emulator + Metro): gated auto-connect timing measured via a 500 ms monitor across fresh boot / JS reload / force-stop / flapping-target / Metro-restart scenarios; export payloads inspected off the clipboard; the logcat cap exercised past 5,000 lines with burst-frame captures confirming a pinned bottom edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)