### PR TITLE
Keep hidden mirror alive for a grace window before teardown

### DIFF
--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
@@ -1,0 +1,31 @@
+/// Pure decisions for how the mirror reacts to its tab hiding or returning,
+/// extracted from `ScreenMirrorView` so the recording exemption and the
+/// return-retarget rules are pinned by AppTests rather than only by eye.
+/// (The grace-window *timing* stays view glue; only the branching lives here.)
+enum MirrorTabPolicy {
+    /// What returning to the tab does with a session the grace window kept.
+    enum ReturnAction: Equatable {
+        /// Keep the live session in place — no reconnect flash.
+        case resume
+        /// Connect fresh to the selected device (also the no-session path).
+        case reconnect
+    }
+
+    /// `sessionEnded`: the session failed or stopped while hidden.
+    /// `deviceChanged`: the device-bar selection no longer matches the
+    /// session's device. A recording always resumes in place — it stays on
+    /// its device until the user deals with it.
+    static func onReturn(
+        hasSession: Bool, isRecording: Bool, sessionEnded: Bool, deviceChanged: Bool
+    ) -> ReturnAction {
+        guard hasSession else { return .reconnect }
+        if isRecording { return .resume }
+        return (sessionEnded || deviceChanged) ? .reconnect : .resume
+    }
+
+    /// Whether hiding the tab schedules the grace-window teardown — never for
+    /// a recording, which must keep capturing.
+    static func schedulesTeardownOnHide(isRecording: Bool) -> Bool {
+        !isRecording
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -17,6 +17,14 @@ final class MirrorViewModel {
     }
 
     private(set) var status: Status = .connecting
+    /// Whether the session ended (failed or stopped) — e.g. the device dropped
+    /// while the tab was hidden — so returning to the tab needs a fresh connect.
+    var hasEnded: Bool {
+        switch status {
+        case .failed, .stopped: return true
+        case .connecting, .streaming: return false
+        }
+    }
     private(set) var isRecording = false
     private(set) var isPaused = false
     private var recordBusy = false
@@ -38,7 +46,9 @@ final class MirrorViewModel {
 
     private let adb: AdbClient
     private let locator: ToolLocator
-    private let serial: String
+    /// The device this session is bound to — set once at init (a session never
+    /// re-targets; the view reconnects to follow the device-bar selection).
+    let serial: String
 
     private var session: MirrorSession?
     private var displayTask: Task<Void, Never>?

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -6,6 +6,13 @@ import SwiftUI
 /// control-bar toggle opts in (and persists).
 let mirrorIncludeAudioKey = "mirrorIncludeAudio"
 
+/// How long a hidden mirror keeps streaming before it's torn down. Switching
+/// tabs used to stop-and-reconnect instantly, so flipping away and back — even
+/// for a moment — flashed the "Connecting…" screen every time. Holding the live
+/// session for this window lets a quick return resume in place; only a genuinely
+/// abandoned tab pays the teardown to reclaim the video-encode CPU.
+let mirrorHiddenGraceSeconds: TimeInterval = 120
+
 /// In-app screen mirror: a native scrcpy client renders the device live, in
 /// window. The toolbar takes a screenshot (→ annotate in place) or records
 /// (→ video editor on stop) without interrupting the live, controllable mirror.
@@ -20,6 +27,8 @@ struct ScreenMirrorView: View {
     @State private var connectTask: Task<Void, Never>?
     /// Identifies this view's leave guard so a stale clear can't wipe another's.
     @State private var exitGuardID = UUID()
+    /// Delayed teardown for a hidden tab; cancelled if the tab returns in time.
+    @State private var teardownTask: Task<Void, Never>?
 
     var body: some View {
         ZStack {
@@ -66,14 +75,17 @@ struct ScreenMirrorView: View {
         }
         .onChange(of: tabIsActive) { _, active in
             if active {
+                // Returned to the tab: cancel any pending teardown so a session
+                // still inside its grace window resumes in place (no reconnect
+                // flash). Only reconnect if it was already torn down.
+                teardownTask?.cancel()
+                teardownTask = nil
                 if model == nil { scheduleReconnect(to: state.targetSerials.first) }
             } else if model?.isRecording != true {
-                // Pause the live mirror while hidden — unless it's recording,
-                // which must keep capturing.
-                connectTask?.cancel()
-                let leaving = model
-                model = nil
-                Task { await leaving?.stop() }
+                // Hidden — keep streaming for a grace window instead of tearing
+                // down instantly, so a quick tab flip doesn't stop-and-reconnect.
+                // Recording sessions must keep capturing regardless.
+                scheduleHiddenTeardown()
             }
         }
         .onChange(of: includeAudio) { _, include in
@@ -105,10 +117,27 @@ struct ScreenMirrorView: View {
         }
         .onDisappear {
             state.clearExitGuard(exitGuardID)
+            teardownTask?.cancel()
             connectTask?.cancel()
             let leaving = model
             model = nil
             Task { await leaving?.stop() }
+        }
+    }
+
+    /// Stop the hidden mirror after the grace window elapses, unless the tab
+    /// returns first (which cancels this task). Reclaims the video-encode CPU
+    /// of a mirror the user has actually left behind. Runs on the main actor,
+    /// so mutating `model` here is safe.
+    private func scheduleHiddenTeardown() {
+        teardownTask?.cancel()
+        teardownTask = Task {
+            try? await Task.sleep(for: .seconds(mirrorHiddenGraceSeconds))
+            guard !Task.isCancelled else { return }
+            connectTask?.cancel()
+            let leaving = model
+            model = nil
+            await leaving?.stop()
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -77,11 +77,19 @@ struct ScreenMirrorView: View {
             if active {
                 // Returned to the tab: cancel any pending teardown so a session
                 // still inside its grace window resumes in place (no reconnect
-                // flash). Only reconnect if it was already torn down.
+                // flash). Reconnect when there's nothing to resume — torn down,
+                // ended while hidden, or the device-bar selection moved on while
+                // hidden (resuming then would silently mirror and control the
+                // wrong device; a recording always stays on its device).
                 teardownTask?.cancel()
                 teardownTask = nil
-                if model == nil { scheduleReconnect(to: state.targetSerials.first) }
-            } else if model?.isRecording != true {
+                let action = MirrorTabPolicy.onReturn(
+                    hasSession: model != nil,
+                    isRecording: model?.isRecording == true,
+                    sessionEnded: model?.hasEnded == true,
+                    deviceChanged: model?.serial != state.targetSerials.first)
+                if action == .reconnect { scheduleReconnect(to: state.targetSerials.first) }
+            } else if MirrorTabPolicy.schedulesTeardownOnHide(isRecording: model?.isRecording == true) {
                 // Hidden — keep streaming for a grace window instead of tearing
                 // down instantly, so a quick tab flip doesn't stop-and-reconnect.
                 // Recording sessions must keep capturing regardless.
@@ -134,6 +142,9 @@ struct ScreenMirrorView: View {
         teardownTask = Task {
             try? await Task.sleep(for: .seconds(mirrorHiddenGraceSeconds))
             guard !Task.isCancelled else { return }
+            // Fired: drop the handle now (before the await) so a fresh
+            // hide can't schedule a successor this stale task would clobber.
+            teardownTask = nil
             connectTask?.cancel()
             let leaving = model
             model = nil

--- a/App/Tests/MirrorTabPolicyTests.swift
+++ b/App/Tests/MirrorTabPolicyTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+/// The mirror tab's hide/return decisions — the recording exemption and the
+/// wrong-device retarget rule are the bug-prone branches the grace window
+/// introduced (a resumed session is bound to its original device forever).
+@Suite struct MirrorTabPolicyTests {
+    @Test func hidingSchedulesTeardownUnlessRecording() {
+        #expect(MirrorTabPolicy.schedulesTeardownOnHide(isRecording: false))
+        #expect(!MirrorTabPolicy.schedulesTeardownOnHide(isRecording: true))
+    }
+
+    @Test func returningWithNoSessionReconnects() {
+        #expect(
+            MirrorTabPolicy.onReturn(
+                hasSession: false, isRecording: false, sessionEnded: false, deviceChanged: false)
+                == .reconnect)
+    }
+
+    /// The grace window's whole point: a live session on the still-selected
+    /// device resumes in place with no reconnect flash.
+    @Test func returningToALiveSessionResumes() {
+        #expect(
+            MirrorTabPolicy.onReturn(
+                hasSession: true, isRecording: false, sessionEnded: false, deviceChanged: false)
+                == .resume)
+    }
+
+    /// Switching the device bar while hidden must re-target on return —
+    /// resuming would silently mirror (and control) the wrong device.
+    @Test func returningAfterADeviceSwitchReconnects() {
+        #expect(
+            MirrorTabPolicy.onReturn(
+                hasSession: true, isRecording: false, sessionEnded: false, deviceChanged: true)
+                == .reconnect)
+    }
+
+    /// A session that died while hidden reconnects on return instead of
+    /// resuming into the stopped/failed card.
+    @Test func returningToAnEndedSessionReconnects() {
+        #expect(
+            MirrorTabPolicy.onReturn(
+                hasSession: true, isRecording: false, sessionEnded: true, deviceChanged: false)
+                == .reconnect)
+    }
+
+    /// A recording is never torn down or re-targeted out from under the user —
+    /// it stays on its device even if the bar selection moved on.
+    @Test func recordingAlwaysResumesInPlace() {
+        #expect(
+            MirrorTabPolicy.onReturn(
+                hasSession: true, isRecording: true, sessionEnded: false, deviceChanged: true)
+                == .resume)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -148,6 +148,7 @@ targets:
       - App/Sources/State/LaunchPrompt.swift
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
+      - App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
     dependencies:
       # Theme.swift's fill styles call into WindowEffects (ADBKit).
       - package: ADBKit


### PR DESCRIPTION
## Problem

Switching tabs away from the **Screen Mirror** feature tore the mirror session down immediately (`model = nil` + `stop()`). Returning to the tab always reconnected from scratch, flashing the "Connecting…" screen — so a quick flip away and back (even a couple of seconds) reconnected every time. Poor UX.

## Fix

Hold the live session for a **2-minute grace window** when the tab loses focus, instead of tearing down instantly:

- Tab hides → `scheduleHiddenTeardown()` schedules a cancellable delayed teardown (`Task.sleep`) rather than stopping now.
- Tab returns → the pending teardown is cancelled, so a session still inside the window resumes in place with no reconnect. It only reconnects if the window already elapsed.
- `.onDisappear` cancels the pending teardown and stops cleanly (real navigation away is unaffected).
- Recording sessions remain exempt — they keep capturing regardless, as before.

Only a genuinely abandoned tab pays the teardown to reclaim the video-encode CPU, so the original "a hidden mirror is heavy video encode for nothing" concern is preserved — just deferred by the grace window. Grace duration is a named constant (`mirrorHiddenGraceSeconds = 120`).

## Testing

- `make build` — succeeds, zero warnings (warnings-as-errors).
- App-layer only; no ADBKit logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)