### PR TITLE
Recover the update pill from an interrupted install

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/UpdatePolicy.swift
+++ b/ADBKit/Sources/ADBKit/Services/UpdatePolicy.swift
@@ -122,4 +122,28 @@ public enum UpdatePolicy {
         guard let oldAutomaticChecks, !oldAutomaticChecks else { return nil }
         return false
     }
+
+    /// Where the pill lands after an install attempt stops with the app
+    /// still running — the quit was declined (a leave confirmation was
+    /// cancelled) or Sparkle abandoned the session. "Installing…" has no
+    /// affordance, so a phase that outlives its attempt pins the pill on an
+    /// indeterminate spinner forever.
+    public enum InterruptedInstallPhase: Equatable, Sendable {
+        /// A relaunch handler survives — the staged update installs on the
+        /// next click; offer "Relaunch to update" again.
+        case readyToRelaunch
+        /// Every handler is consumed but the update is known — offer "Update
+        /// available"; its click re-enters the updater, which resumes the
+        /// staged install with a fresh handler.
+        case available
+        /// No update in hand — hide the pill.
+        case idle
+    }
+
+    public static func phaseAfterInterruptedInstall(
+        canRelaunch: Bool, updateKnown: Bool
+    ) -> InterruptedInstallPhase {
+        guard updateKnown else { return .idle }
+        return canRelaunch ? .readyToRelaunch : .available
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/UpdatePolicyTests.swift
+++ b/ADBKit/Tests/ADBKitTests/UpdatePolicyTests.swift
@@ -193,4 +193,34 @@ import Testing
         #expect(UpdatePolicy.migratedAutoDownload(oldAutomaticChecks: nil) == nil)
         #expect(UpdatePolicy.migratedAutoDownload(oldAutomaticChecks: true) == nil)
     }
+
+    // MARK: interrupted install
+
+    /// A declined quit keeps its relaunch handler — the pill must return to
+    /// the actionable "Relaunch to update", not spin on "Installing…".
+    @Test func declinedQuitReturnsToReadyToRelaunch() {
+        #expect(
+            UpdatePolicy.phaseAfterInterruptedInstall(canRelaunch: true, updateKnown: true)
+                == .readyToRelaunch)
+    }
+
+    /// An aborted session consumed every handler — fall back to "Update
+    /// available", whose click re-enters the updater and resumes the staged
+    /// install with a fresh reply.
+    @Test func abortedSessionFallsBackToAvailable() {
+        #expect(
+            UpdatePolicy.phaseAfterInterruptedInstall(canRelaunch: false, updateKnown: true)
+                == .available)
+    }
+
+    /// With no update in hand there is nothing to offer — hide the pill
+    /// rather than promise an install that can't happen.
+    @Test func interruptionWithoutAKnownUpdateHidesThePill() {
+        #expect(
+            UpdatePolicy.phaseAfterInterruptedInstall(canRelaunch: false, updateKnown: false)
+                == .idle)
+        #expect(
+            UpdatePolicy.phaseAfterInterruptedInstall(canRelaunch: true, updateKnown: false)
+                == .idle)
+    }
 }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1191,8 +1191,14 @@ final class AppState {
     /// Abandon a quit `applicationShouldTerminate` deferred: clear the
     /// delegate's in-quit flag first, so a later window close still routes
     /// through background mode instead of being mistaken for quit teardown.
+    /// The updater must hear about it too — a quit it requested that got
+    /// cancelled here would otherwise leave its pill on "Installing…"
+    /// forever (that phase's only exit was this quit).
     private func cancelDeferredQuit() {
         appDelegate?.isQuitting = false
+        #if !APPSTORE
+            SparkleUpdater.shared.noteQuitDeclined()
+        #endif
         NSApp.reply(toApplicationShouldTerminate: false)
     }
 

--- a/App/Sources/Updates/SparkleUpdater.swift
+++ b/App/Sources/Updates/SparkleUpdater.swift
@@ -198,6 +198,35 @@ final class UpdaterViewModel: NSObject, ObservableObject {
     /// (dirty-state confirmations); the pill retries through it.
     private var retryTerminate: (() -> Void)?
 
+    /// The app declined the quit an install requested (a leave confirmation
+    /// was cancelled — `AppState.cancelDeferredQuit`). Without this,
+    /// "Installing…" outlives the attempt and the pill spins forever on a
+    /// phase whose only exit was the quit that just got cancelled.
+    func noteQuitDeclined() {
+        resolveInterruptedInstall()
+    }
+
+    /// Map a dead `.installing` back to an actionable pill. With a handler
+    /// still in hand the staged update relaunches on click; with all of them
+    /// consumed, "Update available" re-enters the updater, whose re-check
+    /// resumes the staged install with a fresh reply.
+    private func resolveInterruptedInstall() {
+        guard case .installing = phase else { return }
+        let canRelaunch = retryTerminate != nil || immediateInstall != nil || heldReply != nil
+        switch UpdatePolicy.phaseAfterInterruptedInstall(
+            canRelaunch: canRelaunch, updateKnown: currentInfo != nil
+        ) {
+        case .readyToRelaunch:
+            guard let currentInfo else { return phase = .idle }
+            phase = .readyToRelaunch(currentInfo)
+        case .available:
+            guard let currentInfo else { return phase = .idle }
+            phase = .available(currentInfo)
+        case .idle:
+            phase = .idle
+        }
+    }
+
     // MARK: - Settings bindings
 
     /// Settings toggles bind to these computed properties, whose truth lives
@@ -493,7 +522,13 @@ extension UpdaterViewModel: SPUUserDriver {
         switch phase {
         case .checking, .downloading:
             phase = .idle
-        case .idle, .upToDate, .available, .readyToRelaunch, .installing:
+        case .installing:
+            // An abort with the app still alive (installer error, superseded
+            // session) — on the successful hand-off the app is quitting and
+            // nobody sees the pill change. Left as-is, "Installing…" spins
+            // forever with every handler cleared and clicks doing nothing.
+            resolveInterruptedInstall()
+        case .idle, .upToDate, .available, .readyToRelaunch:
             break
         }
     }


### PR DESCRIPTION
## What

A user reported the sidebar pill stuck on **"Installing update… / Relaunches in a moment"** for 30+ minutes with no relaunch. The `.installing` phase had no exit except a successful quit; two paths left it spinning forever:

1. **Quit declined.** `relaunchNow` asks Sparkle to install, Sparkle asks the app to quit, and `applicationShouldTerminate` shows a confirmation (close-all-terminals, unsaved work). Cancelling it runs `AppState.cancelDeferredQuit`, which replied false to AppKit but never told the updater — the pill kept its indeterminate spinner with no visible affordance (clicking did retry, but nothing said so).
2. **Session aborted.** On an installer error or superseded check, `dismissUpdateInstallation` deliberately kept `.installing` while also clearing `retryTerminate` — the pill spun forever and clicks were a no-op.

## How

- `UpdatePolicy.phaseAfterInterruptedInstall(canRelaunch:updateKnown:)` (ADBKit, pure): live handler → `readyToRelaunch`; handlers consumed → `available` (its click re-enters the updater, which resumes the staged install with a fresh reply); no update in hand → `idle`.
- `UpdaterViewModel.noteQuitDeclined()` + a `resolveInterruptedInstall()` shared by the dismiss path; `cancelDeferredQuit` calls it under `#if !APPSTORE`.
- 3 new `UpdatePolicyTests` cover the three outcomes.

## Verification

- `swift test --filter UpdatePolicyTests`: 23 tests pass.
- `xcodebuild` Debug build succeeds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)