### PR TITLE
Clamp welcome tour paging to the pages range

### DIFF
--- a/App/Sources/FeatureDetail/Views/TourPaging.swift
+++ b/App/Sources/FeatureDetail/Views/TourPaging.swift
@@ -1,0 +1,17 @@
+/// Pure paging math for the welcome tour's Back/Next controls.
+///
+/// Button actions can fire twice between SwiftUI renders (⏎ auto-repeat on
+/// the default action, a double-click racing the view update), and the bounds
+/// the rendered controls enforce — Next absent on the last page, Back absent
+/// on the first — lag one render behind. So every step clamps instead of
+/// trusting which buttons existed (DROIDECTIVE-MAC-2H: an unclamped double
+/// Next reached `pages[6]` and trapped in `Array._checkSubscript`).
+enum TourPaging {
+    static func next(from index: Int, count: Int) -> Int {
+        min(index + 1, count - 1)
+    }
+
+    static func back(from index: Int) -> Int {
+        max(index - 1, 0)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/TourView.swift
+++ b/App/Sources/FeatureDetail/Views/TourView.swift
@@ -238,7 +238,7 @@ struct TourView: View {
             HStack(spacing: 8) {
                 if index > 0 {
                     // On the try page this returns to the pick-hotkey page.
-                    Button("Back") { withAnimation { index -= 1 } }
+                    Button("Back") { withAnimation { index = TourPaging.back(from: index) } }
                 }
                 if isLast {
                     // Pressing the hotkey is the celebrated finish (confetti
@@ -249,7 +249,9 @@ struct TourView: View {
                 } else {
                     // The try page needs a hotkey to press, so the pick page
                     // holds the gate.
-                    Button("Next") { withAnimation { index += 1 } }
+                    Button("Next") {
+                        withAnimation { index = TourPaging.next(from: index, count: Self.pages.count) }
+                    }
                         .keyboardShortcut(.defaultAction)
                         .disabled(isHotkeyPage && quickActionsShortcut == nil)
                 }

--- a/App/Tests/TourPagingTests.swift
+++ b/App/Tests/TourPagingTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+/// The tour crash class (DROIDECTIVE-MAC-2H): a Next that double-fired
+/// between renders stepped past the last page and `pages[index]` trapped.
+/// The steps must clamp at both ends no matter how many times they fire.
+@Suite struct TourPagingTests {
+    @Test func nextAdvancesWithinBounds() {
+        #expect(TourPaging.next(from: 0, count: 6) == 1)
+        #expect(TourPaging.next(from: 4, count: 6) == 5)
+    }
+
+    /// The crash repro: a second fire landing while already on the last page.
+    @Test func nextClampsAtTheLastPage() {
+        #expect(TourPaging.next(from: 5, count: 6) == 5)
+        #expect(TourPaging.next(from: TourPaging.next(from: 4, count: 6), count: 6) == 5)
+    }
+
+    @Test func backRetreatsWithinBounds() {
+        #expect(TourPaging.back(from: 5) == 4)
+        #expect(TourPaging.back(from: 1) == 0)
+    }
+
+    /// The same race backward: a double Back from page 1 must not reach -1.
+    @Test func backClampsAtTheFirstPage() {
+        #expect(TourPaging.back(from: 0) == 0)
+        #expect(TourPaging.back(from: TourPaging.back(from: 1)) == 0)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,7 @@ targets:
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
+      - App/Sources/FeatureDetail/Views/TourPaging.swift
       - App/Sources/Updates/ReleaseNotesStyler.swift
     dependencies:
       # Theme.swift's fill styles call into WindowEffects (ADBKit).


### PR DESCRIPTION
## What

The welcome tour's Back/Next buttons mutated the page index with bare `index += 1` / `index -= 1`. The bounds were enforced only by which buttons existed at the last render, and button actions can fire twice between SwiftUI renders (⏎ auto-repeat on the default action, or a double-click racing the view update) — a double Next on the pick-hotkey page reached `pages[6]` and trapped in `Array._checkSubscript`. Sentry issue [DROIDECTIVE-MAC-2H](https://ro-is.sentry.io/issues/DROIDECTIVE-MAC-2H): 13 crashes across 9 users on 3.0.1–3.3.1, all mid-onboarding.

- The step math moves into a pure `TourPaging` helper clamped at both ends (`next` at `count - 1`, `back` at 0).
- `TourView`'s Back/Next actions route through it.
- `TourPaging.swift` joins the AppTests logic bundle; `TourPagingTests` covers in-bounds steps and the double-fire clamp in both directions.

Fixes DROIDECTIVE-MAC-2H

## Verification

- AppTests: 54 tests pass (including the 4 new ones).
- `xcodebuild` Debug build succeeds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)