### PR TITLE
Ship a universal (arm64 + x86_64) app and bundled ffmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: brew install xcodegen
       - name: Build app
         run: |
+          ./scripts/unpack-ffmpeg.sh
           xcodegen generate
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Debug -derivedDataPath DerivedData build CODE_SIGNING_ALLOWED=NO
       - name: Run App tests
@@ -126,8 +127,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          ./scripts/unpack-ffmpeg.sh
           xcodegen generate
+          # generic/platform=macOS builds every arch in ARCHS (universal);
+          # the default concrete-Mac destination builds arm64 only.
           xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release \
+            -destination "generic/platform=macOS" \
             -derivedDataPath DerivedData build \
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
             SENTRY_DSN="$SENTRY_DSN" POSTHOG_KEY="$POSTHOG_KEY" \

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ AuthKey_*.p8
 !.claude/skills/
 node_modules/
 website/dist/
+App/Resources/ffmpeg

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SIGNING := CODE_SIGN_IDENTITY="$(SIGN_IDENTITY)" DEVELOPMENT_TEAM="$(DEVELOPMENT
 endif
 
 generate:
+	./scripts/unpack-ffmpeg.sh
 	xcodegen generate
 
 build: generate
@@ -32,8 +33,11 @@ run: build
 	@sleep 0.3
 	open "DerivedData/Build/Products/Debug/Droidective.app"
 
+# The generic destination is what makes the build universal: xcodebuild's
+# default (the concrete local Mac) builds the active arch only, silently
+# dropping the x86_64 slice. package-dmg.sh verifies both slices are present.
 dmg: generate
-	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -derivedDataPath DerivedData build $(TELEMETRY) $(SIGNING)
+	xcodebuild -project Droidective.xcodeproj -scheme App -configuration Release -destination "generic/platform=macOS" -derivedDataPath DerivedData build $(TELEMETRY) $(SIGNING)
 	SIGN_IDENTITY="$(SIGN_IDENTITY)" ./scripts/package-dmg.sh $(VERSION)
 
 clean:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,14 @@
 # Releasing Droidective
 
