### PR TITLE
Reactotron MCP: serve the relay's data to AI agents over localhost HTTP

### DIFF
--- a/ADBKit/Package.resolved
+++ b/ADBKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "517b41fc75f11c9282b6d2d24bc0c8a3a875b17067a390760dbda6b20dd5e03a",
+  "originHash" : "a832b40ff9c55c8a7ae523fa75f2b588dd3904ea6a541ce21c04210717a09576",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,51 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "70caa8dea43e2d273cd5ab78885d7eff01df550c",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "ee5b5705b0038f0c44646cde5fe972bb65387596",
+        "version" : "3.61.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -62,6 +107,15 @@
       "state" : {
         "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
         "version" : "1.7.4"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "state" : {
+        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
+        "version" : "1.13.0"
       }
     }
   ],

--- a/ADBKit/Package.resolved
+++ b/ADBKit/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "517b41fc75f11c9282b6d2d24bc0c8a3a875b17067a390760dbda6b20dd5e03a",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ADBKit/Package.swift
+++ b/ADBKit/Package.swift
@@ -1,17 +1,43 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
     name: "ADBKit",
     platforms: [.macOS(.v14)],
     products: [
-        .library(name: "ADBKit", targets: ["ADBKit"])
+        .library(name: "ADBKit", targets: ["ADBKit"]),
+        .library(name: "ReactotronMCP", targets: ["ReactotronMCP"]),
+    ],
+    dependencies: [
+        // Pre-1.0 SDK: pinned exactly; upgrades are deliberate, reviewed
+        // changes (re-run the MCP socket/contract suites after bumping).
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.1"),
+        // HTTP listener for the MCP endpoint — the same stack the SDK's own
+        // conformance server uses. Version graph is pinned by Package.resolved.
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
     ],
     targets: [
         // Pin the Swift 6 language mode (complete strict concurrency) explicitly
         // rather than inheriting it from the tools version, so it can't silently
         // relax if the tools-version line is ever lowered.
+        // ADBKit stays dependency-free: everything MCP lives in ReactotronMCP.
         .target(name: "ADBKit", swiftSettings: [.swiftLanguageMode(.v6)]),
+        .target(
+            name: "ReactotronMCP",
+            dependencies: [
+                "ADBKit",
+                .product(name: "MCP", package: "swift-sdk"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
         .testTarget(name: "ADBKitTests", dependencies: ["ADBKit"], swiftSettings: [.swiftLanguageMode(.v6)]),
+        .testTarget(
+            name: "ReactotronMCPTests",
+            dependencies: ["ReactotronMCP"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
     ]
 )

--- a/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureModel.swift
@@ -81,7 +81,7 @@ public enum UserRole: String, Sendable, Codable, CaseIterable, Identifiable {
     public var blurb: String {
         switch self {
         case .androidDeveloper: return "Logs, app internals, files, and device connection."
-        case .reactNativeDeveloper: return "Metro reload, dev menu, logs, and performance — Android & iOS."
+        case .reactNativeDeveloper: return "Reactotron, JS console, dev menu, and logs — Android & iOS."
         case .iosDeveloper: return "Simulators, push testing, capture, and deep links."
         case .qaTester: return "Capture, recording, crash hunting, and state simulation."
         case .supportTriage: return "Device diagnostics, connection, and quick checks."

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -697,6 +697,12 @@ public enum FeatureRegistry {
         (featuresByRole[role] ?? []).filter { byID[$0] != nil }
     }
 
+    /// The React Native stack tools the role picker's "I work with React
+    /// Native" toggle adds to any chosen role — a React Native QA is both
+    /// "QA" and "React Native", so the role picks the workflow and this
+    /// toggle picks the stack. Ordered as they should lead the sidebar.
+    public static let reactNativeStackIDs = ["react-native", "reactotron", "js-console"]
+
     /// The device platforms a role works with. The device bar, the virtual-
     /// device launch lists, and the Emulators screen show only these; `nil`
     /// ("all features") shows both. iOS Developer is simulator-only, React

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -152,6 +152,7 @@ public enum FeatureRegistry {
                 "reactotron", "inspector", "timeline", "redux", "mst", "state",
                 "network", "api", "display", "log", "debug", "react native", "rn",
                 "9090", "infinite red", "devtools",
+                "mcp", "ai", "agent", "claude", "cursor",
             ],
             category: .reactNative, icon: "antenna.radiowaves.left.and.right", kind: .view,
             needsDevice: false

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -279,14 +279,23 @@ public struct LayoutState: Codable, Sendable, Equatable {
     /// sidebar order to the curated order. Marks `knownIds`/`didEnableAll` so
     /// `adoptNewDefaults`/`adoptAllEnabled` can't re-expand the set back to
     /// all-on. Used at first-run pick and when changing role later.
-    public mutating func seedRole(_ role: UserRole) {
-        let ids = FeatureRegistry.featureIDs(for: role)
+    /// `includeReactNativeStack` unions the RN stack tools
+    /// (`FeatureRegistry.reactNativeStackIDs`) into the seed, leading the
+    /// sidebar — the picker's "I work with React Native" toggle. The
+    /// role-additions baseline (`seededRoleIds`) stays the pure role list so
+    /// `adoptNewRoleFeatures` keeps working from the role's own curation.
+    public mutating func seedRole(_ role: UserRole, includeReactNativeStack: Bool = false) {
+        let roleIds = FeatureRegistry.featureIDs(for: role)
+        var ids = roleIds
+        if includeReactNativeStack {
+            ids = FeatureRegistry.reactNativeStackIDs.filter { !ids.contains($0) } + ids
+        }
         selectedRole = role.rawValue
         roleChosen = true
         enabledIds = ids
         sidebarOrder = ids
         categoryOrder = FeatureRegistry.categoryOrder(for: role)
-        seededRoleIds = ids
+        seededRoleIds = roleIds
         knownIds = FeatureRegistry.all.map(\.id)
         didEnableAll = true
     }

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -92,6 +92,10 @@ public actor ReactotronServer {
     private var clientIds: [Int: String] = [:]
     private var nextConnectionId = 1
     private var continuation: AsyncStream<Event>.Continuation?
+    /// Additive observers of the same events the primary stream carries (the
+    /// MCP layer holds one). Keyed so a tap whose consumer went away can be
+    /// removed without touching the others.
+    private var taps: [UUID: AsyncStream<Event>.Continuation] = [:]
     private var pingTask: Task<Void, Never>?
 
     /// - Parameters:
@@ -178,7 +182,37 @@ public actor ReactotronServer {
         return stream
     }
 
+    /// An additional, independent stream of the same events `start()` delivers.
+    /// Registering a tap never affects the primary stream, and a tap survives
+    /// `stop()`/`start()` cycles — it ends when its consumer stops iterating.
+    /// Buffering matches the primary stream so a slow tap drops its own oldest
+    /// events instead of back-pressuring the server.
+    public func tap() -> AsyncStream<Event> {
+        let id = UUID()
+        let (stream, tapContinuation) = AsyncStream.makeStream(
+            of: Event.self, bufferingPolicy: .bufferingNewest(512))
+        taps[id] = tapContinuation
+        tapContinuation.onTermination = { [weak self] _ in
+            Task { await self?.removeTap(id) }
+        }
+        return stream
+    }
+
+    private func removeTap(_ id: UUID) {
+        taps[id] = nil
+    }
+
+    /// Deliver an event to the primary stream and every tap.
+    private func emit(_ event: Event) {
+        continuation?.yield(event)
+        for tapContinuation in taps.values {
+            tapContinuation.yield(event)
+        }
+    }
+
     /// Tear down the listener and all client sockets. Safe to call repeatedly.
+    /// Taps deliberately survive — `start()` calls this to restart, and a tap
+    /// consumer (the MCP layer) must keep receiving across restarts.
     public func stop() {
         pingTask?.cancel()
         pingTask = nil
@@ -199,7 +233,7 @@ public actor ReactotronServer {
 
     private func listenerBecameReady() {
         guard let port = listener?.port?.rawValue else { return }
-        continuation?.yield(.listening(port: port))
+        emit(.listening(port: port))
         startPinging()
     }
 
@@ -235,7 +269,7 @@ public actor ReactotronServer {
         if case let .posix(code) = error, code == .EADDRINUSE {
             portInUse = true
         }
-        continuation?.yield(.failed(reason: "\(error)", portInUse: portInUse))
+        emit(.failed(reason: "\(error)", portInUse: portInUse))
         stop()
     }
 
@@ -289,7 +323,7 @@ public actor ReactotronServer {
         // the close still drain into the timeline, then the consumer ends.
         frameFeeds.removeValue(forKey: id)?.finish()
         box.connection.cancel()
-        continuation?.yield(.disconnected(connectionId: id, reason: reason))
+        emit(.disconnected(connectionId: id, reason: reason))
     }
 
     /// Recursive receive loop, off the actor (like `MirrorTransport.receiveLoop`).
@@ -330,11 +364,14 @@ public actor ReactotronServer {
         }
     }
 
-    private func handleFrame(connectionId id: Int, data: Data) {
+    /// Internal (not private) so tests can drive the drained-frame paths
+    /// deterministically — racing a real socket against `dropConnection` isn't
+    /// reliably reproducible.
+    func handleFrame(connectionId id: Int, data: Data) {
         guard let command = try? ReactotronCommand.decode(data) else {
             let raw = String(data: data, encoding: .utf8) ?? "<\(data.count) bytes>"
             let preview = String(raw.prefix(300))
-            continuation?.yield(.command(
+            emit(.command(
                 connectionId: id,
                 command: ReactotronCommand(type: "(undecodable)", payload: .string(preview)),
                 frameBytes: preview.utf8.count
@@ -342,10 +379,16 @@ public actor ReactotronServer {
             return
         }
         if command.commandType == .clientIntro {
+            // A `client.intro` draining after `dropConnection` must not
+            // resurrect a ghost client: the connection is gone, so there is
+            // no handshake to complete and no future `.disconnected` to pair
+            // with a `.connected`. Ordinary commands still drain below —
+            // they're timeline data, not client state.
+            guard connections[id] != nil else { return }
             completeHandshake(connectionId: id, intro: command)
-            continuation?.yield(.connected(connectionId: id, intro: command, frameBytes: data.count))
+            emit(.connected(connectionId: id, intro: command, frameBytes: data.count))
         } else {
-            continuation?.yield(.command(connectionId: id, command: command, frameBytes: data.count))
+            emit(.command(connectionId: id, command: command, frameBytes: data.count))
         }
     }
 
@@ -380,7 +423,7 @@ public actor ReactotronServer {
             clientIds[staleId] = nil
             frameFeeds.removeValue(forKey: staleId)?.finish()
             guard let stale = connections.removeValue(forKey: staleId) else { continue }
-            continuation?.yield(.disconnected(connectionId: staleId, reason: nil))
+            emit(.disconnected(connectionId: staleId, reason: nil))
             Task {
                 try? await Task.sleep(for: .milliseconds(500))
                 stale.connection.cancel()

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -58,7 +58,10 @@ public actor ReactotronServer {
     /// its retained payloads within a byte budget.
     public enum Event: Sendable {
         case listening(port: UInt16)
-        case connected(connectionId: Int, intro: ReactotronCommand, frameBytes: Int)
+        /// `clientId` is the resolved Reactotron client id — the one from the
+        /// intro payload, or the server-generated id sent back via
+        /// `setClientId` when the client connected without one.
+        case connected(connectionId: Int, clientId: String, intro: ReactotronCommand, frameBytes: Int)
         case command(connectionId: Int, command: ReactotronCommand, frameBytes: Int)
         /// `reason` is nil for teardown-driven drops (stop, listener death).
         case disconnected(connectionId: Int, reason: DisconnectReason?)
@@ -385,8 +388,9 @@ public actor ReactotronServer {
             // with a `.connected`. Ordinary commands still drain below —
             // they're timeline data, not client state.
             guard connections[id] != nil else { return }
-            completeHandshake(connectionId: id, intro: command)
-            emit(.connected(connectionId: id, intro: command, frameBytes: data.count))
+            let clientId = completeHandshake(connectionId: id, intro: command)
+            emit(.connected(
+                connectionId: id, clientId: clientId, intro: command, frameBytes: data.count))
         } else {
             emit(.command(connectionId: id, command: command, frameBytes: data.count))
         }
@@ -398,8 +402,9 @@ public actor ReactotronServer {
     /// stale connection that shares the clientId (an app reload reconnects
     /// before its old socket dies), then send the (empty) subscription list to
     /// complete the handshake — exactly what `reactotron-core-server` does.
-    private func completeHandshake(connectionId id: Int, intro: ReactotronCommand) {
-        guard let box = connections[id] else { return }
+    /// Returns the resolved clientId, carried on the `.connected` event.
+    private func completeHandshake(connectionId id: Int, intro: ReactotronCommand) -> String {
+        guard let box = connections[id] else { return "connection-\(id)" }
         var clientId = intro.payload?["clientId"]?.stringValue
         if clientId == nil || clientId?.isEmpty == true {
             let generated = UUID().uuidString
@@ -411,6 +416,7 @@ public actor ReactotronServer {
             clientIds[id] = clientId
         }
         send(type: "state.values.subscribe", payload: .object(["paths": .array([])]), to: box)
+        return clientId ?? "connection-\(id)"
     }
 
     /// Forget other connections carrying the same clientId — reported with a

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronService.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronService.swift
@@ -72,6 +72,13 @@ public actor ReactotronService {
         }
     }
 
+    /// An additive observer stream of the server's events (see
+    /// `ReactotronServer.tap()`). The MCP layer subscribes here; the primary
+    /// `start()` stream the timeline view consumes is unaffected.
+    public func tap() async -> AsyncStream<ReactotronServer.Event> {
+        await server.tap()
+    }
+
     /// Send a server→client frame to a specific connection.
     public func send(type: String, payload: JSONValue, toConnection id: Int) async {
         await server.send(type: type, payload: payload, toConnection: id)

--- a/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
@@ -1,0 +1,268 @@
+import ADBKit
+import Foundation
+
+/// A command as retained by the MCP buffer: the raw wire command plus the
+/// server-enriched fields upstream's `Command` carries (`messageId` assigned
+/// monotonically here, `clientId` resolved from the connection's handshake).
+public struct McpBufferedCommand: Sendable, Equatable {
+    public let messageId: Int
+    public let connectionId: Int
+    public let clientId: String?
+    public let command: ReactotronCommand
+    public let frameBytes: Int
+
+    public init(
+        messageId: Int, connectionId: Int, clientId: String?,
+        command: ReactotronCommand, frameBytes: Int
+    ) {
+        self.messageId = messageId
+        self.connectionId = connectionId
+        self.clientId = clientId
+        self.command = command
+        self.frameBytes = frameBytes
+    }
+}
+
+/// A connected app, derived from its `client.intro` (upstream reads
+/// `server.connections`; this store derives the same list from events).
+public struct McpClientRecord: Sendable, Equatable {
+    public let connectionId: Int
+    public let clientId: String
+    public let intro: ReactotronCommand
+    /// The app's `mcpRedaction` wishes from the intro payload, if any.
+    public let redaction: McpRedactionConfig?
+
+    public var name: String? { intro.payload?["name"]?.stringValue }
+    public var platform: String? { intro.payload?["platform"]?.stringValue }
+    public var platformVersion: String? { intro.payload?["platformVersion"]?.stringValue }
+}
+
+/// The MCP layer's own retention — upstream's `commandBuffer` beside the
+/// relay, independent of the UI timeline (`clear_timeline` clears only this).
+/// Fed by a `ReactotronServer` tap via `ingest`; everything else is reads.
+///
+/// Reliability posture: bounded by item count *and* bytes (upstream caps only
+/// count), and request/response correlation is event-driven (upstream polls
+/// every 100 ms) — `awaitCommand` resumes on ingest, with an `afterMessageId`
+/// marker so a response can never be satisfied by a stale earlier command.
+public actor McpCommandStore {
+    private var buffer: [McpBufferedCommand] = []
+    private var totalBytes = 0
+    private var nextMessageId = 1
+
+    private var clients: [McpClientRecord] = []
+    /// clientId → latest `state.values.response` payload (the
+    /// `reactotron://state/current` cache).
+    private var latestStateByClient: [String: JSONValue] = [:]
+    /// clientId → command name → registration payload
+    /// (from `customCommand.register`/`unregister`).
+    private var customCommandsByClient: [String: [String: JSONValue]] = [:]
+    /// State paths currently subscribed via the MCP tools (mirrors upstream
+    /// `server.subscriptions`, refreshed by `state.values.change`).
+    private var subscriptionPaths: [String] = []
+
+    private var listeningPort: UInt16?
+
+    private struct PendingWait {
+        let type: String
+        let clientId: String?
+        let afterMessageId: Int
+        let continuation: CheckedContinuation<McpBufferedCommand?, Never>
+    }
+
+    private var pendingWaits: [UUID: PendingWait] = [:]
+
+    private let maxItems: Int
+    private let maxBytes: Int
+
+    public init(maxItems: Int = McpConstants.bufferSize, maxBytes: Int = McpConstants.maxBufferBytes) {
+        self.maxItems = maxItems
+        self.maxBytes = maxBytes
+    }
+
+    // MARK: - Ingest
+
+    /// Feed one relay event in. The caller owns the task iterating the tap:
+    /// `for await event in tap { await store.ingest(event) }`.
+    public func ingest(_ event: ReactotronServer.Event) {
+        switch event {
+        case let .listening(port):
+            listeningPort = port
+        case let .connected(connectionId, clientId, intro, frameBytes):
+            clients.removeAll { $0.connectionId == connectionId || $0.clientId == clientId }
+            clients.append(McpClientRecord(
+                connectionId: connectionId,
+                clientId: clientId,
+                intro: intro,
+                redaction: McpRedactionConfig(json: intro.payload?["mcpRedaction"])
+            ))
+            append(command: intro, connectionId: connectionId, frameBytes: frameBytes)
+        case let .command(connectionId, command, frameBytes):
+            append(command: command, connectionId: connectionId, frameBytes: frameBytes)
+        case let .disconnected(connectionId, _):
+            if let dropped = clients.first(where: { $0.connectionId == connectionId }) {
+                customCommandsByClient[dropped.clientId] = nil
+            }
+            clients.removeAll { $0.connectionId == connectionId }
+        case .failed:
+            listeningPort = nil
+        }
+    }
+
+    private func append(command: ReactotronCommand, connectionId: Int, frameBytes: Int) {
+        let clientId = clients.first { $0.connectionId == connectionId }?.clientId
+        let buffered = McpBufferedCommand(
+            messageId: nextMessageId,
+            connectionId: connectionId,
+            clientId: clientId,
+            command: command,
+            frameBytes: frameBytes
+        )
+        nextMessageId += 1
+        buffer.append(buffered)
+        totalBytes += frameBytes
+        trim()
+        deriveSideState(from: buffered)
+        resolveWaits(with: buffered)
+    }
+
+    private func trim() {
+        let drop = ReactotronTimeline.dropCount(
+            sizes: buffer.lazy.map(\.frameBytes),
+            count: buffer.count,
+            totalBytes: totalBytes,
+            maxCount: maxItems,
+            maxBytes: maxBytes
+        )
+        guard drop > 0 else { return }
+        for dropped in buffer.prefix(drop) { totalBytes -= dropped.frameBytes }
+        buffer.removeFirst(drop)
+    }
+
+    private func deriveSideState(from buffered: McpBufferedCommand) {
+        let command = buffered.command
+        switch command.commandType {
+        case .stateValuesResponse:
+            latestStateByClient[buffered.clientId ?? ""] = command.payload ?? .null
+        case .stateValuesChange:
+            // Mirror upstream: the change event names the currently
+            // subscribed paths.
+            if let changes = command.payload?["changes"]?.arrayValue {
+                subscriptionPaths = changes.compactMap { $0["path"]?.stringValue }
+            }
+        case .customCommandRegister:
+            guard let clientId = buffered.clientId,
+                  let name = command.payload?["command"]?.stringValue else { break }
+            customCommandsByClient[clientId, default: [:]][name] = command.payload ?? .null
+        case .customCommandUnregister:
+            guard let clientId = buffered.clientId,
+                  let name = command.payload?["command"]?.stringValue else { break }
+            customCommandsByClient[clientId]?[name] = nil
+        default:
+            break
+        }
+    }
+
+    // MARK: - Reads
+
+    public var isListening: Bool { listeningPort != nil }
+    public var port: UInt16? { listeningPort }
+    public var connectedClients: [McpClientRecord] { clients }
+    public var lastMessageId: Int { nextMessageId - 1 }
+    public var bufferedCount: Int { buffer.count }
+    public var subscriptions: [String] { subscriptionPaths }
+
+    /// Buffered commands, oldest first, optionally filtered.
+    public func commands(ofType type: String? = nil, clientId: String? = nil) -> [McpBufferedCommand] {
+        buffer.filter { buffered in
+            (type == nil || buffered.command.type == type)
+                && (clientId == nil || buffered.clientId == clientId)
+        }
+    }
+
+    /// Distinct command types currently in the buffer (drives the
+    /// `reactotron://timeline/{type}` template's completion).
+    public func bufferedTypes() -> [String] {
+        var seen = Set<String>()
+        return buffer.compactMap { seen.insert($0.command.type).inserted ? $0.command.type : nil }
+    }
+
+    /// Latest cached `state.values.response` payload for a client (or the
+    /// sole/anonymous client when nil).
+    public func latestState(clientId: String?) -> JSONValue? {
+        if let clientId { return latestStateByClient[clientId] }
+        if clients.count == 1, let sole = clients.first {
+            return latestStateByClient[sole.clientId]
+        }
+        return latestStateByClient[""]
+    }
+
+    /// Registered custom commands for a client, registration order not
+    /// guaranteed (upstream returns a Map's values).
+    public func customCommands(clientId: String) -> [JSONValue] {
+        Array((customCommandsByClient[clientId] ?? [:]).values)
+    }
+
+    /// Empty the MCP buffer (the UI timeline is untouched — upstream parity).
+    public func clear() {
+        buffer.removeAll()
+        totalBytes = 0
+    }
+
+    /// Replace the subscribed-paths list (kept when tools subscribe before
+    /// any `state.values.change` confirms).
+    public func setSubscriptions(_ paths: [String]) {
+        subscriptionPaths = paths
+    }
+
+    // MARK: - Correlation
+
+    /// Wait for the next command of `type` (optionally from `clientId`) whose
+    /// `messageId` is greater than `afterMessageId`. Call with
+    /// `afterMessageId: store.lastMessageId` captured *before* sending the
+    /// request — a response already in flight still matches, a stale one
+    /// can't. Returns nil on timeout. Every continuation resumes exactly once.
+    public func awaitCommand(
+        ofType type: String,
+        clientId: String?,
+        afterMessageId: Int,
+        timeout: Duration = McpConstants.commandTimeout
+    ) async -> McpBufferedCommand? {
+        // Already arrived between send and await? Serve it from the buffer.
+        if let existing = buffer.last(where: { buffered in
+            buffered.messageId > afterMessageId
+                && buffered.command.type == type
+                && (clientId == nil || buffered.clientId == clientId)
+        }) {
+            return existing
+        }
+
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                pendingWaits[id] = PendingWait(
+                    type: type, clientId: clientId,
+                    afterMessageId: afterMessageId, continuation: continuation
+                )
+                Task { [weak self] in
+                    try? await Task.sleep(for: timeout)
+                    await self?.expireWait(id)
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in await self?.expireWait(id) }
+        }
+    }
+
+    private func expireWait(_ id: UUID) {
+        pendingWaits.removeValue(forKey: id)?.continuation.resume(returning: nil)
+    }
+
+    private func resolveWaits(with buffered: McpBufferedCommand) {
+        for (id, wait) in pendingWaits where wait.type == buffered.command.type
+            && buffered.messageId > wait.afterMessageId
+            && (wait.clientId == nil || wait.clientId == buffered.clientId) {
+            pendingWaits.removeValue(forKey: id)?.continuation.resume(returning: buffered)
+        }
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
@@ -63,6 +63,11 @@ public actor McpCommandStore {
 
     private var listeningPort: UInt16?
 
+    /// Server-side redaction posture, hot-updatable from Settings (upstream
+    /// `updateRedactionConfig`). Lives here so tools/resources and the UI
+    /// share one source of truth.
+    private var redactionServerConfig: McpRedactionServerConfig = .standard
+
     private struct PendingWait {
         let type: String
         let clientId: String?
@@ -164,6 +169,12 @@ public actor McpCommandStore {
     }
 
     // MARK: - Reads
+
+    public var redactionConfig: McpRedactionServerConfig { redactionServerConfig }
+
+    public func setRedactionConfig(_ config: McpRedactionServerConfig) {
+        redactionServerConfig = config
+    }
 
     public var isListening: Bool { listeningPort != nil }
     public var port: UInt16? { listeningPort }

--- a/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpCommandStore.swift
@@ -220,6 +220,15 @@ public actor McpCommandStore {
         totalBytes = 0
     }
 
+    /// Forget all connected clients — called when the relay is torn down,
+    /// which cancels sockets without per-connection disconnect events, so
+    /// agents would otherwise see ghost apps.
+    public func clearClients() {
+        clients.removeAll()
+        customCommandsByClient.removeAll()
+        listeningPort = nil
+    }
+
     /// Replace the subscribed-paths list (kept when tools subscribe before
     /// any `state.values.change` confirms).
     public func setSubscriptions(_ paths: [String]) {

--- a/ADBKit/Sources/ReactotronMCP/McpConstants.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpConstants.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Caps and defaults for the MCP layer. Names deliberately mirror upstream
+/// `lib/reactotron-mcp` (`mcp-server.ts` / `serialization.ts`) so an upstream
+/// diff maps to a one-line change here — see `UPSTREAM_VERSIONS` for the
+/// commit this contract targets.
+public enum McpConstants {
+    /// Upstream `BUFFER_SIZE`: most commands the MCP ring buffer retains.
+    public static let bufferSize = 500
+
+    /// Droidective addition (upstream has no byte cap): most cumulative wire
+    /// bytes the buffer retains — a single `image`/`api.response` payload can
+    /// be megabytes, and 500 of those would not be a "small ring buffer".
+    public static let maxBufferBytes = 32 * 1024 * 1024
+
+    /// Upstream `MAX_RESPONSE_CHARS`: every tool/resource result is compact
+    /// JSON truncated to this, with guidance appended for the LLM.
+    public static let maxResponseChars = 800_000
+
+    /// Upstream `MAX_PAYLOAD_PREVIEW_CHARS`: timeline `payloadPreview` cap.
+    public static let maxPayloadPreviewChars = 200
+
+    /// Upstream `MAX_BODY_PREVIEW_CHARS`: network request/response body cap.
+    public static let maxBodyPreviewChars = 500
+
+    /// Upstream default MCP port (`docs/mcp.md`, desktop `config.ts`).
+    public static let defaultPort: UInt16 = 4567
+
+    /// Upstream's request/response poll timeout (1500 ms in `tools.ts`) —
+    /// how long `dispatch_action`/`request_state` wait for the app's answer.
+    public static let commandTimeout: Duration = .milliseconds(1500)
+
+    /// Upstream `show_overlay` image cap (2 MB) and allowed formats.
+    public static let maxOverlayImageBytes = 2 * 1024 * 1024
+}

--- a/ADBKit/Sources/ReactotronMCP/McpHTTPListener.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpHTTPListener.swift
@@ -1,0 +1,393 @@
+import Foundation
+import MCP
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+import os
+
+/// The localhost HTTP front door for MCP: a port of the SDK's conformance
+/// `HTTPApp` (the reference implementation its server transport is tested
+/// against). One route (`/mcp`), one `Server` + `StatefulHTTPServerTransport`
+/// per session (a `Server` accepts exactly one initialize — SDK #144), an
+/// idle-session reaper, and the SDK's default validation pipeline
+/// (`OriginValidator.localhost()` — the spec's DNS-rebinding defense) plus an
+/// optional static bearer token. Binds 127.0.0.1 only, never the LAN.
+public actor McpHTTPListener {
+    public struct Configuration: Sendable {
+        public var port: UInt16
+        public var endpoint: String
+        public var sessionIdleTimeout: Duration
+        /// When set, every request must carry `Authorization: Bearer <token>`.
+        public var bearerToken: String?
+
+        public init(
+            port: UInt16 = McpConstants.defaultPort,
+            endpoint: String = "/mcp",
+            sessionIdleTimeout: Duration = .seconds(1800),
+            bearerToken: String? = nil
+        ) {
+            self.port = port
+            self.endpoint = endpoint
+            self.sessionIdleTimeout = sessionIdleTimeout
+            self.bearerToken = bearerToken
+        }
+    }
+
+    public enum ListenerError: Error, Sendable, LocalizedError {
+        case portInUse(UInt16)
+        case bindFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case let .portInUse(port):
+                "Port \(port) is already in use — is another MCP server (or the Reactotron "
+                    + "desktop app) running?"
+            case let .bindFailed(detail):
+                "MCP listener failed to start: \(detail)"
+            }
+        }
+    }
+
+    private static let log = Logger(
+        subsystem: "com.rohindh.droidective", category: "reactotron-mcp")
+
+    private let configuration: Configuration
+    private let factory: McpServerFactory
+    private var group: MultiThreadedEventLoopGroup?
+    private var channel: Channel?
+    private var reaperTask: Task<Void, Never>?
+
+    private struct SessionContext {
+        let server: Server
+        let transport: StatefulHTTPServerTransport
+        var lastAccessedAt: ContinuousClock.Instant
+    }
+
+    private var sessions: [String: SessionContext] = [:]
+
+    public init(configuration: Configuration, factory: McpServerFactory) {
+        self.configuration = configuration
+        self.factory = factory
+    }
+
+    /// The port actually bound (differs from the configured one only when
+    /// constructed with port 0 in tests). Nil until started.
+    public var boundPort: UInt16? {
+        channel?.localAddress?.port.map(UInt16.init)
+    }
+
+    public var activeSessionCount: Int { sessions.count }
+
+    // MARK: - Lifecycle
+
+    /// Bind and start serving. Returns once the socket is listening; throws
+    /// `.portInUse` on EADDRINUSE so the UI can say something useful.
+    public func start() async throws {
+        guard channel == nil else { return }
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        self.group = group
+
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 16)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(HTTPHandler(listener: self))
+                }
+            }
+            .childChannelOption(ChannelOptions.maxMessagesPerRead, value: 1)
+
+        do {
+            // Loopback only — the MCP endpoint must never be LAN-reachable,
+            // regardless of the Reactotron relay's own LAN toggle.
+            channel = try await bootstrap.bind(
+                host: "127.0.0.1", port: Int(configuration.port)
+            ).get()
+        } catch {
+            try? await group.shutdownGracefully()
+            self.group = nil
+            if let ioError = error as? IOError, ioError.errnoCode == EADDRINUSE {
+                throw ListenerError.portInUse(configuration.port)
+            }
+            throw ListenerError.bindFailed("\(error)")
+        }
+
+        Self.log.notice("MCP listener bound on 127.0.0.1:\(self.boundPort ?? 0, privacy: .public)")
+        reaperTask = Task { [weak self, configuration] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                await self?.reapIdleSessions(olderThan: configuration.sessionIdleTimeout)
+            }
+        }
+    }
+
+    /// Close every session and the socket. Safe to call repeatedly.
+    public func stop() async {
+        reaperTask?.cancel()
+        reaperTask = nil
+        for sessionID in sessions.keys {
+            await closeSession(sessionID)
+        }
+        try? await channel?.close()
+        channel = nil
+        if let group {
+            try? await group.shutdownGracefully()
+        }
+        group = nil
+        Self.log.notice("MCP listener stopped")
+    }
+
+    // MARK: - Request routing (port of HTTPApp.handleHTTPRequest)
+
+    nonisolated var endpoint: String { configuration.endpoint }
+
+    func handleHTTPRequest(_ request: HTTPRequest) async -> HTTPResponse {
+        let sessionID = request.header(HTTPHeaderName.sessionID)
+
+        if let sessionID, var session = sessions[sessionID] {
+            session.lastAccessedAt = .now
+            sessions[sessionID] = session
+
+            let response = await session.transport.handleRequest(request)
+            if request.method.uppercased() == "DELETE", response.statusCode == 200 {
+                sessions.removeValue(forKey: sessionID)
+            }
+            return response
+        }
+
+        if request.method.uppercased() == "POST",
+           let body = request.body,
+           Self.isInitializeRequest(body) {
+            return await createSessionAndHandle(request)
+        }
+
+        if sessionID != nil {
+            return .error(
+                statusCode: 404,
+                .invalidRequest("Not Found: Session not found or expired"))
+        }
+        return .error(
+            statusCode: 400,
+            .invalidRequest("Bad Request: Missing \(HTTPHeaderName.sessionID) header"))
+    }
+
+    /// The SDK's `JSONRPCMessageKind` is package-scoped; this is the one
+    /// check the router needs from it.
+    static func isInitializeRequest(_ body: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: body) else { return false }
+        if let dict = object as? [String: Any] {
+            return dict["method"] as? String == "initialize"
+        }
+        if let array = object as? [Any] {
+            return array.contains { ($0 as? [String: Any])?["method"] as? String == "initialize" }
+        }
+        return false
+    }
+
+    // MARK: - Sessions
+
+    private struct FixedSessionIDGenerator: SessionIDGenerator {
+        let sessionID: String
+        func generateSessionID() -> String { sessionID }
+    }
+
+    /// The SDK's default validators, plus the static bearer check when a
+    /// token is configured (`AuthorizationTokenValidator` below).
+    private func validationPipeline() -> any HTTPRequestValidationPipeline {
+        var validators: [any HTTPRequestValidator] = []
+        if let token = configuration.bearerToken {
+            validators.append(AuthorizationTokenValidator(expectedToken: token))
+        }
+        validators += [
+            OriginValidator.localhost(),
+            AcceptHeaderValidator(mode: .sseRequired),
+            ContentTypeValidator(),
+            ProtocolVersionValidator(),
+            SessionValidator(),
+        ]
+        return StandardValidationPipeline(validators: validators)
+    }
+
+    private func createSessionAndHandle(_ request: HTTPRequest) async -> HTTPResponse {
+        let sessionID = UUID().uuidString
+        let transport = StatefulHTTPServerTransport(
+            sessionIDGenerator: FixedSessionIDGenerator(sessionID: sessionID),
+            validationPipeline: validationPipeline()
+        )
+
+        do {
+            let server = await factory.makeServer()
+            try await server.start(transport: transport)
+            sessions[sessionID] = SessionContext(
+                server: server, transport: transport, lastAccessedAt: .now)
+
+            let response = await transport.handleRequest(request)
+            if case .error = response {
+                sessions.removeValue(forKey: sessionID)
+                await transport.disconnect()
+            }
+            return response
+        } catch {
+            await transport.disconnect()
+            return .error(
+                statusCode: 500,
+                .internalError("Failed to create session: \(error.localizedDescription)"))
+        }
+    }
+
+    private func closeSession(_ sessionID: String) async {
+        guard let session = sessions.removeValue(forKey: sessionID) else { return }
+        await session.transport.disconnect()
+        await session.server.stop()
+    }
+
+    private func reapIdleSessions(olderThan timeout: Duration) async {
+        let now = ContinuousClock.Instant.now
+        let expired = sessions.filter { now - $0.value.lastAccessedAt > timeout }
+        for sessionID in expired.keys {
+            Self.log.notice("MCP session idle-expired")
+            await closeSession(sessionID)
+        }
+    }
+}
+
+/// Rejects requests whose `Authorization` header doesn't carry the expected
+/// static bearer token — the right weight for a localhost devtool (the SDK's
+/// `BearerTokenValidator` models full OAuth resource servers).
+struct AuthorizationTokenValidator: HTTPRequestValidator {
+    let expectedToken: String
+
+    func validate(_ request: HTTPRequest, context: HTTPValidationContext) -> HTTPResponse? {
+        guard let authorization = request.header(HTTPHeaderName.authorization),
+              authorization == "Bearer \(expectedToken)" else {
+            return .error(
+                statusCode: 401,
+                .invalidRequest("Unauthorized: missing or invalid bearer token"))
+        }
+        return nil
+    }
+}
+
+// MARK: - NIO adapter (port of HTTPApp.HTTPHandler)
+
+/// Converts between NIO HTTP parts and the SDK's framework-agnostic
+/// `HTTPRequest`/`HTTPResponse`, delegating all logic to the listener actor.
+/// State is only touched on the channel's event loop; responses are written
+/// back through `eventLoop.execute`.
+private final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private let listener: McpHTTPListener
+
+    private struct RequestState {
+        var head: HTTPRequestHead
+        var bodyBuffer: ByteBuffer
+    }
+
+    /// `ChannelHandlerContext` isn't Sendable; it's only touched through
+    /// `eventLoop.execute`, so box it to cross the Task hop (the same
+    /// pattern as `ReactotronServer.ConnectionBox`).
+    private struct ContextBox: @unchecked Sendable {
+        let context: ChannelHandlerContext
+    }
+
+    private var requestState: RequestState?
+
+    init(listener: McpHTTPListener) {
+        self.listener = listener
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case let .head(head):
+            requestState = RequestState(
+                head: head, bodyBuffer: context.channel.allocator.buffer(capacity: 0))
+        case var .body(buffer):
+            requestState?.bodyBuffer.writeBuffer(&buffer)
+        case .end:
+            guard let state = requestState else { return }
+            requestState = nil
+            // Convert to the SDK's Sendable HTTPRequest *before* leaving the
+            // event loop — NIO's head/buffer types can't cross the Task hop.
+            let request = makeHTTPRequest(from: state)
+            let version = state.head.version
+            let box = ContextBox(context: context)
+            Task { await self.handleRequest(request, version: version, box: box) }
+        }
+    }
+
+    private func handleRequest(
+        _ request: HTTPRequest, version: HTTPVersion, box: ContextBox
+    ) async {
+        guard request.path == listener.endpoint else {
+            await writeResponse(
+                .error(statusCode: 404, .invalidRequest("Not Found")),
+                version: version, box: box)
+            return
+        }
+        let response = await listener.handleHTTPRequest(request)
+        await writeResponse(response, version: version, box: box)
+    }
+
+    private func makeHTTPRequest(from state: RequestState) -> HTTPRequest {
+        var headers: [String: String] = [:]
+        for (name, value) in state.head.headers {
+            headers[name] = headers[name].map { $0 + ", " + value } ?? value
+        }
+        let body: Data? = state.bodyBuffer.readableBytes > 0
+            ? state.bodyBuffer.getBytes(at: 0, length: state.bodyBuffer.readableBytes)
+                .map { Data($0) }
+            : nil
+        let path = String(state.head.uri.split(separator: "?").first ?? Substring(state.head.uri))
+        return HTTPRequest(
+            method: state.head.method.rawValue, headers: headers, body: body, path: path)
+    }
+
+    private func writeResponse(
+        _ response: HTTPResponse, version: HTTPVersion, box: ContextBox
+    ) async {
+        let eventLoop = box.context.eventLoop
+        let statusCode = response.statusCode
+        let headers = response.headers
+
+        switch response {
+        case let .stream(stream, _):
+            eventLoop.execute {
+                var head = HTTPResponseHead(
+                    version: version, status: HTTPResponseStatus(statusCode: statusCode))
+                for (name, value) in headers { head.headers.add(name: name, value: value) }
+                box.context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+                box.context.flush()
+            }
+            do {
+                for try await chunk in stream {
+                    eventLoop.execute {
+                        var buffer = box.context.channel.allocator.buffer(capacity: chunk.count)
+                        buffer.writeBytes(chunk)
+                        box.context.writeAndFlush(
+                            self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                    }
+                }
+            } catch {
+                // Stream ended with an error — fall through and close out.
+            }
+            eventLoop.execute {
+                box.context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+            }
+        default:
+            let bodyData = response.bodyData
+            eventLoop.execute {
+                var head = HTTPResponseHead(
+                    version: version, status: HTTPResponseStatus(statusCode: statusCode))
+                for (name, value) in headers { head.headers.add(name: name, value: value) }
+                box.context.write(self.wrapOutboundOut(.head(head)), promise: nil)
+                if let body = bodyData {
+                    var buffer = box.context.channel.allocator.buffer(capacity: body.count)
+                    buffer.writeBytes(body)
+                    box.context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                }
+                box.context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+            }
+        }
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpHTTPListener.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpHTTPListener.swift
@@ -3,7 +3,9 @@ import MCP
 import NIOCore
 import NIOHTTP1
 import NIOPosix
+#if canImport(os)
 import os
+#endif
 
 /// The localhost HTTP front door for MCP: a port of the SDK's conformance
 /// `HTTPApp` (the reference implementation its server transport is tested
@@ -48,8 +50,15 @@ public actor McpHTTPListener {
         }
     }
 
-    private static let log = Logger(
-        subsystem: "com.rohindh.droidective", category: "reactotron-mcp")
+    /// Unified-log notice, gated so the target stays portable (the port
+    /// branch's Linux daemon builds this file; everything else here is
+    /// cross-platform — NIO, the MCP SDK, Foundation).
+    private static func note(_ message: String) {
+        #if canImport(os)
+        Logger(subsystem: "com.rohindh.droidective", category: "reactotron-mcp")
+            .notice("\(message, privacy: .public)")
+        #endif
+    }
 
     private let configuration: Configuration
     private let factory: McpServerFactory
@@ -111,7 +120,7 @@ public actor McpHTTPListener {
             throw ListenerError.bindFailed("\(error)")
         }
 
-        Self.log.notice("MCP listener bound on 127.0.0.1:\(self.boundPort ?? 0, privacy: .public)")
+        Self.note("MCP listener bound on 127.0.0.1:\(boundPort ?? 0)")
         reaperTask = Task { [weak self, configuration] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(60))
@@ -133,7 +142,7 @@ public actor McpHTTPListener {
             try? await group.shutdownGracefully()
         }
         group = nil
-        Self.log.notice("MCP listener stopped")
+        Self.note("MCP listener stopped")
     }
 
     // MARK: - Request routing (port of HTTPApp.handleHTTPRequest)
@@ -244,7 +253,7 @@ public actor McpHTTPListener {
         let now = ContinuousClock.Instant.now
         let expired = sessions.filter { now - $0.value.lastAccessedAt > timeout }
         for sessionID in expired.keys {
-            Self.log.notice("MCP session idle-expired")
+            Self.note("MCP session idle-expired")
             await closeSession(sessionID)
         }
     }

--- a/ADBKit/Sources/ReactotronMCP/McpRedaction.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpRedaction.swift
@@ -1,0 +1,430 @@
+import ADBKit
+import Foundation
+
+/// Redaction rule set — the Swift form of upstream's `McpRedactionRules`
+/// (`reactotron-core-contract/src/mcpRedaction.ts`).
+public struct McpRedactionRules: Sendable, Equatable, Codable {
+    public var sensitiveKeys: [String]
+    public var statePathPatterns: [String]
+    public var valuePatterns: [String]
+
+    public init(
+        sensitiveKeys: [String] = [],
+        statePathPatterns: [String] = [],
+        valuePatterns: [String] = []
+    ) {
+        self.sensitiveKeys = sensitiveKeys
+        self.statePathPatterns = statePathPatterns
+        self.valuePatterns = valuePatterns
+    }
+}
+
+/// A client's redaction wishes, sent as `mcpRedaction` inside `client.intro` —
+/// upstream's `McpRedactionConfig`. `removeRules`/`disableRedaction` only take
+/// effect when the matching server-side permission is on (the two-key model).
+public struct McpRedactionConfig: Sendable, Equatable {
+    public var disableRedaction: Bool
+    public var additionalRules: McpRedactionRules?
+    public var removeRules: McpRedactionRules?
+
+    public init(
+        disableRedaction: Bool = false,
+        additionalRules: McpRedactionRules? = nil,
+        removeRules: McpRedactionRules? = nil
+    ) {
+        self.disableRedaction = disableRedaction
+        self.additionalRules = additionalRules
+        self.removeRules = removeRules
+    }
+
+    /// Lenient parse from the `client.intro` payload's `mcpRedaction` field.
+    /// Nil when the field is absent or not an object — never fails the intro.
+    public init?(json: JSONValue?) {
+        guard let object = json?.objectValue else { return nil }
+        disableRedaction = object["disableRedaction"]?.boolValue ?? false
+        additionalRules = Self.rules(from: object["additionalRules"])
+        removeRules = Self.rules(from: object["removeRules"])
+    }
+
+    private static func rules(from json: JSONValue?) -> McpRedactionRules? {
+        guard let object = json?.objectValue else { return nil }
+        func strings(_ key: String) -> [String] {
+            object[key]?.arrayValue?.compactMap(\.stringValue) ?? []
+        }
+        return McpRedactionRules(
+            sensitiveKeys: strings("sensitiveKeys"),
+            statePathPatterns: strings("statePathPatterns"),
+            valuePatterns: strings("valuePatterns")
+        )
+    }
+}
+
+/// Server-side redaction posture — upstream's `McpRedactionServerConfig`.
+public struct McpRedactionServerConfig: Sendable, Equatable, Codable {
+    public var defaults: McpRedactionRules
+    public var allowClientDisable: Bool
+    public var allowClientRemoveRules: Bool
+
+    public init(
+        defaults: McpRedactionRules = McpRedaction.defaultRules,
+        allowClientDisable: Bool = false,
+        allowClientRemoveRules: Bool = false
+    ) {
+        self.defaults = defaults
+        self.allowClientDisable = allowClientDisable
+        self.allowClientRemoveRules = allowClientRemoveRules
+    }
+
+    /// Upstream `DEFAULT_SERVER_CONFIG`: default rules on, both opt-out
+    /// permissions off.
+    public static let standard = McpRedactionServerConfig()
+}
+
+/// Rules compiled for repeated application. `NSRegularExpression` is immutable
+/// and documented thread-safe, hence the unchecked conformance.
+public struct McpParsedRules: @unchecked Sendable {
+    let sensitiveKeysLower: Set<String>
+    /// All valid `valuePatterns` folded into one alternation (upstream
+    /// `compileCombinedValueRegex`); nil when none compile.
+    let combinedValueRegex: NSRegularExpression?
+    let statePathPatterns: [String]
+    /// Gates path-string allocation — only pay for it when patterns exist.
+    let trackPaths: Bool
+}
+
+/// The redaction engine — a pure port of upstream `redaction.ts`, applied at
+/// the MCP boundary only (the Droidective UI stays unredacted, like the
+/// Reactotron desktop). Everything operates on `JSONValue`, so there are no
+/// circular references to defend against (upstream's `seen` set has no
+/// equivalent here by construction).
+public enum McpRedaction {
+    public static let redactedMarker = "[REDACTED]"
+
+    static let maxJsonStringDepth = 5
+    static let maxJsonParseLength = 1_000_000
+    static let maxFormEncodedLength = 8192
+
+    /// Upstream `DEFAULT_REDACTION_RULES`, verbatim.
+    public static let defaultRules = McpRedactionRules(
+        sensitiveKeys: [
+            // Credentials
+            "password", "passwd", "pwd",
+            "secret", "client_secret", "clientsecret",
+            "credentials", "ssn", "creditcard",
+            "privatekey", "private_key",
+            // API keys
+            "apikey", "api_key", "x-api-key",
+            // Auth tokens
+            "accesstoken", "access_token",
+            "refreshtoken", "refresh_token",
+            "idtoken", "id_token",
+            "token", "bearer", "jwt",
+            // Session / CSRF
+            "session", "sessionid", "session_id",
+            "csrf", "xsrf", "csrf_token", "xsrf_token",
+            // HTTP headers
+            "authorization", "cookie", "set-cookie", "proxy-authorization",
+            "x-auth-token", "x-csrf-token", "x-xsrf-token", "csrf-token",
+            "x-forwarded-for", "x-real-ip",
+        ],
+        statePathPatterns: [],
+        valuePatterns: [
+            // Bearer tokens
+            #"Bearer\s+[A-Za-z0-9\-._~+/]+=*"#,
+            // JWTs (header.payload[.signature])
+            #"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"#,
+            // OpenAI-style keys
+            #"sk-[a-zA-Z0-9_-]{20,}"#,
+            // Anthropic API keys
+            #"sk-ant-[a-zA-Z0-9_-]{20,}"#,
+            // GitHub PATs / fine-grained tokens
+            #"gh[pousr]_[A-Za-z0-9]{30,}"#,
+            // Slack tokens
+            #"xox[bpoas]-[a-zA-Z0-9\-]{10,}"#,
+            // AWS access key IDs
+            #"AKIA[0-9A-Z]{16}"#,
+            // Google API keys
+            #"AIza[0-9A-Za-z\-_]{35}"#,
+            // Stripe keys (live/test, secret/publishable/restricted)
+            #"(?:sk|pk|rk)_(?:test|live)_[A-Za-z0-9]{24,}"#,
+            // PEM-encoded private key blocks
+            #"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]+?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----"#,
+        ]
+    )
+
+    // MARK: - Rule resolution (the two-key model)
+
+    /// Merge server defaults with a client's config. `additionalRules` apply
+    /// unconditionally; `disableRedaction`/`removeRules` need the matching
+    /// server permission. Nil result = redaction disabled for this client.
+    public static func resolveEffectiveRules(
+        server: McpRedactionServerConfig,
+        client: McpRedactionConfig?
+    ) -> McpRedactionRules? {
+        guard let client else { return server.defaults }
+        if client.disableRedaction, server.allowClientDisable { return nil }
+        var rules = server.defaults
+        if let remove = client.removeRules, server.allowClientRemoveRules {
+            rules = subtract(rules, removing: remove)
+        }
+        if let additional = client.additionalRules {
+            rules = merge(rules, adding: additional)
+        }
+        return rules
+    }
+
+    static func merge(_ base: McpRedactionRules, adding additional: McpRedactionRules) -> McpRedactionRules {
+        McpRedactionRules(
+            sensitiveKeys: dedupe(base.sensitiveKeys + additional.sensitiveKeys),
+            statePathPatterns: dedupe(base.statePathPatterns + additional.statePathPatterns),
+            valuePatterns: dedupe(base.valuePatterns + additional.valuePatterns)
+        )
+    }
+
+    static func subtract(_ base: McpRedactionRules, removing remove: McpRedactionRules) -> McpRedactionRules {
+        let removeKeys = Set(remove.sensitiveKeys.map { $0.lowercased() })
+        let removePaths = Set(remove.statePathPatterns)
+        let removePatterns = Set(remove.valuePatterns)
+        return McpRedactionRules(
+            sensitiveKeys: base.sensitiveKeys.filter { !removeKeys.contains($0.lowercased()) },
+            statePathPatterns: base.statePathPatterns.filter { !removePaths.contains($0) },
+            valuePatterns: base.valuePatterns.filter { !removePatterns.contains($0) }
+        )
+    }
+
+    private static func dedupe(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+
+    // MARK: - Compilation
+
+    /// Validate each pattern individually so one bad regex doesn't kill the
+    /// rest, then fold survivors into a single alternation.
+    public static func parse(_ rules: McpRedactionRules) -> McpParsedRules {
+        let valid = rules.valuePatterns.filter {
+            (try? NSRegularExpression(pattern: $0)) != nil
+        }
+        let combined = valid.isEmpty
+            ? nil
+            : try? NSRegularExpression(pattern: valid.map { "(?:\($0))" }.joined(separator: "|"))
+        return McpParsedRules(
+            sensitiveKeysLower: Set(rules.sensitiveKeys.map { $0.lowercased() }),
+            combinedValueRegex: combined,
+            statePathPatterns: rules.statePathPatterns,
+            trackPaths: !rules.statePathPatterns.isEmpty
+        )
+    }
+
+    // MARK: - Redaction
+
+    /// Deep-redact a generic payload (network entry, log event, action…).
+    public static func redact(_ value: JSONValue, parsed: McpParsedRules) -> JSONValue {
+        redactValue(value, parsed: parsed, currentPath: "", jsonStringDepth: 0)
+    }
+
+    /// Redact a state payload anchored at `statePath` ("" for the full tree),
+    /// so `statePathPatterns` written against the whole tree still line up
+    /// when the app returned a subtree.
+    public static func redactState(
+        _ value: JSONValue, parsed: McpParsedRules, statePath: String
+    ) -> JSONValue {
+        redactValue(value, parsed: parsed, currentPath: statePath, jsonStringDepth: 0)
+    }
+
+    /// Redact an AsyncStorage mutation payload: the *storage key* carries the
+    /// sensitive name (`auth:password`), so match keys by substring first,
+    /// then deep-walk whatever remains.
+    public static func redactAsyncStorage(_ value: JSONValue, parsed: McpParsedRules) -> JSONValue {
+        guard !parsed.sensitiveKeysLower.isEmpty else { return value }
+        return redact(redactAsyncStorageItem(value, parsed: parsed), parsed: parsed)
+    }
+
+    private static func redactValue(
+        _ value: JSONValue, parsed: McpParsedRules, currentPath: String, jsonStringDepth: Int
+    ) -> JSONValue {
+        switch value {
+        case .null, .bool, .number:
+            return value
+        case let .string(text):
+            return .string(redactString(text, parsed: parsed, jsonStringDepth: jsonStringDepth))
+        case let .array(items):
+            if !parsed.trackPaths {
+                return .array(items.map {
+                    redactValue($0, parsed: parsed, currentPath: "", jsonStringDepth: jsonStringDepth)
+                })
+            }
+            return .array(items.enumerated().map { index, item in
+                let childPath = currentPath.isEmpty ? String(index) : "\(currentPath).\(index)"
+                return redactValue(
+                    item, parsed: parsed, currentPath: childPath, jsonStringDepth: jsonStringDepth)
+            })
+        case let .object(dict):
+            var result: [String: JSONValue] = [:]
+            result.reserveCapacity(dict.count)
+            for (key, child) in dict {
+                if parsed.sensitiveKeysLower.contains(key.lowercased()) {
+                    result[key] = .string(redactedMarker)
+                    continue
+                }
+                if parsed.trackPaths {
+                    let childPath = currentPath.isEmpty ? key : "\(currentPath).\(key)"
+                    if matchesStatePath(childPath, patterns: parsed.statePathPatterns) {
+                        result[key] = .string(redactedMarker)
+                        continue
+                    }
+                    result[key] = redactValue(
+                        child, parsed: parsed, currentPath: childPath, jsonStringDepth: jsonStringDepth)
+                } else {
+                    result[key] = redactValue(
+                        child, parsed: parsed, currentPath: "", jsonStringDepth: jsonStringDepth)
+                }
+            }
+            return .object(result)
+        }
+    }
+
+    static func redactString(
+        _ value: String, parsed: McpParsedRules, jsonStringDepth: Int
+    ) -> String {
+        var result = value
+
+        // JSON embedded in a string: parse → redact → re-stringify, guarded by
+        // depth (nested stringify layers) and size (don't parse huge strings).
+        if jsonStringDepth < maxJsonStringDepth, result.count <= maxJsonParseLength {
+            let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+            let looksLikeJson = (trimmed.hasPrefix("{") && trimmed.hasSuffix("}"))
+                || (trimmed.hasPrefix("[") && trimmed.hasSuffix("]"))
+            if looksLikeJson,
+               let inner = try? JSONDecoder().decode(JSONValue.self, from: Data(result.utf8)),
+               inner.objectValue != nil || inner.arrayValue != nil {
+                let redacted = redactValue(
+                    inner, parsed: parsed, currentPath: "", jsonStringDepth: jsonStringDepth + 1)
+                return redacted.jsonString
+            }
+        }
+
+        if !parsed.sensitiveKeysLower.isEmpty {
+            if result.contains("?") {
+                result = redactUrlQueryParams(result, sensitiveKeysLower: parsed.sensitiveKeysLower)
+            } else if looksLikeFormEncoded(result) {
+                result = redactFormEncodedParams(result, sensitiveKeysLower: parsed.sensitiveKeysLower)
+            }
+        }
+
+        if let regex = parsed.combinedValueRegex {
+            result = regex.stringByReplacingMatches(
+                in: result, range: NSRange(result.startIndex..., in: result),
+                withTemplate: redactedMarker
+            )
+        }
+        return result
+    }
+
+    /// Detect a form-urlencoded body ("user=alice&password=x"). The strict
+    /// `^k=v(&k=v)*$` anchor avoids false positives on prose like "x=5".
+    private static let formEncodedRegex = try? NSRegularExpression(
+        pattern: #"^[\w.\-+~*\[\]%]+=[^&]*(?:&[\w.\-+~*\[\]%]+=[^&]*)*$"#
+    )
+
+    static func looksLikeFormEncoded(_ value: String) -> Bool {
+        guard !value.isEmpty, value.count <= maxFormEncodedLength,
+              let regex = formEncodedRegex else { return false }
+        let range = NSRange(value.startIndex..., in: value)
+        return regex.firstMatch(in: value, range: range) != nil
+    }
+
+    static func redactFormEncodedParams(_ value: String, sensitiveKeysLower: Set<String>) -> String {
+        value.components(separatedBy: "&").map { param in
+            redactParam(param, sensitiveKeysLower: sensitiveKeysLower)
+        }.joined(separator: "&")
+    }
+
+    static func redactUrlQueryParams(_ value: String, sensitiveKeysLower: Set<String>) -> String {
+        guard let questionIndex = value.firstIndex(of: "?") else { return value }
+        let base = String(value[...questionIndex])
+        let queryString = String(value[value.index(after: questionIndex)...])
+
+        let query: String
+        let fragment: String
+        if let hashIndex = queryString.firstIndex(of: "#") {
+            query = String(queryString[..<hashIndex])
+            fragment = String(queryString[hashIndex...])
+        } else {
+            query = queryString
+            fragment = ""
+        }
+
+        let redacted = query.components(separatedBy: "&").map { param in
+            redactParam(param, sensitiveKeysLower: sensitiveKeysLower)
+        }.joined(separator: "&")
+        return base + redacted + fragment
+    }
+
+    private static func redactParam(_ param: String, sensitiveKeysLower: Set<String>) -> String {
+        guard let equalsIndex = param.firstIndex(of: "=") else { return param }
+        let name = String(param[..<equalsIndex])
+        guard sensitiveKeysLower.contains(name.lowercased()) else { return param }
+        return "\(name)=\(redactedMarker)"
+    }
+
+    static func matchesStatePath(_ currentPath: String, patterns: [String]) -> Bool {
+        for pattern in patterns {
+            if pattern.hasSuffix(".*") {
+                let prefix = String(pattern.dropLast(2))
+                // "auth.tokens.*" matches "auth.tokens.access" but NOT
+                // "auth.tokens" itself.
+                if currentPath.hasPrefix(prefix + "."), currentPath.count > prefix.count + 1 {
+                    return true
+                }
+            } else if currentPath == pattern {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - AsyncStorage shapes
+
+    static func storageKeyIsSensitive(_ storageKey: String, sensitiveKeysLower: Set<String>) -> Bool {
+        let keyLower = storageKey.lowercased()
+        return sensitiveKeysLower.contains { keyLower.contains($0) }
+    }
+
+    private static func redactAsyncStorageItem(_ value: JSONValue, parsed: McpParsedRules) -> JSONValue {
+        // [key, value] tuple from a multiSet/multiMerge `pairs` entry.
+        if let pair = value.arrayValue, pair.count == 2, let key = pair[0].stringValue {
+            if storageKeyIsSensitive(key, sensitiveKeysLower: parsed.sensitiveKeysLower) {
+                return .array([.string(key), .string(redactedMarker)])
+            }
+            if let text = pair[1].stringValue {
+                return .array([
+                    .string(key),
+                    .string(redactString(text, parsed: parsed, jsonStringDepth: 0)),
+                ])
+            }
+            return value
+        }
+
+        guard var object = value.objectValue else { return value }
+
+        // multiSet / multiMerge: { pairs: [[key, value], ...] }
+        if let pairs = object["pairs"]?.arrayValue {
+            object["pairs"] = .array(pairs.map { redactAsyncStorageItem($0, parsed: parsed) })
+            return .object(object)
+        }
+
+        // setItem / mergeItem: { key, value }
+        if let key = object["key"]?.stringValue {
+            if storageKeyIsSensitive(key, sensitiveKeysLower: parsed.sensitiveKeysLower),
+               object["value"] != nil {
+                object["value"] = .string(redactedMarker)
+            } else if let text = object["value"]?.stringValue {
+                object["value"] = .string(redactString(text, parsed: parsed, jsonStringDepth: 0))
+            }
+            return .object(object)
+        }
+
+        return value
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpRedactor.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpRedactor.swift
@@ -1,0 +1,51 @@
+import ADBKit
+import Foundation
+
+/// Scoped redactor caching resolved rules per clientId — create one per MCP
+/// request so an aggregated read resolves each distinct app's rules once
+/// (upstream `createRedactor`). A nil parsed entry means that client is
+/// allowed to run unredacted (two-key opt-out granted).
+struct McpRedactor {
+    private let config: McpRedactionServerConfig
+    private let clients: [McpClientRecord]
+    private var cache: [String: McpParsedRules?] = [:]
+
+    private static let noClientKey = "\0__no_client__"
+
+    init(config: McpRedactionServerConfig, clients: [McpClientRecord]) {
+        self.config = config
+        self.clients = clients
+    }
+
+    private mutating func parsedRules(for clientId: String?) -> McpParsedRules? {
+        let key = clientId ?? Self.noClientKey
+        if let cached = cache[key] { return cached }
+
+        let clientConfig: McpRedactionConfig? = if let clientId {
+            clients.first { $0.clientId == clientId }?.redaction
+        } else if clients.count == 1 {
+            clients.first?.redaction
+        } else {
+            nil
+        }
+        let rules = McpRedaction.resolveEffectiveRules(server: config, client: clientConfig)
+        let parsed = rules.map(McpRedaction.parse)
+        cache[key] = parsed
+        return parsed
+    }
+
+    mutating func redact(_ value: JSONValue, clientId: String?) -> JSONValue {
+        guard let parsed = parsedRules(for: clientId) else { return value }
+        return McpRedaction.redact(value, parsed: parsed)
+    }
+
+    mutating func redactState(_ value: JSONValue, clientId: String?, statePath: String) -> JSONValue {
+        guard let parsed = parsedRules(for: clientId) else { return value }
+        return McpRedaction.redactState(value, parsed: parsed, statePath: statePath)
+    }
+
+    mutating func redactAsyncStorage(_ value: JSONValue, clientId: String?) -> JSONValue {
+        guard let parsed = parsedRules(for: clientId) else { return value }
+        return McpRedaction.redactAsyncStorage(value, parsed: parsed)
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpResources.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpResources.swift
@@ -1,0 +1,356 @@
+import ADBKit
+import Foundation
+import MCP
+
+/// The 8-resource contract of upstream `lib/reactotron-mcp/src/resources.ts`:
+/// seven static resources plus the `reactotron://timeline/{type}` template
+/// (listed per buffered type, completable). All reads snapshot the store,
+/// redact per originating client, and serialize through the 800k truncation.
+public struct McpResources: Sendable {
+    let store: McpCommandStore
+
+    public init(store: McpCommandStore) {
+        self.store = store
+    }
+
+    // MARK: - Listing
+
+    struct StaticResource {
+        let name: String
+        let uri: String
+        let description: String
+    }
+
+    static let staticResources: [StaticResource] = [
+        StaticResource(
+            name: "timeline", uri: "reactotron://timeline",
+            description: "Read this first to understand what's happening in the app. Returns "
+                + "summarized debug events (type, timestamp, and a short preview) newest-first. "
+                + "Payloads are stripped to keep the response small. Use the timeline_by_type "
+                + "resource template to get full event data filtered by type "
+                + "(e.g. reactotron://timeline/api.response)."
+        ),
+        StaticResource(
+            name: "state", uri: "reactotron://state/current",
+            description: "Latest cached Redux/MST state snapshot. May be stale — use the "
+                + "request_state tool for a fresh snapshot. Returns no_state_received if the "
+                + "app hasn't sent state yet."
+        ),
+        StaticResource(
+            name: "network", uri: "reactotron://network/log",
+            description: "Captured HTTP requests and responses. Each entry shows URL, method, "
+                + "status, duration, headers, and previews of request/response bodies "
+                + "(truncated to 500 chars). Use timeline_by_type with type 'api.response' "
+                + "for full request/response data."
+        ),
+        StaticResource(
+            name: "apps", uri: "reactotron://apps",
+            description: "Apps currently connected to Reactotron with their clientId, name, "
+                + "platform, and version. Read this to find the clientId needed for "
+                + "multi-app filtering."
+        ),
+        StaticResource(
+            name: "benchmarks", uri: "reactotron://benchmarks",
+            description: "Performance benchmark results from connected apps, sorted by time. "
+                + "Each has title, steps, and durations."
+        ),
+        StaticResource(
+            name: "subscriptions", uri: "reactotron://state/subscriptions",
+            description: "State subscription changes. Shows values at subscribed paths whenever "
+                + "they change. Use the subscribe_state tool to add subscriptions."
+        ),
+        StaticResource(
+            name: "asyncstorage", uri: "reactotron://asyncstorage",
+            description: "AsyncStorage mutations captured from the app. Shows setItem, "
+                + "removeItem, mergeItem, multiSet, multiRemove, multiMerge, and clear "
+                + "operations with their keys and values."
+        ),
+    ]
+
+    static let timelineTemplate = Resource.Template(
+        uriTemplate: "reactotron://timeline/{type}",
+        name: "timeline_by_type",
+        description: "Timeline events filtered by command type, with full payloads. Available "
+            + "types depend on what the app has sent (e.g. api.response, log, "
+            + "state.values.response, benchmark.report). Read the timeline resource first "
+            + "to see which types are present.",
+        mimeType: "application/json"
+    )
+
+    /// `resources/list`: the static resources plus one entry per buffered
+    /// command type (upstream's ResourceTemplate `list` callback).
+    public func list() async -> [Resource] {
+        var resources = Self.staticResources.map {
+            Resource(name: $0.name, uri: $0.uri, description: $0.description,
+                     mimeType: "application/json")
+        }
+        for type in await store.bufferedTypes() {
+            resources.append(Resource(
+                name: "timeline:\(type)",
+                uri: "reactotron://timeline/\(type)",
+                mimeType: "application/json"
+            ))
+        }
+        return resources
+    }
+
+    public func templates() -> [Resource.Template] {
+        [Self.timelineTemplate]
+    }
+
+    /// Completion values for the template's `type` argument.
+    public func completeType(prefix: String) async -> [String] {
+        await store.bufferedTypes().filter { $0.hasPrefix(prefix) }
+    }
+
+    // MARK: - Reading
+
+    public func read(uri: String) async throws -> ReadResource.Result {
+        switch uri {
+        case "reactotron://timeline": return await timeline(uri: uri)
+        case "reactotron://state/current": return await currentState(uri: uri)
+        case "reactotron://network/log": return await networkLog(uri: uri)
+        case "reactotron://apps": return await apps(uri: uri)
+        case "reactotron://benchmarks": return await benchmarks(uri: uri)
+        case "reactotron://state/subscriptions": return await stateSubscriptions(uri: uri)
+        case "reactotron://asyncstorage": return await asyncStorage(uri: uri)
+        default:
+            if uri.hasPrefix("reactotron://timeline/") {
+                let type = String(uri.dropFirst("reactotron://timeline/".count))
+                return await timelineByType(uri: uri, type: type)
+            }
+            throw MCPError.invalidParams("Unknown resource: \(uri)")
+        }
+    }
+
+    // MARK: - Shared shaping (ports of connectionMeta / filterByClient / json)
+
+    private struct Snapshot {
+        let clients: [McpClientRecord]
+        var redactor: McpRedactor
+    }
+
+    private func snapshot() async -> Snapshot {
+        let clients = await store.connectedClients
+        return await Snapshot(
+            clients: clients,
+            redactor: McpRedactor(config: store.redactionConfig, clients: clients)
+        )
+    }
+
+    private func appInfo(_ client: McpClientRecord) -> JSONValue {
+        var info: [String: JSONValue] = [
+            "id": .number(Double(client.connectionId)),
+            "clientId": .string(client.clientId),
+        ]
+        if let name = client.name { info["name"] = .string(name) }
+        if let platform = client.platform { info["platform"] = .string(platform) }
+        if let version = client.platformVersion { info["platformVersion"] = .string(version) }
+        return .object(info)
+    }
+
+    private func connectionMeta(_ clients: [McpClientRecord]) -> JSONValue {
+        if clients.isEmpty {
+            return .object([
+                "connection": .string("no_apps_connected"),
+                "hint": .string("No apps are connected to Reactotron. Start your React Native / "
+                    + "React app with Reactotron configured."),
+            ])
+        }
+        if clients.count == 1 {
+            let sole = clients[0]
+            return .object([
+                "connection": .string("single_app"),
+                "app": appInfo(sole),
+                "hint": .string("Connected to \(sole.name ?? "?") (\(sole.platform ?? "?")). "
+                    + "All data is from this app."),
+            ])
+        }
+        return .object([
+            "connection": .string("multiple_apps"),
+            "apps": .array(clients.map(appInfo)),
+            "hint": .string("Multiple apps are connected. If the user hasn't specified which "
+                + "app, ask them. Then pass clientId to filter data. Check the workspace's "
+                + "package.json name to see if it matches one of these app names."),
+        ])
+    }
+
+    /// Single connected app ⇒ scope to it; multiple ⇒ aggregate all.
+    private func filterByClient(
+        _ commands: [McpBufferedCommand], clients: [McpClientRecord]
+    ) -> [McpBufferedCommand] {
+        guard clients.count == 1, let sole = clients.first else { return commands }
+        return commands.filter { $0.clientId == sole.clientId }
+    }
+
+    private func fullCommand(_ buffered: McpBufferedCommand) -> JSONValue {
+        var object: [String: JSONValue] = [
+            "type": .string(buffered.command.type),
+            "messageId": .number(Double(buffered.messageId)),
+            "important": .bool(buffered.command.isImportant),
+        ]
+        if let payload = buffered.command.payload { object["payload"] = payload }
+        if let date = buffered.command.date { object["date"] = .string(date) }
+        if let deltaTime = buffered.command.deltaTime { object["deltaTime"] = .number(deltaTime) }
+        if let clientId = buffered.clientId { object["clientId"] = .string(clientId) }
+        return .object(object)
+    }
+
+    private func jsonContent(uri: String, _ data: JSONValue, guidance: String? = nil) -> ReadResource.Result {
+        ReadResource.Result(contents: [.text(
+            McpSerialization.safeSerialize(data, guidance: guidance),
+            uri: uri,
+            mimeType: "application/json"
+        )])
+    }
+
+    // MARK: - The resources
+
+    private func timeline(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let events = filterByClient(await store.commands(), clients: snapshot.clients)
+        let summarized = events.reversed().map { buffered in
+            snapshot.redactor.redact(
+                McpSerialization.summarizeCommand(buffered), clientId: buffered.clientId)
+        }
+        return jsonContent(
+            uri: uri,
+            .object([
+                "_meta": connectionMeta(snapshot.clients),
+                "eventCount": .number(Double(events.count)),
+                "events": .array(Array(summarized)),
+            ]),
+            guidance: "Events are summarized. Use the timeline_by_type resource "
+                + "(e.g. reactotron://timeline/api.response) to get full payloads for a "
+                + "specific event type."
+        )
+    }
+
+    private func timelineByType(uri: String, type: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let events = filterByClient(await store.commands(ofType: type), clients: snapshot.clients)
+        let redacted = events.reversed().map { buffered in
+            snapshot.redactor.redact(fullCommand(buffered), clientId: buffered.clientId)
+        }
+        return jsonContent(
+            uri: uri,
+            .object([
+                "_meta": connectionMeta(snapshot.clients),
+                "type": .string(type),
+                "eventCount": .number(Double(events.count)),
+                "events": .array(Array(redacted)),
+            ]),
+            guidance: "Too many \(type) events to return in full. Try clear_timeline to "
+                + "reset, then reproduce the issue to capture fewer events."
+        )
+    }
+
+    private func currentState(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let stateResponses = filterByClient(
+            await store.commands(ofType: "state.values.response"), clients: snapshot.clients)
+        let latest = stateResponses.last
+        let stateValue = latest?.command.payload?["value"] ?? .object([
+            "status": .string("no_state_received"),
+            "message": .string("No state snapshot received yet. Use the request_state tool "
+                + "to request one."),
+        ])
+        // payload.path anchors state-path patterns when the cached snapshot
+        // is a subtree (from a prior request_state with a path).
+        let statePath = latest?.command.payload?["path"]?.stringValue ?? ""
+        let redacted = snapshot.redactor.redactState(
+            stateValue, clientId: latest?.clientId, statePath: statePath)
+        return jsonContent(
+            uri: uri,
+            .object(["_meta": connectionMeta(snapshot.clients), "state": redacted]),
+            guidance: "State is too large. Use the request_state tool with a path like "
+                + "'user.profile' to fetch a specific slice. Use request_state_keys to "
+                + "explore the state shape first."
+        )
+    }
+
+    private func networkLog(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let requests = filterByClient(
+            await store.commands(ofType: "api.response"), clients: snapshot.clients)
+        let entries = requests.map { buffered in
+            snapshot.redactor.redact(
+                McpSerialization.summarizeNetworkEntry(buffered), clientId: buffered.clientId)
+        }
+        return jsonContent(
+            uri: uri,
+            .object(["_meta": connectionMeta(snapshot.clients), "entries": .array(entries)]),
+            guidance: "Network log is too large. Use timeline_by_type with type "
+                + "'api.response' for full data, or clear_timeline to reset and capture "
+                + "fewer events."
+        )
+    }
+
+    private func apps(uri: String) async -> ReadResource.Result {
+        let clients = await store.connectedClients
+        return jsonContent(uri: uri, .object([
+            "_meta": connectionMeta(clients),
+            "apps": .array(clients.map(appInfo)),
+        ]))
+    }
+
+    private func benchmarks(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let reports = filterByClient(
+            await store.commands(ofType: "benchmark.report"), clients: snapshot.clients)
+        let entries = reports.map { buffered in
+            var merged: [String: JSONValue] = buffered.command.payload?.objectValue ?? [:]
+            if let date = buffered.command.date { merged["date"] = .string(date) }
+            if let clientId = buffered.clientId { merged["clientId"] = .string(clientId) }
+            return snapshot.redactor.redact(.object(merged), clientId: buffered.clientId)
+        }
+        return jsonContent(uri: uri, .object([
+            "_meta": connectionMeta(snapshot.clients),
+            "benchmarks": .array(entries),
+        ]))
+    }
+
+    private func stateSubscriptions(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let changes = filterByClient(
+            await store.commands(ofType: "state.values.change"), clients: snapshot.clients)
+        let entries = changes.map { buffered in
+            var merged: [String: JSONValue] = buffered.command.payload?.objectValue ?? [:]
+            if let date = buffered.command.date { merged["date"] = .string(date) }
+            if let clientId = buffered.clientId { merged["clientId"] = .string(clientId) }
+            return snapshot.redactor.redact(.object(merged), clientId: buffered.clientId)
+        }
+        let active = await store.subscriptions
+        return jsonContent(
+            uri: uri,
+            .object([
+                "_meta": connectionMeta(snapshot.clients),
+                "activeSubscriptions": .array(active.map(JSONValue.string)),
+                "changes": .array(entries),
+            ]),
+            guidance: "Subscription changes are too large. Consider unsubscribing from paths "
+                + "with large values, or use request_state with a specific path instead."
+        )
+    }
+
+    private func asyncStorage(uri: String) async -> ReadResource.Result {
+        var snapshot = await snapshot()
+        let mutations = filterByClient(
+            await store.commands(ofType: "asyncStorage.mutation"), clients: snapshot.clients)
+        let entries = mutations.map { buffered -> JSONValue in
+            var entry: [String: JSONValue] = [:]
+            if let date = buffered.command.date { entry["date"] = .string(date) }
+            if let clientId = buffered.clientId { entry["clientId"] = .string(clientId) }
+            entry["action"] = buffered.command.payload?["action"] ?? .null
+            entry["data"] = snapshot.redactor.redactAsyncStorage(
+                buffered.command.payload?["data"] ?? .null, clientId: buffered.clientId)
+            return .object(entry)
+        }
+        return jsonContent(
+            uri: uri,
+            .object(["_meta": connectionMeta(snapshot.clients), "mutations": .array(entries)]),
+            guidance: "AsyncStorage mutations are too large. Try clear_timeline to reset, "
+                + "then reproduce the specific interaction you want to inspect."
+        )
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpSerialization.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpSerialization.swift
@@ -1,0 +1,141 @@
+import ADBKit
+import Foundation
+
+/// Result shaping — the Swift form of upstream `serialization.ts`: compact
+/// JSON, hard truncation with LLM guidance, and the per-command summaries the
+/// timeline/network reads return.
+public enum McpSerialization {
+    /// Compact JSON with sorted keys (deterministic for tests and fixtures).
+    public static func compactJson(_ value: JSONValue) -> String {
+        value.jsonString
+    }
+
+    /// Truncate to `limit` characters, appending guidance telling the LLM how
+    /// to get a smaller answer (pass a path, filter by type, clear the buffer).
+    public static func truncate(_ text: String, limit: Int, guidance: String? = nil) -> String {
+        guard text.count > limit else { return text }
+        let kilochars = Int((Double(text.count) / 1000).rounded())
+        let suffix = if let guidance {
+            "\n\n[TRUNCATED — response was ~\(kilochars)K chars. \(guidance)]"
+        } else {
+            "\n\n[TRUNCATED — response was ~\(kilochars)K chars.]"
+        }
+        return String(text.prefix(max(0, limit - suffix.count))) + suffix
+    }
+
+    /// Compact-serialize then truncate — every tool/resource result goes
+    /// through this (upstream `safeSerialize`).
+    public static func safeSerialize(
+        _ value: JSONValue,
+        limit: Int = McpConstants.maxResponseChars,
+        guidance: String? = nil
+    ) -> String {
+        truncate(compactJson(value), limit: limit, guidance: guidance)
+    }
+
+    // MARK: - Summaries
+
+    /// Timeline row: metadata + a short type-specific preview, payload
+    /// stripped (upstream `summarizeCommand`).
+    public static func summarizeCommand(_ buffered: McpBufferedCommand) -> JSONValue {
+        let command = buffered.command
+        let preview: String = switch command.commandType {
+        case .apiResponse: apiResponsePreview(command.payload)
+        case .log: logPreview(command.payload)
+        case .stateValuesResponse: "path: \(command.payload?["path"]?.stringValue ?? "(root)")"
+        case .stateValuesChange: "\(command.payload?["changes"]?.arrayValue?.count ?? 0) change(s)"
+        case .stateActionComplete:
+            command.payload?["type"]?.stringValue ?? genericPreview(command.payload)
+        case .benchmark: command.payload?["title"]?.stringValue ?? "benchmark"
+        default: genericPreview(command.payload)
+        }
+
+        var summary: [String: JSONValue] = [
+            "type": .string(command.type),
+            "messageId": .number(Double(buffered.messageId)),
+            "important": .bool(command.isImportant),
+            "payloadPreview": .string(preview),
+        ]
+        if let date = command.date { summary["date"] = .string(date) }
+        if let deltaTime = command.deltaTime { summary["deltaTime"] = .number(deltaTime) }
+        if let clientId = buffered.clientId { summary["clientId"] = .string(clientId) }
+        return .object(summary)
+    }
+
+    /// Network row: method/url/status/duration/headers + body previews capped
+    /// at `maxBodyPreviewChars` (upstream `summarizeNetworkEntry`).
+    public static func summarizeNetworkEntry(_ buffered: McpBufferedCommand) -> JSONValue {
+        let payload = buffered.command.payload
+        let request = payload?["request"]
+        let response = payload?["response"]
+
+        var requestSummary: [String: JSONValue] = [:]
+        if let method = request?["method"] { requestSummary["method"] = method }
+        if let url = request?["url"] { requestSummary["url"] = url }
+        if let headers = request?["headers"] { requestSummary["headers"] = headers }
+        if let data = request?["data"], !data.isNull {
+            requestSummary["data"] = .string(preview(of: data, limit: McpConstants.maxBodyPreviewChars))
+        }
+
+        var responseSummary: [String: JSONValue] = [:]
+        if let status = response?["status"] { responseSummary["status"] = status }
+        if let headers = response?["headers"] { responseSummary["headers"] = headers }
+        if let body = response?["body"], !body.isNull {
+            responseSummary["body"] = .string(preview(of: body, limit: McpConstants.maxBodyPreviewChars))
+        }
+
+        var entry: [String: JSONValue] = [
+            "messageId": .number(Double(buffered.messageId)),
+            "request": .object(requestSummary),
+            "response": .object(responseSummary),
+        ]
+        if let clientId = buffered.clientId { entry["clientId"] = .string(clientId) }
+        if let date = buffered.command.date { entry["date"] = .string(date) }
+        if let duration = payload?["duration"] { entry["duration"] = duration }
+        return .object(entry)
+    }
+
+    // MARK: - Previews
+
+    private static func apiResponsePreview(_ payload: JSONValue?) -> String {
+        let method = payload?["request"]?["method"]?.stringValue ?? "?"
+        let url = payload?["request"]?["url"]?.stringValue ?? "?"
+        let status = payload?["response"]?["status"]?.intValue.map(String.init) ?? "?"
+        let duration = payload?["duration"]?.doubleValue.map { " (\(Self.milliseconds($0))ms)" } ?? ""
+        return "\(method) \(url) -> \(status)\(duration)"
+    }
+
+    private static func milliseconds(_ value: Double) -> String {
+        value.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(value)) : String(value)
+    }
+
+    private static func logPreview(_ payload: JSONValue?) -> String {
+        let level = payload?["level"]?.stringValue ?? "log"
+        let message: String = if let text = payload?["message"]?.stringValue {
+            text
+        } else if let value = payload?["message"] {
+            value.compactPreview(maxLength: McpConstants.maxPayloadPreviewChars)
+        } else {
+            ""
+        }
+        let capped = message.count > McpConstants.maxPayloadPreviewChars
+            ? String(message.prefix(McpConstants.maxPayloadPreviewChars)) + "..."
+            : message
+        return "[\(level)] \(capped)"
+    }
+
+    private static func genericPreview(_ payload: JSONValue?) -> String {
+        guard let payload, !payload.isNull else { return "" }
+        let text = payload.compactPreview(maxLength: McpConstants.maxPayloadPreviewChars + 1)
+        return text.count > McpConstants.maxPayloadPreviewChars
+            ? String(text.prefix(McpConstants.maxPayloadPreviewChars)) + "..."
+            : text
+    }
+
+    /// A capped preview of any value: strings stay raw, everything else goes
+    /// through compact JSON (upstream `truncateValue`).
+    static func preview(of value: JSONValue, limit: Int) -> String {
+        let text = value.stringValue ?? value.compactPreview(maxLength: limit + 1)
+        return text.count > limit ? String(text.prefix(limit)) + "..." : text
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpServerController.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpServerController.swift
@@ -1,0 +1,91 @@
+import ADBKit
+import Foundation
+
+/// The one type the App layer talks to: owns the MCP command store, the tap
+/// consumption task, and the HTTP listener. Downstream-only — the Reactotron
+/// relay never waits on anything here, and stopping MCP never touches the
+/// relay or the UI timeline.
+public actor McpServerController {
+    public enum Status: Sendable, Equatable {
+        case stopped
+        case listening(port: UInt16)
+        case failed(String)
+    }
+
+    private let store = McpCommandStore()
+    private var listener: McpHTTPListener?
+    private var tapTask: Task<Void, Never>?
+    private var currentStatus: Status = .stopped
+
+    public init() {}
+
+    public var status: Status { currentStatus }
+
+    /// The store, exposed for status UI (connected apps, buffered count) —
+    /// reads only.
+    public var commandStore: McpCommandStore { store }
+
+    public var redactionConfig: McpRedactionServerConfig {
+        get async { await store.redactionConfig }
+    }
+
+    public func setRedactionConfig(_ config: McpRedactionServerConfig) async {
+        await store.setRedactionConfig(config)
+    }
+
+    /// Start serving MCP: subscribe to the relay's event tap and bind the
+    /// localhost listener. `events` is `ReactotronService.tap()`; `sender`
+    /// is the service itself. Throws (and records `.failed`) if the port is
+    /// taken — the relay tap is torn back down so a retry starts clean.
+    public func start(
+        events: AsyncStream<ReactotronServer.Event>,
+        sender: any McpCommandSender,
+        version: String,
+        port: UInt16 = McpConstants.defaultPort,
+        bearerToken: String? = nil
+    ) async throws {
+        await stopListener()
+
+        tapTask?.cancel()
+        let store = store
+        tapTask = Task {
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                await store.ingest(event)
+            }
+        }
+
+        let factory = McpServerFactory(store: store, sender: sender, version: version)
+        let listener = McpHTTPListener(
+            configuration: McpHTTPListener.Configuration(port: port, bearerToken: bearerToken),
+            factory: factory
+        )
+        do {
+            try await listener.start()
+        } catch {
+            tapTask?.cancel()
+            tapTask = nil
+            currentStatus = .failed(error.localizedDescription)
+            throw error
+        }
+        self.listener = listener
+        let bound = await listener.boundPort ?? port
+        currentStatus = .listening(port: bound)
+    }
+
+    /// Stop serving. Bounded work (session closes + socket close), so it is
+    /// safe inside the app's quit budget.
+    public func stop() async {
+        tapTask?.cancel()
+        tapTask = nil
+        await stopListener()
+        currentStatus = .stopped
+    }
+
+    private func stopListener() async {
+        if let listener {
+            await listener.stop()
+        }
+        listener = nil
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpServerController.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpServerController.swift
@@ -73,6 +73,13 @@ public actor McpServerController {
         currentStatus = .listening(port: bound)
     }
 
+    /// The Reactotron relay went down: keep serving MCP (agents get
+    /// `no_apps_connected` guidance), but drop the ghost client records —
+    /// the relay's teardown cancels sockets without disconnect events.
+    public func noteRelayStopped() async {
+        await store.clearClients()
+    }
+
     /// Stop serving. Bounded work (session closes + socket close), so it is
     /// safe inside the app's quit budget.
     public func stop() async {

--- a/ADBKit/Sources/ReactotronMCP/McpServerFactory.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpServerFactory.swift
@@ -1,0 +1,63 @@
+import ADBKit
+import Foundation
+import MCP
+
+/// Builds one fully-wired `MCP.Server` per MCP session. A single `Server`
+/// accepts exactly one `initialize` (SDK #144), so the HTTP layer calls this
+/// factory for every new session; all servers share the one store/sender.
+public struct McpServerFactory: Sendable {
+    public let store: McpCommandStore
+    let sender: any McpCommandSender
+    let version: String
+
+    public init(store: McpCommandStore, sender: any McpCommandSender, version: String) {
+        self.store = store
+        self.sender = sender
+        self.version = version
+    }
+
+    public func makeServer() async -> Server {
+        let handlers = McpToolHandlers(store: store, sender: sender)
+        let resources = McpResources(store: store)
+
+        let server = Server(
+            name: "droidective-reactotron",
+            version: version,
+            instructions: "Reactotron debugging data from Droidective. Read the "
+                + "reactotron://timeline resource (or ask for recent events) first to see "
+                + "what the connected React Native app is doing, then use the tools to "
+                + "query state or drive the app.",
+            capabilities: Server.Capabilities(
+                completions: Server.Capabilities.Completions(),
+                resources: Server.Capabilities.Resources(subscribe: false, listChanged: false),
+                tools: Server.Capabilities.Tools(listChanged: false)
+            )
+        )
+
+        await server.withMethodHandler(ListTools.self) { _ in
+            ListTools.Result(tools: McpToolRegistry.all.compactMap(\.tool))
+        }
+        await server.withMethodHandler(CallTool.self) { params in
+            try await handlers.call(name: params.name, arguments: params.arguments)
+        }
+        await server.withMethodHandler(ListResources.self) { _ in
+            ListResources.Result(resources: await resources.list())
+        }
+        await server.withMethodHandler(ListResourceTemplates.self) { _ in
+            ListResourceTemplates.Result(templates: resources.templates())
+        }
+        await server.withMethodHandler(ReadResource.self) { params in
+            try await resources.read(uri: params.uri)
+        }
+        await server.withMethodHandler(Complete.self) { params in
+            guard case let .resource(reference) = params.ref,
+                  reference.uri == "reactotron://timeline/{type}",
+                  params.argument.name == "type" else {
+                return Complete.Result(completion: .init(values: []))
+            }
+            let values = await resources.completeType(prefix: params.argument.value)
+            return Complete.Result(completion: .init(values: values))
+        }
+        return server
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpToolHandlers.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpToolHandlers.swift
@@ -1,0 +1,376 @@
+import ADBKit
+import Foundation
+import MCP
+
+/// The outbound seam to the Reactotron relay. `ReactotronService` conforms;
+/// tests substitute a recorder.
+public protocol McpCommandSender: Sendable {
+    func send(type: String, payload: JSONValue, toConnection id: Int) async
+    func broadcast(type: String, payload: JSONValue) async
+}
+
+extension ReactotronService: McpCommandSender {}
+
+/// Executes the 10 registry tools against the store and the relay — the
+/// Swift port of upstream `tools.ts` handlers. Every result is
+/// `safeSerialize`d text; correlation is event-driven (`store.awaitCommand`)
+/// instead of upstream's 100 ms buffer polling.
+public struct McpToolHandlers: Sendable {
+    let store: McpCommandStore
+    let sender: any McpCommandSender
+    /// Reads local overlay images; tests point it at fixtures. Kept as a
+    /// closure so handlers stay testable without touching the disk.
+    let readFile: @Sendable (String) throws -> Data
+
+    public init(
+        store: McpCommandStore,
+        sender: any McpCommandSender,
+        readFile: @escaping @Sendable (String) throws -> Data = {
+            try Data(contentsOf: URL(fileURLWithPath: $0))
+        }
+    ) {
+        self.store = store
+        self.sender = sender
+        self.readFile = readFile
+    }
+
+    public func call(name: String, arguments: [String: Value]?) async throws -> CallTool.Result {
+        guard McpToolRegistry.def(named: name) != nil else {
+            throw MCPError.methodNotFound("Unknown tool: \(name)")
+        }
+        let args = (arguments ?? [:]).jsonObject
+        switch name {
+        case "dispatch_action": return await dispatchAction(args)
+        case "request_state": return await requestState(args)
+        case "request_state_keys": return await requestStateKeys(args)
+        case "swap_state": return await swapState(args)
+        case "send_custom_command": return await sendCustomCommand(args)
+        case "list_custom_commands": return await listCustomCommands(args)
+        case "show_overlay": return await showOverlay(args)
+        case "clear_timeline": return await clearTimeline()
+        case "subscribe_state": return await subscribeState(args, subscribe: true)
+        case "unsubscribe_state": return await subscribeState(args, subscribe: false)
+        default:
+            throw MCPError.methodNotFound("Tool \(name) is registered but has no handler")
+        }
+    }
+
+    // MARK: - Target resolution (upstream `resolveClientId`)
+
+    struct ResolvedTarget {
+        let clientId: String
+        let connectionId: Int?
+    }
+
+    private enum Resolution {
+        case resolved(ResolvedTarget)
+        case error(String)
+    }
+
+    private func resolveTarget(_ args: [String: JSONValue]) async -> Resolution {
+        let requested = args["clientId"]?.stringValue
+        let clients = await store.connectedClients
+        if clients.isEmpty {
+            return .error("No apps connected to Reactotron.")
+        }
+        if clients.count > 1, requested == nil {
+            let apps = clients
+                .map { "\($0.name ?? "?") (\($0.platform ?? "?")): \($0.clientId)" }
+                .joined(separator: ", ")
+            return .error("Multiple apps connected. Specify clientId. Available: \(apps)")
+        }
+        let clientId = requested ?? clients[0].clientId
+        let connectionId = clients.first { $0.clientId == clientId }?.connectionId
+        return .resolved(ResolvedTarget(clientId: clientId, connectionId: connectionId))
+    }
+
+    /// Runs `body` with the resolved target app, or returns the resolve
+    /// error result (the shape every targeted tool shares).
+    private func withTarget(
+        _ args: [String: JSONValue],
+        _ body: (ResolvedTarget) async -> CallTool.Result
+    ) async -> CallTool.Result {
+        switch await resolveTarget(args) {
+        case let .error(message): errorResult(message)
+        case let .resolved(target): await body(target)
+        }
+    }
+
+    private func send(type: String, payload: JSONValue, to target: ResolvedTarget) async {
+        guard let connectionId = target.connectionId else { return }
+        await sender.send(type: type, payload: payload, toConnection: connectionId)
+    }
+
+    // MARK: - Result shaping
+
+    private func textResult(_ data: JSONValue, guidance: String? = nil) -> CallTool.Result {
+        CallTool.Result(content: [.text(
+            text: McpSerialization.safeSerialize(data, guidance: guidance),
+            annotations: nil, _meta: nil
+        )])
+    }
+
+    private func errorResult(_ message: String) -> CallTool.Result {
+        textResult(.object(["status": .string("error"), "message": .string(message)]))
+    }
+
+    private func redactor() async -> McpRedactor {
+        await McpRedactor(config: store.redactionConfig, clients: store.connectedClients)
+    }
+
+    // MARK: - Tools
+
+    private func dispatchAction(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        let action = JSONValue.object([
+            "type": args["actionType"] ?? .null,
+            "payload": args["actionPayload"] ?? .null,
+        ])
+        let marker = await store.lastMessageId
+        await send(type: "state.action.dispatch", payload: .object(["action": action]), to: target)
+
+        let confirmation = await store.awaitCommand(
+            ofType: "state.action.complete", clientId: target.clientId, afterMessageId: marker)
+        var redactor = await redactor()
+        let redactedAction = redactor.redact(action, clientId: target.clientId)
+        if confirmation != nil {
+            return textResult(.object([
+                "status": .string("dispatched"), "action": redactedAction, "confirmed": .bool(true),
+            ]))
+        }
+        return textResult(.object([
+            "status": .string("dispatched"), "action": redactedAction, "confirmed": .bool(false),
+            "note": .string("Action was sent but no confirmation received. "
+                + "The app may not have the Redux plugin configured."),
+        ]))
+        }
+    }
+
+    private func requestState(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        let path = args["path"]?.stringValue ?? ""
+        let marker = await store.lastMessageId
+        await send(type: "state.values.request", payload: .object(["path": .string(path)]), to: target)
+
+        guard let response = await store.awaitCommand(
+            ofType: "state.values.response", clientId: target.clientId, afterMessageId: marker
+        ) else {
+            return textResult(.object([
+                "status": .string("no_response"),
+                "message": .string("The app did not respond to the state request. It likely "
+                    + "doesn't have a state management plugin (Redux or MST) configured in Reactotron."),
+            ]))
+        }
+        let stateValue = response.command.payload?["value"] ?? response.command.payload ?? .null
+        var redactor = await redactor()
+        let redacted = redactor.redactState(stateValue, clientId: target.clientId, statePath: path)
+        return textResult(
+            .object(["status": .string("success"), "state": redacted]),
+            guidance: "State response is too large. Use request_state with a more specific path "
+                + "(e.g. 'user.profile') to narrow the response. Use request_state_keys to "
+                + "explore the state shape."
+        )
+        }
+    }
+
+    private func requestStateKeys(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        let path = args["path"]?.stringValue ?? ""
+        let marker = await store.lastMessageId
+        await send(type: "state.keys.request", payload: .object(["path": .string(path)]), to: target)
+
+        guard let response = await store.awaitCommand(
+            ofType: "state.keys.response", clientId: target.clientId, afterMessageId: marker
+        ) else {
+            return textResult(.object([
+                "status": .string("no_response"),
+                "message": .string("The app did not respond to the keys request. It likely "
+                    + "doesn't have a state management plugin (Redux or MST) configured in Reactotron."),
+            ]))
+        }
+        return textResult(.object([
+            "status": .string("success"),
+            "path": response.command.payload?["path"] ?? .string(path),
+            "keys": response.command.payload?["keys"] ?? .array([]),
+            "valid": response.command.payload?["valid"] ?? .bool(true),
+        ]))
+        }
+    }
+
+    private func swapState(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        await send(
+            type: "state.restore.request",
+            payload: .object(["state": args["state"] ?? .object([:])]),
+            to: target
+        )
+        return textResult(.object([
+            "status": .string("swapped"), "message": .string("State replacement sent to app."),
+        ]))
+        }
+    }
+
+    private func sendCustomCommand(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        let command = args["command"] ?? .null
+        await send(
+            type: "custom",
+            payload: .object(["command": command, "args": args["args"] ?? .null]),
+            to: target
+        )
+        return textResult(.object(["status": .string("sent"), "command": command]))
+        }
+    }
+
+    private func listCustomCommands(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        let commands = await store.customCommands(clientId: target.clientId).map { payload in
+            JSONValue.object([
+                "id": payload["id"] ?? .null,
+                "command": payload["command"] ?? .null,
+                "title": payload["title"] ?? .null,
+                "description": payload["description"] ?? .null,
+            ])
+        }
+        if commands.isEmpty {
+            return textResult(.object([
+                "status": .string("none"),
+                "message": .string("No custom commands registered by the app."),
+            ]))
+        }
+        return textResult(.object(["status": .string("success"), "commands": .array(commands)]))
+        }
+    }
+
+    private func showOverlay(_ args: [String: JSONValue]) async -> CallTool.Result {
+        await withTarget(args) { target in
+        var payload: [String: JSONValue] = [:]
+        for (key, value) in args where key != "clientId" && !value.isNull {
+            payload[key] = value
+        }
+        if args["uri"]?.isNull == true { payload["uri"] = .null }
+
+        // Local file → data: URI (PNG/JPEG/GIF, 2 MB cap), like upstream.
+        if let uri = payload["uri"]?.stringValue,
+           !uri.hasPrefix("data:"), !uri.hasPrefix("http") {
+            let filePath = uri.hasPrefix("file://") ? String(uri.dropFirst("file://".count)) : uri
+            let ext = (filePath as NSString).pathExtension.lowercased()
+            let mimeByExtension = [
+                "png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "gif": "image/gif",
+            ]
+            guard let mime = mimeByExtension[ext] else {
+                return errorResult("Unsupported image format: .\(ext). Use PNG, JPEG, or GIF.")
+            }
+            guard let data = try? readFile(filePath) else {
+                return errorResult("Could not read file: \(filePath)")
+            }
+            if data.count > McpConstants.maxOverlayImageBytes {
+                let megabytes = String(format: "%.1f", Double(data.count) / 1024 / 1024)
+                return errorResult("Image too large (\(megabytes)MB). Maximum is 2MB. "
+                    + "Resize or compress the image first.")
+            }
+            payload["uri"] = .string("data:\(mime);base64,\(data.base64EncodedString())")
+            if payload["width"] == nil || payload["height"] == nil,
+               let size = McpImageProbe.size(of: data, extension: ext) {
+                if payload["width"] == nil { payload["width"] = .number(Double(size.width)) }
+                if payload["height"] == nil { payload["height"] = .number(Double(size.height)) }
+            }
+        }
+
+        // Defaults matching the desktop app's overlay behavior.
+        payload["opacity"] = payload["opacity"] ?? .number(0.5)
+        payload["marginTop"] = payload["marginTop"] ?? .number(0)
+        payload["marginRight"] = payload["marginRight"] ?? .number(0)
+        payload["marginBottom"] = payload["marginBottom"] ?? .number(0)
+        payload["marginLeft"] = payload["marginLeft"] ?? .number(0)
+        payload["growToWindow"] = payload["growToWindow"] ?? .bool(false)
+        payload["justifyContent"] = payload["justifyContent"] ?? .string("center")
+        payload["alignItems"] = payload["alignItems"] ?? .string("center")
+
+        let uriLength = payload["uri"]?.stringValue?.count ?? 0
+        await send(type: "overlay", payload: .object(payload), to: target)
+
+        var echoed = payload
+        echoed["uri"] = uriLength > 0 ? .string("(\(uriLength) chars)") : .null
+        return textResult(.object(["status": .string("sent"), "overlay": .object(echoed)]))
+        }
+    }
+
+    private func clearTimeline() async -> CallTool.Result {
+        let count = await store.bufferedCount
+        await store.clear()
+        return textResult(.object([
+            "status": .string("cleared"), "eventsRemoved": .number(Double(count)),
+        ]))
+    }
+
+    private func subscribeState(_ args: [String: JSONValue], subscribe: Bool) async -> CallTool.Result {
+        guard let path = args["path"]?.stringValue, !path.isEmpty else {
+            return errorResult("path is required")
+        }
+        var paths = await store.subscriptions
+        if subscribe {
+            if !paths.contains(path) { paths.append(path) }
+        } else {
+            paths.removeAll { $0 == path }
+        }
+        await store.setSubscriptions(paths)
+        // Like upstream's stateValuesSubscribe: the full path list goes to
+        // every client.
+        await sender.broadcast(
+            type: "state.values.subscribe",
+            payload: .object(["paths": .array(paths.map(JSONValue.string))])
+        )
+        return textResult(.object([
+            "status": .string(subscribe ? "subscribed" : "unsubscribed"),
+            "path": .string(path),
+            "activeSubscriptions": .array(paths.map(JSONValue.string)),
+        ]))
+    }
+}
+
+/// Width/height extraction from PNG/JPEG/GIF headers — a pure port of
+/// upstream `getImageSize` so `show_overlay` can fill missing dimensions.
+enum McpImageProbe {
+    static func size(of data: Data, extension ext: String) -> (width: Int, height: Int)? {
+        let bytes = [UInt8](data)
+        switch ext {
+        case "png":
+            // Width at offset 16, height at offset 20 (big-endian uint32).
+            guard bytes.count > 24 else { return nil }
+            return (Int(bigEndian32(bytes, at: 16)), Int(bigEndian32(bytes, at: 20)))
+        case "jpg", "jpeg":
+            guard bytes.count > 2, bytes[0] == 0xFF, bytes[1] == 0xD8 else { return nil }
+            var offset = 2
+            while offset < bytes.count - 8 {
+                guard bytes[offset] == 0xFF else { break }
+                let marker = bytes[offset + 1]
+                if marker == 0xC0 || marker == 0xC2 {
+                    let height = Int(bigEndian16(bytes, at: offset + 5))
+                    let width = Int(bigEndian16(bytes, at: offset + 7))
+                    return (width, height)
+                }
+                offset += 2 + Int(bigEndian16(bytes, at: offset + 2))
+            }
+            return nil
+        case "gif":
+            // Width at offset 6, height at offset 8 (little-endian uint16).
+            guard bytes.count > 10 else { return nil }
+            return (
+                Int(bytes[6]) | (Int(bytes[7]) << 8),
+                Int(bytes[8]) | (Int(bytes[9]) << 8)
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func bigEndian32(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+        (UInt32(bytes[offset]) << 24) | (UInt32(bytes[offset + 1]) << 16)
+            | (UInt32(bytes[offset + 2]) << 8) | UInt32(bytes[offset + 3])
+    }
+
+    private static func bigEndian16(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+        (UInt16(bytes[offset]) << 8) | UInt16(bytes[offset + 1])
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpToolRegistry.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpToolRegistry.swift
@@ -1,0 +1,166 @@
+import Foundation
+import MCP
+
+/// One MCP tool: name, description, and its JSON-Schema input — the
+/// declarative registry the `FeatureRegistry` way, so `tools/list` and
+/// dispatch are driven from one table and an invariant test keeps the
+/// handler map 1:1 with it.
+public struct McpToolDef: Sendable {
+    public let name: String
+    public let description: String
+    /// JSON Schema as JSON text (decoded to an SDK `Value` on listing; a
+    /// registry test decodes every schema so a typo fails `swift test`).
+    public let inputSchemaJSON: String
+
+    var inputSchema: Value? {
+        try? JSONDecoder().decode(Value.self, from: Data(inputSchemaJSON.utf8))
+    }
+
+    var tool: Tool? {
+        guard let schema = inputSchema else { return nil }
+        return Tool(name: name, description: description, inputSchema: schema)
+    }
+}
+
+/// The 10-tool contract of upstream `lib/reactotron-mcp/src/tools.ts` —
+/// names, descriptions, and schemas ported verbatim (descriptions matter:
+/// they are the LLM's only manual). See `UPSTREAM_VERSIONS` for the pinned
+/// upstream commit; `scripts/check-reactotron-upstream.sh` diffs against it.
+public enum McpToolRegistry {
+    static let clientIdProperty =
+        #""clientId":{"type":"string","description":"Target app clientId (required when multiple apps connected)."}"#
+
+    public static let all: [McpToolDef] = [
+        McpToolDef(
+            name: "dispatch_action",
+            description: "Dispatch a Redux action to the connected app. "
+                + "Requires the Reactotron Redux plugin to be configured in the app. "
+                + "Example: { type: 'user/setName', payload: { name: 'Alice' } }",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "actionType":{"type":"string","description":"Action type, e.g. 'counter/increment' or 'RESET'"},
+              "actionPayload":{"description":"Optional action payload, e.g. { name: 'Alice' }"},
+              \(clientIdProperty)},
+             "required":["actionType"]}
+            """
+        ),
+        McpToolDef(
+            name: "request_state",
+            description: "Request a fresh state snapshot from the connected app. "
+                + "Requires Redux or MST plugin configured in the app. "
+                + "IMPORTANT: Always specify a path to avoid oversized responses. "
+                + "The full state tree can be millions of characters. "
+                + "Use request_state_keys first to explore the state shape, then request specific slices. "
+                + "Example path: 'user.profile' to get just that slice.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "path":{"type":"string","description":"Dot-separated state path, e.g. 'user.profile'. STRONGLY RECOMMENDED — omitting this returns the full state tree which may be too large."},
+              \(clientIdProperty)}}
+            """
+        ),
+        McpToolDef(
+            name: "request_state_keys",
+            description: "List the keys at a state path without fetching values. "
+                + "Use this to explore the state tree structure before requesting specific slices with request_state. "
+                + "Returns an array of key names at the given path. "
+                + "Example: path='' returns root keys, path='user' returns keys under user.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "path":{"type":"string","description":"Dot-separated state path. Omit or pass empty string for root keys."},
+              \(clientIdProperty)}}
+            """
+        ),
+        McpToolDef(
+            name: "swap_state",
+            description: "Replace the entire app state tree. WARNING: this is destructive and cannot be undone. "
+                + "Requires the Reactotron state plugin (Redux or MST). "
+                + "Use request_state first to get the current state, modify it, then swap.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "state":{"type":"object","description":"The complete replacement state tree as a JSON object."},
+              \(clientIdProperty)},
+             "required":["state"]}
+            """
+        ),
+        McpToolDef(
+            name: "send_custom_command",
+            description: "Send a named custom command to the app. "
+                + "The app must have registered a handler for this command name. "
+                + "Use list_custom_commands first to see what commands are available. "
+                + "Example: command='showDebugOverlay', args={ enabled: true }",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "command":{"type":"string","description":"The custom command name, e.g. 'ping' or 'showDebugOverlay'"},
+              "args":{"description":"Optional arguments to pass to the command handler"},
+              \(clientIdProperty)},
+             "required":["command"]}
+            """
+        ),
+        McpToolDef(
+            name: "list_custom_commands",
+            description: "List all custom commands registered by the connected app. "
+                + "These are commands the app has set up handlers for. "
+                + "Use this before send_custom_command to see what's available.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{\(clientIdProperty)}}
+            """
+        ),
+        McpToolDef(
+            name: "show_overlay",
+            description: "Show an image overlay on top of the running app. "
+                + "Useful for comparing a design mockup against the actual UI. "
+                + "The app must have the overlay plugin enabled (it is by default in React Native). "
+                + "Pass uri=null or opacity=0 to hide the overlay.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "uri":{"type":["string","null"],"description":"Image to display. Accepts a local file path (/path/to/image.png), file:// URI, http/https URL, or data: URI. Local files are automatically converted to base64. Pass null to clear the overlay."},
+              "opacity":{"type":"number","description":"Overlay opacity from 0 to 1 (default: 0.5)"},
+              "growToWindow":{"type":"boolean","description":"Scale image to fill the entire window (default: false)"},
+              "resizeMode":{"type":"string","enum":["cover","contain","stretch","center"],"description":"How to resize the image when growToWindow is true (default: cover)"},
+              "width":{"type":"number","description":"Image width in pixels (ignored if growToWindow is true)"},
+              "height":{"type":"number","description":"Image height in pixels (ignored if growToWindow is true)"},
+              "marginTop":{"type":"number","description":"Top margin offset in pixels"},
+              "marginBottom":{"type":"number","description":"Bottom margin offset in pixels"},
+              "marginLeft":{"type":"number","description":"Left margin offset in pixels"},
+              "marginRight":{"type":"number","description":"Right margin offset in pixels"},
+              "justifyContent":{"type":"string","enum":["flex-start","flex-end","center","space-between","space-around","space-evenly"],"description":"Vertical alignment of the overlay image (default: center)"},
+              "alignItems":{"type":"string","enum":["flex-start","flex-end","center","stretch","baseline"],"description":"Horizontal alignment of the overlay image (default: center)"},
+              "showDebug":{"type":"boolean","description":"Show debug info overlay with current overlay settings (useful for positioning)"},
+              \(clientIdProperty)},
+             "required":["uri"]}
+            """
+        ),
+        McpToolDef(
+            name: "clear_timeline",
+            description: "Clear the MCP event buffer. This only affects what you see via MCP resources — "
+                + "the Reactotron timeline in the app is not affected. "
+                + "Useful to discard old events and focus on what happens next.",
+            inputSchemaJSON: #"{"type":"object","properties":{}}"#
+        ),
+        McpToolDef(
+            name: "subscribe_state",
+            description: "Subscribe to a state path. The app will send state.values.change events "
+                + "whenever the value at this path changes. "
+                + "Read the state/subscriptions resource to see changes. "
+                + "Requires Redux or MST plugin. Example path: 'user.profile.name'",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "path":{"type":"string","description":"Dot-separated state path to subscribe to, e.g. 'user.profile' or 'cart.items'"}},
+             "required":["path"]}
+            """
+        ),
+        McpToolDef(
+            name: "unsubscribe_state",
+            description: "Unsubscribe from a state path. Stops receiving change events for this path.",
+            inputSchemaJSON: """
+            {"type":"object","properties":{
+              "path":{"type":"string","description":"State path to unsubscribe from"}},
+             "required":["path"]}
+            """
+        ),
+    ]
+
+    public static func def(named name: String) -> McpToolDef? {
+        all.first { $0.name == name }
+    }
+}

--- a/ADBKit/Sources/ReactotronMCP/McpValueBridge.swift
+++ b/ADBKit/Sources/ReactotronMCP/McpValueBridge.swift
@@ -1,0 +1,41 @@
+import ADBKit
+import Foundation
+import MCP
+
+/// Bridging between ADBKit's `JSONValue` (the Reactotron payload type) and
+/// the MCP SDK's `Value` (JSON-RPC arguments/results). Both are plain JSON
+/// trees; the only care points are `Value`'s int/double split and its binary
+/// case, which JSON can't carry.
+extension JSONValue {
+    var mcpValue: Value {
+        switch self {
+        case .null: .null
+        case let .bool(flag): .bool(flag)
+        case let .number(number):
+            number.truncatingRemainder(dividingBy: 1) == 0 && abs(number) < 9e15
+                ? .int(Int(number)) : .double(number)
+        case let .string(text): .string(text)
+        case let .array(items): .array(items.map(\.mcpValue))
+        case let .object(dict): .object(dict.mapValues(\.mcpValue))
+        }
+    }
+}
+
+extension Value {
+    var jsonValue: JSONValue {
+        switch self {
+        case .null: .null
+        case let .bool(flag): .bool(flag)
+        case let .int(number): .number(Double(number))
+        case let .double(number): .number(number)
+        case let .string(text): .string(text)
+        case let .data(_, data): .string(data.base64EncodedString())
+        case let .array(items): .array(items.map(\.jsonValue))
+        case let .object(dict): .object(dict.mapValues(\.jsonValue))
+        }
+    }
+}
+
+extension [String: Value] {
+    var jsonObject: [String: JSONValue] { mapValues(\.jsonValue) }
+}

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -698,6 +698,35 @@ import Testing
         #expect(mustCover.isSubset(of: covered), "uncovered catalog features: \(mustCover.subtracting(covered))")
     }
 
+    @Test func reactNativeStackIDsAreRealNonAbsorbedFeatures() {
+        for id in FeatureRegistry.reactNativeStackIDs {
+            #expect(FeatureRegistry.byID[id] != nil, "unknown RN stack id \(id)")
+            #expect(!FeatureRegistry.absorbedFeatureIDs.contains(id),
+                    "\(id) is a hub member — reference the hub instead")
+        }
+    }
+
+    @Test func seedRoleWithReactNativeStackLeadsWithTheStackTools() {
+        var layout = LayoutState()
+        layout.seedRole(.qaTester, includeReactNativeStack: true)
+        let curated = FeatureRegistry.featureIDs(for: .qaTester)
+        let expected = FeatureRegistry.reactNativeStackIDs + curated
+        #expect(layout.enabledIds == expected)
+        #expect(layout.sidebarOrder == expected)
+        #expect(layout.effectiveEnabledIDs.contains("reactotron"))
+        // The role-additions baseline stays the pure role list, so future
+        // role-curation changes still reach this user.
+        #expect(layout.seededRoleIds == curated)
+        #expect(Set(layout.enabledIds ?? []).count == (layout.enabledIds ?? []).count)
+    }
+
+    @Test func seedRoleWithReactNativeStackIsANoOpForTheRNRole() {
+        var layout = LayoutState()
+        layout.seedRole(.reactNativeDeveloper, includeReactNativeStack: true)
+        // The RN role already carries its stack — no duplicates, no reorder.
+        #expect(layout.enabledIds == FeatureRegistry.featureIDs(for: .reactNativeDeveloper))
+    }
+
     @Test func seedRoleSetsGroupOrderFromTheCuration() {
         var layout = LayoutState()
         layout.seedRole(.securityTester)

--- a/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
@@ -160,6 +160,78 @@ import Testing
         }
     }
 
+    /// A `client.intro` that drains out of a connection's frame feed *after*
+    /// the connection dropped must not resurrect a ghost client: no
+    /// `.connected` is emitted for a connection the server no longer tracks.
+    /// Ordinary commands still drain — they're timeline data, not client state.
+    @Test(.timeLimit(.minutes(1)))
+    func drainedIntroAfterDropDoesNotResurrectAGhostClient() async throws {
+        let server = ReactotronServer(port: 0)
+        let stream = try await server.start()
+        defer { Task { await server.stop() } }
+        var iterator = stream.makeAsyncIterator()
+        _ = try await waitForListening(&iterator)
+
+        // Connection 999 was never accepted (stands in for one already
+        // dropped): its drained intro must vanish, its drained log must land.
+        let intro = Data(
+            #"{"type":"client.intro","payload":{"name":"Ghost"},"important":false,"date":"d","deltaTime":0}"#
+                .utf8)
+        await server.handleFrame(connectionId: 999, data: intro)
+        let log = Data(
+            #"{"type":"log","payload":{"level":"debug","message":"drained"},"important":false,"date":"d","deltaTime":1}"#
+                .utf8)
+        await server.handleFrame(connectionId: 999, data: log)
+
+        let event = try await nextEvent(&iterator)
+        guard case let .command(connectionId, command, _) = event else {
+            Issue.record("expected the drained log as the next event, got \(event)")
+            return
+        }
+        #expect(connectionId == 999)
+        #expect(command.commandType == .log)
+    }
+
+    /// A tap receives the same events as the primary stream without stealing
+    /// from it, and keeps receiving across a `stop()`/`start()` restart.
+    @Test(.timeLimit(.minutes(1)))
+    func tapMirrorsThePrimaryStreamAndSurvivesRestart() async throws {
+        let server = ReactotronServer(port: 0)
+        let stream = try await server.start()
+        var iterator = stream.makeAsyncIterator()
+        var tapIterator = await server.tap().makeAsyncIterator()
+        _ = try await waitForListening(&iterator)
+
+        let frame = Data(
+            #"{"type":"log","payload":{"level":"warn","message":"both"},"important":false,"date":"d","deltaTime":1}"#
+                .utf8)
+        await server.handleFrame(connectionId: 1, data: frame)
+
+        guard case let .command(_, primary, _) = try await nextEvent(&iterator) else {
+            Issue.record("expected .command on the primary stream"); return
+        }
+        // The tap also carries lifecycle events (.listening) — drain to the
+        // first command rather than assuming arrival order.
+        let tapped = try await nextTapCommand(&tapIterator)
+        #expect(primary == tapped)
+
+        // Restart: the primary stream is replaced, the tap keeps flowing.
+        await server.stop()
+        let restarted = try await server.start()
+        var restartedIterator = restarted.makeAsyncIterator()
+        _ = try await waitForListening(&restartedIterator)
+        await server.handleFrame(connectionId: 2, data: frame)
+        _ = try await nextTapCommand(&tapIterator)
+        await server.stop()
+    }
+
+    private func nextTapCommand(_ iterator: inout Iterator) async throws -> ReactotronCommand {
+        while let event = await iterator.next() {
+            if case let .command(_, command, _) = event { return command }
+        }
+        throw ReactotronServer.ServerError.startFailed("tap ended before a command arrived")
+    }
+
     private func waitForListening(_ iterator: inout Iterator) async throws -> UInt16 {
         while let event = await iterator.next() {
             if case let .listening(port) = event { return port }

--- a/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronServerTests.swift
@@ -28,7 +28,7 @@ import Testing
         try await task.send(.string(introFrame))
 
         let connected = try await nextEvent(&iterator)
-        guard case let .connected(_, intro, introBytes) = connected else {
+        guard case let .connected(_, _, intro, introBytes) = connected else {
             Issue.record("expected .connected, got \(connected)"); return
         }
         #expect(intro.commandType == .clientIntro)
@@ -79,7 +79,7 @@ import Testing
         }
 
         let first = try await connect(clientId: "same-app")
-        guard case let .connected(firstId, _, _) = try await nextEvent(&iterator) else {
+        guard case let .connected(firstId, firstClientId, _, _) = try await nextEvent(&iterator) else {
             Issue.record("expected first .connected"); return
         }
 
@@ -92,10 +92,12 @@ import Testing
         }
         #expect(droppedId == firstId)
         #expect(reason == nil)
-        guard case let .connected(secondId, _, _) = try await nextEvent(&iterator) else {
+        guard case let .connected(secondId, secondClientId, _, _) = try await nextEvent(&iterator) else {
             Issue.record("expected second .connected"); return
         }
         #expect(secondId != firstId)
+        #expect(firstClientId == "same-app")
+        #expect(secondClientId == "same-app")
 
         // A different app coexists — no dedupe, both stay live.
         let third = try await connect(clientId: "other-app")

--- a/ADBKit/Tests/ReactotronMCPTests/McpCommandStoreTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpCommandStoreTests.swift
@@ -1,0 +1,303 @@
+import ADBKit
+import Foundation
+import Testing
+@testable import ReactotronMCP
+
+/// The MCP ring buffer: retention caps, derived side-state (clients, latest
+/// state, custom commands), and event-driven request/response correlation.
+@Suite struct McpCommandStoreTests {
+    private func json(_ text: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(text.utf8))
+    }
+
+    private func intro(name: String, extra: String = "") throws -> ReactotronCommand {
+        ReactotronCommand(
+            type: "client.intro",
+            payload: try json(#"{"name":"\#(name)","platform":"android"\#(extra)}"#)
+        )
+    }
+
+    private func log(_ message: String) -> ReactotronCommand {
+        ReactotronCommand(type: "log", payload: .object(["message": .string(message)]))
+    }
+
+    private func connect(
+        _ store: McpCommandStore, connectionId: Int, clientId: String, name: String
+    ) async throws {
+        await store.ingest(.connected(
+            connectionId: connectionId, clientId: clientId,
+            intro: try intro(name: name), frameBytes: 50
+        ))
+    }
+
+    // MARK: - Buffering
+
+    @Test func buffersCommandsWithMonotonicMessageIdsAndClientAttribution() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        await store.ingest(.command(connectionId: 1, command: log("one"), frameBytes: 10))
+        await store.ingest(.command(connectionId: 1, command: log("two"), frameBytes: 10))
+
+        let all = await store.commands()
+        #expect(all.count == 3) // intro + two logs
+        #expect(all.map(\.messageId) == [1, 2, 3])
+        #expect(all.allSatisfy { $0.clientId == "app-a" })
+        let logs = await store.commands(ofType: "log")
+        #expect(logs.map { $0.command.payload?["message"]?.stringValue } == ["one", "two"])
+    }
+
+    @Test func itemCapDropsOldestFirst() async throws {
+        let store = McpCommandStore(maxItems: 8, maxBytes: .max)
+        for index in 0 ..< 20 {
+            await store.ingest(.command(connectionId: 1, command: log("\(index)"), frameBytes: 10))
+        }
+        let kept = await store.commands()
+        #expect(kept.count <= 8)
+        // Newest always survives; the survivors are a suffix (oldest dropped).
+        #expect(kept.last?.command.payload?["message"]?.stringValue == "19")
+        let numbers = kept.compactMap { $0.command.payload?["message"]?.stringValue }.compactMap(Int.init)
+        #expect(numbers == Array((20 - numbers.count) ..< 20))
+    }
+
+    @Test func byteCapDropsOldestFirstAndKeepsNewest() async throws {
+        let store = McpCommandStore(maxItems: .max, maxBytes: 1000)
+        for index in 0 ..< 10 {
+            await store.ingest(.command(connectionId: 1, command: log("\(index)"), frameBytes: 300))
+        }
+        let kept = await store.commands()
+        #expect(kept.count < 10)
+        #expect(kept.last?.command.payload?["message"]?.stringValue == "9")
+        // A single frame bigger than the whole budget still lands (newest kept).
+        await store.ingest(.command(connectionId: 1, command: log("huge"), frameBytes: 5000))
+        #expect(await store.commands().last?.command.payload?["message"]?.stringValue == "huge")
+    }
+
+    @Test func clearEmptiesTheBufferButKeepsClients() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        await store.ingest(.command(connectionId: 1, command: log("x"), frameBytes: 10))
+        await store.clear()
+        #expect(await store.commands().isEmpty)
+        #expect(await store.connectedClients.count == 1)
+        // messageIds keep climbing after clear — correlation markers stay valid.
+        await store.ingest(.command(connectionId: 1, command: log("y"), frameBytes: 10))
+        #expect(await store.commands().first?.messageId == 3)
+    }
+
+    @Test func bufferedTypesAreDistinctInFirstSeenOrder() async throws {
+        let store = McpCommandStore()
+        await store.ingest(.command(connectionId: 1, command: log("a"), frameBytes: 5))
+        await store.ingest(.command(
+            connectionId: 1, command: ReactotronCommand(type: "display"), frameBytes: 5))
+        await store.ingest(.command(connectionId: 1, command: log("b"), frameBytes: 5))
+        #expect(await store.bufferedTypes() == ["log", "display"])
+    }
+
+    // MARK: - Clients & derived state
+
+    @Test func connectDisconnectMaintainsTheClientList() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        try await connect(store, connectionId: 2, clientId: "app-b", name: "B")
+        #expect(await store.connectedClients.map(\.clientId) == ["app-a", "app-b"])
+        #expect(await store.connectedClients.first?.name == "A")
+
+        await store.ingest(.disconnected(connectionId: 1, reason: nil))
+        #expect(await store.connectedClients.map(\.clientId) == ["app-b"])
+    }
+
+    @Test func reconnectWithSameClientIdReplacesTheRecord() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "Old")
+        try await connect(store, connectionId: 5, clientId: "app-a", name: "New")
+        let clients = await store.connectedClients
+        #expect(clients.count == 1)
+        #expect(clients.first?.connectionId == 5)
+        #expect(clients.first?.name == "New")
+    }
+
+    @Test func introCarriesMcpRedactionConfig() async throws {
+        let store = McpCommandStore()
+        await store.ingest(.connected(
+            connectionId: 1, clientId: "app-a",
+            intro: try intro(
+                name: "A",
+                extra: #","mcpRedaction":{"additionalRules":{"sensitiveKeys":["companyToken"]}}"#
+            ),
+            frameBytes: 80
+        ))
+        let record = try #require(await store.connectedClients.first)
+        #expect(record.redaction?.additionalRules?.sensitiveKeys == ["companyToken"])
+    }
+
+    @Test func latestStateIsCachedPerClient() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "state.values.response",
+                payload: try json(#"{"path":null,"value":{"count":1},"valid":true}"#)),
+            frameBytes: 40
+        ))
+        let cached = try #require(await store.latestState(clientId: "app-a"))
+        #expect(cached["value"]?["count"]?.intValue == 1)
+        // Sole connected client also resolves with no clientId.
+        #expect(await store.latestState(clientId: nil) != nil)
+    }
+
+    @Test func customCommandRegistryFollowsRegisterAndUnregister() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "customCommand.register",
+                payload: try json(#"{"id":1,"command":"show_dev_menu","title":"Dev menu"}"#)),
+            frameBytes: 30
+        ))
+        #expect(await store.customCommands(clientId: "app-a").count == 1)
+
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "customCommand.unregister",
+                payload: try json(#"{"id":1,"command":"show_dev_menu"}"#)),
+            frameBytes: 30
+        ))
+        #expect(await store.customCommands(clientId: "app-a").isEmpty)
+    }
+
+    @Test func disconnectDropsTheClientsCustomCommands() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "customCommand.register",
+                payload: try json(#"{"id":1,"command":"c"}"#)),
+            frameBytes: 20
+        ))
+        await store.ingest(.disconnected(connectionId: 1, reason: nil))
+        #expect(await store.customCommands(clientId: "app-a").isEmpty)
+    }
+
+    @Test func stateValuesChangeRefreshesSubscriptionPaths() async throws {
+        let store = McpCommandStore()
+        await store.setSubscriptions(["stale.path"])
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "state.values.change",
+                payload: try json(#"{"changes":[{"path":"user.name","value":"x"},{"path":"cart","value":[]}]}"#)),
+            frameBytes: 40
+        ))
+        #expect(await store.subscriptions == ["user.name", "cart"])
+    }
+
+    @Test func listeningStateTracksServerLifecycle() async {
+        let store = McpCommandStore()
+        #expect(await !store.isListening)
+        await store.ingest(.listening(port: 9090))
+        #expect(await store.isListening)
+        #expect(await store.port == 9090)
+        await store.ingest(.failed(reason: "boom", portInUse: false))
+        #expect(await !store.isListening)
+    }
+
+    // MARK: - Correlation
+
+    @Test func awaitCommandResumesWhenTheResponseArrives() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        let marker = await store.lastMessageId
+
+        async let waited = store.awaitCommand(
+            ofType: "state.values.response", clientId: "app-a",
+            afterMessageId: marker, timeout: .seconds(5)
+        )
+        // Give the wait a beat to register, then deliver the response.
+        try await Task.sleep(for: .milliseconds(50))
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "state.values.response", payload: try json(#"{"valid":true}"#)),
+            frameBytes: 20
+        ))
+        let result = try #require(await waited)
+        #expect(result.command.type == "state.values.response")
+        #expect(result.clientId == "app-a")
+    }
+
+    @Test func awaitCommandServesAResponseThatBeatTheWait() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        let marker = await store.lastMessageId
+        // Response lands before awaitCommand is even called (send → fast app).
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(type: "state.keys.response", payload: .null),
+            frameBytes: 10
+        ))
+        let result = await store.awaitCommand(
+            ofType: "state.keys.response", clientId: "app-a",
+            afterMessageId: marker, timeout: .milliseconds(100)
+        )
+        #expect(result != nil)
+    }
+
+    @Test func awaitCommandIgnoresStaleResponsesBeforeTheMarker() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        // A stale response from an earlier request sits in the buffer.
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(type: "state.values.response", payload: .null),
+            frameBytes: 10
+        ))
+        let marker = await store.lastMessageId
+        let result = await store.awaitCommand(
+            ofType: "state.values.response", clientId: "app-a",
+            afterMessageId: marker, timeout: .milliseconds(150)
+        )
+        #expect(result == nil) // timed out rather than matching the stale one
+    }
+
+    @Test func awaitCommandTimesOutAtTheDeadline() async {
+        let store = McpCommandStore()
+        let start = ContinuousClock.now
+        let result = await store.awaitCommand(
+            ofType: "never.arrives", clientId: nil,
+            afterMessageId: 0, timeout: .milliseconds(120)
+        )
+        #expect(result == nil)
+        #expect(ContinuousClock.now - start >= .milliseconds(100))
+    }
+
+    @Test func awaitCommandMatchesOnlyTheRequestedClient() async throws {
+        let store = McpCommandStore()
+        try await connect(store, connectionId: 1, clientId: "app-a", name: "A")
+        try await connect(store, connectionId: 2, clientId: "app-b", name: "B")
+        let marker = await store.lastMessageId
+
+        async let waited = store.awaitCommand(
+            ofType: "state.action.complete", clientId: "app-b",
+            afterMessageId: marker, timeout: .milliseconds(400)
+        )
+        try await Task.sleep(for: .milliseconds(50))
+        // The wrong client answers first — must not satisfy the wait.
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(type: "state.action.complete", payload: .null),
+            frameBytes: 10
+        ))
+        try await Task.sleep(for: .milliseconds(50))
+        await store.ingest(.command(
+            connectionId: 2,
+            command: ReactotronCommand(type: "state.action.complete", payload: .null),
+            frameBytes: 10
+        ))
+        let result = try #require(await waited)
+        #expect(result.clientId == "app-b")
+    }
+}

--- a/ADBKit/Tests/ReactotronMCPTests/McpContractTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpContractTests.swift
@@ -1,0 +1,475 @@
+import ADBKit
+import Foundation
+import MCP
+import Testing
+@testable import ReactotronMCP
+
+/// Records what the tools send to the relay; can auto-answer a request type
+/// by feeding a response command back into the store (the fake RN app).
+actor FakeSender: McpCommandSender {
+    struct Sent: Equatable {
+        let type: String
+        let payload: JSONValue
+        let connectionId: Int?
+    }
+
+    private(set) var sent: [Sent] = []
+    private var autoResponses: [String: ReactotronCommand] = [:]
+    private let store: McpCommandStore
+
+    init(store: McpCommandStore) {
+        self.store = store
+    }
+
+    /// When a command of `requestType` is sent, ingest `response` from
+    /// `connectionId` — simulating the app answering.
+    func autoRespond(to requestType: String, with response: ReactotronCommand) {
+        autoResponses[requestType] = response
+    }
+
+    func send(type: String, payload: JSONValue, toConnection id: Int) async {
+        sent.append(Sent(type: type, payload: payload, connectionId: id))
+        if let response = autoResponses[type] {
+            await store.ingest(.command(connectionId: id, command: response, frameBytes: 64))
+        }
+    }
+
+    func broadcast(type: String, payload: JSONValue) async {
+        sent.append(Sent(type: type, payload: payload, connectionId: nil))
+    }
+}
+
+@Suite struct McpContractTests {
+    private func json(_ text: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(text.utf8))
+    }
+
+    private func makeWorld() -> (store: McpCommandStore, sender: FakeSender, handlers: McpToolHandlers) {
+        let store = McpCommandStore()
+        let sender = FakeSender(store: store)
+        let handlers = McpToolHandlers(store: store, sender: sender)
+        return (store, sender, handlers)
+    }
+
+    private func connectApp(
+        _ store: McpCommandStore, connectionId: Int = 1, clientId: String = "app-1",
+        name: String = "TestApp", platform: String = "android"
+    ) async throws {
+        await store.ingest(.connected(
+            connectionId: connectionId, clientId: clientId,
+            intro: ReactotronCommand(
+                type: "client.intro",
+                payload: try json(#"{"name":"\#(name)","platform":"\#(platform)"}"#)),
+            frameBytes: 40
+        ))
+    }
+
+    private func resultBody(_ result: CallTool.Result) throws -> JSONValue {
+        guard case let .text(text, _, _) = try #require(result.content.first) else {
+            throw MCPError.internalError("expected text content")
+        }
+        return try json(text)
+    }
+
+    // MARK: - Registry invariants (the FeatureRegistry pattern)
+
+    @Test func registryHasTheTenUpstreamToolsUniquelyNamed() {
+        let names = McpToolRegistry.all.map(\.name)
+        #expect(names == [
+            "dispatch_action", "request_state", "request_state_keys", "swap_state",
+            "send_custom_command", "list_custom_commands", "show_overlay",
+            "clear_timeline", "subscribe_state", "unsubscribe_state",
+        ])
+        #expect(Set(names).count == names.count)
+    }
+
+    @Test func everyRegisteredSchemaDecodesToAnObjectSchema() throws {
+        for def in McpToolRegistry.all {
+            let schema = try #require(def.inputSchema, "schema for \(def.name) failed to decode")
+            guard case let .object(root) = schema else {
+                Issue.record("schema for \(def.name) is not an object"); continue
+            }
+            #expect(root["type"] == .string("object"), "schema for \(def.name) missing type")
+            #expect(def.tool != nil)
+            #expect(!def.description.isEmpty)
+        }
+    }
+
+    @Test func everyRegisteredToolResolvesToAHandler() async throws {
+        let (store, _, handlers) = makeWorld()
+        try await connectApp(store)
+        for def in McpToolRegistry.all {
+            // Minimal viable arguments per tool; a missing dispatch case
+            // would throw methodNotFound and fail this loop.
+            let args: [String: Value] = switch def.name {
+            case "dispatch_action": ["actionType": .string("PING")]
+            case "swap_state": ["state": .object([:])]
+            case "send_custom_command": ["command": .string("ping")]
+            case "show_overlay": ["uri": .null]
+            case "subscribe_state", "unsubscribe_state": ["path": .string("x")]
+            default: [:]
+            }
+            _ = try await handlers.call(name: def.name, arguments: args)
+        }
+    }
+
+    @Test func unknownToolThrows() async {
+        let (_, _, handlers) = makeWorld()
+        await #expect(throws: MCPError.self) {
+            _ = try await handlers.call(name: "bogus_tool", arguments: nil)
+        }
+    }
+
+    // MARK: - resolveClientId semantics (upstream error strings)
+
+    @Test func toolsErrorWhenNoAppsConnected() async throws {
+        let (_, _, handlers) = makeWorld()
+        let body = try resultBody(try await handlers.call(name: "request_state", arguments: nil))
+        #expect(body["status"]?.stringValue == "error")
+        #expect(body["message"]?.stringValue == "No apps connected to Reactotron.")
+    }
+
+    @Test func toolsListAvailableAppsWhenAmbiguous() async throws {
+        let (store, _, handlers) = makeWorld()
+        try await connectApp(store, connectionId: 1, clientId: "id-a", name: "AppA")
+        try await connectApp(store, connectionId: 2, clientId: "id-b", name: "AppB", platform: "ios")
+        let body = try resultBody(try await handlers.call(name: "request_state", arguments: nil))
+        let message = try #require(body["message"]?.stringValue)
+        #expect(message.hasPrefix("Multiple apps connected. Specify clientId. Available: "))
+        #expect(message.contains("AppA (android): id-a"))
+        #expect(message.contains("AppB (ios): id-b"))
+    }
+
+    // MARK: - Request/response tools against the fake app
+
+    @Test func dispatchActionConfirmsWhenTheAppAnswers() async throws {
+        let (store, sender, handlers) = makeWorld()
+        try await connectApp(store)
+        await sender.autoRespond(
+            to: "state.action.dispatch",
+            with: ReactotronCommand(type: "state.action.complete", payload: .null)
+        )
+        let body = try resultBody(try await handlers.call(
+            name: "dispatch_action",
+            arguments: ["actionType": .string("user/setName"),
+                        "actionPayload": .object(["name": .string("Alice")])]
+        ))
+        #expect(body["status"]?.stringValue == "dispatched")
+        #expect(body["confirmed"]?.boolValue == true)
+        #expect(body["action"]?["type"]?.stringValue == "user/setName")
+
+        let dispatch = try #require(await sender.sent.first)
+        #expect(dispatch.type == "state.action.dispatch")
+        #expect(dispatch.payload["action"]?["type"]?.stringValue == "user/setName")
+        #expect(dispatch.connectionId == 1)
+    }
+
+    @Test func requestStateReturnsTheRedactedSlice() async throws {
+        let (store, sender, handlers) = makeWorld()
+        try await connectApp(store)
+        await sender.autoRespond(
+            to: "state.values.request",
+            with: ReactotronCommand(
+                type: "state.values.response",
+                payload: try json(
+                    #"{"path":"user","value":{"name":"alice","password":"hunter2"},"valid":true}"#))
+        )
+        let body = try resultBody(try await handlers.call(
+            name: "request_state", arguments: ["path": .string("user")]))
+        #expect(body["status"]?.stringValue == "success")
+        #expect(body["state"]?["name"]?.stringValue == "alice")
+        #expect(body["state"]?["password"]?.stringValue == McpRedaction.redactedMarker)
+    }
+
+    @Test func requestStateReportsNoResponseOnTimeout() async throws {
+        let store = McpCommandStore()
+        let sender = FakeSender(store: store) // never answers
+        let handlers = McpToolHandlers(store: store, sender: sender)
+        try await connectApp(store)
+        // Shrink the wait by asking through the store's own timeout: the
+        // handler uses McpConstants.commandTimeout (1.5s) — acceptable here.
+        let body = try resultBody(try await handlers.call(name: "request_state", arguments: nil))
+        #expect(body["status"]?.stringValue == "no_response")
+        #expect(body["message"]?.stringValue?.contains("Redux or MST") == true)
+    }
+
+    @Test func subscribeToolsMaintainThePathListAndBroadcast() async throws {
+        let (store, sender, handlers) = makeWorld()
+        try await connectApp(store)
+        _ = try await handlers.call(
+            name: "subscribe_state", arguments: ["path": .string("user.name")])
+        let body = try resultBody(try await handlers.call(
+            name: "subscribe_state", arguments: ["path": .string("cart")]))
+        #expect(body["activeSubscriptions"]?.arrayValue?.compactMap(\.stringValue)
+            == ["user.name", "cart"])
+
+        let unsubBody = try resultBody(try await handlers.call(
+            name: "unsubscribe_state", arguments: ["path": .string("user.name")]))
+        #expect(unsubBody["activeSubscriptions"]?.arrayValue?.compactMap(\.stringValue) == ["cart"])
+
+        let broadcasts = await sender.sent.filter { $0.type == "state.values.subscribe" }
+        #expect(broadcasts.count == 3)
+        #expect(broadcasts.last?.payload["paths"]?.arrayValue?.compactMap(\.stringValue) == ["cart"])
+    }
+
+    @Test func clearTimelineReportsRemovedCountAndClearsOnlyTheBuffer() async throws {
+        let (store, _, handlers) = makeWorld()
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1, command: ReactotronCommand(type: "log"), frameBytes: 10))
+        let body = try resultBody(try await handlers.call(name: "clear_timeline", arguments: nil))
+        #expect(body["status"]?.stringValue == "cleared")
+        #expect(body["eventsRemoved"]?.intValue == 2)
+        #expect(await store.commands().isEmpty)
+        #expect(await store.connectedClients.count == 1)
+    }
+
+    @Test func showOverlayEmbedsALocalPngAndFillsDimensions() async throws {
+        let (store, sender, handlers) = makeWorld()
+        try await connectApp(store)
+        // Minimal PNG header: signature + IHDR with 320x200 at offsets 16/20.
+        var png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        png += Data([0, 0, 0, 13]) + Data("IHDR".utf8)
+        png += Data([0, 0, 0x01, 0x40, 0, 0, 0, 0xC8, 8, 6, 0, 0, 0])
+        let fixture = png
+        let handlersWithFile = McpToolHandlers(
+            store: store, sender: await sender as any McpCommandSender,
+            readFile: { _ in fixture }
+        )
+        let body = try resultBody(try await handlersWithFile.call(
+            name: "show_overlay", arguments: ["uri": .string("/tmp/mock.png")]))
+        #expect(body["status"]?.stringValue == "sent")
+        #expect(body["overlay"]?["width"]?.intValue == 320)
+        #expect(body["overlay"]?["height"]?.intValue == 200)
+        #expect(body["overlay"]?["opacity"]?.doubleValue == 0.5)
+
+        let overlay = try #require(await sender.sent.last)
+        #expect(overlay.type == "overlay")
+        #expect(overlay.payload["uri"]?.stringValue?.hasPrefix("data:image/png;base64,") == true)
+    }
+
+    @Test func showOverlayRejectsUnsupportedAndOversizedImages() async throws {
+        let (store, _, handlers) = makeWorld()
+        try await connectApp(store)
+        let unsupported = try resultBody(try await handlers.call(
+            name: "show_overlay", arguments: ["uri": .string("/tmp/mock.webp")]))
+        #expect(unsupported["message"]?.stringValue
+            == "Unsupported image format: .webp. Use PNG, JPEG, or GIF.")
+
+        let big = Data(count: McpConstants.maxOverlayImageBytes + 1)
+        let handlersWithBigFile = McpToolHandlers(
+            store: store, sender: FakeSender(store: store), readFile: { _ in big })
+        let oversized = try resultBody(try await handlersWithBigFile.call(
+            name: "show_overlay", arguments: ["uri": .string("/tmp/big.png")]))
+        #expect(oversized["message"]?.stringValue?.contains("Maximum is 2MB") == true)
+    }
+
+    // MARK: - Image probe
+
+    @Test func imageProbeReadsPngJpegGifHeaders() {
+        var png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        png += Data([0, 0, 0, 13]) + Data("IHDR".utf8)
+        png += Data([0, 0, 0x01, 0x40, 0, 0, 0, 0xC8, 8, 6, 0, 0, 0])
+        #expect(McpImageProbe.size(of: png, extension: "png")! == (320, 200))
+
+        var gif = Data("GIF89a".utf8)
+        gif += Data([0x40, 0x01, 0xC8, 0x00, 0, 0, 0, 0, 0])
+        #expect(McpImageProbe.size(of: gif, extension: "gif")! == (320, 200))
+
+        // JPEG: SOI + SOF0 segment carrying 200x320.
+        var jpeg = Data([0xFF, 0xD8])
+        jpeg += Data([0xFF, 0xC0, 0x00, 0x11, 0x08, 0x00, 0xC8, 0x01, 0x40, 0x03])
+        jpeg += Data(count: 16)
+        #expect(McpImageProbe.size(of: jpeg, extension: "jpg")! == (320, 200))
+
+        #expect(McpImageProbe.size(of: Data([0, 1, 2]), extension: "png") == nil)
+        #expect(McpImageProbe.size(of: png, extension: "webp") == nil)
+    }
+
+    // MARK: - Resources
+
+    @Test func timelineResourceSummarizesNewestFirstWithMeta() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "log", payload: try json(#"{"level":"debug","message":"first"}"#)),
+            frameBytes: 20))
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "log", payload: try json(#"{"level":"warn","message":"second"}"#)),
+            frameBytes: 20))
+
+        let result = try await resources.read(uri: "reactotron://timeline")
+        let body = try json(try #require(result.contents.first?.text))
+        #expect(body["_meta"]?["connection"]?.stringValue == "single_app")
+        #expect(body["eventCount"]?.intValue == 3)
+        let previews = try #require(body["events"]?.arrayValue)
+            .compactMap { $0["payloadPreview"]?.stringValue }
+        #expect(previews.first == "[warn] second") // newest first
+        #expect(body["events"]?.arrayValue?.first?["payload"] == nil) // stripped
+    }
+
+    @Test func timelineByTypeReturnsFullRedactedPayloads() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "api.response",
+                payload: try json(#"""
+                {"duration":9,"request":{"method":"GET","url":"https://x.dev/me",
+                 "headers":{"Authorization":"Bearer secret-token-12345"}},
+                 "response":{"status":200,"body":"{}"}}
+                """#)),
+            frameBytes: 80))
+
+        let result = try await resources.read(uri: "reactotron://timeline/api.response")
+        let body = try json(try #require(result.contents.first?.text))
+        #expect(body["type"]?.stringValue == "api.response")
+        let event = try #require(body["events"]?.arrayValue?.first)
+        #expect(event["payload"]?["request"]?["headers"]?["Authorization"]?.stringValue
+            == McpRedaction.redactedMarker)
+        #expect(event["payload"]?["request"]?["url"]?.stringValue == "https://x.dev/me")
+    }
+
+    @Test func networkResourceRedactsSummaries() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "api.response",
+                payload: try json(#"""
+                {"duration":5,"request":{"method":"POST","url":"https://x.dev/login?token=abc&page=1",
+                 "headers":{"Cookie":"session=xyz"},"data":"user=a&password=b"},
+                 "response":{"status":401,"headers":{},"body":"denied"}}
+                """#)),
+            frameBytes: 90))
+
+        let result = try await resources.read(uri: "reactotron://network/log")
+        let body = try json(try #require(result.contents.first?.text))
+        let entry = try #require(body["entries"]?.arrayValue?.first)
+        #expect(entry["request"]?["headers"]?["Cookie"]?.stringValue == McpRedaction.redactedMarker)
+        #expect(entry["request"]?["url"]?.stringValue
+            == "https://x.dev/login?token=\(McpRedaction.redactedMarker)&page=1")
+        #expect(entry["request"]?["data"]?.stringValue
+            == "user=a&password=\(McpRedaction.redactedMarker)")
+        #expect(entry["response"]?["status"]?.intValue == 401)
+    }
+
+    @Test func stateCurrentFallsBackWhenNothingCached() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        let result = try await resources.read(uri: "reactotron://state/current")
+        let body = try json(try #require(result.contents.first?.text))
+        #expect(body["_meta"]?["connection"]?.stringValue == "no_apps_connected")
+        #expect(body["state"]?["status"]?.stringValue == "no_state_received")
+    }
+
+    @Test func appsResourceListsConnectedApps() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        try await connectApp(store, connectionId: 3, clientId: "abc", name: "Foodhub")
+        let result = try await resources.read(uri: "reactotron://apps")
+        let body = try json(try #require(result.contents.first?.text))
+        let app = try #require(body["apps"]?.arrayValue?.first)
+        #expect(app["clientId"]?.stringValue == "abc")
+        #expect(app["name"]?.stringValue == "Foodhub")
+        #expect(app["id"]?.intValue == 3)
+    }
+
+    @Test func asyncStorageResourceRedactsByStorageKey() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "asyncStorage.mutation",
+                payload: try json(
+                    #"{"action":"setItem","data":{"key":"auth:token","value":"tok-123"}}"#)),
+            frameBytes: 40))
+        let result = try await resources.read(uri: "reactotron://asyncstorage")
+        let body = try json(try #require(result.contents.first?.text))
+        let mutation = try #require(body["mutations"]?.arrayValue?.first)
+        #expect(mutation["action"]?.stringValue == "setItem")
+        #expect(mutation["data"]?["value"]?.stringValue == McpRedaction.redactedMarker)
+    }
+
+    @Test func unknownResourceUriThrows() async {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        await #expect(throws: MCPError.self) {
+            _ = try await resources.read(uri: "reactotron://nope")
+        }
+    }
+
+    @Test func resourceListIncludesTemplateInstancesPerBufferedType() async throws {
+        let (store, _, _) = makeWorld()
+        let resources = McpResources(store: store)
+        await store.ingest(.command(
+            connectionId: 1, command: ReactotronCommand(type: "log"), frameBytes: 5))
+        let list = await resources.list()
+        #expect(list.contains { $0.uri == "reactotron://timeline" })
+        #expect(list.contains { $0.uri == "reactotron://timeline/log" && $0.name == "timeline:log" })
+        #expect(await resources.completeType(prefix: "lo") == ["log"])
+        #expect(resources.templates().first?.uriTemplate == "reactotron://timeline/{type}")
+    }
+
+    // MARK: - Full stack over InMemoryTransport
+
+    @Test(.timeLimit(.minutes(1)))
+    func endToEndOverInMemoryTransport() async throws {
+        let (store, sender, _) = makeWorld()
+        try await connectApp(store)
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "log", payload: try json(#"{"level":"error","message":"boom"}"#)),
+            frameBytes: 30))
+        await sender.autoRespond(
+            to: "state.keys.request",
+            with: ReactotronCommand(
+                type: "state.keys.response",
+                payload: try json(#"{"path":"","keys":["user","cart"],"valid":true}"#))
+        )
+
+        let factory = McpServerFactory(store: store, sender: sender, version: "0.0.1-test")
+        let server = await factory.makeServer()
+        let (clientTransport, serverTransport) = await InMemoryTransport.createConnectedPair()
+        try await server.start(transport: serverTransport)
+        let client = Client(name: "test-client", version: "1.0")
+        let initResult = try await client.connect(transport: clientTransport)
+        #expect(initResult.serverInfo.name == "droidective-reactotron")
+
+        let (tools, _) = try await client.listTools()
+        #expect(tools.count == 10)
+        #expect(tools.map(\.name).contains("dispatch_action"))
+
+        let (resources, _) = try await client.listResources()
+        #expect(resources.contains { $0.uri == "reactotron://timeline" })
+
+        let contents = try await client.readResource(uri: "reactotron://timeline")
+        let timeline = try json(try #require(contents.first?.text))
+        #expect(timeline["eventCount"]?.intValue == 2)
+
+        let (keysContent, keysIsError) = try await client.callTool(
+            name: "request_state_keys", arguments: [:])
+        #expect(keysIsError != true)
+        guard case let .text(keysText, _, _) = try #require(keysContent.first) else {
+            Issue.record("expected text content"); return
+        }
+        let keysBody = try json(keysText)
+        #expect(keysBody["status"]?.stringValue == "success")
+        #expect(keysBody["keys"]?.arrayValue?.compactMap(\.stringValue) == ["user", "cart"])
+
+        await client.disconnect()
+        await server.stop()
+    }
+}

--- a/ADBKit/Tests/ReactotronMCPTests/McpContractTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpContractTests.swift
@@ -225,7 +225,7 @@ actor FakeSender: McpCommandSender {
     }
 
     @Test func showOverlayEmbedsALocalPngAndFillsDimensions() async throws {
-        let (store, sender, handlers) = makeWorld()
+        let (store, sender, _) = makeWorld()
         try await connectApp(store)
         // Minimal PNG header: signature + IHDR with 320x200 at offsets 16/20.
         var png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
@@ -233,7 +233,7 @@ actor FakeSender: McpCommandSender {
         png += Data([0, 0, 0x01, 0x40, 0, 0, 0, 0xC8, 8, 6, 0, 0, 0])
         let fixture = png
         let handlersWithFile = McpToolHandlers(
-            store: store, sender: await sender as any McpCommandSender,
+            store: store, sender: sender as any McpCommandSender,
             readFile: { _ in fixture }
         )
         let body = try resultBody(try await handlersWithFile.call(

--- a/ADBKit/Tests/ReactotronMCPTests/McpGoldenContractTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpGoldenContractTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import MCP
+import Testing
+@testable import ReactotronMCP
+
+/// Pins the served MCP contract — tool names, their input properties (with
+/// required markers), and resource URIs — against a golden signature that
+/// matches upstream `lib/reactotron-mcp` at the commit in
+/// `scripts/reactotron-upstream.lock`.
+///
+/// When syncing to a new upstream release: port the change, run this test,
+/// and update the golden below from the failure message's "actual" output —
+/// the diff between the two IS the contract change, reviewable in the PR.
+@Suite struct McpGoldenContractTests {
+    /// `tool(prop,prop…)` with `*` marking required properties, sorted.
+    static let goldenToolSignature = """
+    clear_timeline()
+    dispatch_action(actionPayload,actionType*,clientId)
+    list_custom_commands(clientId)
+    request_state(clientId,path)
+    request_state_keys(clientId,path)
+    send_custom_command(args,clientId,command*)
+    show_overlay(alignItems,clientId,growToWindow,height,justifyContent,marginBottom,marginLeft,marginRight,marginTop,opacity,resizeMode,showDebug,uri*,width)
+    subscribe_state(path*)
+    swap_state(clientId,state*)
+    unsubscribe_state(path*)
+    """
+
+    static let goldenResourceURIs = """
+    reactotron://apps
+    reactotron://asyncstorage
+    reactotron://benchmarks
+    reactotron://network/log
+    reactotron://state/current
+    reactotron://state/subscriptions
+    reactotron://timeline
+    reactotron://timeline/{type}
+    """
+
+    @Test func toolContractMatchesTheGoldenSignature() throws {
+        var lines: [String] = []
+        for def in McpToolRegistry.all.sorted(by: { $0.name < $1.name }) {
+            let schema = try #require(def.inputSchema)
+            guard case let .object(root) = schema,
+                  case let .object(properties)? = root["properties"] else {
+                Issue.record("schema for \(def.name) has no properties object")
+                continue
+            }
+            let required: Set<String> = if case let .array(names)? = root["required"] {
+                Set(names.compactMap { if case let .string(name) = $0 { name } else { nil } })
+            } else {
+                []
+            }
+            let props = properties.keys.sorted()
+                .map { required.contains($0) ? "\($0)*" : $0 }
+                .joined(separator: ",")
+            lines.append("\(def.name)(\(props))")
+        }
+        let actual = lines.joined(separator: "\n")
+        #expect(
+            actual == Self.goldenToolSignature,
+            "Tool contract drifted. Actual signature:\n\(actual)"
+        )
+    }
+
+    @Test func resourceContractMatchesTheGoldenURIs() {
+        var uris = McpResources.staticResources.map(\.uri)
+        uris.append(McpResources.timelineTemplate.uriTemplate)
+        let actual = uris.sorted().joined(separator: "\n")
+        #expect(
+            actual == Self.goldenResourceURIs,
+            "Resource contract drifted. Actual URIs:\n\(actual)"
+        )
+    }
+}

--- a/ADBKit/Tests/ReactotronMCPTests/McpHTTPListenerTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpHTTPListenerTests.swift
@@ -1,0 +1,232 @@
+import ADBKit
+import Foundation
+import MCP
+import Testing
+@testable import ReactotronMCP
+
+/// Real-socket tests: the NIO listener on an OS-assigned port, exercised by
+/// the SDK's own Streamable HTTP client (the realistic interop check) and by
+/// raw URLSession requests for the rejection paths.
+@Suite struct McpHTTPListenerTests {
+    private func json(_ text: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(text.utf8))
+    }
+
+    private func makeListener(
+        bearerToken: String? = nil
+    ) async throws -> (listener: McpHTTPListener, store: McpCommandStore, port: UInt16) {
+        let store = McpCommandStore()
+        let sender = FakeSender(store: store)
+        let factory = McpServerFactory(store: store, sender: sender, version: "0.0.1-test")
+        let listener = McpHTTPListener(
+            configuration: McpHTTPListener.Configuration(port: 0, bearerToken: bearerToken),
+            factory: factory
+        )
+        try await listener.start()
+        let port = try #require(await listener.boundPort)
+        return (listener, store, port)
+    }
+
+    private static let initializeBody = Data(#"""
+    {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+      "protocolVersion":"2025-11-25","capabilities":{},
+      "clientInfo":{"name":"raw-test","version":"1.0"}}}
+    """#.utf8)
+
+    /// Raw POST /mcp; returns status + response headers.
+    private func rawPost(
+        port: UInt16,
+        body: Data = McpHTTPListenerTests.initializeBody,
+        path: String = "/mcp",
+        headers: [String: String] = [:]
+    ) async throws -> (status: Int, headers: [AnyHashable: Any]) {
+        var request = URLRequest(url: try #require(
+            URL(string: "http://127.0.0.1:\(port)\(path)")))
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        for (name, value) in headers {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        let (_, response) = try await URLSession.shared.data(for: request)
+        let http = try #require(response as? HTTPURLResponse)
+        return (http.statusCode, http.allHeaderFields)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func fullClientRoundTripOverRealHTTP() async throws {
+        let (listener, store, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+
+        // A connected fake app with one buffered log.
+        await store.ingest(.connected(
+            connectionId: 1, clientId: "app-1",
+            intro: ReactotronCommand(
+                type: "client.intro",
+                payload: try json(#"{"name":"SocketApp","platform":"android"}"#)),
+            frameBytes: 40))
+        await store.ingest(.command(
+            connectionId: 1,
+            command: ReactotronCommand(
+                type: "log", payload: try json(#"{"level":"warn","message":"over http"}"#)),
+            frameBytes: 30))
+
+        let transport = HTTPClientTransport(
+            endpoint: try #require(URL(string: "http://127.0.0.1:\(port)/mcp")))
+        let client = Client(name: "socket-test", version: "1.0")
+        let initResult = try await client.connect(transport: transport)
+        #expect(initResult.serverInfo.name == "droidective-reactotron")
+        #expect(await listener.activeSessionCount == 1)
+
+        let (tools, _) = try await client.listTools()
+        #expect(tools.count == 10)
+
+        let contents = try await client.readResource(uri: "reactotron://timeline")
+        let timeline = try json(try #require(contents.first?.text))
+        #expect(timeline["eventCount"]?.intValue == 2)
+        #expect(timeline["_meta"]?["app"]?["name"]?.stringValue == "SocketApp")
+
+        let (cleared, isError) = try await client.callTool(name: "clear_timeline", arguments: [:])
+        #expect(isError != true)
+        guard case let .text(text, _, _) = try #require(cleared.first) else {
+            Issue.record("expected text content"); return
+        }
+        #expect(try json(text)["status"]?.stringValue == "cleared")
+
+        await client.disconnect()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func concurrentSessionsGetIndependentServers() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+        let url = try #require(URL(string: "http://127.0.0.1:\(port)/mcp"))
+
+        let first = Client(name: "client-a", version: "1.0")
+        let second = Client(name: "client-b", version: "1.0")
+        _ = try await first.connect(transport: HTTPClientTransport(endpoint: url))
+        _ = try await second.connect(transport: HTTPClientTransport(endpoint: url))
+        #expect(await listener.activeSessionCount == 2)
+
+        async let toolsA = first.listTools()
+        async let toolsB = second.listTools()
+        let (a, b) = try await (toolsA, toolsB)
+        #expect(a.tools.count == 10)
+        #expect(b.tools.count == 10)
+
+        await first.disconnect()
+        await second.disconnect()
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func requestsOffTheEndpointAre404() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+        let (status, _) = try await rawPost(port: port, path: "/other")
+        #expect(status == 404)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func nonInitializePostWithoutSessionIs400() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+        let (status, _) = try await rawPost(
+            port: port,
+            body: Data(#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#.utf8))
+        #expect(status == 400)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func crossOriginInitializeIsRejected() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+        // DNS-rebinding shape: a browser page on evil.com posting to
+        // 127.0.0.1. OriginValidator.localhost() must reject it.
+        let (status, _) = try await rawPost(
+            port: port, headers: ["Origin": "http://evil.example.com"])
+        #expect(status == 403)
+
+        // Localhost origins pass (the validator's patterns require a port).
+        let (allowed, _) = try await rawPost(
+            port: port, headers: ["Origin": "http://localhost:3000"])
+        #expect(allowed == 200)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func bearerTokenIsEnforcedWhenConfigured() async throws {
+        let (listener, _, port) = try await makeListener(bearerToken: "sekrit-123")
+        defer { Task { await listener.stop() } }
+
+        let (missing, _) = try await rawPost(port: port)
+        #expect(missing == 401)
+
+        let (wrong, _) = try await rawPost(
+            port: port, headers: ["Authorization": "Bearer nope"])
+        #expect(wrong == 401)
+
+        let (right, headers) = try await rawPost(
+            port: port, headers: ["Authorization": "Bearer sekrit-123"])
+        #expect(right == 200)
+        #expect(headers["Mcp-Session-Id"] != nil || headers["MCP-Session-Id"] != nil)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func deleteEndsTheSession() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+
+        let (status, headers) = try await rawPost(port: port)
+        #expect(status == 200)
+        let sessionID = try #require(
+            (headers["Mcp-Session-Id"] ?? headers["MCP-Session-Id"]) as? String)
+        #expect(await listener.activeSessionCount == 1)
+
+        var request = URLRequest(url: try #require(
+            URL(string: "http://127.0.0.1:\(port)/mcp")))
+        request.httpMethod = "DELETE"
+        request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        #expect(await listener.activeSessionCount == 0)
+    }
+
+    @Test func controllerStartsStopsAndReportsStatus() async throws {
+        let controller = McpServerController()
+        #expect(await controller.status == .stopped)
+
+        let (stream, continuation) = AsyncStream.makeStream(of: ReactotronServer.Event.self)
+        let store = await controller.commandStore
+        let sender = FakeSender(store: store)
+        try await controller.start(
+            events: stream, sender: sender, version: "0.0.1-test", port: 0)
+        guard case let .listening(port) = await controller.status else {
+            Issue.record("expected .listening"); return
+        }
+        #expect(port > 0)
+
+        // Events flow through the tap into the controller's store.
+        continuation.yield(.command(
+            connectionId: 1, command: ReactotronCommand(type: "log"), frameBytes: 10))
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(await store.bufferedCount == 1)
+
+        await controller.stop()
+        #expect(await controller.status == .stopped)
+        continuation.finish()
+    }
+
+    @Test func portConflictSurfacesAsPortInUse() async throws {
+        let (listener, _, port) = try await makeListener()
+        defer { Task { await listener.stop() } }
+
+        let store = McpCommandStore()
+        let factory = McpServerFactory(
+            store: store, sender: FakeSender(store: store), version: "t")
+        let second = McpHTTPListener(
+            configuration: McpHTTPListener.Configuration(port: port), factory: factory)
+        await #expect(throws: McpHTTPListener.ListenerError.self) {
+            try await second.start()
+        }
+    }
+}

--- a/ADBKit/Tests/ReactotronMCPTests/McpRedactionTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpRedactionTests.swift
@@ -1,0 +1,344 @@
+import ADBKit
+import Foundation
+import Testing
+@testable import ReactotronMCP
+
+/// Port of upstream `lib/reactotron-mcp/test/redaction.test.ts` — the cases
+/// that define the redaction contract. Fixtures build `JSONValue` from JSON
+/// text so they read like the originals.
+@Suite struct McpRedactionTests {
+    private let redacted = McpRedaction.redactedMarker
+
+    private let rules = McpRedactionRules(
+        sensitiveKeys: ["password", "secret", "api_key", "authorization", "cookie"],
+        statePathPatterns: ["auth.tokens.*", "user.ssn"],
+        valuePatterns: [
+            #"Bearer\s+[A-Za-z0-9\-._~+/]+=*"#,
+            #"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"#,
+        ]
+    )
+
+    private func json(_ text: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(text.utf8))
+    }
+
+    private func redact(_ value: JSONValue, rules: McpRedactionRules? = nil) -> JSONValue {
+        McpRedaction.redact(value, parsed: McpRedaction.parse(rules ?? self.rules))
+    }
+
+    // MARK: - redact()
+
+    @Test func redactsSensitiveKeyNamesCaseInsensitive() throws {
+        let result = redact(try json(
+            #"{"username":"alice","Password":"s3cret","SECRET":"abc"}"#))
+        #expect(result["username"]?.stringValue == "alice")
+        #expect(result["Password"]?.stringValue == redacted)
+        #expect(result["SECRET"]?.stringValue == redacted)
+    }
+
+    @Test func redactsNestedSensitiveKeys() throws {
+        let result = redact(try json(#"{"user":{"name":"alice","password":"s3cret"}}"#))
+        #expect(result["user"]?["name"]?.stringValue == "alice")
+        #expect(result["user"]?["password"]?.stringValue == redacted)
+    }
+
+    @Test func redactsHeaderNamesAnywhereTheyAppear() throws {
+        let result = redact(try json(#"""
+        {"lastResponse":{"requestHeaders":{
+            "Authorization":"Bearer abc123","Cookie":"session=xyz",
+            "Content-Type":"application/json"}}}
+        """#))
+        let headers = result["lastResponse"]?["requestHeaders"]
+        #expect(headers?["Authorization"]?.stringValue == redacted)
+        #expect(headers?["Cookie"]?.stringValue == redacted)
+        #expect(headers?["Content-Type"]?.stringValue == "application/json")
+    }
+
+    @Test func redactsASetCookieArrayValueNotJustString() throws {
+        let setCookieRules = McpRedactionRules(sensitiveKeys: ["set-cookie"])
+        let result = redact(
+            try json(#"{"headers":{"Set-Cookie":["session=xyz; HttpOnly","remember=1"]}}"#),
+            rules: setCookieRules
+        )
+        #expect(result["headers"]?["Set-Cookie"]?.stringValue == redacted)
+    }
+
+    @Test func redactsValuesMatchingValuePatterns() throws {
+        let result = redact(try json(
+            #"{"message":"Token is Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0 and more"}"#))
+        let message = try #require(result["message"]?.stringValue)
+        #expect(!message.contains("Bearer"))
+        #expect(message.contains(redacted))
+        #expect(message.contains("and more"))
+    }
+
+    @Test func redactsJwtLikeValues() throws {
+        let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+            + "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0"
+        let result = redact(try json(#"{"token":"\#(jwt)","label":"test"}"#))
+        #expect(result["token"]?.stringValue == redacted)
+        #expect(result["label"]?.stringValue == "test")
+    }
+
+    @Test func redactsStatePathsMatchingPatterns() throws {
+        let result = redact(try json(#"""
+        {"auth":{"tokens":{"access":"abc","refresh":"def"},"username":"alice"},
+         "user":{"ssn":"123-45-6789","name":"Alice"}}
+        """#))
+        #expect(result["auth"]?["tokens"]?["access"]?.stringValue == redacted)
+        #expect(result["auth"]?["tokens"]?["refresh"]?.stringValue == redacted)
+        #expect(result["auth"]?["username"]?.stringValue == "alice")
+        #expect(result["user"]?["ssn"]?.stringValue == redacted)
+        #expect(result["user"]?["name"]?.stringValue == "Alice")
+    }
+
+    @Test func statePathAnchoringForSubtreeRequests() throws {
+        // The app returned the subtree at "auth.tokens" — patterns written
+        // against the full tree still line up via the statePath anchor.
+        let subtree = try json(#"{"access":"abc","refresh":"def"}"#)
+        let result = McpRedaction.redactState(
+            subtree, parsed: McpRedaction.parse(rules), statePath: "auth.tokens")
+        #expect(result["access"]?.stringValue == redacted)
+        #expect(result["refresh"]?.stringValue == redacted)
+    }
+
+    @Test func handlesNullValues() throws {
+        #expect(redact(.null) == .null)
+        let result = redact(try json(#"{"key":null,"password":"secret"}"#))
+        #expect(result["key"] == .null)
+        #expect(result["password"]?.stringValue == redacted)
+    }
+
+    @Test func handlesArrays() throws {
+        let result = redact(try json(
+            #"[{"password":"s3cret","name":"alice"},{"password":"p4ss","name":"bob"}]"#))
+        let items = try #require(result.arrayValue)
+        #expect(items[0]["password"]?.stringValue == redacted)
+        #expect(items[0]["name"]?.stringValue == "alice")
+        #expect(items[1]["password"]?.stringValue == redacted)
+        #expect(items[1]["name"]?.stringValue == "bob")
+    }
+
+    @Test func handlesPrimitives() {
+        #expect(redact(.number(42)) == .number(42))
+        #expect(redact(.bool(true)) == .bool(true))
+        #expect(redact(.string("plain text")) == .string("plain text"))
+    }
+
+    @Test func redactsSensitiveQueryParametersInUrls() throws {
+        var withKey = rules
+        withKey.sensitiveKeys += ["key", "token"]
+        let result = redact(
+            try json(#"{"url":"https://api.example.com/games?key=14e7149770cd4fdf&other=visible"}"#),
+            rules: withKey
+        )
+        #expect(result["url"]?.stringValue
+            == "https://api.example.com/games?key=\(redacted)&other=visible")
+    }
+
+    @Test func redactsMultipleSensitiveQueryParameters() throws {
+        var withKey = rules
+        withKey.sensitiveKeys += ["key", "token"]
+        let result = redact(
+            try json(#"{"url":"https://api.example.com/data?key=abc&token=xyz&page=1"}"#),
+            rules: withKey
+        )
+        #expect(result["url"]?.stringValue
+            == "https://api.example.com/data?key=\(redacted)&token=\(redacted)&page=1")
+    }
+
+    @Test func preservesUrlFragmentsWhileRedactingQuery() throws {
+        var withKey = rules
+        withKey.sensitiveKeys += ["token"]
+        let result = redact(
+            try json(#"{"url":"https://x.dev/a?token=abc#section"}"#), rules: withKey)
+        #expect(result["url"]?.stringValue == "https://x.dev/a?token=\(redacted)#section")
+    }
+
+    @Test func doesNotRedactQueryParamsWhenNoSensitiveKeysMatch() throws {
+        let result = redact(try json(#"{"url":"https://api.example.com/data?page=1&limit=10"}"#))
+        #expect(result["url"]?.stringValue == "https://api.example.com/data?page=1&limit=10")
+    }
+
+    @Test func doesNotRedactNonMatchingKeysOrValues() throws {
+        let data = try json(#"{"username":"alice","email":"alice@example.com","count":42}"#)
+        #expect(redact(data) == data)
+    }
+
+    @Test func emptyRulesRedactNothing() throws {
+        let data = try json(#"{"password":"secret","headers":{"Authorization":"Bearer xyz"}}"#)
+        #expect(redact(data, rules: McpRedactionRules()) == data)
+    }
+
+    @Test func redactsFormEncodedBodies() throws {
+        let result = redact(try json(#"{"body":"user=alice&password=hunter2&stay=1"}"#))
+        #expect(result["body"]?.stringValue == "user=alice&password=\(redacted)&stay=1")
+    }
+
+    @Test func proseWithEqualsIsNotFormEncoded() {
+        #expect(!McpRedaction.looksLikeFormEncoded("the answer is x=5 in this equation"))
+        #expect(McpRedaction.looksLikeFormEncoded("user=alice&password=x"))
+        #expect(!McpRedaction.looksLikeFormEncoded(""))
+    }
+
+    @Test func redactsInsideJsonEncodedStrings() throws {
+        // A request body serialized as a JSON string still gets key redaction.
+        let result = redact(try json(
+            #"{"data":"{\"username\":\"alice\",\"password\":\"hunter2\"}"}"#))
+        let body = try #require(result["data"]?.stringValue)
+        #expect(body.contains(redacted))
+        #expect(!body.contains("hunter2"))
+        #expect(body.contains("alice"))
+    }
+
+    @Test func invalidRegexPatternsAreSkippedNotFatal() throws {
+        let withBadPattern = McpRedactionRules(
+            sensitiveKeys: ["password"],
+            valuePatterns: ["([unclosed", #"Bearer\s+\w+"#]
+        )
+        let result = redact(
+            try json(#"{"note":"Bearer abc123","password":"x"}"#), rules: withBadPattern)
+        #expect(result["note"]?.stringValue == redacted)
+        #expect(result["password"]?.stringValue == redacted)
+    }
+
+    // MARK: - Default rules & value patterns
+
+    @Test func defaultRulesCoverTheUpstreamKeyList() {
+        let keys = Set(McpRedaction.defaultRules.sensitiveKeys)
+        for expected in [
+            "authorization", "cookie", "set-cookie", "x-api-key",
+            "x-csrf-token", "x-xsrf-token", "csrf-token",
+            "x-forwarded-for", "x-real-ip",
+            "password", "passwd", "pwd", "secret", "access_token",
+            "token", "bearer", "jwt", "id_token", "idtoken",
+            "session", "sessionid", "csrf", "xsrf",
+            "client_secret", "clientsecret",
+        ] {
+            #expect(keys.contains(expected), "missing default key \(expected)")
+        }
+    }
+
+    @Test func valuePatternsMatchCommonTokenFormats() {
+        let patternRules = McpRedactionRules(valuePatterns: McpRedaction.defaultRules.valuePatterns)
+        func redactedString(_ text: String) -> String? {
+            redact(.string(text), rules: patternRules).stringValue
+        }
+        #expect(redactedString("Bearer abc123def456") == redacted)
+        #expect(redactedString("sk-abcdefghijklmnopqrstuvwxyz") == redacted)
+        #expect(redactedString("ghp_abcdefghijklmnopqrstuvwxyz1234567") == redacted)
+        #expect(redactedString("xoxb-abc123-def456-ghi789") == redacted)
+        // Built at runtime so secret scanning doesn't flag the test file.
+        #expect(redactedString(["sk", "ant"].joined(separator: "-") + "-"
+            + String(repeating: "x", count: 32)) == redacted)
+        #expect(redactedString("AKI" + "A" + String(repeating: "X", count: 16)) == redacted)
+        #expect(redactedString("AIz" + "a" + String(repeating: "X", count: 35)) == redacted)
+        #expect(redactedString(["sk", "live", String(repeating: "X", count: 28)]
+            .joined(separator: "_")) == redacted)
+        #expect(redactedString(
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----")
+            == redacted)
+        #expect(redactedString("hello world") == "hello world")
+    }
+
+    // MARK: - resolveEffectiveRules (the two-key model)
+
+    @Test func returnsServerDefaultsWhenNoClientConfig() {
+        let result = McpRedaction.resolveEffectiveRules(server: .standard, client: nil)
+        #expect(result == McpRedactionServerConfig.standard.defaults)
+    }
+
+    @Test func mergesAdditionalRulesFromClient() throws {
+        let client = McpRedactionConfig(
+            additionalRules: McpRedactionRules(sensitiveKeys: ["myCustomField", "x-custom-auth"]))
+        let result = try #require(McpRedaction.resolveEffectiveRules(server: .standard, client: client))
+        #expect(result.sensitiveKeys.contains("myCustomField"))
+        #expect(result.sensitiveKeys.contains("x-custom-auth"))
+        #expect(result.sensitiveKeys.contains("password"))
+        #expect(result.sensitiveKeys.contains("authorization"))
+    }
+
+    @Test func ignoresRemoveRulesWhenServerDisallows() throws {
+        let client = McpRedactionConfig(
+            removeRules: McpRedactionRules(sensitiveKeys: ["authorization"]))
+        let result = try #require(McpRedaction.resolveEffectiveRules(server: .standard, client: client))
+        #expect(result.sensitiveKeys.contains("authorization"))
+    }
+
+    @Test func honorsRemoveRulesWhenServerAllows() throws {
+        var server = McpRedactionServerConfig.standard
+        server.allowClientRemoveRules = true
+        let client = McpRedactionConfig(
+            removeRules: McpRedactionRules(sensitiveKeys: ["AUTHORIZATION", "PASSWORD"]))
+        let result = try #require(McpRedaction.resolveEffectiveRules(server: server, client: client))
+        #expect(!result.sensitiveKeys.contains("authorization"))
+        #expect(!result.sensitiveKeys.contains("password"))
+        #expect(result.sensitiveKeys.contains("cookie"))
+    }
+
+    @Test func ignoresDisableRedactionWhenServerDisallows() {
+        let client = McpRedactionConfig(disableRedaction: true)
+        let result = McpRedaction.resolveEffectiveRules(server: .standard, client: client)
+        #expect(result == McpRedactionServerConfig.standard.defaults)
+    }
+
+    @Test func disablesWhenClientAsksAndServerAllows() {
+        var server = McpRedactionServerConfig.standard
+        server.allowClientDisable = true
+        let client = McpRedactionConfig(disableRedaction: true)
+        #expect(McpRedaction.resolveEffectiveRules(server: server, client: client) == nil)
+    }
+
+    @Test func removeAndAdditionalRulesCombine() throws {
+        var server = McpRedactionServerConfig.standard
+        server.allowClientRemoveRules = true
+        let client = McpRedactionConfig(
+            additionalRules: McpRedactionRules(sensitiveKeys: ["mySecret"]),
+            removeRules: McpRedactionRules(sensitiveKeys: ["password"])
+        )
+        let result = try #require(McpRedaction.resolveEffectiveRules(server: server, client: client))
+        #expect(!result.sensitiveKeys.contains("password"))
+        #expect(result.sensitiveKeys.contains("mySecret"))
+        #expect(result.sensitiveKeys.contains("secret"))
+    }
+
+    @Test func parsesClientConfigFromIntroPayload() throws {
+        let payload = try json(#"""
+        {"mcpRedaction":{"disableRedaction":true,
+          "additionalRules":{"sensitiveKeys":["companyToken"]},
+          "removeRules":{"valuePatterns":["p"]}}}
+        """#)
+        let config = try #require(McpRedactionConfig(json: payload["mcpRedaction"]))
+        #expect(config.disableRedaction)
+        #expect(config.additionalRules?.sensitiveKeys == ["companyToken"])
+        #expect(config.removeRules?.valuePatterns == ["p"])
+        #expect(McpRedactionConfig(json: nil) == nil)
+        #expect(McpRedactionConfig(json: .string("nope")) == nil)
+    }
+
+    // MARK: - AsyncStorage
+
+    @Test func redactsSetItemWithSensitiveStorageKey() throws {
+        let parsed = McpRedaction.parse(rules)
+        let result = McpRedaction.redactAsyncStorage(
+            try json(#"{"key":"auth:password","value":"hunter2"}"#), parsed: parsed)
+        #expect(result["key"]?.stringValue == "auth:password")
+        #expect(result["value"]?.stringValue == redacted)
+    }
+
+    @Test func leavesSetItemWithBenignStorageKey() throws {
+        let parsed = McpRedaction.parse(rules)
+        let result = McpRedaction.redactAsyncStorage(
+            try json(#"{"key":"theme","value":"dark"}"#), parsed: parsed)
+        #expect(result["value"]?.stringValue == "dark")
+    }
+
+    @Test func redactsMultiSetPairs() throws {
+        let parsed = McpRedaction.parse(rules)
+        let result = McpRedaction.redactAsyncStorage(
+            try json(#"{"pairs":[["user.api_key","sk-123"],["lang","en"]]}"#), parsed: parsed)
+        let pairs = try #require(result["pairs"]?.arrayValue)
+        #expect(pairs[0].arrayValue?[1].stringValue == redacted)
+        #expect(pairs[1].arrayValue?[1].stringValue == "en")
+    }
+}

--- a/ADBKit/Tests/ReactotronMCPTests/McpSerializationTests.swift
+++ b/ADBKit/Tests/ReactotronMCPTests/McpSerializationTests.swift
@@ -1,0 +1,170 @@
+import ADBKit
+import Foundation
+import Testing
+@testable import ReactotronMCP
+
+/// Port of upstream `test/serialization.test.ts` plus the buffered-command
+/// summary shapes the tools/resources return.
+@Suite struct McpSerializationTests {
+    private func json(_ text: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(text.utf8))
+    }
+
+    private func buffered(
+        _ command: ReactotronCommand, messageId: Int = 7, clientId: String? = "app-1"
+    ) -> McpBufferedCommand {
+        McpBufferedCommand(
+            messageId: messageId, connectionId: 1, clientId: clientId,
+            command: command, frameBytes: 100
+        )
+    }
+
+    // MARK: - compactJson / truncate / safeSerialize
+
+    @Test func compactJsonProducesNoIndentation() throws {
+        let text = McpSerialization.compactJson(try json(#"{"a":1,"b":[1,2]}"#))
+        #expect(!text.contains("\n"))
+        #expect(!text.contains("  "))
+        #expect(text.contains(#""a":1"#))
+    }
+
+    @Test func truncateReturnsOriginalWhenUnderLimit() {
+        #expect(McpSerialization.truncate("short", limit: 100) == "short")
+    }
+
+    @Test func truncateAppendsDefaultMessageWhenOverLimit() {
+        let result = McpSerialization.truncate(String(repeating: "x", count: 5000), limit: 1000)
+        #expect(result.count <= 1000)
+        #expect(result.contains("[TRUNCATED — response was ~5K chars.]"))
+    }
+
+    @Test func truncateAppendsCustomGuidance() {
+        let result = McpSerialization.truncate(
+            String(repeating: "x", count: 5000), limit: 1000,
+            guidance: "Pass a path to narrow the state read."
+        )
+        #expect(result.contains("Pass a path to narrow the state read."))
+        #expect(result.count <= 1000)
+    }
+
+    @Test func safeSerializeUsesMaxResponseCharsAsDefaultLimit() throws {
+        let big = JSONValue.array(
+            (0 ..< 60_000).map { .string("item-\($0)-padding-padding") })
+        let result = McpSerialization.safeSerialize(big)
+        #expect(result.count <= McpConstants.maxResponseChars)
+        #expect(result.contains("[TRUNCATED"))
+        let small = McpSerialization.safeSerialize(try json(#"{"ok":true}"#))
+        #expect(small == #"{"ok":true}"#)
+    }
+
+    // MARK: - summarizeCommand
+
+    @Test func summaryKeepsMetadataAndStripsPayload() throws {
+        let command = ReactotronCommand(
+            type: "display",
+            payload: try json(#"{"name":"BIG","value":{"huge":"payload"}}"#),
+            important: true, date: "2026-07-20T10:00:00.000Z", deltaTime: 12
+        )
+        let summary = McpSerialization.summarizeCommand(buffered(command))
+        #expect(summary["type"]?.stringValue == "display")
+        #expect(summary["messageId"]?.intValue == 7)
+        #expect(summary["clientId"]?.stringValue == "app-1")
+        #expect(summary["important"]?.boolValue == true)
+        #expect(summary["deltaTime"]?.doubleValue == 12)
+        #expect(summary["payload"] == nil)
+        #expect(summary["payloadPreview"] != nil)
+    }
+
+    @Test func apiResponseGetsAOneLinerPreview() throws {
+        let command = ReactotronCommand(
+            type: "api.response",
+            payload: try json(#"""
+            {"duration":123,
+             "request":{"method":"POST","url":"https://api.x.dev/login"},
+             "response":{"status":200}}
+            """#)
+        )
+        let summary = McpSerialization.summarizeCommand(buffered(command))
+        #expect(summary["payloadPreview"]?.stringValue
+            == "POST https://api.x.dev/login -> 200 (123ms)")
+    }
+
+    @Test func logGetsALevelPrefixedPreview() throws {
+        let command = ReactotronCommand(
+            type: "log", payload: try json(#"{"level":"warn","message":"disk full"}"#))
+        let summary = McpSerialization.summarizeCommand(buffered(command))
+        #expect(summary["payloadPreview"]?.stringValue == "[warn] disk full")
+    }
+
+    @Test func longLogMessagesAreCapped() throws {
+        let long = String(repeating: "m", count: 500)
+        let command = ReactotronCommand(
+            type: "log", payload: try json(#"{"level":"debug","message":"\#(long)"}"#))
+        let preview = try #require(
+            McpSerialization.summarizeCommand(buffered(command))["payloadPreview"]?.stringValue)
+        #expect(preview.hasSuffix("..."))
+        #expect(preview.count <= McpConstants.maxPayloadPreviewChars + 16)
+    }
+
+    @Test func stateValuesResponseShowsThePath() throws {
+        let command = ReactotronCommand(
+            type: "state.values.response", payload: try json(#"{"path":"user.profile"}"#))
+        #expect(McpSerialization.summarizeCommand(buffered(command))["payloadPreview"]?.stringValue
+            == "path: user.profile")
+        let rootCommand = ReactotronCommand(
+            type: "state.values.response", payload: try json(#"{"valid":true}"#))
+        #expect(McpSerialization.summarizeCommand(buffered(rootCommand))["payloadPreview"]?.stringValue
+            == "path: (root)")
+    }
+
+    @Test func genericPayloadPreviewIsTruncated() throws {
+        let command = ReactotronCommand(
+            type: "custom.thing",
+            payload: try json(#"{"blob":"\#(String(repeating: "z", count: 400))"}"#)
+        )
+        let preview = try #require(
+            McpSerialization.summarizeCommand(buffered(command))["payloadPreview"]?.stringValue)
+        #expect(preview.hasSuffix("..."))
+        #expect(preview.count <= McpConstants.maxPayloadPreviewChars + 3)
+    }
+
+    // MARK: - summarizeNetworkEntry
+
+    @Test func networkEntryKeepsUrlMethodStatusDuration() throws {
+        let command = ReactotronCommand(
+            type: "api.response",
+            payload: try json(#"""
+            {"duration":45.5,
+             "request":{"method":"GET","url":"https://x.dev/v1/items",
+                        "headers":{"Accept":"application/json"},"data":null},
+             "response":{"status":304,"headers":{"ETag":"abc"},"body":""}}
+            """#),
+            date: "2026-07-20T10:00:00.000Z"
+        )
+        let entry = McpSerialization.summarizeNetworkEntry(buffered(command))
+        #expect(entry["request"]?["method"]?.stringValue == "GET")
+        #expect(entry["request"]?["url"]?.stringValue == "https://x.dev/v1/items")
+        #expect(entry["response"]?["status"]?.intValue == 304)
+        #expect(entry["duration"]?.doubleValue == 45.5)
+        #expect(entry["messageId"]?.intValue == 7)
+        #expect(entry["request"]?["data"] == nil)
+    }
+
+    @Test func largeBodiesArePreviewTruncated() throws {
+        let bigBody = String(repeating: "b", count: 2000)
+        let command = ReactotronCommand(
+            type: "api.response",
+            payload: try json(#"""
+            {"request":{"method":"POST","url":"u","data":"\#(bigBody)"},
+             "response":{"status":200,"body":"\#(bigBody)"}}
+            """#)
+        )
+        let entry = McpSerialization.summarizeNetworkEntry(buffered(command))
+        let requestData = try #require(entry["request"]?["data"]?.stringValue)
+        let responseBody = try #require(entry["response"]?["body"]?.stringValue)
+        #expect(requestData.count == McpConstants.maxBodyPreviewChars + 3)
+        #expect(requestData.hasSuffix("..."))
+        #expect(responseBody.count == McpConstants.maxBodyPreviewChars + 3)
+        #expect(responseBody.hasSuffix("..."))
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -131,9 +131,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             isQuitting = true
             // The leave prompt's resolution (quit / cancel) drives termination.
             if !appState.requestQuit() { return .terminateLater }
-            guard appState.reactotronSession.isRunning else { return .terminateNow }
+            guard appState.reactotronSession.isRunning || appState.mcp.isEnabled else {
+                return .terminateNow
+            }
             Task { @MainActor in
-                await appState.reactotronSession.stopForQuit()
+                await appState.mcp.stopForQuit()
+                if appState.reactotronSession.isRunning {
+                    await appState.reactotronSession.stopForQuit()
+                }
                 NSApp.reply(toApplicationShouldTerminate: true)
             }
             return .terminateLater

--- a/App/Sources/FeatureDetail/Views/ReactotronMcpGuideSheet.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronMcpGuideSheet.swift
@@ -28,11 +28,14 @@ struct McpAgentGuideSheet: View {
                 stepOne
                 stepTwo
                 stepThree
-                footerSection
             }
             .formStyle(.grouped)
             Divider()
-            HStack {
+            HStack(spacing: 12) {
+                SettingsLink {
+                    Text("Settings ▸ MCP")
+                }
+                .help("Port, bearer token, and redaction rules")
                 Text("Localhost only. Passwords, tokens, and keys are redacted "
                     + "before anything reaches an agent.")
                     .font(.app(.footnote))
@@ -54,8 +57,8 @@ struct McpAgentGuideSheet: View {
                 .onChange(of: mcpEnabled) { state.mcp.applySettings() }
             LabeledContent("Status") { statusLabel }
             Text("Agents get this timeline, the network log, and Redux/MST state — "
-                + "plus tools to dispatch actions, run the app's custom commands, and "
-                + "query state. The server keeps running while the window is closed.")
+                + "plus tools to dispatch actions and run the app's custom commands. "
+                + "Keeps running while the window is closed.")
                 .font(.app(.footnote))
                 .foregroundStyle(.textMuted)
         }
@@ -212,13 +215,4 @@ struct McpAgentGuideSheet: View {
         }
     }
 
-    private var footerSection: some View {
-        Section {
-            LabeledContent("Port, token, and redaction rules") {
-                SettingsLink {
-                    Text("Open Settings ▸ MCP")
-                }
-            }
-        }
-    }
 }

--- a/App/Sources/FeatureDetail/Views/ReactotronMcpGuideSheet.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronMcpGuideSheet.swift
@@ -1,0 +1,224 @@
+import ADBKit
+import AppKit
+import ReactotronMCP
+import SwiftUI
+
+/// The in-feature onboarding for MCP: turn the server on, connect an agent,
+/// try a prompt — all from the Reactotron screen (Settings ▸ MCP stays the
+/// place for port/token/redaction options). Opened from the header's
+/// "AI Agents" button.
+struct McpAgentGuideSheet: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage(mcpEnabledKey) private var mcpEnabled = false
+    @State private var agent: Agent = .claudeCode
+
+    enum Agent: String, CaseIterable, Identifiable {
+        case claudeCode = "Claude Code"
+        case cursor = "Cursor"
+        case vsCode = "VS Code"
+        case other = "Any MCP client"
+
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Form {
+                stepOne
+                stepTwo
+                stepThree
+                footerSection
+            }
+            .formStyle(.grouped)
+            Divider()
+            HStack {
+                Text("Localhost only. Passwords, tokens, and keys are redacted "
+                    + "before anything reaches an agent.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(12)
+        }
+        .frame(width: 560, height: 620)
+    }
+
+    // MARK: - Step 1: turn it on
+
+    private var stepOne: some View {
+        Section("Step 1 — Turn on the MCP server") {
+            Toggle("Serve Reactotron data to AI agents", isOn: $mcpEnabled)
+                .onChange(of: mcpEnabled) { state.mcp.applySettings() }
+            LabeledContent("Status") { statusLabel }
+            Text("Agents get this timeline, the network log, and Redux/MST state — "
+                + "plus tools to dispatch actions, run the app's custom commands, and "
+                + "query state. The server keeps running while the window is closed.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+        }
+    }
+
+    @ViewBuilder private var statusLabel: some View {
+        switch state.mcp.status {
+        case .off:
+            Text(mcpEnabled ? "Starting…" : "Off")
+                .foregroundStyle(.textMuted)
+        case .starting:
+            Text("Starting…").foregroundStyle(.textMuted)
+        case let .listening(port):
+            Label("Serving on 127.0.0.1:\(String(port))", systemImage: "circle.fill")
+                .foregroundStyle(.green)
+                .font(.app(.callout))
+        case let .listeningWithoutRelay(port):
+            Label("Serving on 127.0.0.1:\(String(port)) — Reactotron server stopped",
+                  systemImage: "circle.fill")
+                .foregroundStyle(.orange)
+                .font(.app(.callout))
+        case let .failed(reason):
+            VStack(alignment: .trailing, spacing: 4) {
+                Label("Failed", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.app(.callout))
+                Text(reason)
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.trailing)
+                Button("Retry") { state.mcp.applySettings() }
+            }
+        }
+    }
+
+    // MARK: - Step 2: connect the agent
+
+    private var stepTwo: some View {
+        Section("Step 2 — Connect your agent") {
+            Picker("Agent", selection: $agent) {
+                ForEach(Agent.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            Text(instructions)
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+
+            snippetBox(snippet)
+        }
+    }
+
+    private var livePort: UInt16 {
+        if case let .listening(port) = state.mcp.status { return port }
+        if case let .listeningWithoutRelay(port) = state.mcp.status { return port }
+        return McpCoordinator.configuredPort
+    }
+
+    private var endpointURL: String { "http://127.0.0.1:\(livePort)/mcp" }
+
+    private var instructions: String {
+        switch agent {
+        case .claudeCode:
+            "Run this in your React Native project's terminal, then ask Claude "
+                + "about your app (add --scope project to share it via .mcp.json)."
+        case .cursor:
+            "Save this as .mcp.json in your project root, or paste the server "
+                + "into Cursor Settings ▸ MCP. Cursor picks it up on reload."
+        case .vsCode:
+            "Save this as .vscode/mcp.json in your project. Copilot Chat's "
+                + "agent mode lists the reactotron tools once the server starts."
+        case .other:
+            "Any client that speaks MCP's Streamable HTTP transport can "
+                + "connect to the endpoint below"
+                + (McpCoordinator.bearerToken != nil
+                    ? " — send the Authorization header from Settings ▸ MCP."
+                    : ".")
+        }
+    }
+
+    private var snippet: String {
+        switch agent {
+        case .claudeCode:
+            return McpCoordinator.claudeAddCommand
+        case .cursor:
+            return McpCoordinator.mcpJsonSnippet
+        case .vsCode:
+            let headers = McpCoordinator.bearerToken.map {
+                ",\n      \"headers\": { \"Authorization\": \"Bearer \($0)\" }"
+            } ?? ""
+            return """
+            {
+              "servers": {
+                "reactotron": {
+                  "type": "http",
+                  "url": "\(endpointURL)"\(headers)
+                }
+              }
+            }
+            """
+        case .other:
+            return endpointURL
+        }
+    }
+
+    private func snippetBox(_ content: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            ScrollView(.horizontal) {
+                Text(content)
+                    .font(.app(.footnote).monospaced())
+                    .textSelection(.enabled)
+                    .padding(8)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(content, forType: .string)
+                state.showToast(Toast(message: "Copied", ok: true))
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
+    }
+
+    // MARK: - Step 3: try it
+
+    private static let samplePrompts = [
+        "What's happening in my app right now?",
+        "Show me the failed network requests and what caused them.",
+        "Read the redux state under user and tell me what's wrong with it.",
+    ]
+
+    private var stepThree: some View {
+        Section("Step 3 — Try it") {
+            ForEach(Self.samplePrompts, id: \.self) { prompt in
+                HStack(spacing: 8) {
+                    Text("“\(prompt)”")
+                        .font(.app(.callout))
+                        .foregroundStyle(.textMuted)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(prompt, forType: .string)
+                        state.showToast(Toast(message: "Copied", ok: true))
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy prompt")
+                }
+            }
+        }
+    }
+
+    private var footerSection: some View {
+        Section {
+            LabeledContent("Port, token, and redaction rules") {
+                SettingsLink {
+                    Text("Open Settings ▸ MCP")
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -170,6 +170,18 @@ final class ReactotronSession {
                 self?.handle(event)
             }
         }
+        // The MCP layer (if enabled) taps the fresh server — additive only,
+        // never this session's stream.
+        app?.mcp.reactotronServerChanged()
+    }
+
+    /// MCP attachment: an independent event tap plus the outbound sender,
+    /// when the relay is up. The tap never affects this session's stream.
+    func mcpAttachment() async -> (
+        events: AsyncStream<ReactotronServer.Event>, sender: ReactotronService
+    )? {
+        guard let service else { return nil }
+        return (await service.tap(), service)
     }
 
     func applyReverse(serials: [String]) async {
@@ -234,6 +246,7 @@ final class ReactotronSession {
         service = nil
         await stopping?.stop(serials: serials)
         reset()
+        app?.mcp.reactotronServerChanged()
     }
 
     /// Stop on app termination, bounded so a hung adb can't freeze quit. The
@@ -480,7 +493,7 @@ final class ReactotronSession {
         switch event {
         case .listening:
             if clients.isEmpty { connection = .listening }
-        case let .connected(connectionId, intro, frameBytes):
+        case let .connected(connectionId, _, intro, frameBytes):
             let parsed = ReactotronEvent(command: intro)
             var name = "App"
             var platform: String?

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -763,6 +763,8 @@ struct ReactotronView: View {
     /// One-time first-open intro (the recorded split/filter demo).
     @AppStorage("hasSeenReactotronIntro") private var hasSeenIntro = false
     @State private var showIntro = false
+    /// The MCP onboarding sheet (header "AI Agents" button).
+    @State private var showMcpGuide = false
 
     private var session: ReactotronSession { state.reactotronSession }
 
@@ -825,6 +827,9 @@ struct ReactotronView: View {
         }
         .sheet(isPresented: $showIntro, onDismiss: { hasSeenIntro = true }) {
             ReactotronIntroSheet()
+        }
+        .sheet(isPresented: $showMcpGuide) {
+            McpAgentGuideSheet()
         }
     }
 
@@ -938,6 +943,13 @@ struct ReactotronView: View {
         }
         .controlSize(.small)
         .help("Run adb reverse tcp:9090 tcp:9090 on connected devices")
+        Button {
+            showMcpGuide = true
+        } label: {
+            Label("AI Agents", systemImage: "sparkles")
+        }
+        .controlSize(.small)
+        .help("Serve this timeline to Claude Code, Cursor, or any MCP client")
     }
 
     /// The server failing (port taken, socket error) used to be a red dot with a

--- a/App/Sources/FeatureDetail/Views/RolePickerView.swift
+++ b/App/Sources/FeatureDetail/Views/RolePickerView.swift
@@ -13,6 +13,11 @@ struct RolePickerView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @AppStorage("hasChosenRole") private var hasChosenRole = false
     @State private var appeared = false
+    /// "I work with React Native": unions the RN stack tools (Reactotron,
+    /// JS Console, the RN hub) into whichever role is chosen — a React
+    /// Native QA is both "QA" and "React Native", so the role picks the
+    /// workflow and this picks the stack.
+    @State private var includeRNTools = false
 
     private let columns = [GridItem(.adaptive(minimum: 236), spacing: 14)]
 
@@ -21,7 +26,7 @@ struct RolePickerView: View {
             header
             LazyVGrid(columns: columns, spacing: 14) {
                 ForEach(Array(UserRole.allCases.enumerated()), id: \.element) { index, role in
-                    RoleCard(role: role) { choose(role) }
+                    RoleCard(role: role, includeRNStack: includeRNTools) { choose(role) }
                         .opacity(appeared ? 1 : 0)
                         .offset(y: appeared ? 0 : 14)
                         .animation(
@@ -31,14 +36,7 @@ struct RolePickerView: View {
                 }
             }
             .frame(maxWidth: 790)
-            // The #1 miss from feedback: React Native folks picking QA and
-            // concluding Reactotron isn't in the app. One targeted line.
-            Text("Build React Native apps? Choose **React Native** — that's where Reactotron, the JS console, and the RN tools live.")
-                .font(.app(.footnote))
-                .foregroundStyle(.textMuted)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 480)
-                .fixedSize(horizontal: false, vertical: true)
+            rnStackToggle
             skipButton
         }
         .padding(40)
@@ -92,6 +90,40 @@ struct RolePickerView: View {
         }
     }
 
+    /// The #1 miss from feedback: React Native folks picked QA and concluded
+    /// Reactotron wasn't in the app. Role and stack are different axes, so
+    /// the stack is its own control — flipping it adds the RN tools to every
+    /// card (their counts update live) instead of forcing the RN role.
+    private var rnStackToggle: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "atom")
+                .font(.app(size: 16, weight: .medium))
+                .foregroundStyle(.brandAccent)
+            VStack(alignment: .leading, spacing: 2) {
+                Toggle("I work with React Native", isOn: $includeRNTools.animation())
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .font(.app(.callout).weight(.medium))
+                    .foregroundStyle(.textMain)
+                Text("Adds Reactotron, the JS Console, and the React Native hub to any role you pick.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+        .background(
+            Color.brandAccent.opacity(includeRNTools ? 0.10 : 0.04),
+            in: RoundedRectangle(cornerRadius: 11, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .strokeBorder(
+                    Color.brandAccent.opacity(includeRNTools ? 0.45 : 0.15), lineWidth: 1)
+        )
+    }
+
     /// Deliberately quiet next to the cards (one primary action per screen),
     /// but with a real hit area and the concrete outcome in the label.
     private var skipButton: some View {
@@ -112,7 +144,7 @@ struct RolePickerView: View {
 
     private func choose(_ role: UserRole?) {
         hasChosenRole = true
-        state.chooseRole(role)
+        state.chooseRole(role, includeReactNativeStack: includeRNTools)
     }
 }
 
@@ -123,12 +155,24 @@ struct RolePickerView: View {
 /// method sees a distinct state.
 private struct RoleCard: View {
     let role: UserRole
+    let includeRNStack: Bool
     let action: () -> Void
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var hovering = false
     @FocusState private var focused: Bool
 
     private var curated: [String] { FeatureRegistry.featuresByRole[role] ?? [] }
+
+    /// What this card would seed with the RN stack toggle applied — counts
+    /// update live so flipping the toggle visibly changes every card.
+    private var seededCount: Int {
+        includeRNStack
+            ? Set(curated).union(FeatureRegistry.reactNativeStackIDs).count
+            : curated.count
+    }
+
+    /// True when the toggle adds tools this role doesn't already carry.
+    private var stackAdds: Bool { includeRNStack && seededCount > curated.count }
 
     private var previewFeatures: [FeatureDef] {
         // Presented for the card's role, so the iOS card previews
@@ -151,12 +195,20 @@ private struct RoleCard: View {
                             in: RoundedRectangle(cornerRadius: 9, style: .continuous)
                         )
                     Spacer(minLength: 8)
-                    Text("\(curated.count) tools")
-                        .font(.app(.caption))
-                        .foregroundStyle(.textMuted)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(.bgRoot, in: Capsule())
+                    HStack(spacing: 4) {
+                        if stackAdds {
+                            Image(systemName: "atom")
+                                .font(.app(size: 9, weight: .semibold))
+                                .foregroundStyle(.brandAccent)
+                        }
+                        Text("\(seededCount) tools")
+                            .font(.app(.caption))
+                            .foregroundStyle(stackAdds ? .brandAccent : .textMuted)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(.bgRoot, in: Capsule())
+                    .contentTransition(.numericText())
                 }
                 Text(role.label)
                     .font(.app(.title3).weight(.semibold))

--- a/App/Sources/FeatureDetail/Views/RolePickerView.swift
+++ b/App/Sources/FeatureDetail/Views/RolePickerView.swift
@@ -31,6 +31,14 @@ struct RolePickerView: View {
                 }
             }
             .frame(maxWidth: 790)
+            // The #1 miss from feedback: React Native folks picking QA and
+            // concluding Reactotron isn't in the app. One targeted line.
+            Text("Build React Native apps? Choose **React Native** — that's where Reactotron, the JS console, and the RN tools live.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 480)
+                .fixedSize(horizontal: false, vertical: true)
             skipButton
         }
         .padding(40)

--- a/App/Sources/Settings/McpSettingsView.swift
+++ b/App/Sources/Settings/McpSettingsView.swift
@@ -1,0 +1,173 @@
+import ADBKit
+import AppKit
+import ReactotronMCP
+import SwiftUI
+
+/// Settings ▸ MCP: serve the Reactotron relay's data to AI agents (Claude
+/// Code, Cursor) over localhost Streamable HTTP — the same contract as the
+/// official Reactotron desktop's MCP server, off by default.
+struct McpSettingsView: View {
+    @Environment(AppState.self) private var state
+    @AppStorage(mcpEnabledKey) private var mcpEnabled = false
+    @AppStorage(mcpPortKey) private var mcpPort = Int(McpConstants.defaultPort)
+    @AppStorage(mcpTokenEnabledKey) private var tokenEnabled = false
+    @AppStorage(mcpTokenKey) private var token = ""
+    @AppStorage(mcpAllowClientRemoveRulesKey) private var allowClientRemoveRules = false
+    @AppStorage(mcpAllowClientDisableKey) private var allowClientDisable = false
+
+    var body: some View {
+        Form {
+            serverSection
+            connectSection
+            authSection
+            redactionSection
+        }
+        .formStyle(.grouped)
+    }
+
+    // MARK: - Server
+
+    private var serverSection: some View {
+        Section("MCP server") {
+            Toggle("Serve Reactotron data to AI agents", isOn: $mcpEnabled)
+                .onChange(of: mcpEnabled) { state.mcp.applySettings() }
+            LabeledContent("Status") {
+                statusLabel
+            }
+            LabeledContent("Port") {
+                TextField("", value: $mcpPort, format: .number.grouping(.never))
+                    .labelsHidden()
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+                    .onSubmit { state.mcp.applySettings() }
+            }
+            Text("Enabling starts the Reactotron server (port 9090) and an MCP endpoint "
+                + "on 127.0.0.1 that AI agents can query: the event timeline, network "
+                + "log, Redux/MST state, and tools to dispatch actions or run custom "
+                + "commands. Localhost only — never reachable from the network.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+        }
+    }
+
+    @ViewBuilder private var statusLabel: some View {
+        switch state.mcp.status {
+        case .off:
+            Text("Off").foregroundStyle(.textMuted)
+        case .starting:
+            Text("Starting…").foregroundStyle(.textMuted)
+        case let .listening(port):
+            Label("Listening on 127.0.0.1:\(String(port))", systemImage: "circle.fill")
+                .foregroundStyle(.green)
+                .font(.app(.callout))
+        case let .listeningWithoutRelay(port):
+            VStack(alignment: .trailing, spacing: 4) {
+                Label("Listening on 127.0.0.1:\(String(port))", systemImage: "circle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.app(.callout))
+                Text("The Reactotron server is stopped — agents see no apps. "
+                    + "Open the Reactotron feature to start it.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.trailing)
+            }
+        case let .failed(reason):
+            VStack(alignment: .trailing, spacing: 4) {
+                Label("Failed", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.app(.callout))
+                Text(reason)
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .multilineTextAlignment(.trailing)
+                Button("Retry") { state.mcp.applySettings() }
+            }
+        }
+    }
+
+    // MARK: - Connect
+
+    private var connectSection: some View {
+        Section("Connect an agent") {
+            LabeledContent("Claude Code") {
+                copyButton(McpCoordinator.claudeAddCommand, label: "Copy command")
+            }
+            LabeledContent("Cursor / .mcp.json") {
+                copyButton(McpCoordinator.mcpJsonSnippet, label: "Copy JSON")
+            }
+            Text("Same setup as the official Reactotron MCP server — agents get the "
+                + "identical tools and resources.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+        }
+    }
+
+    private func copyButton(_ content: String, label: String) -> some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(content, forType: .string)
+            state.showToast(Toast(message: "Copied", ok: true))
+        } label: {
+            Label(label, systemImage: "doc.on.doc")
+        }
+    }
+
+    // MARK: - Authentication
+
+    private var authSection: some View {
+        Section("Authentication") {
+            Toggle("Require a bearer token", isOn: $tokenEnabled)
+                .onChange(of: tokenEnabled) {
+                    if tokenEnabled, token.isEmpty { token = UUID().uuidString }
+                    state.mcp.applySettings()
+                }
+            if tokenEnabled {
+                LabeledContent("Token") {
+                    HStack(spacing: 8) {
+                        Text(token)
+                            .font(.app(.footnote).monospaced())
+                            .foregroundStyle(.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: 220, alignment: .trailing)
+                        Button("Regenerate") {
+                            token = UUID().uuidString
+                            state.mcp.applySettings()
+                        }
+                    }
+                }
+            }
+            Text("Off (the Reactotron default), any local process can query the "
+                + "endpoint. On, requests must send the token — the copy buttons "
+                + "above include it automatically.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+        }
+    }
+
+    // MARK: - Redaction
+
+    private var redactionSection: some View {
+        Section("Redaction") {
+            LabeledContent("Sensitive values") {
+                Label(
+                    allowClientDisable ? "Apps may opt out" : "Always redacted",
+                    systemImage: allowClientDisable ? "shield" : "shield.fill"
+                )
+                .foregroundStyle(allowClientDisable ? .orange : .green)
+                .font(.app(.callout))
+            }
+            Toggle("Let apps remove specific rules", isOn: $allowClientRemoveRules)
+                .onChange(of: allowClientRemoveRules) { state.mcp.redactionSettingsChanged() }
+            Toggle("Let apps disable redaction entirely", isOn: $allowClientDisable)
+                .onChange(of: allowClientDisable) { state.mcp.redactionSettingsChanged() }
+            Text("Passwords, tokens, cookies, API keys, and key-shaped values are "
+                + "redacted before anything reaches an agent (the Reactotron window "
+                + "itself is never redacted). Apps can add their own rules via "
+                + "mcpRedaction in their Reactotron config; removing or disabling "
+                + "rules also needs the matching permission above.")
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+        }
+    }
+}

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -13,6 +13,8 @@ struct SettingsView: View {
                 .tabItem { Label("Appearance", systemImage: "paintbrush") }
             PrivacySettingsView()
                 .tabItem { Label("Privacy", systemImage: "hand.raised") }
+            McpSettingsView()
+                .tabItem { Label("MCP", systemImage: "sparkles") }
             DoctorSettingsView()
                 .tabItem { Label("Doctor", systemImage: "stethoscope") }
             ManagedToolsSettingsView()

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -5,6 +5,18 @@ import ServiceManagement
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(AppState.self) private var state
+
+    /// The MCP tab rides the Reactotron feature: React Native and
+    /// all-features users see it, as does anyone who added Reactotron to
+    /// another role's set — other roles don't carry a tab for a feature
+    /// they don't have.
+    private var showsMcpTab: Bool {
+        state.selectedRole == nil
+            || state.selectedRole == .reactNativeDeveloper
+            || state.enabledFeatures.contains { $0.id == "reactotron" }
+    }
+
     var body: some View {
         TabView {
             GeneralSettingsView()
@@ -13,8 +25,10 @@ struct SettingsView: View {
                 .tabItem { Label("Appearance", systemImage: "paintbrush") }
             PrivacySettingsView()
                 .tabItem { Label("Privacy", systemImage: "hand.raised") }
-            McpSettingsView()
-                .tabItem { Label("MCP", systemImage: "sparkles") }
+            if showsMcpTab {
+                McpSettingsView()
+                    .tabItem { Label("MCP", systemImage: "sparkles") }
+            }
             DoctorSettingsView()
                 .tabItem { Label("Doctor", systemImage: "stethoscope") }
             ManagedToolsSettingsView()

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1464,6 +1464,16 @@ final class AppState {
         // stop each one's background work explicitly — otherwise kept-alive
         // sessions (terminal shells, the Reactotron server) leak with no UI
         // left to reach them.
+        // A role without Reactotron also loses the Settings ▸ MCP tab — a
+        // running MCP server would have no visible off-switch, so turn it
+        // off with the role switch (re-enable any time from a role that has
+        // the feature). Before the stop loop below: with the pref cleared,
+        // `keepsRelayAlive` no longer exempts the Reactotron session.
+        if mcp.isEnabled, role != nil, role != .reactNativeDeveloper,
+           !enabledFeatures.contains(where: { $0.id == "reactotron" }) {
+            UserDefaults.standard.set(false, forKey: mcpEnabledKey)
+            mcp.applySettings()
+        }
         for id in workspace.groups.flatMap(\.openTabs) {
             stopBackgroundWork(for: id)
         }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -236,6 +236,9 @@ final class AppState {
     /// The Reactotron server + timeline, owned here (not by the view) so leaving
     /// the feature can keep the connection alive and return to an intact session.
     let reactotronSession: ReactotronSession
+    /// Settings ▸ MCP: serves the Reactotron relay's data to AI agents over
+    /// localhost Streamable HTTP. Strictly downstream of the relay.
+    let mcp = McpCoordinator()
 
     /// The JS Console (Hermes CDP) session — owned here so its log buffer and
     /// connection survive leaving the feature, like the Reactotron session.
@@ -531,6 +534,7 @@ final class AppState {
         jsConsoleSession = JSConsoleSession(adb: env.client)
         reactotronSession.app = self
         jsConsoleSession.app = self
+        mcp.app = self
         // Typing `exit` (or a shell crash) closes that tab like the × does.
         // The contains-check drops late callbacks racing a killAll teardown.
         terminals.onShellExited = { [weak self] id in
@@ -560,6 +564,8 @@ final class AppState {
             restoreTabs(from: layout)
         }
         didLoadLayout = true
+        // MCP enabled in a previous run comes back up with the app.
+        if mcp.isEnabled { mcp.applySettings() }
         // Replay feature opens that raced the load (e.g. openAPKs from Finder),
         // then persist for the first time now that `layout` is authoritative.
         for id in pendingFeatureOpens {
@@ -1045,7 +1051,9 @@ final class AppState {
     /// closing their tab has to tear them down explicitly. A feature is open in at
     /// most one tab, so once it's closed no other tab still needs it.
     private func stopBackgroundWork(for id: String) {
-        if id == "reactotron", reactotronSession.isRunning {
+        // With MCP on, the relay must survive tab/window close — agents keep
+        // querying while the user isn't looking (Settings ▸ MCP turns it off).
+        if id == "reactotron", reactotronSession.isRunning, !mcp.keepsRelayAlive {
             Task { await reactotronSession.stop() }
         }
         if id == "js-console" {
@@ -1217,6 +1225,7 @@ final class AppState {
             rememberTerminalDirectories()
         }
         Task {
+            await mcp.stopForQuit()
             if reactotronSession.isRunning { await reactotronSession.stopForQuit() }
             // Flush the layout store before termination proceeds —
             // `persistLayout` saves through a fire-and-forget Task, and the

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1441,12 +1441,12 @@ final class AppState {
     /// Apply the user's role choice (first-run or "Change role"): curate the
     /// enabled set + sidebar order to that role, or keep everything on for
     /// `nil` ("show me everything"). Persists and lands on the launchpad.
-    func chooseRole(_ role: UserRole?) {
+    func chooseRole(_ role: UserRole?, includeReactNativeStack: Bool = false) {
         let isChange = layout.selectedRole != nil
         Telemetry.shared.trackRoleChosen(role?.rawValue ?? "all", isChange: isChange)
         Telemetry.shared.applyRole(role?.rawValue)
         if let role {
-            layout.seedRole(role)
+            layout.seedRole(role, includeReactNativeStack: includeReactNativeStack)
         } else {
             layout.seedEverything()
         }

--- a/App/Sources/State/McpCoordinator.swift
+++ b/App/Sources/State/McpCoordinator.swift
@@ -1,0 +1,199 @@
+import ADBKit
+import Foundation
+import ReactotronMCP
+import SwiftUI
+
+let mcpEnabledKey = "mcpServerEnabled"
+let mcpPortKey = "mcpServerPort"
+let mcpTokenEnabledKey = "mcpTokenEnabled"
+let mcpTokenKey = "mcpToken"
+let mcpAllowClientRemoveRulesKey = "mcpAllowClientRemoveRules"
+let mcpAllowClientDisableKey = "mcpAllowClientDisable"
+
+/// App-side owner of the Reactotron MCP server: reads the Settings ▸ MCP
+/// preferences, keeps the `McpServerController` in sync with them and with
+/// the Reactotron relay's lifecycle, and reports a display status.
+///
+/// Strictly downstream of the relay: it *taps* the session's server (never
+/// consumes its UI stream), and the only relay control it exercises is
+/// bringing the session up when MCP is enabled while the relay is down —
+/// and back down on disable only if MCP started it and no app is connected.
+@MainActor @Observable
+final class McpCoordinator {
+    enum DisplayStatus: Equatable {
+        case off
+        case starting
+        case listening(port: UInt16)
+        /// Serving MCP, but the Reactotron relay is stopped — agents see
+        /// no connected apps until it's started again.
+        case listeningWithoutRelay(port: UInt16)
+        case failed(String)
+    }
+
+    private(set) var status: DisplayStatus = .off
+
+    @ObservationIgnored private let controller = McpServerController()
+    @ObservationIgnored weak var app: AppState?
+    /// True when enabling MCP is what started the relay — so disabling MCP
+    /// can put it back down without killing a user-started session.
+    @ObservationIgnored private var startedRelay = false
+    /// Serializes apply/enable/disable so a toggle flurry can't interleave.
+    @ObservationIgnored private var applyTask: Task<Void, Never>?
+
+    var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: mcpEnabledKey)
+    }
+
+    /// With MCP on, the relay must survive window close / tab close — the
+    /// whole point is agents working while the user isn't looking.
+    var keepsRelayAlive: Bool { isEnabled }
+
+    static var configuredPort: UInt16 {
+        let stored = UserDefaults.standard.integer(forKey: mcpPortKey)
+        guard stored > 0, stored <= 65535 else { return McpConstants.defaultPort }
+        return UInt16(stored)
+    }
+
+    static var bearerToken: String? {
+        guard UserDefaults.standard.bool(forKey: mcpTokenEnabledKey) else { return nil }
+        if let existing = UserDefaults.standard.string(forKey: mcpTokenKey), !existing.isEmpty {
+            return existing
+        }
+        let generated = UUID().uuidString
+        UserDefaults.standard.set(generated, forKey: mcpTokenKey)
+        return generated
+    }
+
+    static var redactionConfig: McpRedactionServerConfig {
+        McpRedactionServerConfig(
+            allowClientDisable: UserDefaults.standard.bool(forKey: mcpAllowClientDisableKey),
+            allowClientRemoveRules: UserDefaults.standard.bool(forKey: mcpAllowClientRemoveRulesKey)
+        )
+    }
+
+    /// The copy-paste line for Claude Code, reflecting the live settings.
+    static var claudeAddCommand: String {
+        var command = "claude mcp add --transport http reactotron "
+            + "http://127.0.0.1:\(configuredPort)/mcp"
+        if let token = bearerToken {
+            command += " --header \"Authorization: Bearer \(token)\""
+        }
+        return command
+    }
+
+    /// The `.mcp.json` server entry for Cursor and other HTTP clients.
+    static var mcpJsonSnippet: String {
+        let headers = bearerToken.map {
+            ",\n      \"headers\": { \"Authorization\": \"Bearer \($0)\" }"
+        } ?? ""
+        return """
+        {
+          "mcpServers": {
+            "reactotron": {
+              "type": "http",
+              "url": "http://127.0.0.1:\(Self.configuredPort)/mcp"\(headers)
+            }
+          }
+        }
+        """
+    }
+
+    // MARK: - Lifecycle
+
+    /// Bring the server in line with the persisted settings — called at
+    /// launch, on every Settings ▸ MCP change, and from the Retry button.
+    /// Restarts the listener, so live agent sessions reconnect.
+    func applySettings() {
+        let previous = applyTask
+        applyTask = Task { [weak self] in
+            await previous?.value
+            await self?.reconcile()
+        }
+    }
+
+    /// Redaction permissions changed: push the new config without restarting
+    /// the listener (live sessions keep running).
+    func redactionSettingsChanged() {
+        Task { await controller.setRedactionConfig(Self.redactionConfig) }
+    }
+
+    /// The Reactotron relay restarted or stopped (session start/stop/network
+    /// scope change). With the relay up, re-attach to the fresh server's tap.
+    /// With the relay down, keep serving but drop the stale client records so
+    /// agents see `no_apps_connected` instead of ghosts — deliberately NOT
+    /// restarting a relay the user just stopped.
+    func reactotronServerChanged() {
+        guard isEnabled, let app else { return }
+        if app.reactotronSession.isRunning {
+            applySettings()
+        } else {
+            startedRelay = false
+            let listeningPort: UInt16? = if case let .listening(port) = status {
+                port
+            } else if case let .listeningWithoutRelay(port) = status {
+                port
+            } else {
+                nil
+            }
+            if let listeningPort { status = .listeningWithoutRelay(port: listeningPort) }
+            Task { await controller.noteRelayStopped() }
+        }
+    }
+
+    /// Bounded teardown for app quit — closing sessions and the socket is
+    /// fast, but never allowed to hold the quit hostage.
+    func stopForQuit() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.controller.stop() }
+            group.addTask { try? await Task.sleep(for: .seconds(2)) }
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
+    // MARK: - Reconcile
+
+    private func reconcile() async {
+        guard let app else { return }
+        guard isEnabled else {
+            await controller.stop()
+            if startedRelay, app.reactotronSession.isRunning,
+               !app.reactotronSession.hasLiveConnection {
+                await app.reactotronSession.stop()
+            }
+            startedRelay = false
+            status = .off
+            return
+        }
+
+        status = .starting
+        if !app.reactotronSession.isRunning {
+            await app.reactotronSession.start(serials: app.reactotronSession.readyAndroidSerials)
+            if app.reactotronSession.isRunning { startedRelay = true }
+        }
+        guard let (events, sender) = await app.reactotronSession.mcpAttachment() else {
+            await controller.stop()
+            status = .failed("The Reactotron server isn't running — open the Reactotron "
+                + "feature and start it, then retry.")
+            return
+        }
+
+        await controller.setRedactionConfig(Self.redactionConfig)
+        do {
+            try await controller.start(
+                events: events,
+                sender: sender,
+                version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+                    ?? "dev",
+                port: Self.configuredPort,
+                bearerToken: Self.bearerToken
+            )
+        } catch {
+            status = .failed(error.localizedDescription)
+            return
+        }
+        if case let .listening(port) = await controller.status {
+            status = .listening(port: port)
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,33 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   `apk-sign`) into one workspace over a single loaded APK — Inspect · Decompile ·
   Recompile · Sign tabs (the views take an optional injected APK so they embed in
   the studio and still work standalone via hotkey).
+- **`ReactotronMCP/`** — a *separate* SwiftPM target in the ADBKit package
+  (its own product; ADBKit itself stays dependency-free) serving the
+  Reactotron relay's data to AI agents over localhost Streamable HTTP —
+  the same contract as the official Reactotron desktop's embedded MCP
+  server (`claude mcp add --transport http reactotron
+  http://127.0.0.1:4567/mcp`). Deps: `modelcontextprotocol/swift-sdk`
+  (pinned exact) + swift-nio (listener only). Strictly downstream of the
+  relay: it consumes an additive `ReactotronServer.tap()` (the UI stream is
+  untouched) into `McpCommandStore` (actor; its own 500-item + 32 MiB ring
+  buffer, independent of the UI timeline; event-driven `awaitCommand`
+  correlation with afterMessageId markers — no polling), and its failure
+  can never take the relay down. `McpToolRegistry` (declarative 10-tool
+  table, FeatureRegistry-style, with invariant + golden-signature tests) →
+  `McpToolHandlers`; `McpResources` (8 URIs incl. the `timeline/{type}`
+  template); `McpRedaction` (default-ON at the MCP boundary only — the
+  Reactotron UI is never redacted — with upstream's two-key opt-out:
+  client `mcpRedaction` in `client.intro`, server permissions in
+  Settings ▸ MCP); `McpHTTPListener` (NIO port of the SDK's conformance
+  HTTPApp: per-session `Server`+`StatefulHTTPServerTransport` — one
+  initialize per Server, SDK #144 — idle reaper, 127.0.0.1-only,
+  `OriginValidator.localhost()`, optional static bearer token; never use
+  the SDK's Stateless transport — concurrency bugs #254/#255);
+  `McpServerController` (the facade the App layer calls). App side:
+  `McpCoordinator` (@MainActor, owned by AppState) + Settings ▸ MCP —
+  off by default; enabling starts the relay and keeps it alive across
+  tab/window close; it never restarts a relay the user stopped (status
+  goes amber, ghost clients cleared via `noteRelayStopped`).
 
 ## The 58 features
 
@@ -256,6 +283,49 @@ shows a "works with Android devices" state with a switch-device button when a
 simulator is selected. New cross-platform features add a `dispatchIOS` case +
 an arg-vector test; `everyIOSCapableActionResolvesToASimctlRunner` catches a
 platforms annotation without a runner.
+
+## Reactotron MCP — syncing with upstream
+
+The MCP surface mirrors `infinitered/reactotron`'s `lib/reactotron-mcp` at
+the commit pinned in `scripts/reactotron-upstream.lock`. When Reactotron
+changes (new tools, new command types, new redaction rules), the upgrade is
+mechanical — follow this recipe:
+
+1. **Detect**: `./scripts/check-reactotron-upstream.sh` (run before releases).
+   It diffs the contract-defining upstream files against the pinned commit and
+   checks the `reactotron-mcp` npm version. "✓ in sync" means stop here.
+2. **Locate**: the target layout mirrors upstream file-for-file, so the
+   script's diff tells you exactly which Swift file to touch —
+   `tools.ts` → `McpToolRegistry.swift` + `McpToolHandlers.swift`;
+   `resources.ts` → `McpResources.swift`; `redaction.ts` →
+   `McpRedaction.swift` (rule lists ported verbatim); `serialization.ts` →
+   `McpSerialization.swift` + `McpConstants.swift` (caps keep upstream's
+   names: `BUFFER_SIZE`→`bufferSize`, `MAX_RESPONSE_CHARS`→
+   `maxResponseChars`, …); `mcp-server.ts` → `McpHTTPListener.swift` +
+   `McpCommandStore.swift`; `reactotron-core-contract/command.ts` →
+   ADBKit's `ReactotronProtocol.swift`.
+3. **Port**: a new *tool* is one `McpToolDef` table entry + one handler case
+   + a contract test (the invariant tests fail on a missing handler or a
+   schema that doesn't decode). A new *resource* is a `staticResources`
+   entry + a `read` case. A new *wire command type* needs **zero** MCP code
+   for visibility — raw commands flow into `reactotron://timeline` and
+   `timeline/{type}` automatically (the type list is derived from the
+   buffer) — add the `ReactotronCommandType` case + parser case + test only
+   for typed conveniences.
+4. **Re-pin**: update `McpGoldenContractTests`' golden signature (the test
+   failure prints the actual — the diff IS the contract change, reviewable
+   in the PR), bump `scripts/reactotron-upstream.lock`, `swift test`.
+5. **SDK bumps** (`modelcontextprotocol/swift-sdk` is pinned exact in
+   `ADBKit/Package.swift`): treat as a deliberate change — bump, re-run the
+   `McpHTTPListenerTests` socket suite, and re-check the two known traps:
+   per-session `Server` instances (#144) and never the Stateless transport
+   (#254/#255).
+6. The npm `reactotron-mcp` package is a *different* surface (a standalone
+   stdio proxy on port 9091, `get_*`-style tools + 5 prompts) — not what we
+   mirror, but new capabilities there are candidates to adopt as extensions.
+
+The full design analysis (upstream ground truth, decisions, failure-mode
+table) is in `docs/reactotron-mcp-analysis.md`.
 
 ## Conventions / gotchas learned the hard way
 
@@ -484,6 +554,11 @@ compile or test time* — lean on it instead of manual vigilance.
 ## Status
 
 Feature-complete across all planned milestones plus several UX rounds.
+Unreleased on `main`/in flight: **Reactotron MCP support** (Settings ▸ MCP:
+an embedded localhost Streamable-HTTP MCP server with upstream Reactotron's
+exact 10-tool/8-resource contract and default-on redaction — see the
+"Reactotron MCP" bullet and sync recipe above; `ReactotronMCP` target,
+~100 new tests incl. real-socket and golden-contract suites).
 (Latest release: **v3.6.1** — a resize-performance fix: `LogScrollView`
 applies the log document width only after a drag rests (autoresizing
 re-wrapped the whole buffer per tick — a pegged core while dragging with

--- a/docs/reactotron-mcp-analysis.md
+++ b/docs/reactotron-mcp-analysis.md
@@ -1,0 +1,526 @@
+# Reactotron MCP support — implementation analysis
+
+*Analysis date: 2026-07-20. Sources: Droidective `main` @ a49fca9; `infinitered/reactotron`
+master @ 763c1c8 (2026-05-28); npm `reactotron-mcp` 0.3.0 (published 2026-03-25);
+`modelcontextprotocol/swift-sdk` 0.12.1 (2026-04-29). All upstream claims below were read
+from cloned source, not docs.*
+
+## 1. Executive summary
+
+Reactotron shipped first-party MCP support in two forms. Droidective should mirror the
+newer, embedded form: an **opt-in Streamable HTTP MCP server bound to `127.0.0.1:4567/mcp`**
+running inside the app, reading a dedicated ring buffer fed by our existing
+`ReactotronServer` WebSocket relay, exposing Reactotron's exact 10-tool + 8-resource
+contract (plus a default-on redaction layer), built on the official
+`modelcontextprotocol/swift-sdk` `Server` + `StatefulHTTPServerTransport`.
+
+Users then connect any MCP client with the same one-liner Reactotron documents:
+
+```bash
+claude mcp add --transport http reactotron http://localhost:4567/mcp
+```
+
+Nothing changes on the wire to the RN app (WebSocket 9090, same protocol), nothing changes
+in the existing Reactotron UI, and the MCP layer is a separate ADBKit-package target that
+can fail, stop, or be disabled without touching the relay.
+
+**The one decision needing user sign-off:** the HTTP listener. Reliability favors adding
+`swift-nio` and porting the SDK's own tested reference listener (§6.3); the repo's
+no-new-dependencies policy favors a hand-rolled `NWListener` HTTP server. Everything else
+in this document is unchanged either way.
+
+## 2. Ground truth: what upstream actually built
+
+Two distinct first-party implementations exist. They have different transports, different
+tool names, and different architectures. Chronology matters:
+
+### 2.1 npm `reactotron-mcp` 0.3.0 (standalone proxy — March 2026)
+
+A stdio MCP server run via `npx -y reactotron-mcp`. It interposes a **WebSocket proxy on
+port 9091** between the RN app and the desktop app: the RN app must be reconfigured
+(`Reactotron.configure({ port: 9091 })`), the proxy forwards to 9090 and captures
+everything. 16 `get_*`-style tools, 11 resources, 5 MCP prompts (`debug_app`,
+`trace_action`, `diagnose_network`, `debug_performance`, `debug_errors`). Env config:
+`REACTOTRON_PROXY_PORT=9091`, `REACTOTRON_PORT=9090`, `REACTOTRON_TIMEOUT=5000`.
+
+Notable: **this works against Droidective today with zero changes on our side** — the
+proxy forwards to whatever serves 9090, which is us. It's a fallback story, not the
+feature: it requires an RN-side port change, an extra Node process, and its capture buffer
+lives in the proxy, duplicating what Droidective already holds.
+
+### 2.2 Embedded `lib/reactotron-mcp` (in the desktop app — May 2026, master)
+
+The newer direction, shipped inside `reactotron-app` 3.11.0 and the design to mirror:
+
+- **Transport**: Streamable HTTP via `@modelcontextprotocol/sdk` (^1.27.0). Raw Node
+  `http.createServer` bound to **`127.0.0.1` only, default port 4567**, single route
+  `POST /mcp` (405 on GET, 404 elsewhere, 204 on OPTIONS preflight).
+- **Stateless**: a fresh `McpServer` + `StreamableHTTPServerTransport(sessionIdGenerator:
+  undefined)` per request, closed when the response closes. No session persistence.
+- **Off by default** — toggled from the app's footer "MCP" button; settings in a modal;
+  config persisted.
+- **Data source**: subscribes to the relay's `command` event and keeps its own in-memory
+  ring buffer, **`BUFFER_SIZE = 500`** commands, oldest dropped. That buffer is the entire
+  query surface — independent of the desktop timeline (`clear_timeline` clears only the
+  MCP buffer).
+- **Request/response tools** (e.g. `request_state`) send a command over the relay and
+  **poll the buffer** for the matching response type + clientId — 100 ms tick, **1500 ms
+  timeout**.
+- **Output caps**: every result compact-serialized then truncated at
+  **`MAX_RESPONSE_CHARS = 800_000`** with an inline `[TRUNCATED …]` suffix that tells the
+  LLM how to narrow (pass a `path`, use `timeline/{type}`, `clear_timeline`). Payload
+  previews 200 chars, network body previews 500 chars.
+- **Multi-app**: `resolveClientId` errors "No apps connected" at 0 and "Multiple apps
+  connected. Specify clientId. Available: …" at >1 with none given; auto-selects a sole app.
+- **Redaction** (§7): default-on, applied only at the MCP boundary.
+
+**Tools (exactly 10, verified in `src/tools.ts`):** `dispatch_action`, `request_state`,
+`request_state_keys`, `swap_state`, `send_custom_command`, `list_custom_commands`,
+`show_overlay`, `clear_timeline`, `subscribe_state`, `unsubscribe_state`.
+
+**Resources (8, `src/resources.ts`):** `reactotron://timeline` (newest-first summaries,
+payloads stripped to 200-char previews), `reactotron://timeline/{type}` (ResourceTemplate
+with completion over types seen in the buffer; full payloads),
+`reactotron://state/current` (latest cached `state.values.response`),
+`reactotron://network/log` (api.response summaries), `reactotron://apps`,
+`reactotron://benchmarks`, `reactotron://state/subscriptions`, `reactotron://asyncstorage`.
+All return `application/json` with a `_meta` connection block
+(`no_apps_connected`/`single_app`/`multiple_apps` + a hint).
+
+### 2.3 Wire protocol facts that matter for the MCP layer
+
+From `reactotron-core-server` 3.3.0 / `reactotron-core-contract` 0.4.0 (authoritative
+`Command` envelope: `{type, connectionId, clientId?, date, deltaTime, important,
+messageId (server-assigned monotonic), payload}`):
+
+- There is **no request/response correlation id** in the protocol. Correlation is by
+  (command type, clientId, arrival-after-send) — inherently racy; upstream accepts it.
+- `custom` and `setClientId` are string-literal types outside the `CommandType` enum.
+- `client.intro` carries an optional **`mcpRedaction`** field (`McpRedactionConfig`)
+  — the per-app redaction handshake (§7). ADBKit's parser currently ignores unknown intro
+  fields leniently, so reading it is additive.
+- Droidective's `ReactotronServer` already mirrors the handshake (clientId assignment,
+  stale-twin drop, `state.values.subscribe` replay) and the full command-type set —
+  ADBKit's `ReactotronCommandType` covers every type in the upstream enum.
+
+## 3. Ground truth: what Droidective already has
+
+Inventory from `ADBKit/Sources/ADBKit/Services/Reactotron/` and
+`App/Sources/FeatureDetail/Views/ReactotronView.swift`:
+
+| Layer | Type | Notes |
+|---|---|---|
+| Relay server | `actor ReactotronServer` | NWListener + NWProtocolWebSocket, port 9090, loopback-or-LAN scope, 30 s ping, 64 MiB max frame, per-connection FIFO frame feeds, multi-client with stale-twin dedup — the same job as `reactotron-core-server` |
+| Orchestrator | `actor ReactotronService` | owns the server, runs `adb reverse tcp:9090` (3× retry), forwards `send`/`broadcast` |
+| Protocol | `ReactotronCommand` / `ReactotronEvent` / `JSONValue` | lenient Codable decode, sentinel repair, pure `ReactotronEvent(command:)` parser — all Sendable |
+| Retention math | `enum ReactotronTimeline` | pure drop-count budgeting (2000 items / 128 MiB, hysteresis) |
+| Retention store | `@MainActor @Observable ReactotronSession` (App layer) | **the timeline items live on the MainActor UI session** — the one structural gap for MCP |
+| Outbound commands | `ReactotronSession` → `service.send/broadcast` | dispatch action, state request/keys/backup/restore, subscribe, custom command, REPL — the exact surface upstream's tools drive |
+| Tests | `ReactotronServerTests` (real loopback WS client), `ReactotronProtocolTests` (~35), `ReactotronTimelineTests`, `ReactotronCurlTests` | the server test file is the template for MCP socket tests |
+
+No MCP or JSON-RPC code exists anywhere in the repo. Relevant known bug (backlog): a
+`client.intro` frame draining after `dropConnection` can resurrect a ghost client in the
+UI's client list — must be fixed before MCP reads client state (§8, P0).
+
+Key architectural consequence: **`ReactotronServer.start()` returns a single-consumer
+`AsyncStream`**, currently consumed by the UI session. MCP needs a second consumer, so the
+service layer gains event fan-out (§6.4). Upstream's design (a separate MCP buffer, UI
+untouched) fits us perfectly: no refactor of the 3,000-line `ReactotronView`.
+
+## 4. Goals and non-goals
+
+**Goals**
+
+1. An AI agent (Claude Code, Cursor) can read the live Reactotron timeline — logs, network
+   requests, Redux/MST state, benchmarks — and drive the app (dispatch actions, custom
+   commands) while Droidective runs. No RN-app changes beyond what Reactotron itself needs.
+2. Contract parity with upstream's embedded server: same URL shape, same 10 tools, same 8
+   resources, same redaction semantics — so upstream docs, prompts, and user muscle memory
+   transfer.
+3. Reliability as the top requirement: bounded memory, no polling loops, no unbounded
+   sessions, isolated failure domains, and the whole logic layer testable in `swift test`
+   without a device or a socket.
+
+**Non-goals (v1)**
+
+- The stdio-proxy mode (npm 0.3.0 covers that user today).
+- MCP resource *subscriptions* (`notifications/resources/updated`) — client support is
+  weak (Cursor ignores resources; Claude Code doesn't drive loops off pushes). Tools are
+  the load-bearing surface; resources ship because they're nearly free off the same buffer.
+- Exposing non-Reactotron Droidective data (logcat, device info) over MCP. Tempting, out
+  of scope here; the module layout deliberately leaves room for it.
+- LAN-reachable MCP. Loopback only, always (the WS relay's LAN toggle is unrelated).
+
+## 5. Architecture
+
+```
+RN app ──ws://localhost:9090──▶ ReactotronServer (actor, existing)
+                                      │ AsyncStream<Event>
+                                ReactotronService (actor, existing)
+                                      │ NEW: event fan-out (N subscribers)
+              ┌───────────────────────┴───────────────────────┐
+   ReactotronSession (@MainActor, UI — unchanged)     McpCommandStore (actor, NEW)
+                                                       ring buffer ≤500 cmds + byte cap
+                                                       clients / state cache / custom cmds
+                                                       awaitCommand() correlation
+                                                              │
+                                                     McpToolHandlers + McpResources (NEW)
+                                                       redaction → summarize → truncate
+                                                              │
+                                            MCP.Server (per session, official swift-sdk)
+                                                              │
+                                            StatefulHTTPServerTransport (swift-sdk)
+                                                              │
+                                            McpHTTPListener (NEW) 127.0.0.1:4567 /mcp
+                                                              │
+                                            Claude Code / Cursor (Streamable HTTP)
+```
+
+Failure isolation: the MCP stack (store → listener) is downstream of the relay and can
+crash, stop, or be toggled off without affecting the WS server or the UI. The relay never
+awaits the MCP layer.
+
+## 6. Design decisions
+
+### D1 — Embedded Streamable HTTP server; no stdio shim. *(decided)*
+
+MCP clients normally spawn a stdio child, but our server lives in a running GUI app. The
+two proven Mac-app patterns: Figma Dev Mode runs a localhost HTTP MCP endpoint in the app
+(`127.0.0.1:3845/mcp`); Xcode 26 ships an `mcpbridge` stdio shim over XPC. Upstream
+Reactotron chose embedded HTTP. Claude Code (`--transport http`) and Cursor
+(`"type": "http"` in `.mcp.json`) both speak Streamable HTTP natively, so a shim buys
+nothing today. Revisit only if a target client without HTTP support appears.
+
+### D2 — Official `modelcontextprotocol/swift-sdk`, pinned. *(decided)*
+
+v0.12.1 targets MCP spec 2025-11-25, macOS 13+, swift-tools 6.1, `StrictConcurrency`
+enabled on the `MCP` target — clean against our Swift 6 strict-concurrency build. Library
+deps are modest (swift-system, swift-log, mattt/eventsource); **swift-nio is used only by
+the SDK's conformance executable, `import MCP` does not pull it in**. Server API:
+`actor Server` + `withMethodHandler(CallTool.self) { … }` closures; ships
+`StatefulHTTPServerTransport` with session IDs, POST→SSE, standalone GET SSE, DELETE
+teardown, `Last-Event-ID` resumability, and built-in `OriginValidator.localhost()`.
+
+Hand-rolling JSON-RPC + Streamable HTTP semantics (sessions, SSE resumability, protocol
+version negotiation) is exactly the kind of subtle surface that erodes reliability.
+Pre-1.0 API churn is real → **pin the exact version** in `Package.swift` and treat
+upgrades as deliberate changes.
+
+Two SDK pitfalls found in open issues, both avoided by construction:
+
+- **Never use `StatelessHTTPServerTransport`** (issues #254/#255: response waiters keyed
+  by raw JSON-RPC id collide across concurrent clients → hangs + leaked continuations;
+  `notifications/cancelled` leaves the POST hanging).
+- **One `Server` accepts one `initialize`** (#144) → create a fresh
+  `Server` + `StatefulHTTPServerTransport` per MCP session via a factory, with an
+  idle-session reaper — the SDK's own conformance server
+  (`Sources/MCPConformance/Server/HTTPApp.swift`) demonstrates precisely this.
+
+### D3 — HTTP listener: port the SDK's NIO reference vs. hand-rolled NWListener. *(user decision)*
+
+The SDK's HTTP server transport is framework-agnostic: you hand it a parsed
+`HTTPRequest {method, headers, body, path}` and write back
+`.ok/.data/.stream(AsyncThrowingStream<Data,_>)/.error`. Someone must own the socket +
+HTTP/1.1 parsing + SSE flushing:
+
+| | A: `swift-nio`, port `HTTPApp.swift` | B: `NWListener` + hand-rolled HTTP/1.1 |
+|---|---|---|
+| Reliability | The SDK authors' own tested reference (parsing, chunked bodies, keep-alive, SSE flush, session cleanup loop) — lowest bug surface | We re-implement HTTP parsing and SSE backpressure on `NWConnection`; the SSE path is the classic source of subtle bugs |
+| Dependencies | +swift-nio (Apple-maintained, already in the SDK's package graph) | zero new deps; framework we already use (`ReactotronServer`, Mirror) |
+| Effort | small (adapt ~300 lines) | moderate (HTTP request parser + SSE writer + tests for both) |
+
+**Recommendation: A.** Reliability is the stated top requirement and NIO is a
+well-maintained Apple dependency confined to one target. B is defensible under the repo's
+dependency policy — if chosen, budget real test time for chunked/pipelined requests and
+SSE teardown, and port `HTTPApp`'s session-lifecycle logic regardless. Either way the
+listener hides behind a small protocol so tool/resource logic tests use
+`InMemoryTransport` and never touch sockets.
+
+### D4 — Separate MCP command store; UI untouched. *(decided)*
+
+Mirror upstream: `McpCommandStore` is a new ADBKit actor holding its own ring buffer of
+raw `ReactotronCommand`s (cap 500 like upstream, **plus a total-byte cap upstream lacks** —
+reuse `ReactotronTimeline`'s hysteresis math; a single `image` payload can be megabytes and
+64 MiB frames are legal on our relay). It also derives, from the same event stream:
+connected clients (intro payloads), the latest `state.values.response` per client, the
+per-client custom-command registry, and the subscription list.
+
+Feeding it requires the only change to existing code: `ReactotronService` grows
+**multi-subscriber event fan-out** (per-subscriber `AsyncStream` continuations,
+`.bufferingNewest` policy so a slow consumer can never back-pressure the relay). The UI
+session migrates from consuming the server stream directly to being subscriber #1 — a
+small, mechanical change; the alternative (moving retention off the MainActor session)
+would refactor a 3,000-line view for no additional capability.
+
+`clear_timeline` clears only the MCP buffer (upstream parity); the UI timeline is separate
+state with its own Clear.
+
+### D5 — Contract: match the embedded server exactly, then extend. *(decided)*
+
+Port **4567**, route `/mcp`, the 10 tool names with upstream's input schemas and result
+shapes, the 8 resource URIs, `_meta` connection blocks, the 800k/200/500-char caps, the
+`[TRUNCATED …]` guidance suffix, the 1.5 s correlation timeout, and `resolveClientId`
+error strings. Parity means upstream's docs and any prompts users wrote against desktop
+Reactotron work verbatim against Droidective. (Port conflict with an actually-running
+Reactotron desktop isn't a real scenario — it would already be fighting us for WS 9090.)
+
+Extensions (clearly ours, additive, v1.5 candidates once parity ships): filterable query
+tools in the spirit of npm 0.3.0 (`get_logs(level, contains, limit)`,
+`get_network(url, method, status, minDuration, limit)`, a consolidated `get_errors`), and
+its five MCP prompts — `debug_app`, `trace_action`, `diagnose_network`,
+`debug_performance`, `debug_errors` — which are cheap, high-leverage, and clients surface
+as slash commands.
+
+### D6 — Stateful sessions, not upstream's per-request-stateless mode. *(decided)*
+
+Upstream creates a throwaway `McpServer` per POST. That works but forfeits SSE
+notifications and resumability, and the Swift SDK's stateless transport is the buggy one
+(D2). We use stateful sessions (`MCP-Session-Id`, per-session `Server`, GET SSE stream,
+DELETE teardown) with an idle reaper (5 min, configurable). Clients that never open the
+GET stream lose nothing.
+
+### D7 — Redaction: port upstream's layer, default-on. *(decided — see §7)*
+
+### D8 — Security posture. *(decided)*
+
+- Bind `127.0.0.1` only, hard-coded — never `0.0.0.0`, regardless of the relay's LAN toggle.
+- Keep the SDK's default validation pipeline: `OriginValidator.localhost()` (DNS-rebinding
+  defense the MCP spec mandates), Accept/Content-Type/protocol-version/session validators.
+- **Feature off by default** — a Settings toggle, like upstream's footer button and
+  Figma/Xcode's opt-ins.
+- Optional bearer token (SDK ships `BearerTokenValidator`): default **off** for parity and
+  frictionless `claude mcp add`; a Settings toggle generates one and the UI shows
+  `claude mcp add … -H "Authorization: Bearer <token>"`. Localhost + Origin checks +
+  default-on redaction is the same posture upstream and Figma ship; the token covers users
+  who want other-local-process isolation.
+
+### D9 — Lifecycle. *(decided)*
+
+- MCP enabled ⇒ `ReactotronService` starts (if not already) and **joins the kept-alive
+  set**: `AppState.enterBackground()` currently stops Reactotron on window close; with the
+  MCP toggle on, both the relay and the listener stay up (that's the point — the agent
+  works while the user isn't looking at the window). Quit teardown stays bounded (existing
+  2 s budget): stop listener → DELETE-equivalent close of sessions → relay stop.
+- adb reverse for newly-appearing devices must keep running while MCP is on (the session's
+  device-list watcher already runs with the view closed; it must also run with MCP on and
+  the feature never opened).
+- Port 4567 busy ⇒ fail visibly (Settings shows the error + a port override field +
+  Retry), never silently pick another port — the copy-paste client config must match
+  reality. Single-instance: first app instance binds; a second shows "MCP served by the
+  other instance."
+- MCP server state surfaces in the Reactotron view header and Settings: Off / Listening on
+  4567 / Error(reason), plus a copy button for the `claude mcp add` line and a
+  `.mcp.json` snippet.
+
+## 7. Redaction layer (the biggest single work item)
+
+Agents will read network headers, request bodies, and full Redux state — bearer tokens,
+session cookies, PII. Upstream treats this as first-class; so do we. Port
+`lib/reactotron-mcp/src/redaction.ts` to a pure ADBKit `enum McpRedaction` over
+`JSONValue`:
+
+- **Default rules**: ~40 case-insensitive sensitive key names matched at any depth
+  (password, token, secret, authorization, cookie, api_key, session, csrf,
+  x-forwarded-for, …) + value regexes (Bearer/JWT, `sk-`, `sk-ant-`, `gh[pousr]_`,
+  `xox[bpoas]-`, `AKIA`, `AIza`, Stripe keys, PEM private keys). Blocklist model.
+- URL query params and form-urlencoded bodies with sensitive param names are redacted;
+  JSON embedded in strings is recursively parsed and redacted (depth ≤5, ≤1 MB).
+- `statePathPatterns` anchor state-tree redaction using the response's `payload.path`.
+- **Two-key opt-out**: the RN app may send `mcpRedaction` in `client.intro`
+  (`additionalRules` always honored; `removeRules`/`disableRedaction` honored only if the
+  user also enables `allowClientRemoveRules`/`allowClientDisable` in Droidective settings,
+  both default off). Resolution cached per clientId; aggregated resources redact each
+  app's events under that app's rules.
+- Applied **only at the MCP boundary** — the Droidective UI stays unredacted, exactly like
+  upstream.
+- UI: a shield indicator (green = enforced, amber = a client opted out) + a rules editor in
+  the MCP settings — port of upstream's `McpSettingsModal` semantics.
+
+This is pure data-in/data-out → it lives in ADBKit with the heaviest test file of the
+feature. Upstream's `lib/reactotron-mcp/test/` cases port directly as fixtures.
+
+## 8. Correlation engine (replacing upstream's polling)
+
+Upstream polls its buffer every 100 ms. We do it event-driven, copying the proven
+`JSConsoleClient` patterns (pending-continuation map, early-result buffer, generation
+counter): `McpCommandStore.awaitCommand(type:clientId:after:timeout:)` registers a
+`CheckedContinuation` resumed by the store's own event loop on the first matching command
+whose **arrival time is after the send time** (the protocol has no correlation ids;
+the arrival-time gate prevents a stale `state.values.response` from a previous request
+satisfying a new one — a race upstream tolerates). Timeout 1.5 s (upstream parity) via a
+structured race; every continuation is resumed exactly once (leaked continuations are a
+crash in Swift — the JSConsole pattern already handles teardown-resumes-all).
+
+Tool → command mapping (all already supported by `ReactotronService.send/broadcast`):
+
+| Tool | Sends | Awaits | Notes |
+|---|---|---|---|
+| `dispatch_action` | `state.action.dispatch` | `state.action.complete` | reports `confirmed: true/false` on timeout |
+| `request_state` | `state.values.request` | `state.values.response` | description pushes `path` to avoid huge trees |
+| `request_state_keys` | `state.keys.request` | `state.keys.response` | |
+| `swap_state` | `state.restore.request` | — | fire-and-forget, marked destructive |
+| `send_custom_command` | `custom` `{command, args}` | — | |
+| `list_custom_commands` | — | — | reads store's registry (from `customCommand.register`) |
+| `show_overlay` | `overlay` | — | local file → base64 data URI, PNG/JPEG/GIF, 2 MB cap, dims from header parse |
+| `clear_timeline` | — | — | clears MCP buffer only |
+| `subscribe_state` / `unsubscribe_state` | `state.values.subscribe` | — | server-global path list, like upstream |
+
+## 9. Reliability engineering — failure modes and mitigations
+
+| Failure mode | Mitigation |
+|---|---|
+| Port 4567 busy | Visible error + override + retry; never a silent port change (§D9) |
+| App not running when client connects | Connection refused; documented ("launch Droidective, enable MCP"); README + Settings copy |
+| Slow/stalled MCP consumer back-pressures relay | Fan-out uses `bufferingNewest` per subscriber; relay never awaits subscribers |
+| Buffer growth (images, 64 MiB frames) | 500-item cap **and** byte cap with `ReactotronTimeline` hysteresis (improvement over upstream) |
+| Oversized tool results blow the client context | 800k-char truncation with actionable `[TRUNCATED …]` guidance (upstream parity) |
+| Concurrent clients / session collisions | Stateful transport, per-session `Server` (avoids SDK #144), never Stateless (#254/#255) |
+| Session leaks | Idle reaper (HTTPApp pattern); DELETE honored; bounded teardown on quit |
+| SSE disconnects | SDK resumability via `Last-Event-ID`; clients auto-reconnect; fresh initialize ⇒ fresh session |
+| Correlation races (no protocol ids) | Arrival-after-send gating + single-resume continuations + 1.5 s timeout (§8) |
+| Ghost client resurrected by drained `client.intro` (backlog bug) | **Fix first** (guard `.connected` yield on `connections[id] != nil` + test) — MCP's `reactotron://apps` and `resolveClientId` read this state |
+| DNS rebinding / cross-origin | 127.0.0.1 bind + `OriginValidator.localhost()` (spec-mandated, SDK default) |
+| Sensitive data exfiltration to the agent | Default-on redaction, two-key opt-out (§7) |
+| Multiple app instances | First binds; second surfaces a clear status, no crash loop |
+| MCP failure taking down the relay | Strict downstream isolation (§5); listener restart button independent of relay |
+| SDK pre-1.0 churn | Exact-version pin; upgrades are reviewed changes with the conformance tests re-run |
+| Upstream contract drift (they're moving fast: 0.1.0→0.3.0 in 2 days) | Before implementation, re-diff `master` and the npm tarball; record the targeted upstream commit in the test fixtures |
+
+## 10. Module layout
+
+New **library target in the ADBKit package** (keeps the core `ADBKit` target
+dependency-free; `swift test` still covers everything):
+
+```
+ADBKit/Package.swift            + target ReactotronMCP (deps: ADBKit, MCP swift-sdk [, NIO per D3])
+ADBKit/Sources/ReactotronMCP/
+  McpCommandStore.swift         actor: ring buffer, derived state, awaitCommand()
+  McpRedaction.swift            pure rules engine + DEFAULT_REDACTION_RULES port
+  McpSerialization.swift        pure: summaries, previews, 800k truncation + guidance
+  McpConstants.swift            caps with upstream's names (BUFFER_SIZE, MAX_RESPONSE_CHARS, …)
+  McpToolRegistry.swift         declarative McpToolDef table (the FeatureRegistry pattern, §13)
+  McpToolHandlers.swift         the 10 tools over the store + ReactotronService
+  McpResources.swift            the 8 resources + timeline/{type} template + completion
+  McpSessionFactory.swift       per-session Server + StatefulHTTPServerTransport + reaper
+  McpHTTPListener.swift         127.0.0.1 listener → HTTPRequest/HTTPResponse bridge (D3)
+  McpServerController.swift     public facade: start/stop/status/config (what App calls)
+  UPSTREAM_VERSIONS             pinned upstream commit + npm version the contract targets (§13)
+scripts/check-reactotron-upstream.sh   diff contract files vs the pinned commit (§13)
+ADBKit/Sources/ADBKit/Services/Reactotron/
+  ReactotronService.swift       + event fan-out (the only existing-file change)
+ADBKit/Tests/ReactotronMCPTests/  (§11)
+App/Sources/...
+  Settings ▸ Reactotron MCP section (toggle, port, status, token toggle, redaction
+  editor, copy claude-mcp-add / .mcp.json); ReactotronView header status chip;
+  AppState keep-alive exemption (D9)
+```
+
+App-layer views only render and call `McpServerController` — no Process/adb/parsing, per
+the architecture rule. No new `FeatureDef` (this extends `reactotron`); add
+`mcp/ai/claude/cursor/agent` to the reactotron feature's keywords so search finds it.
+
+## 11. Testing strategy
+
+Pyramid, all in `swift test`, no device, no network flakes:
+
+1. **Pure units** (largest layer): `McpRedaction` (port upstream's test fixtures; every
+   default rule, nesting, embedded-JSON depth, two-key permission matrix),
+   `McpSerialization` (truncation boundaries, preview caps, `_meta` blocks), buffer
+   trimming (item + byte caps, hysteresis), correlation (timeout, arrival-time gating,
+   teardown-resumes-all, no double-resume).
+2. **`InMemoryTransport` integration**: real `MCP.Server` with our handlers, scripted
+   client — initialize, tools/list (all 10, schemas), each tool round-trip against a
+   scripted store, resources/list + read + template completion, resolveClientId error
+   strings at 0/2 clients.
+3. **Real-socket integration** (pattern: `ReactotronServerTests`): listener on port 0,
+   `URLSession` client — initialize + `MCP-Session-Id` echo, POST tool call, GET SSE
+   stream, DELETE, evil-Origin → 403, GET on `/mcp` → 405, idle reaping, concurrent
+   sessions.
+4. **End-to-end**: fake RN client over real WS 9090 (existing test harness) emits
+   captured wire frames (`ReactotronCurlTests` fixtures) → MCP client over real HTTP reads
+   the redacted `api.response` via `reactotron://network/log` and `request_state`
+   round-trips through the fake client.
+5. **Live verification** (manual, `verify` skill): debug build + StreamLab RN app +
+   `claude mcp add --transport http … && claude --print "list reactotron tools"`;
+   confirm Cursor config shape.
+6. Registry/engine invariant tests: unaffected (no new feature id).
+
+CI notes: pinned SDK resolves in `swift test`; watch test-time budget (socket tests reuse
+the loopback-port-0 pattern that's already fast); warnings-as-errors applies to the new
+target from day one.
+
+## 12. Phased plan
+
+| Phase | Content | Gate |
+|---|---|---|
+| 0 | Fix ghost-client backlog bug; add `ReactotronService` event fan-out; migrate UI session to subscriber API | existing 925 tests + new fan-out/regression tests green |
+| 1 | `ReactotronMCP` target skeleton + `McpCommandStore` + `McpSerialization` + **`McpRedaction`**; `UPSTREAM_VERSIONS` + golden contract fixtures + sync-check script (§13) | pure unit suite green (the bulk of new tests) |
+| 2 | Tool registry + tools + resources + correlation over `InMemoryTransport` | layer-2 tests green; `tools/list` matches the golden fixture |
+| 3 | Listener (per D3) + session factory + validators | socket + E2E suites green |
+| 4 | App integration: Settings section, status chip, keep-alive, port-conflict UX, copy-config buttons | `make build` zero warnings; manual verify |
+| 5 | Live verification vs Claude Code + Cursor; docs (CLAUDE.md status, site FAQ later); optional v1.5: filter tools + 5 prompts | release gate |
+
+Phases 1–2 are pure logic and parallelize with 3. The redaction port is the single largest
+chunk; the listener is the riskiest (hence D3).
+
+## 13. Staying in sync with upstream (maintainability by design)
+
+Upstream is moving fast (npm 0.1.0→0.3.0 in two days; the embedded server landed two
+months later). The design absorbs future Reactotron changes cheaply through five
+mechanisms, all established in phase 1:
+
+**1. Raw commands in the buffer ⇒ new command types work with zero code.**
+`McpCommandStore` stores raw `ReactotronCommand`s, and ADBKit's decoder already routes
+unknown types to `.unknown` without dropping the frame. So when Reactotron adds a new
+command type, it *automatically* flows into `reactotron://timeline`,
+`reactotron://timeline/{type}` (whose type list is derived from buffer contents, not a
+hardcoded enum), and any timeline-query tool — queryable by agents the day the RN app
+starts emitting it. Code is only needed for typed conveniences: one
+`ReactotronCommandType` case + parser case + test (the existing three-line pattern), and
+optionally a dedicated tool.
+
+**2. File-for-file mirroring of upstream's package.** The `ReactotronMCP` target layout
+(§10) deliberately maps 1:1 onto `lib/reactotron-mcp/src`: `tools.ts` →
+`McpToolHandlers.swift`, `resources.ts` → `McpResources.swift`, `redaction.ts` →
+`McpRedaction.swift`, `serialization.ts` → `McpSerialization.swift`. An upstream diff
+tells you exactly which one Swift file to touch. Constants keep upstream's names
+(`BUFFER_SIZE`, `MAX_RESPONSE_CHARS`, …) in one `McpConstants.swift` so cap changes are a
+one-line diff.
+
+**3. Declarative tool/resource registry — the repo's own `FeatureRegistry` pattern.**
+Tools are not ad-hoc registrations scattered through handler code: a single
+`McpToolDef` table (name, description, input schema, handler reference) drives
+`tools/list` and dispatch, exactly like `FeatureDef`/`FeatureEngine`. Adding an upstream
+tool = one table entry + one handler + one test. Registry-invariant tests copy the
+`everyImplementedActionResolvesToARunner` pattern: every def has a handler, every handler
+has a def, names are unique.
+
+**4. Golden contract fixtures pinned to an upstream commit.** Check in JSON snapshots of
+the advertised contract — the `tools/list` and `resources/list` outputs and the default
+redaction rule set — generated against a recorded upstream commit (an `UPSTREAM_VERSIONS`
+file in the target: reactotron commit hash + `reactotron-mcp` npm version). A test asserts
+our live `tools/list` matches the fixture. Syncing to a new upstream release is then
+mechanical: regenerate fixtures, and the failing diff *is* the work list.
+
+**5. A sync-check script, like `scripts/update-bundled-tools.sh`.**
+`scripts/check-reactotron-upstream.sh`: shallow-clone upstream, diff the five
+contract-defining files (`tools.ts`, `resources.ts`, `redaction.ts`, `serialization.ts`,
+`reactotron-core-contract/src/command.ts`) against the commit recorded in
+`UPSTREAM_VERSIONS`, plus `npm view reactotron-mcp version` — prints what changed or "in
+sync". Run manually before releases (or as a non-blocking scheduled CI job). This turns
+"did Reactotron change something?" from archaeology into a 30-second command.
+
+Two guardrails keep the surface *scalable* rather than just syncable: decoding stays
+lenient end-to-end (new upstream payload fields are preserved in `JSONValue` and pass
+through to agents even before we type them), and the MCP layer's only coupling to the
+rest of the app is the `ReactotronService` fan-out — so contract growth never touches the
+relay, the UI, or `AppState`.
+
+## 14. Open questions for sign-off
+
+1. **D3**: swift-nio listener (recommended) vs. hand-rolled NWListener HTTP?
+2. Default port 4567 (upstream parity, recommended) vs. a Droidective-specific default?
+3. Should the MCP toggle live in Settings ▸ Privacy (it's a data-exposure switch) or a new
+   Settings ▸ MCP/AI section? (Recommend: its own section, linked from the Reactotron view.)
+4. v1.5 extensions (filter tools + prompts) in the first release or a follow-up? (Recommend:
+   follow-up; parity first.)

--- a/project.yml
+++ b/project.yml
@@ -47,6 +47,8 @@ targets:
     dependencies:
       - package: ADBKit
         product: ADBKit
+      - package: ADBKit
+        product: ReactotronMCP
       - package: KeyboardShortcuts
         product: KeyboardShortcuts
       - package: SwiftTerm

--- a/scripts/check-reactotron-upstream.sh
+++ b/scripts/check-reactotron-upstream.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Did Reactotron change the MCP contract since we last synced?
+#
+# Diffs the contract-defining upstream files against the commit pinned in
+# scripts/reactotron-upstream.lock and checks the reactotron-mcp npm version.
+# Read-only: prints what changed (or "in sync") and never touches this repo.
+# Run before releases, or whenever Reactotron ships something MCP-related.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+lock="$repo_root/scripts/reactotron-upstream.lock"
+# shellcheck source=/dev/null
+source "$lock"
+
+# The files that define the contract ReactotronMCP mirrors, and where each
+# one lands on our side (see CLAUDE.md ▸ "Reactotron MCP — syncing with upstream").
+contract_paths=(
+  "lib/reactotron-mcp/src/tools.ts"          # → ADBKit/Sources/ReactotronMCP/McpToolRegistry.swift + McpToolHandlers.swift
+  "lib/reactotron-mcp/src/resources.ts"      # → McpResources.swift
+  "lib/reactotron-mcp/src/redaction.ts"      # → McpRedaction.swift
+  "lib/reactotron-mcp/src/serialization.ts"  # → McpSerialization.swift + McpConstants.swift
+  "lib/reactotron-mcp/src/mcp-server.ts"     # → McpHTTPListener.swift + McpCommandStore.swift
+  "lib/reactotron-core-contract/src/command.ts"       # → ADBKit ReactotronProtocol.swift
+  "lib/reactotron-core-contract/src/mcpRedaction.ts"  # → McpRedaction.swift config types
+  "lib/reactotron-core-server/src/reactotron-core-server.ts"  # → ADBKit ReactotronServer.swift
+)
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+echo "Fetching infinitered/reactotron (blobless clone)…"
+git clone --quiet --filter=blob:none --no-checkout \
+  https://github.com/infinitered/reactotron "$workdir/reactotron"
+cd "$workdir/reactotron"
+default_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|origin/||')
+latest=$(git rev-parse "origin/$default_branch")
+
+status=0
+
+echo
+echo "Pinned:  $REACTOTRON_COMMIT ($REACTOTRON_COMMIT_DATE)"
+echo "Latest:  $latest ($default_branch)"
+
+if [ "$latest" = "$REACTOTRON_COMMIT" ]; then
+  echo "✓ Upstream repo unchanged since the pin."
+else
+  changed=$(git diff --name-only "$REACTOTRON_COMMIT" "$latest" -- "${contract_paths[@]}")
+  if [ -z "$changed" ]; then
+    echo "✓ Upstream moved, but no contract-defining file changed."
+  else
+    status=1
+    echo "✗ Contract files changed since the pin:"
+    git diff --stat "$REACTOTRON_COMMIT" "$latest" -- "${contract_paths[@]}" | sed 's/^/    /'
+    echo
+    echo "  Review the diff and port what changed (the comments in this script"
+    echo "  say which Swift file mirrors each upstream file):"
+    echo "    cd $workdir/reactotron && git diff $REACTOTRON_COMMIT $latest -- <file>"
+    echo "  Then bump scripts/reactotron-upstream.lock and re-run swift test"
+    echo "  (McpGoldenContractTests pins the served contract)."
+  fi
+fi
+
+echo
+npm_latest=$(npm view reactotron-mcp version 2>/dev/null || echo "unknown")
+if [ "$npm_latest" = "$REACTOTRON_MCP_NPM_VERSION" ]; then
+  echo "✓ npm reactotron-mcp still $npm_latest."
+else
+  status=1
+  echo "✗ npm reactotron-mcp is $npm_latest (pinned $REACTOTRON_MCP_NPM_VERSION)."
+  echo "  Note: the npm package is the standalone stdio proxy — different"
+  echo "  surface from the embedded server we mirror, but new tools there are"
+  echo "  candidates to adopt. npm pack reactotron-mcp to inspect."
+fi
+
+exit $status

--- a/scripts/reactotron-upstream.lock
+++ b/scripts/reactotron-upstream.lock
@@ -1,0 +1,6 @@
+# The upstream Reactotron state the ReactotronMCP contract targets.
+# Bump these after syncing (see scripts/check-reactotron-upstream.sh and
+# CLAUDE.md ▸ "Reactotron MCP — syncing with upstream").
+REACTOTRON_COMMIT=763c1c8e0d4f33d6357c3ee95567ee595eb287e0
+REACTOTRON_COMMIT_DATE=2026-05-28
+REACTOTRON_MCP_NPM_VERSION=0.3.0


### PR DESCRIPTION
Adds an opt-in MCP server that exposes the Reactotron relay's data to AI agents (Claude Code, Cursor, VS Code) over Streamable HTTP on 127.0.0.1:4567/mcp — the same contract as the official Reactotron desktop's embedded MCP server, so upstream's setup line works verbatim:

    claude mcp add --transport http reactotron http://127.0.0.1:4567/mcp

## What's in the diff

**ADBKit (relay, two changes):**
- Fixes the drained-`client.intro` ghost-client race (backlog item from PR #151): a dead connection can no longer re-enter the client list.
- `ReactotronServer.tap()` / `ReactotronService.tap()`: additive bounded observer streams that survive restarts. The UI's stream and timeline are untouched; the `.connected` event now carries the resolved clientId.

**ReactotronMCP (new SwiftPM target; ADBKit itself gains no dependencies):**
- `McpCommandStore`: a 500-item + 32 MiB ring buffer fed by the tap, with derived client records, per-client state cache, custom-command registry, and event-driven request/response correlation (`awaitCommand` with after-marker gating — upstream polls every 100 ms).
- Upstream's exact 10-tool + 8-resource contract, ported file-for-file from `lib/reactotron-mcp` (tools.ts → `McpToolRegistry`/`McpToolHandlers`, resources.ts → `McpResources`, redaction.ts → `McpRedaction`, serialization.ts → `McpSerialization`/`McpConstants`), including the `timeline/{type}` template with completion and the `_meta` connection hints.
- Redaction on by default at the MCP boundary only (~40 sensitive keys, token/JWT/key-shaped value patterns, URL query and form-body params, embedded-JSON recursion) with upstream's two-key opt-out: clients ask via `mcpRedaction` in `client.intro`, the user grants via Settings.
- `McpHTTPListener`: a NIO port of the MCP Swift SDK's conformance HTTPApp — one `Server` + `StatefulHTTPServerTransport` per session, idle reaper, 127.0.0.1-only bind, `OriginValidator.localhost()` DNS-rebinding defense, optional static bearer token, typed port-in-use error. Dependencies: `modelcontextprotocol/swift-sdk` pinned exact (0.12.1) + swift-nio, confined to this target; the one `os` import is `canImport`-gated for the cross-platform branch.

**App:**
- Settings ▸ MCP (off by default): enable toggle, live status, port, bearer token, redaction permissions, copy-paste setup for Claude Code and Cursor. The tab shows for the React Native / all-features roles, or when Reactotron is enabled in another role's set; switching to a role without Reactotron turns the server off before the tab disappears.
- An "AI Agents" button in the Reactotron header opens a one-screen guide: enable in place, per-agent connection snippets reflecting the live port/token, starter prompts.
- With MCP on, the relay survives tab/window close and relaunch; quit teardown stays bounded. MCP never restarts a relay the user stopped (status turns amber, ghost clients cleared).
- Role picker: an "I work with React Native" stack toggle unions Reactotron, the JS Console, and the RN hub into whichever role is chosen (card tool-counts update live) — from user feedback that RN folks picking QA concluded Reactotron wasn't in the app. The RN card's blurb now names Reactotron first.

**Upstream sync tooling:**
- `scripts/check-reactotron-upstream.sh` + `scripts/reactotron-upstream.lock` diff the contract-defining upstream files against the pinned commit; `McpGoldenContractTests` pins the served tool/resource signature so drift fails `swift test`. CLAUDE.md documents the target and the step-by-step upgrade recipe; the design analysis is in `docs/reactotron-mcp-analysis.md`.

## Testing

- 1,081 ADBKit tests green (109 new): redaction ports upstream's own cases, buffer caps, correlation races, registry invariants, golden contract, `InMemoryTransport` round trips, real-socket HTTP/SSE suites (SDK client end-to-end, concurrent sessions, Origin 403, token 401, DELETE teardown, port conflict), seed-role union.
- Live-verified twice against StreamLab on an emulator: all 10 tools (dispatch confirmed, swap_state read back the injected value, ping executed on-device), all 8 resources, redaction on real wire traffic (header/query/body/response vectors), the two-key opt-out grant/revoke cycle, LAN-scope relay restart reattach, background mode, relaunch auto-start, port-conflict recovery — plus Claude Code itself driving tools via `claude --print`.
- Build clean with warnings-as-errors; UI verified by screenshot (Settings pane, guide sheet, role-picker toggle with live counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)