### PR TITLE
Add shared Claude Code commands and project skills

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,225 @@
+# Fix GitHub Issue
+
+@description End-to-end: plan, implement, test, review, fix, push, and PR for a GitHub issue.
+@arguments $ISSUE_NUMBER: GitHub issue number to fix
+
+Read GitHub Issue #$ISSUE_NUMBER from the canonical repo
+(`gh issue view $ISSUE_NUMBER --repo <owner/name>`) thoroughly.
+Understand the full context: problem description, acceptance
+criteria, linked PRs, and any discussion. Follow linked issues,
+referenced PRs, and external documentation to build complete
+understanding before planning.
+
+Detect the upstream repository: if a git remote named `upstream`
+exists, use it as the canonical repo (fetch from it, base branches
+on it, and submit PRs to it). Otherwise, fall back to `origin`.
+Resolve the canonical repo's `owner/name` (e.g. from `git remote
+get-url upstream`) and store it — use `--repo <owner/name>` on
+every `gh` command (issue views, PR creation, issue comments) to
+ensure they target the correct repository. Run
+`git fetch <upstream-remote>` to ensure you are working with
+up-to-date code.
+
+Execute every step below sequentially. Do not stop or ask for
+confirmation at any step.
+
+## 1. Research (if needed)
+
+Before planning, determine if the issue requires external context
+you don't already have — unfamiliar APIs, protocols, libraries,
+error messages, or domain-specific concepts. If so, use Exa
+(`mcp__exa__web_search_exa`) to search for:
+
+- Official documentation for referenced libraries or APIs
+- Known solutions for the error messages or symptoms described
+- Implementation patterns used by similar projects
+
+Skip this step for straightforward bugs where the fix is clear
+from the codebase alone.
+
+## 2. Plan
+
+Write a detailed implementation plan to `plan-issue-$ISSUE_NUMBER.md`
+in the repo root. The plan must:
+
+- Summarize the issue requirements
+- List every file to create or modify
+- Describe the approach and key design decisions
+- Call out risks or open questions
+- Reference relevant code paths by file:line
+
+## 3. Create branch
+
+Create the working branch before writing any code so changes are
+never left uncommitted on main.
+
+- Determine the branch prefix from the issue type: `fix/` for
+  bugs, `feat/` for features, `refactor/` for refactors, `docs/`
+  for documentation. When ambiguous, use `fix/`.
+- Create a branch named `{prefix}issue-$ISSUE_NUMBER` based on
+  the upstream remote's main branch (e.g. `upstream/main` if the
+  `upstream` remote exists, otherwise `origin/main`)
+
+## 4. Implement
+
+Implement the plan across all necessary files. Follow the
+project's CLAUDE.md standards. Keep changes minimal and focused
+on the issue requirements — no speculative features.
+
+Add tests for the changed behavior as part of implementation —
+tests are code, not a quality gate.
+
+When stuck during implementation — a confusing error, an
+unfamiliar API, or an approach that isn't working — use Exa
+to search for solutions rather than spinning.
+
+## 5. Build, test, lint
+
+### 5a. Discover project checks (CI is the source of truth)
+
+Before running anything, read the project's CI configuration to
+learn what the project *actually* runs. This takes priority over
+the fallback tables below.
+
+1. **Read CI workflows.** Scan `.github/workflows/` for the main
+   CI workflow (typically `ci.yml`, `test.yml`, or `build.yml`).
+   Extract:
+   - Test commands with feature flags (e.g.
+     `cargo test --features foo,bar`)
+   - Lint/format commands with non-default flags
+   - Any step that runs a command then checks `git diff --exit-code`
+     — these are **codegen sync checks** (schema generation,
+     snapshot updates, help text, etc.). Record the command.
+   - Docs/site build commands (e.g. `make site`, `mkdocs build`)
+2. **Read the Makefile** (if present). Cross-reference targets
+   used in CI — these are the ones that matter.
+3. **Read CLAUDE.md** (if present at repo root or `.claude/`).
+   It may define project-specific quality gates.
+
+Store the discovered commands. They override the fallback table
+for any overlapping step.
+
+### 5b. Run the quality pipeline
+
+Detect the project language from manifest files (`Cargo.toml` →
+Rust, `pyproject.toml`/`setup.py` → Python, `package.json` →
+Node/TypeScript, `go.mod` → Go). A project may use multiple
+languages; run checks for each.
+
+Run checks in this order. For each step, use the CI-discovered
+command if one was found; otherwise fall back to the default.
+
+1. **Build** — compile or bundle
+2. **Test** — run the full test suite with the same feature flags
+   CI uses. Iterate on failures until green.
+3. **Lint and format** — fix any issues
+4. **Extended checks** — per-language extras (see fallback table)
+5. **Codegen sync** — for every codegen check discovered in 5a,
+   run the command and verify `git diff --exit-code`. If the diff
+   is non-empty, the generated files are stale — regenerate and
+   stage them.
+6. **Docs build** — if the changes touch documentation files and a
+   docs build command exists, run it to verify the docs compile.
+
+### Fallback defaults (when CI config is absent or unclear)
+
+**Rust** (detected by `Cargo.toml`):
+
+| step         | command                                        |
+|--------------|------------------------------------------------|
+| build        | `cargo build`                                  |
+| test         | `cargo test`                                   |
+| lint         | `cargo clippy -- --deny warnings`              |
+| format       | `cargo fmt --check`                            |
+| supply chain | `cargo deny check` (if `deny.toml` exists)    |
+| careful      | `cargo careful test` (if `cargo-careful` installed) |
+
+**Python** (detected by `pyproject.toml` or `setup.py`):
+
+| step         | command                                        |
+|--------------|------------------------------------------------|
+| test         | `pytest -q`                                    |
+| lint         | `ruff check`                                   |
+| format       | `ruff format --check`                          |
+| types        | `ty check` (or `mypy` if configured)           |
+| supply chain | `pip-audit`                                    |
+
+**Node/TypeScript** (detected by `package.json`):
+
+| step         | command                                        |
+|--------------|------------------------------------------------|
+| build        | per project (`npm run build`, `tsc`, etc.)     |
+| test         | `vitest` (or project test script)              |
+| lint         | `oxlint` (or project lint script)              |
+| format       | `oxfmt --check` (or project format script)     |
+| types        | `tsc --noEmit`                                 |
+| supply chain | `pnpm audit --audit-level=moderate`            |
+
+**Go** (detected by `go.mod`):
+
+| step         | command                                        |
+|--------------|------------------------------------------------|
+| build        | `go build ./...`                               |
+| test         | `go test ./...`                                |
+| lint         | `golangci-lint run`                            |
+| format       | `gofmt -l .`                                   |
+| vet          | `go vet ./...`                                 |
+
+If a tool is not installed, skip it with a note rather than
+failing the pipeline.
+
+## 6. Self-review
+
+For docs-only changes, do a focused manual review (verify links,
+check prose accuracy, confirm rendering). For code changes, use
+`/pr-review-toolkit:review-pr` to run a deep review against the
+diff (compare working tree to the upstream main branch). Produce a
+list of findings ranked by severity (P1 = blocks merge,
+P2 = important, P3 = nice to have).
+
+## 7. Fix findings
+
+Address all P1–P3 findings. For each finding, either:
+
+- **Fix it** — apply the change, or
+- **Dismiss it** — explain why it's a false positive or not worth
+  the churn (e.g. a stylistic disagreement or an impossible edge
+  case). Document the reasoning inline.
+
+After addressing all findings, review your own fixes: read the
+diff of changes made in this step and verify each fix is correct,
+doesn't introduce new issues, and doesn't regress other parts of
+the implementation. If you spot a problem, fix it before
+proceeding.
+
+Then re-run the full quality pipeline (build, test, lint). Iterate
+until clean.
+
+## 8. Commit and push
+
+- Delete the plan file (`plan-issue-$ISSUE_NUMBER.md`) — it was a
+  working artifact and should not be committed
+- Commit all changes with a conventional commit message referencing
+  the issue
+- Push the branch
+
+## 9. Create PR
+
+Create a PR with:
+
+- A concise title (under 70 chars)
+- A description that maps changes back to the issue requirements
+- Link to the issue with "Closes #$ISSUE_NUMBER" (or "Refs" if it
+  doesn't fully close it)
+- If an `upstream` remote exists, submit the PR to the upstream
+  repo using `gh pr create --repo <upstream-owner/repo>`
+
+## 10. Comment on issue
+
+Post a summary comment on Issue #$ISSUE_NUMBER in the canonical
+repo (`gh issue comment $ISSUE_NUMBER --repo <owner/name>`)
+linking to the PR. Include:
+
+- What was implemented (1–3 bullet points)
+- Key design decisions
+- Link to the PR

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,203 @@
+# Review and Fix PR
+
+@description Review an existing PR with parallel agents, fix findings, and push.
+@arguments $PR_NUMBER: GitHub PR number to review and fix
+
+Read PR #$PR_NUMBER using `gh pr view` (description, linked issues,
+commits) and the diff against the base branch.
+
+Detect the upstream repository: if a git remote named `upstream`
+exists, use it as the canonical repo; otherwise `origin`. Resolve
+`owner/name` and pass `--repo <owner/name>` on every `gh` command.
+`git fetch <upstream-remote>`, then check out the PR branch.
+
+Execute every step below sequentially. Do not stop or ask for
+confirmation at any step.
+
+## 0. Prepare shared review inputs (once)
+
+Do this in the main context so agents don't each redo it:
+
+```bash
+DIFF_FILE=$(mktemp -t pr-review-diff)
+git diff <upstream-remote>/<base-branch>...HEAD > "$DIFF_FILE"
+git diff --name-only <upstream-remote>/<base-branch>...HEAD
+DIFF_LINES=$(wc -l < "$DIFF_FILE")
+```
+
+Every review agent prompt must include: the PR title/description
+(one paragraph), the changed-file list, and the path `$DIFF_FILE` —
+instructing the agent to read the diff from that file and only open
+source files it needs beyond the diff. Agents must NOT re-run
+`gh pr view` or regenerate the diff.
+
+## 1. Review
+
+Scale the review to the diff, and never spawn an agent for an
+unavailable external tool.
+
+### Availability pre-check (cheap, main context)
+
+```bash
+command -v codex >/dev/null && echo codex-ok
+command -v gemini >/dev/null && echo gemini-ok
+```
+
+Only run an external pass whose CLI exists. If neither exists,
+note "external passes skipped" in the summary and move on — do not
+spawn agents to discover this.
+
+### Size gate
+
+- **Small PR** (`DIFF_LINES` < 200 and ≤ 5 changed files): launch
+  ONE `pr-review-toolkit:code-reviewer` agent covering quality,
+  silent failures, and test gaps in a single pass. Skip the other
+  two toolkit agents.
+- **Otherwise**: launch all three toolkit agents **in parallel**
+  (single message, multiple tool calls):
+
+| agent | focus |
+|-------|-------|
+| `pr-review-toolkit:code-reviewer` | Code quality, style, project guidelines |
+| `pr-review-toolkit:silent-failure-hunter` | Silent failures, swallowed errors, bad fallbacks |
+| `pr-review-toolkit:pr-test-analyzer` | Test coverage gaps and missing edge cases |
+
+### External second opinions (only if the pre-check passed)
+
+Run these as **background Bash calls** (`run_in_background: true`)
+started in the same message as the toolkit agents — do NOT wrap
+them in general-purpose agents; a subagent context buys nothing
+over reading the command's stdout.
+
+**Codex** (if installed):
+
+```bash
+codex review --base <upstream-remote>/<base-branch> \
+  -c model='"gpt-5.3-codex"'
+```
+
+- Default reasoning effort (do not set `xhigh` — it multiplies
+  wall time for marginal gain on a PR-sized diff)
+- If `gpt-5.3-codex` fails with an auth error, retry once with
+  `gpt-5.2-codex`; if that also fails (auth/login), skip and note it
+- When reading the output, use only the findings — ignore
+  `[thinking]`/`[exec]` blocks and sandbox warnings
+
+**Gemini** (if installed):
+
+```bash
+{
+  echo "Review this diff for bugs, correctness, and quality. Report findings only, one per line, with file:line."
+  if [ -f CLAUDE.md ]; then
+    echo ""; echo "Project conventions:"; echo "---"
+    head -c 8000 CLAUDE.md
+    echo "---"
+  fi
+  echo ""; echo "Diff:"
+  cat "$DIFF_FILE"
+} | gemini -p - -m gemini-3-pro-preview --yolo
+```
+
+- If it exits with an auth error, skip and note it — do not retry
+  or attempt to re-authenticate
+
+While the background commands run, collect the toolkit agents'
+results; read the background outputs when they finish. If an
+external command hasn't finished by the time findings are merged
+and fixes are underway, check it once before committing — don't
+poll.
+
+### Merge findings
+
+Deduplicate across sources — keep the most specific description,
+note consensus. Rank by severity:
+
+- **P1** — blocks merge (correctness bugs, security issues)
+- **P2** — important (missing error handling, test gaps, logic flaws)
+- **P3** — nice to have (style, naming, minor simplifications)
+- **P4** — informational
+
+## 2. Fix findings
+
+Address all P1–P3 findings. For each: **fix it**, or **dismiss it**
+with inline reasoning (false positive, stylistic disagreement,
+impossible edge case). Adversarially verify a finding against the
+actual code before fixing — plausible findings often misread it.
+
+When a fix requires external context (unfamiliar library behavior,
+unrecognized error), search with Exa (`mcp__exa__web_search_exa`)
+rather than guessing.
+
+P4 findings: note, don't fix unless trivial.
+
+After fixing, read the diff of your own fixes and verify each is
+correct and doesn't regress the PR.
+
+## 3. Verify
+
+**If no fixes were applied (all findings dismissed or none found),
+skip this section entirely** — the PR's own CI already covers the
+unchanged branch. Note "no changes; verification delegated to CI"
+in the summary.
+
+### 3a. Resolve project checks (cheapest source first)
+
+1. **CLAUDE.md / Makefile first.** If the repo's CLAUDE.md or
+   Makefile names build/test commands (e.g. `make test`,
+   `make build`), use those. Stop here — do not read CI workflows.
+2. **Otherwise read the main CI workflow** (`.github/workflows/`
+   — typically `ci.yml`/`test.yml`) and extract the test, lint,
+   and codegen-sync commands (steps followed by
+   `git diff --exit-code`).
+3. **Otherwise fall back** by manifest: `Cargo.toml` →
+   `cargo build && cargo test && cargo clippy -- -D warnings &&
+   cargo fmt --check`; `pyproject.toml` → `pytest -q && ruff check
+   && ruff format --check && ty check`; `package.json` → project
+   build/test scripts + `tsc --noEmit`; `go.mod` →
+   `go build ./... && go test ./... && go vet ./...`.
+
+### 3b. Run the pipeline
+
+1. **Build**, 2. **Test** (iterate on failures until green),
+3. **Lint/format**. Run codegen-sync and docs-build checks only if
+the fixes touched generated sources or docs. Run supply-chain
+audits only if the fixes changed dependency manifests. If a tool
+is not installed, skip with a note.
+
+## 4. Commit and push
+
+- Commit fixes as a separate commit (don't squash — preserve
+  review history)
+- Subject: `fix: resolve code review findings for PR #$PR_NUMBER`;
+  body lists findings by severity, fixed vs dismissed (with brief
+  reasoning), and pipeline status
+- Push (regular push, not force-push)
+- Delete any now-resolved `todos/` files the review created
+
+## 5. PR comment
+
+Post a summary via `gh pr comment $PR_NUMBER --repo <owner/name>`:
+
+```
+## Review Summary
+
+### Findings
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | P1 | [description] | Fixed: [what was done] |
+| 2 | P2 | [description] | Dismissed: [reasoning] |
+
+### Verification
+
+- **Tests**: [pass/fail count, or "no fixes — delegated to CI"]
+- **Lint**: [clean/issues]
+
+### Commit
+
+[commit SHA and subject line, or "no changes pushed"]
+
+### Review coverage
+
+[which passes ran: toolkit agents (1 or 3), codex, gemini — and which were skipped and why]
+```

