### PR TITLE
Fix mirror video not re-fitting the pane on split resize

### DIFF
--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
@@ -72,7 +72,26 @@ final class MirrorLayerNSView: NSView {
 
     override func layout() {
         super.layout()
+        syncDisplayLayerFrame()
+    }
+
+    /// `layout()` alone misses direct frame changes (a SwiftUI split-divider
+    /// drag resizes the view without a constraint pass), leaving the layer at
+    /// its old size — video letterboxed against a stale width and drawn past
+    /// the pane. Track every size change explicitly.
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        syncDisplayLayerFrame()
+    }
+
+    private func syncDisplayLayerFrame() {
+        guard displayLayer.frame != bounds else { return }
+        // Sublayer frame changes are implicitly animated — a 0.25s lag per
+        // divider tick reads as the video chasing the drag. Snap instead.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         displayLayer.frame = bounds
+        CATransaction.commit()
     }
 
     // MARK: - Mouse → touch


### PR DESCRIPTION
## Summary

Resizing a split with Mirror Screen open left the video at its old size: black space on one side of the pane and the device screen drawn past the window edge (screenshot in the report).

`MirrorLayerNSView` synced the `AVSampleBufferDisplayLayer` to its bounds only in `layout()`. AppKit runs that on the initial layout pass, but a SwiftUI split-divider drag resizes the view by setting its frame directly — no constraint pass, no `layout()` — so the layer kept the stale frame, and since sublayers don't clip, the aspect-fit video rendered centered in the old width and overflowed the pane.

The fix overrides `setFrameSize` to re-sync the layer frame, wrapped in a `CATransaction` with actions disabled so the video snaps to each divider tick instead of lagging behind it through implicit animations. Covers the in-pane mirror and the pop-out window (same NSView).

## Test plan

- `make build` clean (zero warnings)
- No ADBKit change — this is App-layer AppKit plumbing with no automatable hook; manual check: open Mirror Screen in a split, drag the divider both ways, confirm the video re-letterboxes to the pane at every width and never draws past it

🤖 Generated with [Claude Code](https://claude.com/claude-code)