### PR TITLE
Pace the JS console feed and make incidents self-explanatory

### DIFF
--- a/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
+++ b/ADBKit/Sources/ADBKit/Support/ResourceWatchdog.swift
@@ -94,10 +94,12 @@ public struct ResourceWatchdog: Sendable {
     /// Feed the next sample; returns the threshold events it triggered.
     ///
     /// `cpuLimitOverride` replaces the configured CPU limit for this sample only.
-    /// The App layer raises it (to `.infinity`) while a feature that legitimately
-    /// pegs the CPU is on screen — live screen mirroring and recording decode
-    /// H.264 in-process, so ~two busy cores is expected there, not an incident.
-    /// Memory is always judged against the configured limit.
+    /// The App layer raises it while a feature that legitimately pegs the CPU is
+    /// on screen — live screen mirroring and recording decode H.264 in-process,
+    /// so ~two busy cores is expected there, not an incident. Raised, never
+    /// waived: an unbounded override hid a real mirror-session leak from
+    /// telemetry for hours. Memory is always judged against the configured
+    /// limit.
     public mutating func ingest(
         _ sample: ResourceSample, cpuLimitOverride: Double? = nil
     ) -> [ResourceEvent] {

--- a/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ResourceWatchdogTests.swift
@@ -134,6 +134,25 @@ import Testing
             cpuLimitOverride: .infinity)
         #expect(events == [.began(metric: .memory, value: 1_500 * mb, limit: 1_000 * mb)])
     }
