### PR TITLE
Recurring GitHub-star nudge

### DIFF
--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -24,9 +24,19 @@ struct RootView: View {
     @AppStorage("hasSeenTour") private var hasSeenTour = false
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("launchCount") private var launchCount = 0
-    @AppStorage("starPromptShown") private var starPromptShown = false
+    /// GitHub-star nudge state. `starPromptResolved` ends it for good (the user
+    /// starred); `starPromptSnoozeCount` counts "Maybe Later" taps; and
+    /// `starPromptNextLaunch` is the launch milestone the next ask is due at.
+    /// The pre-3.6 one-time `starPromptShown` flag is intentionally *not* read,
+    /// so users who only ever dismissed the old prompt are re-engaged.
+    @AppStorage("starPromptResolved") private var starPromptResolved = false
+    @AppStorage("starPromptSnoozeCount") private var starPromptSnoozeCount = 0
+    @AppStorage("starPromptNextLaunch") private var starPromptNextLaunch = 10
     @AppStorage("theme") private var theme = "dark"
     @State private var presentStar = false
+    /// Set by the "Star on GitHub" button so the sheet's `onDismiss` records a
+    /// resolve; any other dismissal (Maybe Later, Esc) counts as a snooze.
+    @State private var starStarred = false
     /// True only while the *first-run* role picker is up, so its dismissal
     /// chains into the welcome tour. Changing role later (pill / Settings)
     /// leaves this false, so the tour never reappears.
@@ -40,8 +50,11 @@ struct RootView: View {
     @AppStorage(windowOpacityDefaultsKey) private var windowOpacity = 1.0
     @AppStorage(windowBlurDefaultsKey) private var windowBlur = 0.6
 
-    /// Launches before the one-time GitHub-star nudge.
-    private let starPromptAfterLaunches = 10
+    /// GitHub-star nudge cadence: first ask at 10 launches, then every 10 more
+    /// launches each time the user taps "Maybe Later", up to 5 asks total.
+    private let starPromptFirstLaunch = 10
+    private let starPromptReAskGap = 10
+    private let starPromptMaxAsks = 5
 
     /// Theme color-sync needs two modifiers because they reach different layers,
     /// and neither alone is enough:
@@ -87,11 +100,6 @@ struct RootView: View {
         }
     }
 
-    private var shouldPromptStar: Bool {
-        LaunchPrompt.starDue(
-            starPromptShown: starPromptShown, launchCount: launchCount, afterLaunches: starPromptAfterLaunches)
-    }
-
     var body: some View {
         @Bindable var state = state
         // Read pendingExit here so body re-renders when a navigation is deferred
@@ -135,8 +143,11 @@ struct RootView: View {
             .background {
                 // Its own host view so the star sheet reliably presents (two
                 // .sheet modifiers on one view can drop one).
-                Color.clear.sheet(isPresented: $presentStar) {
-                    StarPromptView(onStar: { state.openRepository() })
+                Color.clear.sheet(isPresented: $presentStar, onDismiss: starPromptDismissed) {
+                    StarPromptView(onStar: {
+                        starStarred = true
+                        state.openRepository()
+                    })
                 }
             }
             #if !APPSTORE
@@ -241,8 +252,9 @@ struct RootView: View {
         installFocusRelease()
         switch LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
-            starPromptShown: starPromptShown,
-            launchCount: launchCount, starAfterLaunches: starPromptAfterLaunches
+            starResolved: starPromptResolved, launchCount: launchCount,
+            snoozeCount: starPromptSnoozeCount, nextLaunch: starPromptNextLaunch,
+            maxAsks: starPromptMaxAsks
         ) {
         case .rolePicker:
             // Brand-new user: pick a role first, then run the tour.
@@ -255,6 +267,20 @@ struct RootView: View {
         case nil:
             break
         }
+    }
+
+    /// Records the outcome of the star nudge. "Star on GitHub" resolves it for
+    /// good; anything else (Maybe Later, or dismissing with Esc) is a snooze
+    /// that schedules the next ask `starPromptReAskGap` launches out — the
+    /// `starDue` cap stops it after `starPromptMaxAsks` asks.
+    private func starPromptDismissed() {
+        if starStarred {
+            starPromptResolved = true
+        } else {
+            starPromptSnoozeCount += 1
+            starPromptNextLaunch = launchCount + starPromptReAskGap
+        }
+        starStarred = false
     }
 
     /// The main window's frame-autosave name — the value must stay

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -25,18 +25,18 @@ struct RootView: View {
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @AppStorage("launchCount") private var launchCount = 0
     /// GitHub-star nudge state. `starPromptResolved` ends it for good (the user
-    /// starred); `starPromptSnoozeCount` counts "Maybe Later" taps; and
-    /// `starPromptNextLaunch` is the launch milestone the next ask is due at.
+    /// starred); `starPromptAskCount` counts asks shown; and
+    /// `starPromptNextLaunch` is the launch milestone the next ask is due at
+    /// (its default is the first-ask milestone). Both advance when the sheet is
+    /// *presented* — recording on dismiss would lose the ask to a quit or
+    /// window close with the sheet open and replay it every launch.
     /// The pre-3.6 one-time `starPromptShown` flag is intentionally *not* read,
     /// so users who only ever dismissed the old prompt are re-engaged.
     @AppStorage("starPromptResolved") private var starPromptResolved = false
-    @AppStorage("starPromptSnoozeCount") private var starPromptSnoozeCount = 0
+    @AppStorage("starPromptAskCount") private var starPromptAskCount = 0
     @AppStorage("starPromptNextLaunch") private var starPromptNextLaunch = 10
     @AppStorage("theme") private var theme = "dark"
     @State private var presentStar = false
-    /// Set by the "Star on GitHub" button so the sheet's `onDismiss` records a
-    /// resolve; any other dismissal (Maybe Later, Esc) counts as a snooze.
-    @State private var starStarred = false
     /// True only while the *first-run* role picker is up, so its dismissal
     /// chains into the welcome tour. Changing role later (pill / Settings)
     /// leaves this false, so the tour never reappears.
@@ -50,9 +50,9 @@ struct RootView: View {
     @AppStorage(windowOpacityDefaultsKey) private var windowOpacity = 1.0
     @AppStorage(windowBlurDefaultsKey) private var windowBlur = 0.6
 
-    /// GitHub-star nudge cadence: first ask at 10 launches, then every 10 more
-    /// launches each time the user taps "Maybe Later", up to 5 asks total.
-    private let starPromptFirstLaunch = 10
+    /// GitHub-star nudge cadence: every `starPromptReAskGap` launches after
+    /// each ask (the first-ask milestone is `starPromptNextLaunch`'s default),
+    /// up to `starPromptMaxAsks` asks total.
     private let starPromptReAskGap = 10
     private let starPromptMaxAsks = 5
 
@@ -143,9 +143,9 @@ struct RootView: View {
             .background {
                 // Its own host view so the star sheet reliably presents (two
                 // .sheet modifiers on one view can drop one).
-                Color.clear.sheet(isPresented: $presentStar, onDismiss: starPromptDismissed) {
+                Color.clear.sheet(isPresented: $presentStar) {
                     StarPromptView(onStar: {
-                        starStarred = true
+                        starPromptResolved = true
                         state.openRepository()
                     })
                 }
@@ -253,7 +253,7 @@ struct RootView: View {
         switch LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
             starResolved: starPromptResolved, launchCount: launchCount,
-            snoozeCount: starPromptSnoozeCount, nextLaunch: starPromptNextLaunch,
+            askCount: starPromptAskCount, nextLaunch: starPromptNextLaunch,
             maxAsks: starPromptMaxAsks
         ) {
         case .rolePicker:
@@ -263,24 +263,17 @@ struct RootView: View {
         case .tour:
             state.presentTour = true
         case .star:
+            // Record the ask now, at presentation — dismissal isn't guaranteed
+            // (a quit or window close with the sheet open skips onDismiss), and
+            // an unrecorded ask would re-fire every launch with the cap never
+            // advancing. "Star on GitHub" resolves it for good in the sheet.
+            starPromptAskCount += 1
+            starPromptNextLaunch = LaunchPrompt.nextAskLaunch(
+                launchCount: launchCount, reAskGap: starPromptReAskGap)
             presentStar = true
         case nil:
             break
         }
-    }
-
-    /// Records the outcome of the star nudge. "Star on GitHub" resolves it for
-    /// good; anything else (Maybe Later, or dismissing with Esc) is a snooze
-    /// that schedules the next ask `starPromptReAskGap` launches out — the
-    /// `starDue` cap stops it after `starPromptMaxAsks` asks.
-    private func starPromptDismissed() {
-        if starStarred {
-            starPromptResolved = true
-        } else {
-            starPromptSnoozeCount += 1
-            starPromptNextLaunch = launchCount + starPromptReAskGap
-        }
-        starStarred = false
     }
 
     /// The main window's frame-autosave name — the value must stay

--- a/App/Sources/Root/StarPromptView.swift
+++ b/App/Sources/Root/StarPromptView.swift
@@ -11,24 +11,29 @@ struct StarPromptView: View {
     let onStar: () -> Void
 
     var body: some View {
-        VStack(spacing: 18) {
+        VStack(spacing: 16) {
             Image(systemName: "star.fill")
-                .font(.app(size: 34, weight: .semibold))
+                .font(.app(size: 20, weight: .semibold))
                 .foregroundStyle(.brandAccent)
-                .frame(width: 64, height: 64)
-                .background(Color.brandAccent.opacity(0.12), in: RoundedRectangle(cornerRadius: 16))
+                .frame(width: 40, height: 40)
+                .background(Color.brandAccent.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
 
-            VStack(spacing: 7) {
+            VStack(spacing: 6) {
                 Text("Enjoying the app?")
-                    .font(.app(.title2).bold())
-                Text("If the project's useful to you, consider giving it a star on GitHub. It takes a moment and genuinely helps others find it.")
-                    .font(.app(.callout))
+                    .font(.app(.title3).bold())
+                Text("If the project's useful to you, a star on GitHub helps others find it.")
+                    .font(.app(.footnote))
                     .foregroundStyle(.textMuted)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                Button("Maybe Later") { dismiss() }
+                    .buttonStyle(.bordered)
+                    .tint(.secondary)
+                    .frame(maxWidth: .infinity)
+
                 Button {
                     onStar()
                     dismiss()
@@ -36,17 +41,13 @@ struct StarPromptView: View {
                     Label("Star on GitHub", systemImage: "star.fill")
                         .frame(maxWidth: .infinity)
                 }
-                .controlSize(.large)
+                .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
                 .tint(.brandAccent)
-
-                Button("Maybe Later") { dismiss() }
-                    .buttonStyle(.plain)
-                    .font(.app(.callout))
-                    .foregroundStyle(.textMuted)
             }
+            .controlSize(.large)
         }
-        .padding(28)
+        .padding(24)
         .frame(width: 380)
         .background(.bgRoot)
     }

--- a/App/Sources/Root/StarPromptView.swift
+++ b/App/Sources/Root/StarPromptView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Recurring nudge to star the project on GitHub, shown every few launches
-/// until the user stars or the ask cap is hit (cadence + outcome handled in
-/// RootView). The view is presentation-only: it opens the repo via `onStar`
-/// and dismisses; RootView's `onDismiss` records the outcome.
+/// until the user stars or the ask cap is hit (cadence handled in RootView,
+/// which records each ask when it presents the sheet). The view is
+/// presentation-only: it reports a star via `onStar` and dismisses.
 struct StarPromptView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -29,10 +29,14 @@ struct StarPromptView: View {
             }
 
             HStack(spacing: 10) {
-                Button("Maybe Later") { dismiss() }
-                    .buttonStyle(.bordered)
-                    .tint(.secondary)
-                    .frame(maxWidth: .infinity)
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Maybe Later")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(.secondary)
 
                 Button {
                     onStar()

--- a/App/Sources/Root/StarPromptView.swift
+++ b/App/Sources/Root/StarPromptView.swift
@@ -1,12 +1,11 @@
 import SwiftUI
 
-/// One-time nudge to star the project on GitHub, shown once the app has been
-/// launched several times (gated in RootView, after the privacy consent). Marks
-/// itself shown the moment it appears, so it never nags twice — whatever the
-/// user does with it.
+/// Recurring nudge to star the project on GitHub, shown every few launches
+/// until the user stars or the ask cap is hit (cadence + outcome handled in
+/// RootView). The view is presentation-only: it opens the repo via `onStar`
+/// and dismisses; RootView's `onDismiss` records the outcome.
 struct StarPromptView: View {
     @Environment(\.dismiss) private var dismiss
-    @AppStorage("starPromptShown") private var starPromptShown = false
 
     /// Opens the GitHub repository (routed through AppState so views stay thin).
     let onStar: () -> Void
@@ -20,9 +19,9 @@ struct StarPromptView: View {
                 .background(Color.brandAccent.opacity(0.12), in: RoundedRectangle(cornerRadius: 16))
 
             VStack(spacing: 7) {
-                Text("Enjoying Droidective?")
+                Text("Enjoying the app?")
                     .font(.app(.title2).bold())
-                Text("A star on GitHub helps other Android and React Native developers find it. It takes a moment and genuinely helps.")
+                Text("If the project's useful to you, consider giving it a star on GitHub. It takes a moment and genuinely helps others find it.")
                     .font(.app(.callout))
                     .foregroundStyle(.textMuted)
                     .multilineTextAlignment(.center)
@@ -50,6 +49,5 @@ struct StarPromptView: View {
         .padding(28)
         .frame(width: 380)
         .background(.bgRoot)
-        .onAppear { starPromptShown = true }
     }
 }

--- a/App/Sources/State/LaunchPrompt.swift
+++ b/App/Sources/State/LaunchPrompt.swift
@@ -19,7 +19,7 @@ enum LaunchPrompt: Equatable {
         hasSeenTour: Bool,
         starResolved: Bool,
         launchCount: Int,
-        snoozeCount: Int,
+        askCount: Int,
         nextLaunch: Int,
         maxAsks: Int
     ) -> LaunchPrompt? {
@@ -27,7 +27,7 @@ enum LaunchPrompt: Equatable {
         if !hasSeenTour { return .tour }
         if starDue(
             resolved: starResolved, launchCount: launchCount,
-            snoozeCount: snoozeCount, nextLaunch: nextLaunch, maxAsks: maxAsks
+            askCount: askCount, nextLaunch: nextLaunch, maxAsks: maxAsks
         ) {
             return .star
         }
@@ -35,12 +35,20 @@ enum LaunchPrompt: Equatable {
     }
 
     /// Whether the recurring GitHub-star nudge is due. It stops for good once
-    /// the user stars (`resolved`) and only re-appears every `nextLaunch`
-    /// milestone up to `maxAsks` times — each "Maybe Later" pushes `nextLaunch`
-    /// out and bumps `snoozeCount`.
+    /// the user stars (`resolved`) or after `maxAsks` asks, and otherwise waits
+    /// for the `nextLaunch` milestone. Each ask is recorded at *presentation*
+    /// (bump `askCount`, push `nextLaunch` out via `nextAskLaunch`), so a quit
+    /// with the sheet still open can't replay the ask every launch.
     static func starDue(
-        resolved: Bool, launchCount: Int, snoozeCount: Int, nextLaunch: Int, maxAsks: Int
+        resolved: Bool, launchCount: Int, askCount: Int, nextLaunch: Int, maxAsks: Int
     ) -> Bool {
-        !resolved && snoozeCount < maxAsks && launchCount >= nextLaunch
+        !resolved && askCount < maxAsks && launchCount >= nextLaunch
+    }
+
+    /// The milestone the next ask is due at, anchored to the *current* launch —
+    /// not the old milestone — so a re-engaged user with an ancient `nextLaunch`
+    /// waits a full gap instead of burning through every stale milestone.
+    static func nextAskLaunch(launchCount: Int, reAskGap: Int) -> Int {
+        launchCount + reAskGap
     }
 }

--- a/App/Sources/State/LaunchPrompt.swift
+++ b/App/Sources/State/LaunchPrompt.swift
@@ -17,20 +17,30 @@ enum LaunchPrompt: Equatable {
     static func next(
         hasChosenRole: Bool,
         hasSeenTour: Bool,
-        starPromptShown: Bool,
+        starResolved: Bool,
         launchCount: Int,
-        starAfterLaunches: Int
+        snoozeCount: Int,
+        nextLaunch: Int,
+        maxAsks: Int
     ) -> LaunchPrompt? {
         if !hasChosenRole && !hasSeenTour { return .rolePicker }
         if !hasSeenTour { return .tour }
-        if starDue(starPromptShown: starPromptShown, launchCount: launchCount, afterLaunches: starAfterLaunches) {
+        if starDue(
+            resolved: starResolved, launchCount: launchCount,
+            snoozeCount: snoozeCount, nextLaunch: nextLaunch, maxAsks: maxAsks
+        ) {
             return .star
         }
         return nil
     }
 
-    /// Whether the one-time GitHub-star nudge is due.
-    static func starDue(starPromptShown: Bool, launchCount: Int, afterLaunches: Int) -> Bool {
-        !starPromptShown && launchCount >= afterLaunches
+    /// Whether the recurring GitHub-star nudge is due. It stops for good once
+    /// the user stars (`resolved`) and only re-appears every `nextLaunch`
+    /// milestone up to `maxAsks` times — each "Maybe Later" pushes `nextLaunch`
+    /// out and bumps `snoozeCount`.
+    static func starDue(
+        resolved: Bool, launchCount: Int, snoozeCount: Int, nextLaunch: Int, maxAsks: Int
+    ) -> Bool {
+        !resolved && snoozeCount < maxAsks && launchCount >= nextLaunch
     }
 }

--- a/App/Tests/LaunchPromptTests.swift
+++ b/App/Tests/LaunchPromptTests.swift
@@ -7,13 +7,14 @@ import Testing
     /// only the inputs it cares about. Thresholds mirror RootView's.
     private func next(
         hasChosenRole: Bool = true, hasSeenTour: Bool = true,
-        starPromptShown: Bool = true,
-        launchCount: Int = 0, starAfterLaunches: Int = 10
+        starResolved: Bool = true,
+        launchCount: Int = 0, snoozeCount: Int = 0,
+        nextLaunch: Int = 10, maxAsks: Int = 5
     ) -> LaunchPrompt? {
         LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
-            starPromptShown: starPromptShown,
-            launchCount: launchCount, starAfterLaunches: starAfterLaunches)
+            starResolved: starResolved, launchCount: launchCount,
+            snoozeCount: snoozeCount, nextLaunch: nextLaunch, maxAsks: maxAsks)
     }
 
     @Test func brandNewUserGetsRolePicker() {
@@ -25,12 +26,29 @@ import Testing
     }
 
     @Test func tourTakesPriorityOverDueStar() {
-        #expect(next(hasSeenTour: false, starPromptShown: false, launchCount: 50) == .tour)
+        #expect(next(hasSeenTour: false, starResolved: false, launchCount: 50) == .tour)
     }
 
     @Test func starNudgeShownOnlyAtItsThreshold() {
-        #expect(next(starPromptShown: false, launchCount: 9) == nil)
-        #expect(next(starPromptShown: false, launchCount: 10) == .star)
+        #expect(next(starResolved: false, launchCount: 9) == nil)
+        #expect(next(starResolved: false, launchCount: 10) == .star)
+    }
+
+    /// A "Maybe Later" tap pushes `nextLaunch` out, so the nudge waits until the
+    /// next milestone instead of reappearing every launch.
+    @Test func starReschedulesAfterSnooze() {
+        #expect(next(starResolved: false, launchCount: 15, snoozeCount: 1, nextLaunch: 20) == nil)
+        #expect(next(starResolved: false, launchCount: 20, snoozeCount: 1, nextLaunch: 20) == .star)
+    }
+
+    /// The ask cap stops the nudge for good even if the launch milestone is met.
+    @Test func starStopsAfterMaxAsks() {
+        #expect(next(starResolved: false, launchCount: 100, snoozeCount: 5, nextLaunch: 60, maxAsks: 5) == nil)
+    }
+
+    /// Starring resolves it permanently.
+    @Test func starNotShownOnceResolved() {
+        #expect(next(starResolved: true, launchCount: 100, snoozeCount: 0, nextLaunch: 10) == nil)
     }
 
     @Test func fullyOnboardedUserSeesNothing() {

--- a/App/Tests/LaunchPromptTests.swift
+++ b/App/Tests/LaunchPromptTests.swift
@@ -8,17 +8,24 @@ import Testing
     private func next(
         hasChosenRole: Bool = true, hasSeenTour: Bool = true,
         starResolved: Bool = true,
-        launchCount: Int = 0, snoozeCount: Int = 0,
+        launchCount: Int = 0, askCount: Int = 0,
         nextLaunch: Int = 10, maxAsks: Int = 5
     ) -> LaunchPrompt? {
         LaunchPrompt.next(
             hasChosenRole: hasChosenRole, hasSeenTour: hasSeenTour,
             starResolved: starResolved, launchCount: launchCount,
-            snoozeCount: snoozeCount, nextLaunch: nextLaunch, maxAsks: maxAsks)
+            askCount: askCount, nextLaunch: nextLaunch, maxAsks: maxAsks)
     }
 
     @Test func brandNewUserGetsRolePicker() {
         #expect(next(hasChosenRole: false, hasSeenTour: false) == .rolePicker)
+    }
+
+    /// The role picker wins even when the star nudge is simultaneously due.
+    @Test func rolePickerTakesPriorityOverDueStar() {
+        #expect(
+            next(hasChosenRole: false, hasSeenTour: false, starResolved: false, launchCount: 100)
+                == .rolePicker)
     }
 
     @Test func roleChosenButTourUnseenGetsTour() {
@@ -34,21 +41,50 @@ import Testing
         #expect(next(starResolved: false, launchCount: 10) == .star)
     }
 
-    /// A "Maybe Later" tap pushes `nextLaunch` out, so the nudge waits until the
+    /// A recorded ask pushes `nextLaunch` out, so the nudge waits until the
     /// next milestone instead of reappearing every launch.
-    @Test func starReschedulesAfterSnooze() {
-        #expect(next(starResolved: false, launchCount: 15, snoozeCount: 1, nextLaunch: 20) == nil)
-        #expect(next(starResolved: false, launchCount: 20, snoozeCount: 1, nextLaunch: 20) == .star)
+    @Test func starReschedulesAfterAnAsk() {
+        #expect(next(starResolved: false, launchCount: 15, askCount: 1, nextLaunch: 20) == nil)
+        #expect(next(starResolved: false, launchCount: 20, askCount: 1, nextLaunch: 20) == .star)
     }
 
     /// The ask cap stops the nudge for good even if the launch milestone is met.
     @Test func starStopsAfterMaxAsks() {
-        #expect(next(starResolved: false, launchCount: 100, snoozeCount: 5, nextLaunch: 60, maxAsks: 5) == nil)
+        #expect(next(starResolved: false, launchCount: 100, askCount: 5, nextLaunch: 60, maxAsks: 5) == nil)
+    }
+
+    /// The last allowed ask (one below the cap) still shows.
+    @Test func starShownOnFinalAllowedAsk() {
+        #expect(next(starResolved: false, launchCount: 100, askCount: 4, nextLaunch: 60, maxAsks: 5) == .star)
     }
 
     /// Starring resolves it permanently.
     @Test func starNotShownOnceResolved() {
-        #expect(next(starResolved: true, launchCount: 100, snoozeCount: 0, nextLaunch: 10) == nil)
+        #expect(next(starResolved: true, launchCount: 100, askCount: 0, nextLaunch: 10) == nil)
+    }
+
+    /// The re-ask milestone anchors to the *current* launch, not the old
+    /// milestone, so a re-engaged user with an ancient `nextLaunch` waits a
+    /// full gap instead of burning through every stale milestone.
+    @Test func nextAskAnchorsToCurrentLaunch() {
+        #expect(LaunchPrompt.nextAskLaunch(launchCount: 200, reAskGap: 10) == 210)
+    }
+
+    /// The full cadence composed, as RootView records it at presentation:
+    /// first ask at launch 10, one every 10 launches, exactly 5 asks, then
+    /// it stops for good.
+    @Test func nudgeAsksExactlyMaxAsksTimesThenStops() {
+        var askCount = 0
+        var nextLaunch = 10
+        var asks: [Int] = []
+        for launch in 1...100 where next(
+            starResolved: false, launchCount: launch,
+            askCount: askCount, nextLaunch: nextLaunch) == .star {
+            asks.append(launch)
+            askCount += 1
+            nextLaunch = LaunchPrompt.nextAskLaunch(launchCount: launch, reAskGap: 10)
+        }
+        #expect(asks == [10, 20, 30, 40, 50])
     }
 
     @Test func fullyOnboardedUserSeesNothing() {


### PR DESCRIPTION
## What changed

<img width="552" height="330" alt="Screenshot 2026-07-22 at 12 06 03 AM" src="https://github.com/user-attachments/assets/70adb365-61cd-40af-8746-a95040283874" />


The GitHub-star nudge is now recurring instead of one-time.

- It reschedules on "Maybe Later": first ask at **10 launches**, then every **+10 launches**, up to **5 asks total**, then it stops for good.
- **Star on GitHub** resolves it permanently (the repo opens and the prompt never returns).
- New persisted keys: `starPromptResolved`, `starPromptSnoozeCount`, `starPromptNextLaunch`. The pre-existing one-time `starPromptShown` flag is no longer read, so users who never starred are re-engaged on the new schedule.
- Prompt copy updated ("Enjoying the app? … consider giving it a star on GitHub").

## Why

The old prompt marked itself shown the moment it appeared, so "Maybe Later" silently meant "never again" — a single missed moment lost the ask forever. A capped, rescheduling nudge asks a few more times without nagging, and stops permanently once the user acts.

## Impact area

- [x] Persisted state schema — three new `UserDefaults` keys under the app domain (additive; old flag left untouched)
- [x] Otherwise isolated to the launch-prompt flow

## How verified

- [x] `make build` succeeds with **zero warnings**
- [x] `AppTests` green — new `LaunchPrompt` cases cover the threshold, reschedule-after-snooze, the ask cap, and resolved-after-star
- [x] Ran the app with the milestone reached and confirmed the sheet appears; Star opens the repo and it does not return, Maybe Later dismisses and re-arms for the next milestone

## Checklist

- [x] Logic lives in a pure, unit-tested type (`LaunchPrompt`), not the SwiftUI view
- [x] New decision logic is tested
- [ ] `prek run` (gitleaks) — not run locally (tool not installed); CI pre-commit will scan
- [x] No secrets, no commented-out code, no relative `..` imports, no AI attribution
