### PR TITLE
Drop stale writes from cancelled view load tasks

### DIFF
--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -120,6 +120,8 @@ struct DeepLinksSection: View {
             return
         }
         let map = await state.env.stores.deepLinks.load()
+        // A re-keyed task (the bundle changed) must not land the old app's links.
+        guard !Task.isCancelled else { return }
         links = map[bundleId] ?? []
     }
 

--- a/App/Sources/FeatureDetail/Views/FridaConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/FridaConsoleView.swift
@@ -73,9 +73,15 @@ struct FridaConsoleView: View {
     private func refresh() async {
         guard let serial else { return }
         do {
-            arch = try await state.env.engine.frida.deviceArch(serial: serial)
-            serverRunning = try await state.env.engine.frida.isServerRunning(serial: serial)
+            // Both probes complete before anything is published, so a re-keyed
+            // task (the device changed) writes neither half.
+            let deviceArch = try await state.env.engine.frida.deviceArch(serial: serial)
+            let running = try await state.env.engine.frida.isServerRunning(serial: serial)
+            guard !Task.isCancelled else { return }
+            arch = deviceArch
+            serverRunning = running
         } catch {
+            guard !Task.isCancelled else { return }
             status = error.localizedDescription
         }
     }

--- a/App/Sources/FeatureDetail/Views/RecordingDecision.swift
+++ b/App/Sources/FeatureDetail/Views/RecordingDecision.swift
@@ -79,6 +79,8 @@ private struct RecordingDecisionModifier: ViewModifier {
         let data = await VideoEditService(
             locator: state.env.client.locator, bundledPath: BundledTools.ffmpegPath()
         ).thumbnail(of: url)
+        // A re-keyed task (a different recording) must not land this frame.
+        guard !Task.isCancelled else { return }
         thumbnail = data.flatMap(NSImage.init(data:))
         loadingThumbnail = false
     }

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -496,10 +496,13 @@ struct VideoEditorPane: View {
     // MARK: loading + export
 
     private func loadAsset() async {
-        if let size = await Self.naturalVideoSize(at: source.url) {
-            videoSize = size
-        }
-        if let loaded = try? await asset.load(.duration) { assetDuration = loaded.seconds }
+        let size = await Self.naturalVideoSize(at: source.url)
+        let loaded = try? await asset.load(.duration)
+        // Both probes complete before anything is published, so a re-keyed task
+        // (a different video) writes none of this one's metadata.
+        guard !Task.isCancelled else { return }
+        if let size { videoSize = size }
+        if let loaded { assetDuration = loaded.seconds }
         player.isMuted = edit.mute
     }
 


### PR DESCRIPTION
## Use case

Four panes reload themselves when their subject changes, via `.task(id:)`:

- **Deep Links** (standalone screen and the React Native hub) — switching the selected app in the bundle bar re-keys on `state.selectedBundleId` and reloads that app's saved links.
- **Frida console** — switching the selected device re-keys on `targetSerials.first` and re-probes the device architecture and whether frida-server is running.
- **Recording decision sheet** — changing the pending recording re-keys on the URL and renders a new preview frame through ffmpeg.
- **Video editor** — loading a different video re-keys on `source.url` and reads the oriented natural size and duration.

## User impact

After a fast switch, the pane could intermittently show the previous subject's data: deep links belonging to the app you just switched away from, or an architecture and frida-server status read off the previous device. The recording sheet could show the previous clip's frame, and the video editor could size its crop overlay and trim summary from the previous video.

It self-corrects — the next switch re-runs the load and the newer result usually lands last — which is exactly why it is hard to catch by hand. It needs the slow probe (an `adb shell` round trip, an ffmpeg spawn, an `AVAsset` track load) to finish *after* the newer task has already written, so it shows up as an occasional wrong-looking pane rather than a reproducible failure.

## The bug

Swift task cancellation is cooperative. When the id changes, SwiftUI cancels the old task and starts the new one, but the old task keeps running until it next checks for cancellation. None of these functions checked, so the interleaving

```
A: await …            B: await …
                      B: write B's data
A: write A's data     ← lands last
```

leaves A's data on screen while B is selected. This is not a data race — everything here is `@MainActor` — it is purely staleness.

`CLAUDE.md` already documents the convention ("Guard `!Task.isCancelled` before writing fetched results into @State"), and 24 of the 29 files using `.task(id:)` follow it. This brings the outliers in line.

## The fix

A `guard !Task.isCancelled else { return }` between the await and the state write in each case.

- **`DeepLinksView.swift`** — guard after `stores.deepLinks.load()`, before assigning `links`. One await, one write.
- **`FridaConsoleView.swift`** — `refresh()` made two awaits and assigned as it went, so a cancelled task could publish `arch` from one device and `serverRunning` from another. Both probes now bind to locals, and one guard sits ahead of both assignments, so a cancelled task writes neither half. The `catch` gets its own guard: cancellation surfaces here as a thrown error, and without it a cancelled task would replace the incoming device's status line with the outgoing device's failure text.
- **`RecordingDecision.swift`** — guard after `VideoEditService.thumbnail(of:)`, before assigning `thumbnail` and clearing `loadingThumbnail`. Both writes sit behind the one guard, so a cancelled task cannot flip the sheet out of its loading state with the wrong frame.
- **`VideoEditorPane.swift`** — `loadAsset()` also interleaved awaits and writes. `naturalVideoSize` and the duration load bind to locals first and one guard precedes `videoSize` / `assetDuration`, so a cancelled task cannot leave the pane with one video's size and another's duration.

### `DeviceBarView.swift` — left unchanged

`DeviceBarView`'s `.task(id:)` calls `state.refreshAvds()` and `state.refreshSimulators()`, which are the fifth candidate. I left it alone for three reasons:

1. **A guard in the view cannot prevent the stale write.** The writes are inside the `AppState` methods (`availableAvds = await …emulators.listAvds(devices:)`, `availableSimulators = SimulatorListParser.quickPicks(await …)`). A guard between the two calls in the view would only skip the second call; the first call's write has already happened by the time control returns. Fixing this would mean editing `AppState+Emulators.swift`.
2. **The data is not selection-scoped, so the stale-pane symptom does not arise.** `availableAvds` / `availableSimulators` are host-wide lists of what is installed on the Mac, not per-device data. The task key is the connected device set, and the only part of the payload that depends on it is `Avd.runningSerial` tagging. There is no "shows A's content while B is selected" failure here.
3. **The property has four other writers that are not cancellable**, so a guard in one of five would not establish ordering. `refreshAvds()` is also called from `AppState.setQuickPanelOpen`, `AppState.chooseRole`, `AppState.stopEmulator`, and `QuickActionsView.loadScreen`, all from unstructured `Task {}`s where `Task.isCancelled` is always false. `availableAvds` is last-writer-wins across those regardless.

The `AppState` methods do not guard internally, so this is not redundancy — it is a different problem (concurrent writers to shared `@Observable` state, whose worst case is a launch row briefly mis-tagged as stopped) that belongs in its own change weighed across all five call sites, not a symmetry edit here.

## Verification

- `make build` — succeeds warning-free (`SWIFT_TREAT_WARNINGS_AS_ERRORS: YES` on the App target, so a warning would fail the build).
- `cd ADBKit && swift test` — 1110 tests in 145 suites pass.
- `xcodebuild test -scheme AppTests` — 65 tests in 9 suites pass.

**Testing limitation, stated plainly: no test exercises these guards, and the change is verified by compilation plus the reasoning above.** All four functions are `private` methods on `View`/`ViewModifier` types that read `@Environment(AppState.self)` and write `@State`. The `AppTests` bundle is a logic-test target that compiles a short allowlist of pure App sources (`LaunchPrompt`, `Theme`, `MirrorTabPolicy`, `TourPaging`, …) with no app host; adding these files to it would pull in `AppState` and most of the view layer, and there would still be no way to drive SwiftUI's `.task(id:)` cancellation from a unit test. Reaching the guards would mean extracting each loader into a separate injectable type — restructuring the views to make a one-line guard testable, which is more risk than the fix. I would rather say so than add a test that constructs its own `Task`, cancels it, and asserts on a check the view never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