+
+    @Test func finiteCpuOverrideStillFiresPastTheRaisedLimit() {
+        // The mirror override is a *raised* limit, not a pass: a leak burning
+        // ~five cores with a mirror tab open must still report. An unbounded
+        // override is what kept the v3.1.0 mirror-session leak (hours at
+        // 250%+) invisible to telemetry.
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1))
+        _ = dog.ingest(cpuSample(at: 0, cpuTime: 0))
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 25), cpuLimitOverride: 450)
+            == [.began(metric: .cpu, value: 500, limit: 450)])
+    }
+
+    @Test func finiteCpuOverrideStillCoversExpectedHeavyLoad() {
+        // Healthy mirroring (~three busy cores) stays inside the raised
+        // limit — expected load must not become incident noise.
+        var dog = ResourceWatchdog(limits: .init(cpuPercent: 200, sustainedSamples: 1))
+        _ = dog.ingest(cpuSample(at: 0, cpuTime: 0))
+        #expect(dog.ingest(cpuSample(at: 5, cpuTime: 15), cpuLimitOverride: 450).isEmpty)
+    }
 }
 
 @Suite struct ProcessStatsTests {

--- a/App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
+++ b/App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
@@ -1,0 +1,24 @@
+import ADBKit
+
+/// Memoized `ConsoleLinkDetector` for console-row rendering. Detection runs
+/// `NSDataDetector` over up to 10k characters, and rows re-render on every
+/// feed flush — a Metro stream is URL-dense (bundle URLs, network logs), so
+/// per-render detection was a sustained main-thread cost (Sentry
+/// DROIDECTIVE-MAC-49). The same text always yields the same spans, so cache
+/// by text; entries are immutable, making the steady state all hits.
+///
+/// Bounded by wholesale clearing at `capacity` instead of LRU bookkeeping —
+/// the worst case after a clear is re-detecting one screenful of rows.
+@MainActor
+enum ConsoleLinkSpanMemo {
+    static let capacity = 2048
+    private static var cache: [String: [ConsoleLinkDetector.Span]] = [:]
+
+    static func spans(in text: String) -> [ConsoleLinkDetector.Span] {
+        if let hit = cache[text] { return hit }
+        let spans = ConsoleLinkDetector.linkSpans(in: text)
+        if cache.count >= capacity { cache.removeAll(keepingCapacity: true) }
+        cache[text] = spans
+        return spans
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
+++ b/App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
@@ -14,6 +14,11 @@ enum ConsoleLinkSpanMemo {
     static let capacity = 2048
     private static var cache: [String: [ConsoleLinkDetector.Span]] = [:]
 
+    /// How many texts are cached — what lets a test prove the memo actually
+    /// memoizes and clears at `capacity` (transparency alone also holds for
+    /// a broken no-op cache).
+    static var cachedTextCount: Int { cache.count }
+
     static func spans(in text: String) -> [ConsoleLinkDetector.Span] {
         if let hit = cache[text] { return hit }
         let spans = ConsoleLinkDetector.linkSpans(in: text)

--- a/App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
+++ b/App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
@@ -10,4 +10,17 @@ enum ConsoleRateBucket {
         while Double(bucket * 10) <= perMinute { bucket *= 10 }
         return bucket
     }
+
+    /// The bucket at which a rate rise counts as a burst worth a breadcrumb.
+    static let burstFloor = 1000
+
+    /// Whether a bucket transition is a burst: only a *rise* landing at or
+    /// above `burstFloor`, and only when a previous publication exists — the
+    /// first publish after a connect is baseline, not news, and a steady or
+    /// falling rate must never crumb (it would spam the timeline on every
+    /// re-publish of an already-busy stream).
+    static func isBurst(from previous: Int?, to next: Int) -> Bool {
+        guard let previous else { return false }
+        return next > previous && next >= burstFloor
+    }
 }

--- a/App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
+++ b/App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
@@ -1,0 +1,13 @@
+/// Order-of-magnitude bucketing for the console's ingest-rate diagnostic:
+/// 0 for under one message per minute, then 1, 10, 100, 1000… The decade —
+/// not the exact rate — is the signal, and the coarse bucket is what keeps
+/// the published diagnostic context from re-publishing on every noisy 2 s
+/// discovery pass.
+enum ConsoleRateBucket {
+    static func decade(_ perMinute: Double) -> Int {
+        guard perMinute >= 1 else { return 0 }
+        var bucket = 1
+        while Double(bucket * 10) <= perMinute { bucket *= 10 }
+        return bucket
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -135,10 +135,12 @@ final class JSConsoleSession {
     /// when `newestFirst` is on.
     // The 128 MB byte budget (Reactotron's figure) matters as much as the
     // count cap: 2000 entries each holding a multi-megabyte logged string
-    // would otherwise retain gigabytes.
+    // would otherwise retain gigabytes. Shared with the pending early-flush
+    // bound so the two can't drift apart when retuned.
+    private static let bufferByteBudget = 128 << 20
     private var buffer = FilteredLogBuffer<JSEntry>(
         capacity: JSConsoleSession.maxEntries,
-        byteBudget: 128 << 20,
+        byteBudget: JSConsoleSession.bufferByteBudget,
         cost: { $0.approximateBytes }
     )
     var filteredEntries: [JSEntry] { buffer.filtered }
@@ -404,7 +406,7 @@ final class JSConsoleSession {
         let snapshot = StreamDiagnostics(
             connected: isConnected,
             bufferedEntries: (buffer.entries.count / 100) * 100,
-            ingestPerMinute: Self.decadeBucket(perMinute)
+            ingestPerMinute: ConsoleRateBucket.decade(perMinute)
         )
         guard snapshot != publishedDiagnostics else { return }
         if let previous = publishedDiagnostics, snapshot.ingestPerMinute > previous.ingestPerMinute,
@@ -418,14 +420,6 @@ final class JSConsoleSession {
             "buffered_entries": snapshot.bufferedEntries,
             "ingest_per_min": snapshot.ingestPerMinute,
         ])
-    }
-
-    /// 0, 10, 100, 1000… — the order of magnitude is the diagnostic signal.
-    private static func decadeBucket(_ perMinute: Double) -> Int {
-        guard perMinute >= 1 else { return 0 }
-        var bucket = 1
-        while Double(bucket * 10) <= perMinute { bucket *= 10 }
-        return bucket
     }
 
     func updateSerials(_ serials: [String]) {
@@ -913,7 +907,7 @@ final class JSConsoleSession {
         // A burst of huge payloads must not sit unrendered for a whole flush
         // window — flush early once pending holds a quarter of the buffer's
         // byte budget, so pending memory stays bounded at any cadence.
-        if pendingBytes >= (128 << 20) / 4 {
+        if pendingBytes >= Self.bufferByteBudget / 4 {
             flushPending()
         } else {
             scheduleFlush()

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -352,6 +352,7 @@ final class JSConsoleSession {
                     }
                 }
             }
+            publishDiagnostics()
             try? await Task.sleep(for: .seconds(2))
         }
         // Tear down only if a newer activation hasn't taken over (rapid
@@ -364,6 +365,67 @@ final class JSConsoleSession {
         await cdp.disconnect()
         connectedTarget = nil
         phase = .searching
+        // Session over — a later hang must not read as "the console did it".
+        Telemetry.shared.setDiagnosticContext("js_console", nil)
+        Telemetry.shared.breadcrumb(category: "js-console", "session stopped")
+        publishedDiagnostics = nil
+    }
+
+    // MARK: Diagnostics
+
+    /// The last stream shape shipped to telemetry, so re-publishing only
+    /// happens on change (each publish crosses both SDKs).
+    private struct StreamDiagnostics: Equatable {
+        var connected: Bool
+        /// Buffered entries, rounded to hundreds — precision isn't the point.
+        var bufferedEntries: Int
+        /// Ingest rate over the last pass, bucketed to its decade so a noisy
+        /// stream doesn't re-publish every 2 s.
+        var ingestPerMinute: Int
+    }
+
+    @ObservationIgnored private var publishedDiagnostics: StreamDiagnostics?
+    @ObservationIgnored private var lastRateCount = 0
+    @ObservationIgnored private var lastRateTime = ContinuousClock.now
+
+    /// Ship the stream's shape as always-on diagnostic context (a Sentry
+    /// context + PostHog super-properties), so any hang/crash/perf event that
+    /// fires carries "what the console was doing" — the missing fact when
+    /// diagnosing the 3.7.0 hang burst from telemetry alone. Runs on the 2 s
+    /// discovery pass; publishes only when a bucketed value changes.
+    private func publishDiagnostics() {
+        let now = ContinuousClock.now
+        let elapsed = lastRateTime.duration(to: now)
+        let seconds = max(0.001, Double(elapsed.components.seconds)
+            + Double(elapsed.components.attoseconds) * 1e-18)
+        let perMinute = Double(receivedCount - lastRateCount) / seconds * 60
+        lastRateCount = receivedCount
+        lastRateTime = now
+        let snapshot = StreamDiagnostics(
+            connected: isConnected,
+            bufferedEntries: (buffer.entries.count / 100) * 100,
+            ingestPerMinute: Self.decadeBucket(perMinute)
+        )
+        guard snapshot != publishedDiagnostics else { return }
+        if let previous = publishedDiagnostics, snapshot.ingestPerMinute > previous.ingestPerMinute,
+           snapshot.ingestPerMinute >= 1000 {
+            Telemetry.shared.breadcrumb(
+                category: "js-console", "stream burst: ~\(snapshot.ingestPerMinute)/min")
+        }
+        publishedDiagnostics = snapshot
+        Telemetry.shared.setDiagnosticContext("js_console", [
+            "connected": snapshot.connected,
+            "buffered_entries": snapshot.bufferedEntries,
+            "ingest_per_min": snapshot.ingestPerMinute,
+        ])
+    }
+
+    /// 0, 10, 100, 1000… — the order of magnitude is the diagnostic signal.
+    private static func decadeBucket(_ perMinute: Double) -> Int {
+        guard perMinute >= 1 else { return 0 }
+        var bucket = 1
+        while Double(bucket * 10) <= perMinute { bucket *= 10 }
+        return bucket
     }
 
     func updateSerials(_ serials: [String]) {
@@ -436,6 +498,9 @@ final class JSConsoleSession {
             phase = .connected
             receivedCount = 0
             replayGate.connectionOpened(resumingSameApp: resumingSameApp)
+            // No target identity in the crumb — bundle ids stay out of
+            // telemetry (the Settings ▸ Privacy promise).
+            Telemetry.shared.breadcrumb(category: "js-console", "connected to a Hermes target")
             consumeTask = Task { [weak self] in
                 for await event in stream {
                     if Task.isCancelled { break }
@@ -485,6 +550,8 @@ final class JSConsoleSession {
             welcomeTask?.cancel()
             welcomeTask = nil
             connectedTarget = nil
+            Telemetry.shared.breadcrumb(
+                category: "js-console", takeover ? "closed: debugger takeover" : "connection closed")
             if takeover {
                 autoReconnectSuspended = true
                 phase = .targetsAvailable
@@ -838,16 +905,41 @@ final class JSConsoleSession {
     /// and flushed together so a thousand-message burst causes a handful of renders,
     /// not one per message (the fix for the multi-second open stall).
     private func enqueue(_ kind: JSEntry.Kind) {
-        pendingEntries.append(JSEntry(id: nextEntryId, kind: kind, at: Date()))
+        let entry = JSEntry(id: nextEntryId, kind: kind, at: Date())
+        pendingEntries.append(entry)
+        pendingBytes += entry.approximateBytes
         nextEntryId += 1
         receivedCount += 1
-        scheduleFlush()
+        // A burst of huge payloads must not sit unrendered for a whole flush
+        // window — flush early once pending holds a quarter of the buffer's
+        // byte budget, so pending memory stays bounded at any cadence.
+        if pendingBytes >= (128 << 20) / 4 {
+            flushPending()
+        } else {
+            scheduleFlush()
+        }
+    }
+
+    /// Bytes waiting in `pendingEntries`, for the early-flush bound.
+    @ObservationIgnored private var pendingBytes = 0
+
+    /// Flush pacing: each flush re-diffs the whole visible feed (a 2000-row
+    /// ForEach), so the old 16 ms cadence meant up to 60 full diffs a second
+    /// under a chatty Metro stream — the sustained main-thread churn behind
+    /// the js-console hang cluster (Sentry DROIDECTIVE-MAC-2N and the 3.7.0
+    /// hang burst; logcat shipped the same 300 ms fix in v3.6.1). Entries
+    /// keep accumulating between flushes; only rendering is paced. While the
+    /// app is inactive nobody is reading in real time, so the feed coasts at
+    /// 1 s — streaming with the window unfocused used to burn CPU for hours.
+    private var flushInterval: Duration {
+        NSApp.isActive ? .milliseconds(250) : .seconds(1)
     }
 
     private func scheduleFlush() {
         guard flushTask == nil else { return }
+        let interval = flushInterval
         flushTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(16))
+            try? await Task.sleep(for: interval)
             guard let self, !Task.isCancelled else { return }
             self.flushPending()
         }
@@ -859,6 +951,7 @@ final class JSConsoleSession {
         guard !pendingEntries.isEmpty else { return }
         let batch = pendingEntries
         pendingEntries.removeAll(keepingCapacity: true)
+        pendingBytes = 0
         PerfLog.measure(PerfLog.console, "flush \(batch.count) entries into \(buffer.filtered.count)") {
             appendEntries(batch)
         }
@@ -881,6 +974,7 @@ final class JSConsoleSession {
         flushTask?.cancel()
         flushTask = nil
         pendingEntries.removeAll(keepingCapacity: true)
+        pendingBytes = 0
         buffer.removeAll()
         findMatchIDs = []
     }
@@ -2269,6 +2363,7 @@ extension EnvironmentValues {
 
 /// Syntax-colored `Text` for a value's tokens, with find matches highlighted
 /// and http(s) URLs linkified. Bounded to `jsDisplayCharacterLimit` characters.
+@MainActor
 func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool, underlineLinks: Bool = false) -> Text {
     var attr = AttributedString()
     var remaining = jsDisplayCharacterLimit
@@ -2297,6 +2392,7 @@ func coloredTokenText(_ tokens: [JSToken], query: String, current: Bool, underli
 /// A single-color `Text` (input/notice/error lines) with find matches
 /// highlighted and http(s) URLs linkified. Bounded to
 /// `jsDisplayCharacterLimit` characters.
+@MainActor
 func highlightedText(
     _ string: String, query: String, base: Color, current: Bool = false, underlineLinks: Bool = false
 ) -> Text {
@@ -2318,10 +2414,12 @@ func highlightedText(
 /// browser. Detection — including the explicit-scheme guard and the
 /// UTF-16 → Character offset mapping — is `ConsoleLinkDetector` (pure, tested
 /// in ADBKit); this only applies the SwiftUI attributes at the returned
-/// offsets.
+/// offsets, and reads detection through `ConsoleLinkSpanMemo` so a row's
+/// re-renders don't re-run `NSDataDetector` on unchanged text.
+@MainActor
 func applyLinkAttributes(_ attr: inout AttributedString, underlined: Bool) {
     let plain = String(attr.characters)
-    for span in ConsoleLinkDetector.linkSpans(in: plain) {
+    for span in ConsoleLinkSpanMemo.spans(in: plain) {
         let lower = attr.index(attr.startIndex, offsetByCharacters: span.start)
         let upper = attr.index(lower, offsetByCharacters: span.count)
         attr[lower ..< upper].link = span.url

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -409,8 +409,9 @@ final class JSConsoleSession {
             ingestPerMinute: ConsoleRateBucket.decade(perMinute)
         )
         guard snapshot != publishedDiagnostics else { return }
-        if let previous = publishedDiagnostics, snapshot.ingestPerMinute > previous.ingestPerMinute,
-           snapshot.ingestPerMinute >= 1000 {
+        if ConsoleRateBucket.isBurst(
+            from: publishedDiagnostics?.ingestPerMinute, to: snapshot.ingestPerMinute
+        ) {
             Telemetry.shared.breadcrumb(
                 category: "js-console", "stream burst: ~\(snapshot.ingestPerMinute)/min")
         }

--- a/App/Sources/Telemetry/PerformanceMonitor.swift
+++ b/App/Sources/Telemetry/PerformanceMonitor.swift
@@ -33,7 +33,8 @@ final class PerformanceMonitor {
     private static let mirrorCPULimitPercent: Double = 450
 
     /// Whether a CPU-intensive feature is on screen (focused or open in either
-    /// pane), so CPU-overuse incidents should be waived for this sample.
+    /// pane), so this sample is judged against the raised mirror limit
+    /// instead of the base one.
     private static func cpuExpectedHigh(_ context: FeatureContext) -> Bool {
         if let active = context.activeFeature, cpuIntensiveFeatures.contains(active) { return true }
         return context.openFeatures.contains { cpuIntensiveFeatures.contains($0) }

--- a/App/Sources/Telemetry/PerformanceMonitor.swift
+++ b/App/Sources/Telemetry/PerformanceMonitor.swift
@@ -20,10 +20,17 @@ final class PerformanceMonitor {
 
     /// Features that legitimately peg the CPU while on screen: live screen
     /// mirroring and recording both decode H.264 in-process, so ~two busy cores
-    /// is expected, not an incident. CPU overuse is not reported while one of
-    /// these is on screen; the per-feature baseline (`feature_perf`) still
-    /// records it, and memory is watched regardless.
+    /// is expected, not an incident. CPU overuse gets a raised limit — not a
+    /// waiver — while one of these is open; the per-feature baseline
+    /// (`feature_perf`) still records it, and memory is watched regardless.
     private static let cpuIntensiveFeatures: Set<String> = ["scrcpy", "screen-record"]
+
+    /// The raised CPU limit while a mirror feature is open. The old waiver
+    /// was `.infinity`, which made the v3.1.0 mirror-session leak invisible:
+    /// a user burned 250%+ for hours with a scrcpy tab open and telemetry
+    /// never fired an incident. Healthy mirroring is ~two busy cores; well
+    /// past four sustained is a leak, and it must report.
+    private static let mirrorCPULimitPercent: Double = 450
 
     /// Whether a CPU-intensive feature is on screen (focused or open in either
     /// pane), so CPU-overuse incidents should be waived for this sample.
@@ -48,7 +55,7 @@ final class PerformanceMonitor {
                 guard let self else { return }
                 guard let sample = ProcessStats.sample() else { continue }
                 let context = context()
-                let cpuLimitOverride = Self.cpuExpectedHigh(context) ? Double.infinity : nil
+                let cpuLimitOverride = Self.cpuExpectedHigh(context) ? Self.mirrorCPULimitPercent : nil
                 for event in self.watchdog.ingest(sample, cpuLimitOverride: cpuLimitOverride) {
                     Telemetry.shared.reportResourceEvent(event, context: context)
                 }

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import AppKit
 import Foundation
 import PostHog
 import Sentry
@@ -58,6 +59,80 @@ final class Telemetry {
     func start() {
         if crashReportingEnabled { startSentry() }
         if analyticsEnabled { startAnalytics() }
+        trackAppActivity()
+    }
+
+    /// Keep an `app_active` flag on every event from both sinks. Hangs and
+    /// perf incidents that fire while the user is in another app are a
+    /// different bug class (work running behind the user's back) than ones
+    /// mid-interaction — this one flag separates them at a glance, where
+    /// before it took manually correlating event sequences.
+    private func trackAppActivity() {
+        let update: @MainActor (Bool) -> Void = { [weak self] active in
+            guard let self else { return }
+            if self.crashReportingEnabled, self.sentryRunning {
+                SentrySDK.configureScope { $0.setTag(value: active ? "true" : "false", key: "app_active") }
+            }
+            if self.analyticsEnabled, self.postHogReady {
+                PostHogSDK.shared.register(["app_active": active])
+            }
+        }
+        update(NSApp.isActive)
+        for (name, active) in [
+            (NSApplication.didBecomeActiveNotification, true),
+            (NSApplication.didResignActiveNotification, false),
+        ] {
+            NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in
+                // The observer queue is main; hop is compile-time ceremony.
+                MainActor.assumeIsolated { update(active) }
+            }
+        }
+    }
+
+    // MARK: - Diagnostic context
+
+    /// PostHog super-property names registered per diagnostic key, so clearing
+    /// a context unregisters exactly what it registered.
+    private var diagnosticKeys: [String: [String]] = [:]
+
+    /// Attach always-on diagnostic state that rides every *subsequent* event
+    /// on both sinks — a Sentry context block and prefixed PostHog
+    /// super-properties. Costs no extra event volume: the values only ship
+    /// attached to events that were being sent anyway (hangs, crashes, perf
+    /// incidents), which is what makes root causes readable from a single
+    /// event on the free plans. Pass nil to clear. Callers should publish on
+    /// state *changes*, not on a hot path — every call crosses both SDKs.
+    func setDiagnosticContext(_ key: String, _ values: [String: Any]?) {
+        if crashReportingEnabled, sentryRunning {
+            SentrySDK.configureScope { scope in
+                if let values {
+                    scope.setContext(value: values, key: key)
+                } else {
+                    scope.removeContext(key: key)
+                }
+            }
+        }
+        guard analyticsEnabled, postHogReady else { return }
+        if let values {
+            var flat: [String: Any] = [:]
+            for (name, value) in values { flat["\(key)_\(name)"] = value }
+            diagnosticKeys[key] = Array(flat.keys)
+            PostHogSDK.shared.register(flat)
+        } else {
+            for name in diagnosticKeys.removeValue(forKey: key) ?? [] {
+                PostHogSDK.shared.unregister(name)
+            }
+        }
+    }
+
+    /// A Sentry breadcrumb — free until an event ships, then it's the
+    /// timeline explaining that event. For state transitions worth seeing
+    /// leading up to a hang or crash (session connects, bursts, teardowns).
+    func breadcrumb(category: String, _ message: String) {
+        guard crashReportingEnabled, sentryRunning else { return }
+        let crumb = Breadcrumb(level: .info, category: category)
+        crumb.message = message
+        SentrySDK.addBreadcrumb(crumb)
     }
 
     func setCrashReporting(_ enabled: Bool) {

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -112,13 +112,18 @@ final class Telemetry {
                 }
             }
         }
-        guard analyticsEnabled, postHogReady else { return }
         if let values {
+            guard analyticsEnabled, postHogReady else { return }
             var flat: [String: Any] = [:]
             for (name, value) in values { flat["\(key)_\(name)"] = value }
             diagnosticKeys[key] = Array(flat.keys)
             PostHogSDK.shared.register(flat)
-        } else {
+        } else if postHogReady {
+            // Clearing is deliberately not gated on the consent toggle:
+            // super-properties persist in the SDK across opt-out/opt-in, so
+            // a clear that lands while opted out must still unregister —
+            // otherwise a re-opt-in resurrects a dead session's context on
+            // every event.
             for name in diagnosticKeys.removeValue(forKey: key) ?? [] {
                 PostHogSDK.shared.unregister(name)
             }

--- a/App/Tests/ConsoleLinkSpanMemoTests.swift
+++ b/App/Tests/ConsoleLinkSpanMemoTests.swift
@@ -1,0 +1,36 @@
+import ADBKit
+import Testing
+
+/// The memo must be invisible to callers: same spans as direct detection,
+/// stable across repeated calls, and correct straight through an eviction.
+@MainActor
+@Suite struct ConsoleLinkSpanMemoTests {
+    @Test func matchesDirectDetection() {
+        let samples = [
+            "loading http://localhost:8081/index.bundle done",
+            "no links in this line",
+            "two: https://react.dev and http://example.com/a?b=1",
+            "emoji 🚀 before https://example.com shifts offsets",
+        ]
+        for text in samples {
+            #expect(ConsoleLinkSpanMemo.spans(in: text) == ConsoleLinkDetector.linkSpans(in: text))
+        }
+    }
+
+    @Test func repeatedCallsReturnTheSameSpans() {
+        let text = "bundle at http://localhost:8081/index.bundle?platform=android"
+        let first = ConsoleLinkSpanMemo.spans(in: text)
+        #expect(ConsoleLinkSpanMemo.spans(in: text) == first)
+        #expect(!first.isEmpty)
+    }
+
+    @Test func survivesEviction() {
+        let text = "kept: https://example.com/kept"
+        let before = ConsoleLinkSpanMemo.spans(in: text)
+        // Overflow the cache so it clears wholesale, then re-ask.
+        for index in 0 ..< (ConsoleLinkSpanMemo.capacity + 1) {
+            _ = ConsoleLinkSpanMemo.spans(in: "filler line \(index) http://example.com/\(index)")
+        }
+        #expect(ConsoleLinkSpanMemo.spans(in: text) == before)
+    }
+}

--- a/App/Tests/ConsoleLinkSpanMemoTests.swift
+++ b/App/Tests/ConsoleLinkSpanMemoTests.swift
@@ -47,13 +47,15 @@ import Testing
     }
 
     @Test func clearsWholesaleAtCapacity() {
-        // Fill to at least capacity, then one more insert must clear first —
-        // the count right after is 1 (just the newest entry), never above
-        // capacity.
-        for index in 0 ..< ConsoleLinkSpanMemo.capacity {
+        // Top the cache up to exactly capacity (other tests may have left
+        // entries behind — the count, not the iteration total, is what
+        // arms the clear), then one more insert must clear wholesale and
+        // leave only itself.
+        var index = 0
+        while ConsoleLinkSpanMemo.cachedTextCount < ConsoleLinkSpanMemo.capacity {
             _ = ConsoleLinkSpanMemo.spans(in: "fill-\(#function)-\(index)")
+            index += 1
         }
-        #expect(ConsoleLinkSpanMemo.cachedTextCount <= ConsoleLinkSpanMemo.capacity)
         _ = ConsoleLinkSpanMemo.spans(in: "overflow-\(#function)")
         #expect(ConsoleLinkSpanMemo.cachedTextCount == 1)
     }

--- a/App/Tests/ConsoleLinkSpanMemoTests.swift
+++ b/App/Tests/ConsoleLinkSpanMemoTests.swift
@@ -33,4 +33,28 @@ import Testing
         }
         #expect(ConsoleLinkSpanMemo.spans(in: text) == before)
     }
+
+    /// Transparency also holds for a no-op cache — these two pin the memo's
+    /// actual point: entries are stored (not recomputed) and the store stays
+    /// bounded by the wholesale clear.
+    @Test func storesEachTextOnceAndRepeatsDoNotGrowIt() {
+        let text = "unique-\(#function) https://example.com/memo"
+        let before = ConsoleLinkSpanMemo.cachedTextCount
+        _ = ConsoleLinkSpanMemo.spans(in: text)
+        #expect(ConsoleLinkSpanMemo.cachedTextCount == before + 1)
+        _ = ConsoleLinkSpanMemo.spans(in: text)
+        #expect(ConsoleLinkSpanMemo.cachedTextCount == before + 1)
+    }
+
+    @Test func clearsWholesaleAtCapacity() {
+        // Fill to at least capacity, then one more insert must clear first —
+        // the count right after is 1 (just the newest entry), never above
+        // capacity.
+        for index in 0 ..< ConsoleLinkSpanMemo.capacity {
+            _ = ConsoleLinkSpanMemo.spans(in: "fill-\(#function)-\(index)")
+        }
+        #expect(ConsoleLinkSpanMemo.cachedTextCount <= ConsoleLinkSpanMemo.capacity)
+        _ = ConsoleLinkSpanMemo.spans(in: "overflow-\(#function)")
+        #expect(ConsoleLinkSpanMemo.cachedTextCount == 1)
+    }
 }

--- a/App/Tests/ConsoleRateBucketTests.swift
+++ b/App/Tests/ConsoleRateBucketTests.swift
@@ -1,0 +1,25 @@
+import Testing
+
+/// The ingest-rate decade bucket: 0 below one per minute, then 1, 10, 100…
+/// The [1, 10) → 1 rung is the easy one to get wrong (it isn't in the
+/// "10, 100, 1000" mental model), and the exact rung edges are what keep
+/// the diagnostic context from re-publishing on rate noise.
+@Suite struct ConsoleRateBucketTests {
+    @Test func quietStreamsBucketToZero() {
+        #expect(ConsoleRateBucket.decade(0) == 0)
+        #expect(ConsoleRateBucket.decade(0.9) == 0)
+    }
+
+    @Test func singleDigitRatesBucketToOne() {
+        #expect(ConsoleRateBucket.decade(1) == 1)
+        #expect(ConsoleRateBucket.decade(9.99) == 1)
+    }
+
+    @Test func edgesLandOnTheirOwnDecade() {
+        #expect(ConsoleRateBucket.decade(10) == 10)
+        #expect(ConsoleRateBucket.decade(99) == 10)
+        #expect(ConsoleRateBucket.decade(100) == 100)
+        #expect(ConsoleRateBucket.decade(1234) == 1000)
+        #expect(ConsoleRateBucket.decade(60000) == 10000)
+    }
+}

--- a/App/Tests/ConsoleRateBucketTests.swift
+++ b/App/Tests/ConsoleRateBucketTests.swift
@@ -22,4 +22,23 @@ import Testing
         #expect(ConsoleRateBucket.decade(1234) == 1000)
         #expect(ConsoleRateBucket.decade(60000) == 10000)
     }
+
+    // A burst breadcrumb fires only on a rise that reaches the floor — the
+    // first publish, a steady rate, and a falling rate must all stay quiet.
+
+    @Test func risesToTheFloorAndAboveAreBursts() {
+        #expect(ConsoleRateBucket.isBurst(from: 100, to: 1000))
+        #expect(ConsoleRateBucket.isBurst(from: 1000, to: 10000))
+        #expect(ConsoleRateBucket.isBurst(from: 0, to: 1000))
+    }
+
+    @Test func firstPublishIsBaselineNotABurst() {
+        #expect(!ConsoleRateBucket.isBurst(from: nil, to: 10000))
+    }
+
+    @Test func steadyFallingAndSmallRatesAreNotBursts() {
+        #expect(!ConsoleRateBucket.isBurst(from: 1000, to: 1000))
+        #expect(!ConsoleRateBucket.isBurst(from: 10000, to: 1000))
+        #expect(!ConsoleRateBucket.isBurst(from: 10, to: 100))
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -163,6 +163,7 @@ targets:
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
       - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
+      - App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
       - App/Sources/Updates/ReleaseNotesStyler.swift
     dependencies:
       # Theme.swift's fill styles call into WindowEffects (ADBKit).

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,7 @@ targets:
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
+      - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
       - App/Sources/Updates/ReleaseNotesStyler.swift
     dependencies:
       # Theme.swift's fill styles call into WindowEffects (ADBKit).


### PR DESCRIPTION
## What

Investigation of today's hang burst (99 app hangs from one 3.7.0 user in a morning, all with `js-console` active — [DROIDECTIVE-MAC-2N](https://ro-is.sentry.io/issues/DROIDECTIVE-MAC-2N), plus MAC-42/MAC-49) found three compounding causes in the JS console feed:

1. **16 ms flush cadence** — every flush re-diffs the 2000-row `ForEach`, so a chatty Metro stream drove up to 60 full feed diffs per second on the main thread (the hang stacks sit in `ForEachState.update` over the `JSEntry` array).
2. **Per-render link detection** — every visible row re-ran `NSDataDetector` (up to 10k chars) on each render; Metro logs are URL-dense so the `contains("://")" fast path rarely skips.
3. **Full-rate rendering while inactive** — hang events landed while the app was backgrounded; the stream renders whether or not anyone is looking (the "CPU stays high after I stop using it" report on current builds).

## How

- Flushes pace at **250 ms while active** (logcat's v3.6.1 precedent) and **1 s while the app is inactive**. Entries accumulate between flushes — only rendering is paced — and a pending batch reaching a quarter of the buffer's byte budget flushes early so memory stays bounded.
- **`ConsoleLinkSpanMemo`** caches link spans by row text (immutable entries → steady-state all hits), cleared wholesale at capacity. AppTests cover parity with direct detection, repeat-call stability, and eviction.
- **Telemetry: root cause readable from one event, no extra volume.** `Telemetry.setDiagnosticContext` attaches always-on context to both sinks (Sentry context block + PostHog super-properties — they ride events already being sent, so free-plan quotas are untouched). The console publishes its stream shape (connected, buffered entries, ingest/min decade bucket) from the 2 s discovery pass, only on change; every event also carries `app_active`, and Sentry gets js-console connect/close/burst breadcrumbs.
- **The mirror CPU waiver is now a raised 450% limit, not `.infinity`** — the unbounded waiver is why the v3.1.0 mirror-session leak (258% CPU for hours with a scrcpy tab open) never fired a single `app_perf_incident`. Healthy mirroring is ~2 cores; sustained 4.5+ is a leak and now reports.

Fixes DROIDECTIVE-MAC-2N
Fixes DROIDECTIVE-MAC-49

## Verification

- AppTests: 53 tests pass, including the new `ConsoleLinkSpanMemoTests`.
- `xcodebuild` Debug build succeeds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)