--- a/.claude/skills/debug-app/SKILL.md
+++ b/.claude/skills/debug-app/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: debug-app
+description: Debug a misbehaving Droidective build — where state and logs live, known failure signatures (Sparkle-replaced dev builds, leaked mirror sessions, corrupt stores), and how to reproduce in a test first.
+---
+
+# Debugging Droidective
+
+## Reproduce in ADBKit first
+
+Most bugs live below the UI. Feed the failing input (captured adb output, a
+real wire frame) to the pure parser or service through `MockProcessRunner`
+and turn the repro into a failing test — that's the fix's regression guard.
+Only debug at the UI when the logic layer checks out.
+
+## Where state lives
+
+- Stores: `~/Library/Application Support/Droidective/` — one JSON per
+  `JSONStore` (bundles, deep links, custom commands, layout, presets,
+  overrides, prefs). A corrupt file is set aside as `*.corrupt`, not
+  deleted — inspect it to see what broke.
+- Managed tools: `Application Support/Droidective/tools/` (jadx, apktool,
+  frida, Temurin JRE, the seeded jars).
+- What adb did: Settings ▸ Command Log shows every user-initiated call —
+  if an action's commands are missing there, its code path lacks
+  `CommandLog.userInitiated {}` (that's a bug too).
+
+## Live logs and processes
+
+```bash
+log stream --predicate 'process == "Droidective"' --style compact
+pgrep -fl 'adb|scrcpy|emulator'      # orphaned children after a crash/kill
+```
+
+Device side: the app's own Logcat feature, or `adb logcat` scoped to the
+target app. `DeviceMonitor` polls every 2s — device-list weirdness within
+that window is expected.
+
+## Known failure signatures
+
+- **Dev build behaves like an old release / EPERM re-copy build failures /
+  days-old binary mtimes / no `Droidective.debug.dylib` in `MacOS/`** →
+  Sparkle silently replaced the Debug bundle at its own path on quit. Guard
+  is `SparkleUpdater.updaterAllowed` (never starts in Debug) — if these
+  symptoms appear, that guard regressed. Delete the bundle and rebuild.
+  Debug string-probes go against the `.debug.dylib`, never the stub
+  executable.
+- **Runaway CPU** → leaked mirror sessions: a detached mirror view model
+  restarting itself. Check for multiple scrcpy-server children.
+- **UI freeze / starved async pool** → something blocked a cooperative
+  thread; `SystemProcessRunner` must use handlers, never `waitUntilExit`
+  (the 16-process canary test guards this).
+- **A parser "randomly" missing lines** → CRLF input split on `"\n"`.
+  `"\r\n"` is one Character; use `.newlines`.
+- **A pane's tab drops dead while some feature tab is open** → a
+  feature-wide `.onDrop` intercepting by geometry; drags also die silently
+  when a UTI isn't declared in `UTExportedTypeDeclarations`.
+- **View doesn't reload after a device authorizes** → `.task(id:)` keyed on
+  serial only; the key must include readiness (`targetSerials.first`).
+
+## Debug-build gotchas
+
+- Quit the app before `defaults write` against its domain — it rewrites
+  prefs on exit over yours.
+- `make build` can skip relinking — check the binary timestamp before
+  concluding "my change did nothing".
+- Native notifications may be silently denied for ad-hoc-signed debug
+  builds; verify notification behavior on release builds only.
+
+## Verifying the fix live
+
+Use the `verify` skill — windowed screenshots and AX driving without
+stealing the user's screen.

--- a/.claude/skills/rebase-cross-platform/SKILL.md
+++ b/.claude/skills/rebase-cross-platform/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rebase-cross-platform
+description: Rebase the Windows/Linux port branch (feat/cross-platform-core) onto latest main, resolve the port's known conflict spots, audit main's new ADBKit code for portability traps, then re-verify the gates (macOS suite, make test-linux). Use when asked to rebase/sync the cross-platform branch with main, or after main lands features the port branch needs.
+---
+
+# Rebasing feat/cross-platform-core onto main
+
+The port branch carries compile-gates and portable seams on top of main.
+Rebasing = replay those onto main's latest, then prove the gates still hold.
+Work in the branch's own worktree; never bare `git stash` (the stash stack is
+shared across worktrees).
+
+## 1. Sync and rebase
+
+```
+git fetch origin
+git merge-base HEAD origin/main   # note it — the audit range below
+git rebase origin/main
+```
+
+## 2. Resolve conflicts with the port's intent in mind
+
+- **CLAUDE.md** — keep the port branch's Architecture note, `make test-linux`
+  line, and test counts; fold in main's new Status items.
+- **ADBKit/Package.swift** — keep the swift-crypto dependency and its
+  platform conditions; fold in anything main added.
+- **Gated files** (`Services/Mirror/*`, `ReactotronServer`/`Service`,
+  `ScreenRecorder`, the JSConsole/Mirror/Reactotron wire tests) — keep the
+  `#if canImport` gates wrapping whatever main changed inside them.
+- **Seam files** (`ToolLocator`, `ManagedToolStore`, `SystemProcessRunner`,
+  `JSONStore`, `LogcatStream`, `SimulatorLogStream`, `CustomCommandService`,
+  `SimctlClient`) — keep both: main's logic inside the port's per-OS
+  structure.
+
+## 3. Audit what main landed since the old base
+
+New main code arrives ungated. Sweep the range for the known traps:
+
+```
+git log --stat <old-base>..origin/main -- ADBKit
+rg -n "^import (Network|CoreMedia|AVFoundation|VideoToolbox|CryptoKit|Darwin|os)$" ADBKit/Sources
+```
+
+- A new Apple-only import outside the gated subsystems → gate the file (or
+  route through the existing seam; the per-subsystem table is in
+  `docs/cross-platform.md`).
+- `NSDataDetector`, `FileHandle.bytes`/`.lines`, `FileManager.replaceItemAt`,
+  `OSAllocatedUnfairLock`, raw `posix_spawn` → each has a portable pattern
+  already (`ConsoleLinkDetector` gate, `FileHandleLines`, `JSONStore.save`,
+  `NetworkTrafficMeter`, `EmulatorService.spawnDetached`) — copy it.
+- `URLSession` in a new file → add the `#if canImport(FoundationNetworking)`
+  import block.
+- Hardcoded `/usr/bin/...`, `/bin/zsh` → `HostArchive`,
+  `ToolLocator.loginShell(environment:)`, `CustomCommandService.fallbackShell`.
+- New tests that stat the real filesystem or assume host facts
+  (`/usr/bin/xcrun` exists, zsh is the shell) → use the injectable
+  `isExecutableFile` seams (`SimctlClient`, `ToolLocator`,
+  `FeatureEngine(simctl:)`) and the platform constants.
+- corelibs gotcha to remember: `readabilityHandler` never delivers its empty
+  EOF callback when the final data and the writer's close coincide — never
+  rely on it for EOF off-Darwin (use `FileHandleLines` / the PipeCollector
+  thread pattern).
+
+## 4. Verify the gates, in order
+
+```
+cd ADBKit && swift test                                    # macOS, full suite
+swift build --build-tests -Xswiftc -warnings-as-errors     # zero warnings
+make test-linux           # the port gate (container system start once per boot)
+make build                # the App still builds
+```
+
+## 5. Push
+
+Only ever this branch's own remote, and only with lease:
+
+```
+git push --force-with-lease origin feat/cross-platform-core
+```