-Droidective ships as a Developer ID-signed, notarized DMG via GitHub Releases,
-and updates itself with
+Droidective ships as a Developer ID-signed, notarized, **universal** (Apple
+Silicon + Intel) DMG via GitHub Releases, and updates itself with
 [Sparkle](https://sparkle-project.org). The marketing site and the Sparkle
 appcast are both served from GitHub Pages at
 `https://droidective.com/`.
+
+`ARCHS` is pinned in `project.yml`, the bundled ffmpeg is lipo'd universal by
+`scripts/update-bundled-tools.sh`, and `scripts/package-dmg.sh` refuses to
+package an app whose main executable or ffmpeg is missing a slice.
 
 ## One-time setup
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,8 +15,10 @@ is bundled.
 
 ## ffmpeg
 
-`App/Resources/ffmpeg` is a static build of [ffmpeg](https://ffmpeg.org) (v8.1.2,
-macOS arm64), bundled and run on the Mac to power the video editor's exports
+`App/Resources/ffmpeg.zip` holds a static build of [ffmpeg](https://ffmpeg.org)
+(v8.1.2, macOS universal — arm64 + x86_64; committed compressed because the raw
+binary exceeds GitHub's file size limit, unpacked into the app bundle at build
+time), bundled and run on the Mac to power the video editor's exports
 (trim/crop/rotate/scale/speed and mp4/mov/mkv/webm/gif encoding) without a
 separate ffmpeg install.
 
@@ -24,10 +26,11 @@ separate ffmpeg install.
 - License: **GNU General Public License v3** (this build is configured with
   `--enable-gpl --enable-version3`, which includes GPL components such as
   libx264/libx265). The full license text is at https://www.gnu.org/licenses/gpl-3.0.html
-- Build source: https://ffmpeg.martin-riedl.de (macOS arm64, "release")
-- The pinned SHA-256 in `scripts/update-bundled-tools.sh` is the source of
-  truth for the exact bundled build; update the version stated above whenever
-  that script refreshes the binary.
+- Build source: https://ffmpeg.martin-riedl.de (macOS arm64 + x86_64 "release"
+  builds, combined into one universal binary with `lipo`)
+- The pinned per-slice SHA-256s in `scripts/update-bundled-tools.sh` are the
+  source of truth for the exact bundled build; update the version stated above
+  whenever that script refreshes the binary.
 - The binary is redistributed unmodified. FFmpeg's source is available from
   https://ffmpeg.org/download.html and https://git.ffmpeg.org/ffmpeg.git
 

--- a/project.yml
+++ b/project.yml
@@ -32,10 +32,16 @@ targets:
         excludes:
           - scrcpy-server
           - ffmpeg
+          # The compressed source of the ffmpeg binary — unpacked at generate
+          # time, must not itself ship in the bundle.
+          - ffmpeg.zip
       # Extension-less binaries: force them into the resources phase so they land
       # in the .app bundle (XcodeGen otherwise can't infer the build phase).
       # scrcpy-server is pushed to the device; ffmpeg runs on the Mac for the
       # video editor. See BundledTools + scripts/update-bundled-tools.sh.
+      # ffmpeg is unpacked from the committed ffmpeg.zip by
+      # scripts/unpack-ffmpeg.sh (run it before a bare `xcodegen generate`;
+      # `make generate` and CI already do).
       - path: App/Resources/scrcpy-server
         buildPhase: resources
       - path: App/Resources/ffmpeg
@@ -120,6 +126,11 @@ targets:
       base:
         PRODUCT_NAME: Droidective
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective
+        # Universal app (Intel + Apple Silicon) — pinned so a toolchain default
+        # change can't silently drop a slice. Debug stays fast via
+        # ONLY_ACTIVE_ARCH=YES; scripts/package-dmg.sh verifies the built
+        # product carries both slices before packaging.
+        ARCHS: arm64 x86_64
         SENTRY_DSN: ""
         POSTHOG_KEY: ""
         MARKETING_VERSION: "3.6.1"

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -20,6 +20,19 @@ if [[ ! -d "$APP" ]]; then
   exit 1
 fi
 
+# The release is a universal app (Intel + Apple Silicon). Fail packaging if the
+# main executable or the bundled ffmpeg lost a slice — e.g. an ONLY_ACTIVE_ARCH
+# build slipping through, or a bundled tool refreshed single-arch.
+for bin in "$APP/Contents/MacOS/Droidective" "$APP/Contents/Resources/ffmpeg"; do
+  archs="$(lipo -archs "$bin")"
+  for want in arm64 x86_64; do
+    if [[ " $archs " != *" $want "* ]]; then
+      echo "error: $bin is missing the $want slice (archs: $archs) — the DMG must be universal" >&2
+      exit 1
+    fi
+  done
+done
+
 opts=(--force --sign "$SIGN_IDENTITY")
 if [[ "$SIGN_IDENTITY" != "-" ]]; then
   opts+=(--options runtime --timestamp)

--- a/scripts/unpack-ffmpeg.sh
+++ b/scripts/unpack-ffmpeg.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Unpack the bundled ffmpeg from its committed archive. The universal binary
+# (arm64 + x86_64, ~152 MB) exceeds GitHub's 100 MB file limit, so the repo
+# carries App/Resources/ffmpeg.zip and the unpacked binary is gitignored.
+# Run before `xcodegen generate` (the Makefile and CI both do) — the project
+# references App/Resources/ffmpeg as a bundled resource. No-op when the
+# unpacked binary is already up to date.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RES="$ROOT/App/Resources"
+
+if [[ ! -f "$RES/ffmpeg.zip" ]]; then
+  echo "error: $RES/ffmpeg.zip not found — run scripts/update-bundled-tools.sh" >&2
+  exit 1
+fi
+
+if [[ ! -f "$RES/ffmpeg" || "$RES/ffmpeg.zip" -nt "$RES/ffmpeg" ]]; then
+  unzip -o -q "$RES/ffmpeg.zip" -d "$RES"
+  chmod +x "$RES/ffmpeg"
+  # unzip restores the archived mtime, which predates the zip — bump it so the
+  # staleness check above short-circuits on the next run.
+  touch "$RES/ffmpeg"
+  echo "unpacked App/Resources/ffmpeg"
+fi
+
+archs="$(lipo -archs "$RES/ffmpeg")"
+if [[ "$archs" != *arm64* || "$archs" != *x86_64* ]]; then
+  echo "error: unpacked ffmpeg is not universal (archs: $archs)" >&2
+  exit 1
+fi

--- a/scripts/update-bundled-tools.sh
+++ b/scripts/update-bundled-tools.sh
@@ -6,7 +6,9 @@
 #
 # Downloads:
 #   - scrcpy-server  from the scrcpy GitHub release (default v4.1)
-#   - ffmpeg         latest static build, macOS arm64 (ffmpeg.martin-riedl.de)
+#   - ffmpeg         latest static builds, macOS arm64 + x86_64
+#                    (ffmpeg.martin-riedl.de), lipo'd into one universal binary
+#                    so the app runs natively on Intel Macs too
 #
 # After running, bump the version constants in
 # App/Sources/Bundled/BundledTools.swift if they changed (the scrcpy version
@@ -28,7 +30,11 @@ trap 'rm -rf "$TMP"' EXIT
 # script, read the "got" hash from the mismatch error, and update the constant
 # here in the same commit that bumps the version.
 SCRCPY_SERVER_SHA256="deacb991ed2509715160ffdc7907e47b4160eb30d1566217e9047fd5b8850cae"
-FFMPEG_SHA256="eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d"
+# The two ffmpeg slices are pinned separately; both "latest" redirects must
+# serve the same ffmpeg version when updating (the script checks the lipo'd
+# binary's version, and whoever bumps these pins confirms the pair matches).
+FFMPEG_ARM64_SHA256="eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d"
+FFMPEG_X86_64_SHA256="1ca59dda73668c59898a0b305afd8a88817a989187f222ec62d64e775d614d23"
 BUNDLETOOL_SHA256="a099cfa1543f55593bc2ed16a70a7c67fe54b1747bb7301f37fdfd6d91028e29"
 UBER_APK_SIGNER_SHA256="e1299fd6fcf4da527dd53735b56127e8ea922a321128123b9c32d619bba1d835"
 
@@ -51,13 +57,35 @@ curl -fsSL -o "$TMP/scrcpy-server" \
 verify_sha256 "$TMP/scrcpy-server" "$SCRCPY_SERVER_SHA256" "scrcpy-server"
 mv "$TMP/scrcpy-server" "$RES/scrcpy-server"
 
-echo "==> ffmpeg (static, macOS arm64)"
-curl -fsSL -o "$TMP/ffmpeg.zip" \
-  "https://ffmpeg.martin-riedl.de/redirect/latest/macos/arm64/release/ffmpeg.zip"
-unzip -o -q "$TMP/ffmpeg.zip" -d "$TMP"
-verify_sha256 "$TMP/ffmpeg" "$FFMPEG_SHA256" "ffmpeg"
+echo "==> ffmpeg (static, macOS universal)"
+for arch in arm64 x86_64; do
+  # The build host names the Intel platform folder "amd64".
+  url_arch="$arch"
+  [[ "$arch" == "x86_64" ]] && url_arch="amd64"
+  mkdir -p "$TMP/ffmpeg-$arch"
+  curl -fsSL -o "$TMP/ffmpeg-$arch.zip" \
+    "https://ffmpeg.martin-riedl.de/redirect/latest/macos/${url_arch}/release/ffmpeg.zip"
+  unzip -o -q "$TMP/ffmpeg-$arch.zip" -d "$TMP/ffmpeg-$arch"
+done
+verify_sha256 "$TMP/ffmpeg-arm64/ffmpeg" "$FFMPEG_ARM64_SHA256" "ffmpeg (arm64)"
+verify_sha256 "$TMP/ffmpeg-x86_64/ffmpeg" "$FFMPEG_X86_64_SHA256" "ffmpeg (x86_64)"
+lipo -create "$TMP/ffmpeg-arm64/ffmpeg" "$TMP/ffmpeg-x86_64/ffmpeg" -output "$TMP/ffmpeg"
+# The raw universal binary exceeds GitHub's 100 MB file limit, so the repo
+# commits it zipped (ffmpeg.zip) and scripts/unpack-ffmpeg.sh inflates it
+# before builds (the unpacked binary is gitignored). Fixed mtime + -X make
+# the zip byte-identical across runs, so an unchanged refresh stays clean.
+touch -t 202001010000 "$TMP/ffmpeg"
+rm -f "$RES/ffmpeg.zip"
+(cd "$TMP" && zip -X -9 -q "$RES/ffmpeg.zip" ffmpeg)
 mv "$TMP/ffmpeg" "$RES/ffmpeg"
 chmod +x "$RES/ffmpeg"
+touch "$RES/ffmpeg"
+
+lipo_archs="$(lipo -archs "$RES/ffmpeg")"
+if [[ "$lipo_archs" != *arm64* || "$lipo_archs" != *x86_64* ]]; then
+  echo "ERROR: bundled ffmpeg is not universal (archs: $lipo_archs)" >&2
+  exit 1
+fi
 
 ffmpeg_version="$("$RES/ffmpeg" -version | head -1 | cut -d' ' -f3)"
 


### PR DESCRIPTION
## What

Makes releases run natively on Intel Macs. The shipped v3.6.1 DMG is arm64-only — both the app executable and the bundled ffmpeg — even though the site FAQ states Intel is supported.

Two independent causes, both fixed:

1. `xcodebuild … build` without a `-destination` compiles only the active architecture, even in Release with `ONLY_ACTIVE_ARCH=NO`. CI's release job and `make dmg` now pass `-destination "generic/platform=macOS"`.
2. The bundled ffmpeg was a single-arch (arm64) static build. `update-bundled-tools.sh` now downloads both slices (each pinned by SHA-256) and combines them with `lipo`.

## Changes

- `project.yml` pins `ARCHS: arm64 x86_64`; Debug stays active-arch only via `ONLY_ACTIVE_ARCH`
- `package-dmg.sh` refuses to package a DMG whose app executable or ffmpeg is missing a slice
- The universal ffmpeg (152 MB) exceeds GitHub's 100 MB file limit, so the repo now commits `App/Resources/ffmpeg.zip` (59 MB — smaller than the raw arm64 binary it replaces). `scripts/unpack-ffmpeg.sh` inflates it before `xcodegen generate` (wired into `make generate` and both CI build paths); the unpacked binary is gitignored and excluded from the app bundle glob. The zip is byte-deterministic (fixed mtime, `zip -X`), so an unchanged tool refresh leaves the tree clean
- `THIRD_PARTY_NOTICES.md` / `RELEASING.md` updated

## Verification

- `make dmg`: universal Release build passes the new slice guard; `codesign --verify --deep --strict` clean; `lipo -archs` reports `x86_64 arm64` for the app and ffmpeg
- x86_64 slice smoke-tested under Rosetta (launches and runs)
- `unpack-ffmpeg.sh` tested from a deleted binary and as a no-op re-run; Debug build confirms `ffmpeg` (not `ffmpeg.zip`) lands in the bundle
- shellcheck, `shfmt -i 2`, actionlint, zizmor clean
- DMG grows 50 → 128 MB (the price of the fat static ffmpeg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)