### PR TITLE
Per-pane Reactotron sort order and clear-data restart variants

### DIFF
--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -698,8 +698,8 @@ final class JSConsoleSession {
     /// else the selected bundle. Disconnected — or when detection/relaunch
     /// fails — the installed-apps picker opens instead. Discovery reconnects
     /// by logical-device id once the app is back.
-    func restartApp(clearCache: Bool = false) {
-        Task { [weak self] in await self?.performRestart(clearCache: clearCache) }
+    func restartApp(clearing scope: RestartClearScope? = nil) {
+        Task { [weak self] in await self?.performRestart(clearing: scope) }
     }
 
     /// Drives the fallback installed-apps picker sheet.
@@ -707,12 +707,12 @@ final class JSConsoleSession {
     /// The user's manual pick from the restart sheet, reused on later restarts
     /// whenever the connected target doesn't report its own `appId`.
     private var manualRestartPackage: String?
-    /// Whether the restart currently in flight (including one waiting on the
-    /// fallback picker) should clear the app's cache first.
-    private var pendingClearCache = false
+    /// What the restart currently in flight (including one waiting on the
+    /// fallback picker) should clear first, if anything.
+    private var pendingClear: RestartClearScope?
 
-    private func performRestart(clearCache: Bool) async {
-        pendingClearCache = clearCache
+    private func performRestart(clearing scope: RestartClearScope?) async {
+        pendingClear = scope
         guard !serials.isEmpty else {
             app?.showToast(Toast(message: "Can't restart — no device selected.", ok: false))
             return
@@ -722,17 +722,17 @@ final class JSConsoleSession {
         let detected: String? = isConnected
             ? connectedTarget?.appId ?? manualRestartPackage ?? app?.selectedBundle?.packageId
             : nil
-        if let detected, await restart(package: detected, clearCache: clearCache) { return }
+        if let detected, await restart(package: detected, clearing: scope) { return }
         restartPickerVisible = true
     }
 
     /// A pick from the fallback sheet: restart it and remember the choice.
     func restartPicked(_ package: String) {
         manualRestartPackage = package
-        let clearCache = pendingClearCache
+        let scope = pendingClear
         Task { [weak self] in
             guard let self else { return }
-            if !(await restart(package: package, clearCache: clearCache)) {
+            if !(await restart(package: package, clearing: scope)) {
                 app?.showToast(Toast(
                     message: "Couldn't relaunch \(package) — is it installed on the selected device?",
                     ok: false
@@ -742,55 +742,42 @@ final class JSConsoleSession {
     }
 
     /// Force-stop + relaunch on every target device (the service's `.restart`
-    /// verb), optionally clearing the app's cache first (`pm clear
-    /// --cache-only`, Android 14+ — best-effort, the restart proceeds either
-    /// way); true when any relaunch worked (the toast reports success;
-    /// failures fall back to the picker).
-    private func restart(package: String, clearCache: Bool) async -> Bool {
+    /// verb), optionally clearing the app's cache (`pm clear --cache-only`,
+    /// Android 14+ — best-effort, bounded) or its whole data (`pm clear`)
+    /// first — the restart proceeds either way, and the toast reports what the
+    /// clear did. True when any relaunch worked (failures fall back to the
+    /// picker).
+    private func restart(package: String, clearing scope: RestartClearScope?) async -> Bool {
         let serials = serials
         let control = AppControlService(client: adb)
-        let (relaunched, cacheCleared) = await CommandLog.userInitiated {
+        let (relaunched, cleared) = await CommandLog.userInitiated {
             var relaunched = 0
-            var cacheCleared = true
+            var cleared = true
             for serial in serials {
-                if clearCache, !(await Self.clearCacheBounded(control, serial: serial, package: package)) {
-                    cacheCleared = false
+                if let scope, !(await control.clear(scope, serial: serial, package: package)) {
+                    cleared = false
                 }
                 if let result = try? await control.control(serial: serial, packageId: package, action: .restart),
                    result.ok {
                     relaunched += 1
                 }
             }
-            return (relaunched, cacheCleared)
+            return (relaunched, cleared)
         }
         guard relaunched > 0 else { return false }
-        let message = if !clearCache {
-            "Restarting \(package)…"
-        } else if cacheCleared {
-            "Cleared cache — restarting \(package)…"
-        } else {
-            "Cache clear didn't finish — restarting \(package)…"
+        let message = switch scope {
+        case nil: "Restarting \(package)…"
+        case .cache:
+            cleared
+                ? "Cleared cache — restarting \(package)…"
+                : "Cache clear didn't finish — restarting \(package)…"
+        case .data:
+            cleared
+                ? "Cleared data — restarting \(package)…"
+                : "Data clear failed — restarting \(package)…"
         }
         app?.showToast(Toast(message: message, ok: true))
         return true
-    }
-
-    /// `pm clear --cache-only` never returns on some images (observed live on
-    /// the API 36 emulator), so the clear gets a bounded window — cancelling
-    /// the task kills the adb child — and the restart proceeds either way.
-    private static func clearCacheBounded(
-        _ control: AppControlService, serial: String, package: String
-    ) async -> Bool {
-        let clear = Task {
-            (try? await control.control(serial: serial, packageId: package, action: .clearCache))?.ok == true
-        }
-        let watchdog = Task {
-            try? await Task.sleep(for: .seconds(10))
-            clear.cancel()
-        }
-        let ok = await clear.value
-        watchdog.cancel()
-        return ok
     }
 
     /// Remove the `adb reverse` bindings this console installed. Called when the
@@ -949,6 +936,8 @@ struct JSConsoleView: View {
     @State private var connectionBarWidth: CGFloat = 0
     @State private var inputHeight: CGFloat = 26
     @State private var showLevels = false
+    /// The "Clear data and restart" confirmation (it signs the user out).
+    @State private var confirmClearDataRestart = false
     @FocusState private var findFocused: Bool
     /// This tab stays mounted when the user switches away (see `TabHostView`).
     /// The input is a bare `NSTextView`, which `installFocusRelease` can't
@@ -1083,12 +1072,18 @@ struct JSConsoleView: View {
         }
         if !state.targetSerials.isEmpty {
             // A split button: the primary click restarts, the chevron reveals
-            // the cache-clearing variant (pm clear --cache-only, then relaunch).
+            // the clearing variants — cache (pm clear --cache-only) or full
+            // data (pm clear, behind a confirmation), then relaunch.
             Menu {
                 Button {
-                    session.restartApp(clearCache: true)
+                    session.restartApp(clearing: .cache)
                 } label: {
                     Label("Clear cache and restart", systemImage: "arrow.triangle.2.circlepath")
+                }
+                Button(role: .destructive) {
+                    confirmClearDataRestart = true
+                } label: {
+                    Label("Clear data and restart", systemImage: "trash")
                 }
             } label: {
                 Label("Restart app", systemImage: "restart.circle")
@@ -1099,6 +1094,15 @@ struct JSConsoleView: View {
             .help(session.isConnected
                 ? "Force-stop and relaunch the connected app on the device"
                 : "Pick an app to force-stop and relaunch")
+            .confirmationDialog(
+                "Clear all data for the app and restart? This signs you out and wipes local storage.",
+                isPresented: $confirmClearDataRestart
+            ) {
+                Button("Clear Data & Restart", role: .destructive) {
+                    session.restartApp(clearing: .data)
+                }
+                Button("Cancel", role: .cancel) {}
+            }
         }
         if !state.targetSerials.isEmpty, !session.isConnected {
             Button {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -1807,10 +1807,9 @@ private struct TimelineFilterSheet: View {
 /// One scrollable timeline column with its own filter and search, fed from the
 /// shared event buffer. Used once on its own or twice side-by-side (the
 /// VSCode-style split), so each pane can watch a different slice at the same
-/// time. Filter, API refinements, and search are UserDefaults-backed per pane
-/// index, so each pane keeps its slice across feature switches and relaunches.
-/// The sort order is a per-feature preference (`@AppStorage`), so split panes
-/// flip together and the choice survives relaunches.
+/// time. Filter, API refinements, search, and sort order are
+/// UserDefaults-backed per pane index, so each pane keeps its slice — and its
+/// direction — across feature switches and relaunches.
 private struct TimelinePane: View {
     /// 0 = the single/left pane, 1 = the right split pane — keys the persisted
     /// filters and picks the clear button's wording (the right pane's clear is
@@ -1847,10 +1846,10 @@ private struct TimelinePane: View {
     @AppStorage private var methodFilter: String?
     @AppStorage private var statusFilter: HTTPStatusClass?
     @State private var showFilterSheet = false
-    /// Newest at the top (the Reactotron app's order) unless the toolbar's
-    /// reverse button flips the feed to chronological. Persisted per feature —
-    /// split panes share the key, so they stay in sync.
-    @AppStorage("reactotronNewestFirst") private var newestFirst = true
+    /// Newest at the top (the Reactotron app's order) unless this pane's
+    /// reverse button flips its feed to chronological. Persisted per pane, so
+    /// each side of a split orders independently.
+    @AppStorage private var newestFirst: Bool
 
     init(
         pane: Int,
@@ -1882,6 +1881,12 @@ private struct TimelinePane: View {
         _hiddenKindsRaw = AppStorage(wrappedValue: "", "reactotronPane\(pane)HiddenKinds")
         _methodFilter = AppStorage("reactotronPane\(pane)Method")
         _statusFilter = AppStorage("reactotronPane\(pane)Status")
+        // Seeded from the retired shared-order key so an existing flipped
+        // preference carries into both panes; each persists its own from then on.
+        _newestFirst = AppStorage(
+            wrappedValue: UserDefaults.standard.object(forKey: "reactotronNewestFirst") as? Bool ?? true,
+            "reactotronPane\(pane)NewestFirst"
+        )
     }
 
     /// Decoded view of `hiddenKindsRaw`. Unknown raw values (a kind renamed or
@@ -2956,7 +2961,9 @@ private struct ReactotronIntroSheet: View {
 /// the Reactotron server. Detects the app automatically — the connected
 /// client's reported name matched against installed packages, else the
 /// foreground app — and only opens the searchable picker when detection or
-/// the relaunch fails.
+/// the relaunch fails. A split button (parity with the JS Console): the
+/// primary click restarts, the chevron reveals the clearing variants — cache
+/// (`pm clear --cache-only`) or full data (`pm clear`, behind a confirmation).
 private struct RestartAppMenu: View {
     /// The connected Reactotron client's app name, when one is connected —
     /// the strongest detection signal (it names the exact app to restart).
@@ -2965,22 +2972,48 @@ private struct RestartAppMenu: View {
     @Environment(AppState.self) private var state
     @State private var restarting = false
     @State private var showPicker = false
+    @State private var confirmClearData = false
+    /// What the restart currently in flight (including one waiting on the
+    /// fallback picker) should clear first, if anything.
+    @State private var pendingClear: RestartClearScope?
 
     private var serial: String? {
         state.selectedSerial ?? state.devices.first(where: \.isReady)?.serial
     }
 
     var body: some View {
-        Button {
-            Task { await smartRestart() }
+        Menu {
+            Button {
+                Task { await smartRestart(clearing: .cache) }
+            } label: {
+                Label("Clear cache and restart", systemImage: "arrow.triangle.2.circlepath")
+            }
+            Button(role: .destructive) {
+                confirmClearData = true
+            } label: {
+                Label("Clear data and restart", systemImage: "trash")
+            }
         } label: {
             Label("Restart app", systemImage: "arrow.clockwise.circle")
+        } primaryAction: {
+            Task { await smartRestart() }
         }
+        .fixedSize()
         .disabled(serial == nil || restarting)
+        .confirmationDialog(
+            "Clear all data for the app and restart? This signs you out and wipes local storage.",
+            isPresented: $confirmClearData
+        ) {
+            Button("Clear Data & Restart", role: .destructive) {
+                Task { await smartRestart(clearing: .data) }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         .sheet(isPresented: $showPicker) {
             RestartAppPickerSheet(serial: serial) { package in
+                let scope = pendingClear
                 Task {
-                    if !(await restart(package)) {
+                    if !(await restart(package, clearing: scope)) {
                         state.showToast(Toast(message: "Couldn't restart \(package)", ok: false))
                     }
                 }
@@ -2992,15 +3025,16 @@ private struct RestartAppMenu: View {
     /// wrong thing) is detected, or the relaunch fails. With no client
     /// connected there is nothing trustworthy to detect — the foreground app
     /// could be anything — so ask straight away.
-    private func smartRestart() async {
+    private func smartRestart(clearing scope: RestartClearScope? = nil) async {
         guard serial != nil else { return }
+        pendingClear = scope
         guard clientName != nil else {
             showPicker = true
             return
         }
         restarting = true
         defer { restarting = false }
-        if let detected = await detectPackage(), await restart(detected) { return }
+        if let detected = await detectPackage(), await restart(detected, clearing: scope) { return }
         showPicker = true
     }
 
@@ -3024,15 +3058,31 @@ private struct RestartAppMenu: View {
         }
     }
 
-    private func restart(_ package: String) async -> Bool {
+    private func restart(_ package: String, clearing scope: RestartClearScope? = nil) async -> Bool {
         guard let serial else { return false }
         let service = AppControlService(client: state.env.client)
-        let result = await CommandLog.userInitiated {
+        let (relaunched, cleared) = await CommandLog.userInitiated {
+            var cleared = true
+            if let scope, !(await service.clear(scope, serial: serial, package: package)) {
+                cleared = false
+            }
             _ = try? await service.control(serial: serial, packageId: package, action: .stop)
-            return try? await service.control(serial: serial, packageId: package, action: .open)
+            let result = try? await service.control(serial: serial, packageId: package, action: .open)
+            return (result?.ok == true, cleared)
         }
-        guard result?.ok == true else { return false }
-        state.showToast(Toast(message: "Restarting \(package)…", ok: true))
+        guard relaunched else { return false }
+        let message = switch scope {
+        case nil: "Restarting \(package)…"
+        case .cache:
+            cleared
+                ? "Cleared cache — restarting \(package)…"
+                : "Cache clear didn't finish — restarting \(package)…"
+        case .data:
+            cleared
+                ? "Cleared data — restarting \(package)…"
+                : "Data clear failed — restarting \(package)…"
+        }
+        state.showToast(Toast(message: message, ok: true))
         return true
     }
 }

--- a/App/Sources/FeatureDetail/Views/RestartClearScope.swift
+++ b/App/Sources/FeatureDetail/Views/RestartClearScope.swift
@@ -1,0 +1,43 @@
+import ADBKit
+
+/// What a debug tool's "Restart app" wipes before the relaunch: the app's
+/// cache (`pm clear --cache-only` — safe, keeps you signed in) or its whole
+/// data (`pm clear` — signs you out and wipes local storage, so it always
+/// sits behind a confirmation). Shared by the JS Console and Reactotron
+/// restart menus.
+enum RestartClearScope {
+    case cache
+    case data
+}
+
+extension AppControlService {
+    /// Run the pre-restart clear for `scope`; true when it succeeded. The
+    /// caller's restart proceeds either way — a failed clear is reported in
+    /// the toast, not fatal.
+    func clear(_ scope: RestartClearScope, serial: String, package: String) async -> Bool {
+        switch scope {
+        case .cache:
+            return await clearCacheBounded(serial: serial, package: package)
+        case .data:
+            return (try? await control(serial: serial, packageId: package, action: .clearData))?.ok
+                == true
+        }
+    }
+
+    /// `pm clear --cache-only` never returns on some images (observed live on
+    /// the API 36 emulator), so the cache clear gets a bounded window —
+    /// cancelling the task kills the adb child. A full data clear doesn't need
+    /// this: `pm clear` returns reliably.
+    private func clearCacheBounded(serial: String, package: String) async -> Bool {
+        let clear = Task {
+            (try? await control(serial: serial, packageId: package, action: .clearCache))?.ok == true
+        }
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(10))
+            clear.cancel()
+        }
+        let ok = await clear.value
+        watchdog.cancel()
+        return ok
+    }
+}


### PR DESCRIPTION
## What changed

**Independent per-pane sort order (Reactotron).** The timeline's reverse-order button was backed by one shared preference — flipping either split pane flipped both. Each pane now persists its own order (`reactotronPane<n>NewestFirst`, seeded once from the retired shared key so an existing flipped preference carries over), matching how the panes' filters and search were already per-pane. One pane can read newest-first while the other stays chronological.

**Clear-data restart variant (JS Console + Reactotron).** Both consoles' Restart button now offers two clearing variants behind the chevron:
- *Clear cache and restart* — the existing bounded `pm clear --cache-only` (JS Console already had it; Reactotron gains it)
- *Clear data and restart* — new: full `pm clear`. It signs the user out and wipes local storage, so it sits behind a confirmation dialog (same pattern as the Apps explorer's Clear Data)

Reactotron's plain Restart button becomes the same split button the JS Console uses, and the pending clear scope rides through both features' fallback app pickers. The shared `RestartClearScope` enum + `AppControlService.clear` extension replace the JS-console-private `clearCacheBounded` helper (moved, not duplicated).

No ADBKit changes — `pm clear`/`pm clear --cache-only` arg vectors and quoting were already covered by `AppControlServiceTests`.

## How verified

- `cd ADBKit && swift test` — 972 tests green
- `xcodebuild` App Debug — zero warnings
- Live against the API 35 emulator with a connected Reactotron client (StreamLab):
  - **Clear data & restart**: a marker file planted via `run-as` was wiped and the app relaunched with a new pid — auto-detected from the client name, confirmation dialog exercised, no picker
  - **Clear cache & restart**: app relaunched after the bounded clear window
  - **Per-pane order**: both panes showed the same events in opposite directions simultaneously; `defaults` confirmed `Pane0NewestFirst=0` / `Pane1NewestFirst=1` after flipping only one pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)