--- a/.claude/skills/review-changes/SKILL.md
+++ b/.claude/skills/review-changes/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: review-changes
+description: Review a Droidective diff (working tree, branch, or PR) with the project's review order and its known red flags — ADBKit/App boundary, shellQuote, CRLF splitting, task readiness, CommandLog, translucency tokens.
+---
+
+# Reviewing Droidective changes
+
+Sync first (`git fetch origin`), then review the diff in this order. Stop at
+the first tier with real findings before polishing lower tiers.
+
+## 1. Architecture
+
+- Logic stays in ADBKit, UI in App. Any `Process`, `adb`, or parsing inside a
+  SwiftUI view is a finding — it belongs in an ADBKit service with a pure
+  static parser.
+- No new Apple-only framework imports in ADBKit (Network, CoreMedia,
+  AVFoundation, VideoToolbox, CryptoKit, os, Darwin) outside the already
+  Apple-bound subsystems; a genuinely needed one goes in its own small file.
+  No new `/usr/bin/...` or `/bin/zsh` literals, no corelibs-Foundation traps
+  (`NSDataDetector`, `FileHandle.bytes`, `FileManager.replaceItemAt`,
+  `OSAllocatedUnfairLock`, raw `posix_spawn`, `readabilityHandler` as EOF).
+- Existing seams (`ProcessRunning`, injected directories) intact.
+
+## 2. Correctness — the project's recurring bugs
+
+- **Every user-controlled value reaching `adb shell` is `shellQuote()`d.**
+  Path, URL, SSID, hostname, proxy, locale, free text — no exceptions.
+  Caller-side validation is UX, not the security boundary. `push`/`pull`/
+  `exec-out` are sync-protocol (no shell, no quoting).
+- Output split with `.components(separatedBy: .newlines)`, never `"\n"` —
+  `"\r\n"` is ONE Swift Character and CRLF input silently breaks.
+- `.task(id:)` keys include device readiness (`targetSerials.first`), not
+  just serial; `!Task.isCancelled` guarded before writing fetched results
+  into `@State`; long-running adb work in a cancellable `Task`.
+- Failure paths handled — non-zero exit, empty output, partial output — not
+  optimistic success.
+- View features that run adb directly wrap user actions in
+  `CommandLog.userInitiated {}` (background polling stays out).
+- New UI fills with `.bgRoot`/`.bgSurface` or the translucency modifiers —
+  a raw asset Color, `Color.black`, or default `List`/`Form` material blocks
+  the window glass and only shows up by eye at <100% opacity.
+- Feature-id contract: a new feature followed the CLAUDE.md checklist — the
+  silent failure modes (missing `detailByKind` case → "Coming Soon"; missing
+  hub absorption; missing `userInitiated`) have no automated guard.
+- No feature-wide `.onDrop` (it silently kills tab drops); new drag UTIs
+  declared in `UTExportedTypeDeclarations`.
+
+## 3. Tests
+
+- Parser + arg-vector tests present *and meaningful* — would they fail if
+  the code broke? User input hitting `adb shell` has a test asserting the
+  `shellQuote`d form in `runner.invocations`.
+- Edges covered: empty input, CRLF, malformed/partial output, non-zero exit.
+- A new cross-feature rule got a registry-invariant loop test (the
+  `everyFeature*` pattern), not review folklore.
+- Behavior, not implementation: a behavior-preserving refactor must not
+  break them.
+
+## 4. Quality
+
+- Dead code deleted in the same change (replace, don't deprecate), files
+  stay focused (no new weight on `AppState` or the biggest views), names
+  clear, zero warnings (`swift test -Xswiftc -warnings-as-errors`).
+
+## Verify findings before reporting
+
+Adversarially check each finding against the actual code — plausible
+findings often misread it (a "dead code" removal can delete a live path).
+Report file:line, concrete failure scenario, and a recommended fix.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: testing
+description: Run and write Droidective's ADBKit tests — targeted filters, warnings-as-errors, and the project's standard test kinds (parser, adb arg-vector, registry invariant, canary).
+---
+
+# Testing Droidective
+
+## Running
+
+```bash
+make test                                    # full ADBKit suite (no Xcode, no device)
+cd ADBKit && swift test --filter LogcatParserTests   # one suite while iterating
+cd ADBKit && swift test -Xswiftc -warnings-as-errors # what CI actually runs
+```
+
+Keep the full suite green before pushing; warnings are build errors in CI.
+Device-dependent tests are gated `@Test(.enabled(if:))` on
+`MIRROR_LIVE_TEST=1` and skip cleanly otherwise — don't unskip them in CI
+paths.
+
+## Writing — the four standard kinds
+
+**Parser test.** Every parser is `static func parseX(_:) -> …`, no I/O —
+test it directly with captured output. Always include a CRLF case
+(`"\r\n"` is one Swift Character; splitting on `"\n"` silently breaks) and
+an empty/malformed/partial-output case.
+
+**Arg-vector test.** Services run through `MockProcessRunner`; assert the
+exact adb argument vector in `runner.invocations`. For anything carrying
+user input into `adb shell`, assert the `shellQuote`d form appears —
+a missing quote is command injection (`OverridesServiceTests` is the
+pattern). New action features also add their dispatch case to
+`FeatureEngine.implementedIDs` — `everyImplementedActionResolvesToARunner`
+and `implementedIDsAreAllRealFeatures` catch omissions and typos.
+Cross-platform ids get a `dispatchIOS` case +
+`everyIOSCapableActionResolvesToASimctlRunner` coverage.
+
+**Registry invariant.** A rule that spans features is a loop over
+`FeatureRegistry.all` (the `everyFeature*` /
+`hubsStaySearchableByTheirMembersPrimaryKeyword` pattern), not review
+folklore. Adding a feature bumps `hasAll58Features`.
+
+**Behavioral edge test.** Mock only the boundary (`ProcessRunning`,
+temp-dir filesystems) — never logic. Trigger every handled error path:
+non-zero exit, missing tool, cancelled task.
+
+## Don't regress the guards
+
+- The **16-concurrent-process starvation canary** — process running must
+  never block a cooperative thread.
+- Mock-driven tests must not stat the real filesystem or assume host facts
+  (`/usr/bin/xcrun` exists) — the suite also runs on Linux CI on the port
+  branch.
+- App-layer note: the AppTests logic bundle compiles `Theme.swift`
+  standalone (and links ADBKit for it) — keep that file self-contained.
+
+## Prove a test works
+
+Break the code, confirm the test fails, restore. A test that can't fail is
+documentation, not a test.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: verify
+description: Build, launch, and drive Droidective to verify a change at the real UI. Covers the AX-automation recipe (windowed screenshots, menu/button driving) and its gotchas.
+---
+
+# Verifying Droidective changes live
+
+## Build & launch
+
+```bash
+make build          # xcodegen + xcodebuild; zero warnings required
+pkill -x Droidective; open DerivedData/Build/Products/Debug/Droidective.app
+```
+
+## Screenshot without stealing the user's screen
+
+The user usually works on the Mac alongside you — full-screen `screencapture -x`
+grabs *their* frontmost app. Capture the app window by ID instead:
+
+```bash
+WID=$(swift -e 'import CoreGraphics; let l = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as! [[String: Any]]; for w in l { if (w["kCGWindowOwnerName"] as? String) == "Droidective", (w["kCGWindowLayer"] as? Int) == 0 { print(w["kCGWindowNumber"] as! Int) } }' | head -1)
+screencapture -x -o -l "$WID" out.png
+```
+
+Window IDs go stale after windows close/reopen — refetch on "could not create
+image from window".
+
+## Driving the UI (System Events AX)
+
+- The main window is `window "<current feature title>"` (title follows the open
+  feature — list `name of every window` first). Content lives under `group 1`.
+- SwiftUI `Menu` pills: `click devMenu` then `delay 0.8` then
+  `click menu item "…" of menu 1 of devMenu` in ONE osascript run. Split runs
+  leave the menu stuck open and later clicks land wrong.
+- Sheets: `sheet 1 of window …`, content under `group 1`. SwiftUI buttons here
+  often have NO AX title — address by index; check candidates with
+  `enabled of button N` first.
+- `perform action "AXPress"` works on buttons and works in the background (no
+  frontmost needed).
+- **AX `set value` on a SwiftUI TextField updates the display but NOT the
+  binding** — buttons gated on that state stay disabled and presses no-op.
+  `AXConfirm` doesn't help. Real keystrokes are the only way, which needs
+  focus the user may be using; prefer flows that need no typing, or ask the
+  user to type/test that step.
+- Read ground truth over guessing from pixels: `value of text field 1`,
+  `enabled of button 1`.
+- To prove a button action actually ran, watch for the spawned process:
+  `pgrep -fl "adb connect"` in a background loop around the press.
+
+## Handy real-device stand-ins
+
+- A running emulator counts as a non-wireless ready Android device.
+- `adb connect 127.0.0.1:9` → instant "failed to connect … Connection refused"
+  (exit 0!) — good error-path input.
+- After `adb tcpip 5555` on an emulator it re-registers by itself;
+  `adb connect 127.0.0.1:5555` adds a second (wireless) transport —
+  `adb disconnect 127.0.0.1:5555` cleans up.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ sparkle-private-key.txt
 AuthKey_*.p8
 .claude/*
 !.claude/commands/
+!.claude/skills/
 node_modules/
 website/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ sparkle-private-key.txt
 .env.signing
 *.p12
 AuthKey_*.p8
-.claude/
+.claude/*
+!.claude/commands/
 node_modules/
 website/dist/


### PR DESCRIPTION
## Summary

Ships the Claude Code commands and skills with the repo — anyone who opens the project with Claude Code gets them, instead of them living in one user's home directory.

### Commands (`.claude/commands/`)

- **/review-pr** — reviews an existing PR with parallel agents, fixes the findings, verifies, and pushes. Tuned for cost: external review CLIs (codex/gemini) are availability-checked before anything spawns and run as background shell calls instead of wrapper agents, the diff is generated once and shared with all agents, small PRs (<200 lines) get one reviewer agent instead of three, and the verify pipeline is skipped when no fixes were applied.
- **/fix-issue** — takes a GitHub issue end to end: research, plan, branch, implement with tests, quality pipeline, self-review, PR, and a summary comment on the issue.

### Project skills (`.claude/skills/`)

- **review-changes** — the project review order (architecture → correctness → tests → quality) plus its recurring red flags: ADBKit/App boundary, `shellQuote`, CRLF splitting, `.task(id:)` readiness, `CommandLog.userInitiated`, translucency tokens.
- **testing** — running the suite and the four standard test kinds: parser (with CRLF cases), adb arg-vector via `MockProcessRunner`, registry invariant loops, behavioral edges; the guards not to regress.
- **debug-app** — where state and logs live, known failure signatures (Sparkle-replaced dev builds, leaked mirror sessions, corrupt stores, CRLF parsers), reproduce-in-a-test-first workflow.
- **verify** — build, launch, and AX-drive the app for live verification without stealing the user's screen (previously local-only).
- **rebase-cross-platform** — sync `feat/cross-platform-core` with main: known conflict spots, portability-trap audit, gate order (previously local-only).

`.gitignore` changes from ignoring `.claude/` wholesale to `.claude/*` with `!.claude/commands/` and `!.claude/skills/`, so local worktrees and settings stay untracked.

## Test plan

- No app code touched; `.claude/` content is inert outside Claude Code sessions
- Verified `git status` tracks only `commands/` and `skills/` under `.claude/` (worktrees/ remains ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)