### PR TITLE
Show ffmpeg's error instead of its progress on failure

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
@@ -187,7 +187,7 @@ public actor ScreenRecorder {
         try? FileManager.default.removeItem(at: listURL)
         for url in segments { try? FileManager.default.removeItem(at: url) }
         guard result.exitCode == 0 else {
-            let tail = result.stderrText.split(separator: "\n").suffix(3).joined(separator: "\n")
+            let tail = VideoEditing.stderrTail(result.stderrText)
             throw RecordingError.concatFailed(tail.isEmpty ? "ffmpeg failed" : tail)
         }
         return output

--- a/ADBKit/Sources/ADBKit/Services/VideoEditService.swift
+++ b/ADBKit/Sources/ADBKit/Services/VideoEditService.swift
@@ -81,7 +81,7 @@ public actor VideoEditService {
 
     private func failureMessage(_ output: ProcessOutput) -> String {
         if output.timedOut { return "Export timed out." }
-        let tail = output.stderrText.split(separator: "\n").suffix(3).joined(separator: "\n")
+        let tail = VideoEditing.stderrTail(output.stderrText)
         return tail.isEmpty ? "ffmpeg export failed." : "ffmpeg export failed:\n\(tail)"
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/VideoEditing.swift
+++ b/ADBKit/Sources/ADBKit/Services/VideoEditing.swift
@@ -100,8 +100,9 @@ public struct VideoExportOptions: Sendable, Equatable {
     var normalizedRotation: Int { ((rotationDegrees % 360) + 360) % 360 }
 }
 
-/// Pure ffmpeg argument builder — the test seam for the video editor. UI picks
-/// `VideoExportOptions`; this turns them into an ffmpeg invocation.
+/// Pure ffmpeg argument builder and stderr reader — the test seam for the video
+/// editor. UI picks `VideoExportOptions`; this turns them into an ffmpeg
+/// invocation, and turns a failed run's stderr into a message worth showing.
 public enum VideoEditing {
     /// ffmpeg arguments (excluding the `ffmpeg` executable itself) that apply
     /// `options` to `input` and write `output`.
@@ -144,6 +145,27 @@ public enum VideoEditing {
             "-f", "concat", "-safe", "0", "-i", listFile,
             "-c", "copy", "-movflags", "+faststart", "-y", output,
         ]
+    }
+
+    /// The last `lines` non-blank lines of an ffmpeg stderr dump — the reason a
+    /// run failed, for a user-facing message.
+    ///
+    /// ffmpeg ends each progress update with a carriage return so they overwrite
+    /// one terminal line, which makes `"\n"` the wrong separator: the whole
+    /// `\r`-packed progress blob is a single `"\n"` component and swallows the
+    /// error text that follows. `.newlines` breaks on `\r`, `\n`, and CRLF
+    /// alike; the blank-line filter drops the empty components CRLF leaves
+    /// behind as well as a trailing newline's.
+    ///
+    /// - Parameters:
+    ///   - stderr: raw stderr as ffmpeg wrote it.
+    ///   - lines: how many trailing lines to keep.
+    /// - Returns: the lines joined by `"\n"`, or `""` when there is no output.
+    public static func stderrTail(_ stderr: String, lines: Int = 3) -> String {
+        stderr.components(separatedBy: .newlines)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .suffix(lines)
+            .joined(separator: "\n")
     }
 
     /// Input-side `-ss`/`-t` so trimming composes correctly with speed changes

--- a/ADBKit/Tests/ADBKitTests/VideoEditingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/VideoEditingTests.swift
@@ -213,6 +213,93 @@ import Testing
         #expect(complex?.contains("scale=320:-1:flags=lanczos") == true)
     }
 
+    // MARK: stderr tail
+
+    /// ffmpeg's progress updates are `\r`-separated so they overwrite one
+    /// terminal line — the error that follows them must still be what surfaces.
+    @Test func stderrTailKeepsTheErrorAfterCarriageReturnProgress() {
+        let stderr = """
+        ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers
+          Stream #0:0: Video: h264 (avc1 / 0x31637661), yuv420p, 1080x2400
+
+        """
+            + "frame=   12 fps=0.0 q=28.0 size=     0kB time=00:00:00.00 bitrate=N/A speed=   0x\r"
+            + "frame=   48 fps= 47 q=28.0 size=     0kB time=00:00:01.16 bitrate=0.3kbits/s\r"
+            + "frame=   96 fps= 63 q=28.0 size=   256kB time=00:00:02.76 bitrate=759.0kbits/s\r"
+            + """
+            [out#0/mp4 @ 0x14e004a80] Error muxing a packet
+            [out#0/mp4 @ 0x14e004a80] Error writing trailer: No space left on device
+            Conversion failed!
+
+            """
+
+        #expect(VideoEditing.stderrTail(stderr) == """
+        [out#0/mp4 @ 0x14e004a80] Error muxing a packet
+        [out#0/mp4 @ 0x14e004a80] Error writing trailer: No space left on device
+        Conversion failed!
+        """)
+        #expect(!VideoEditing.stderrTail(stderr).contains("frame="))
+    }
+
+    /// Progress alone still yields the last updates rather than one giant blob.
+    @Test func stderrTailSplitsCarriageReturnOnlyOutput() {
+        let stderr = "frame=  1 fps=0.0\rframe= 30 fps=29\rframe= 60 fps=30\rframe= 90 fps=31\r"
+        #expect(VideoEditing.stderrTail(stderr) == """
+        frame= 30 fps=29
+        frame= 60 fps=30
+        frame= 90 fps=31
+        """)
+    }
+
+    /// `"\r\n"` is one Swift Character, so `split(separator: "\n")` never fires
+    /// on CRLF — the Windows/Linux port's ffmpeg writes it.
+    @Test func stderrTailHandlesCRLF() {
+        let stderr = "ffmpeg version 6.1.1\r\nInput #0, mp4\r\n  Duration: 00:00:12.34\r\n"
+            + "Error opening output file /out.mp4.\r\n"
+        #expect(VideoEditing.stderrTail(stderr) == """
+        Input #0, mp4
+          Duration: 00:00:12.34
+        Error opening output file /out.mp4.
+        """)
+    }
+
+    @Test func stderrTailHandlesLF() {
+        let stderr = "ffmpeg version 6.1.1\nInput #0, mp4\n  Duration: 00:00:12.34\n"
+            + "Error opening output file /out.mp4."
+        #expect(VideoEditing.stderrTail(stderr) == """
+        Input #0, mp4
+          Duration: 00:00:12.34
+        Error opening output file /out.mp4.
+        """)
+    }
+
+    /// The call sites fall back to a generic message on an empty tail.
+    @Test func stderrTailOfBlankOutputIsEmpty() {
+        #expect(VideoEditing.stderrTail("").isEmpty)
+        #expect(VideoEditing.stderrTail("\n\n\n").isEmpty)
+        #expect(VideoEditing.stderrTail("\r\n\r\n").isEmpty)
+        #expect(VideoEditing.stderrTail("   \n\t\n").isEmpty)
+    }
+
+    @Test func stderrTailReturnsEverythingBelowTheLimit() {
+        #expect(VideoEditing.stderrTail("only line") == "only line")
+        #expect(VideoEditing.stderrTail("first\nsecond") == "first\nsecond")
+    }
+
+    /// A trailing newline must not push a real line out of the tail, nor leave a
+    /// blank line at the end of the message.
+    @Test func stderrTailIgnoresATrailingNewline() {
+        #expect(VideoEditing.stderrTail("one\ntwo\nthree\n") == "one\ntwo\nthree")
+        #expect(VideoEditing.stderrTail("one\ntwo\nthree\r\n") == "one\ntwo\nthree")
+    }
+
+    @Test func stderrTailHonoursTheLineLimit() {
+        let stderr = "one\ntwo\nthree\nfour"
+        #expect(VideoEditing.stderrTail(stderr, lines: 1) == "four")
+        #expect(VideoEditing.stderrTail(stderr, lines: 2) == "three\nfour")
+        #expect(VideoEditing.stderrTail(stderr, lines: 10) == stderr)
+    }
+
     // MARK: combined ordering
 
     @Test func filterChainOrderIsCropRotateFlipScaleSpeed() {


### PR DESCRIPTION
## Use case

Two ffmpeg-backed flows in the app:

- **Exporting from the video editor** — Screen Record ▸ open a recording in the editor, trim/crop/rotate it or change the format, then Export. `VideoEditService.export` shells out to the bundled ffmpeg.
- **Stitching screen-recording segments** — pausing and resuming a recording produces one segment per run, and stopping concatenates them into a single file through ffmpeg's concat demuxer (`ScreenRecorder.concatenate`).

When either ffmpeg run exits non-zero, the app builds its error message from the tail of ffmpeg's stderr.

## User impact

The message the user gets is ffmpeg's progress counter, not the reason the run failed. An export that dies on "No space left on device" or an unwritable destination reports something like:

```
ffmpeg export failed:
frame=   12 fps=0.0 q=28.0 size=     0kB time=00:00:00.00 bitrate=N/A speed=   0xframe=   48 fps= 47 …
```

The actual `Error writing trailer: …` / `Conversion failed!` lines are cut off, so the failure can't be diagnosed from the dialog. The concat path shows the same blob with no prefix at all. This is a live bug on macOS today — the CRLF half of it also matters for the Windows/Linux port, where ffmpeg writes `\r\n`.

## The bug

Both sites built the tail by splitting on the literal `"\n"`:

- `ADBKit/Sources/ADBKit/Services/VideoEditService.swift:84` — in `private func failureMessage(_ output: ProcessOutput) -> String`
- `ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift:190` — in the concat-failure path

```swift
let tail = stderrText.split(separator: "\n").suffix(3).joined(separator: "\n")
```

ffmpeg terminates each progress update with a **carriage return**, not a newline, so the updates overwrite one terminal line. Splitting on `"\n"` never breaks between them: the entire `\r`-packed progress run plus the first error line arrive as **one** component, and `.suffix(3)` returns that blob instead of the error text.

The CRLF case is worse. `"\r\n"` is a single Swift `Character`, so `split(separator: "\n")` finds no separator at all and returns the whole stderr dump as one element:

```
"a\r\nb\r\nc\r\n".split(separator: "\n")  // ["a\r\nb\r\nc\r\n"]
```

CLAUDE.md already records this as a project-wide rule ("`\r\n` is ONE Swift Character … use `.components(separatedBy: .newlines)`"); these two sites predate it.

## The fix

A new pure static helper in `ADBKit/Sources/ADBKit/Services/VideoEditing.swift`:

```swift
public static func stderrTail(_ stderr: String, lines: Int = 3) -> String {
    stderr.components(separatedBy: .newlines)
        .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
        .suffix(lines)
        .joined(separator: "\n")
}
```

**Why `VideoEditing`** — it is the existing pure, static, already-tested namespace for the ffmpeg seam (`ffmpegArguments`, `concatArguments`, `remuxArguments`, `thumbnailArguments`), and both call sites already depend on it for their argument vectors. The logic was duplicated in two files and, in `VideoEditService`, sat inside a `private` method no test could reach. Moving it here deduplicates it and makes it directly testable, per the repo's "parsers are pure and static" convention. The enum's doc comment is updated to say it also reads stderr.

**Why `.newlines`** — `CharacterSet.newlines` contains `\r`, `\n`, `\u{85}`, and the Unicode line/paragraph separators, and `components(separatedBy:)` breaks on each. That covers all three shapes ffmpeg emits: `\r` between progress updates, `\n` on macOS/Linux, `\r\n` on Windows. It splits CRLF into two separators, leaving an empty component between them, which is why the blank-line filter is required rather than cosmetic — it also absorbs the empty trailing component a final newline produces, which previously consumed one of the three slots and left a blank line at the end of the message. `AabConvertService.failureSummary` already uses this same components-plus-filter shape.

**Both call sites** now read `VideoEditing.stderrTail(...)`:

- `VideoEditService.failureMessage` → `"ffmpeg export failed:\n\(tail)"`
- `ScreenRecorder.concatenate` → `RecordingError.concatFailed(tail)`

**Deliberately unchanged:** the `output.timedOut` → `"Export timed out."` early return; the generic fallbacks when the tail is empty (`"ffmpeg export failed."` and `"ffmpeg failed"`); the `"ffmpeg export failed:\n"` prefix; the three-line count; the `"\n"` join. No user-visible string changes beyond the tail content itself.

## Tests

8 tests added to `ADBKit/Tests/ADBKitTests/VideoEditingTests.swift`, covering:

- `\r`-separated progress followed by real error lines — asserts the three error lines are the exact result and that the tail contains no `frame=` progress text
- `\r`-only output (progress and nothing else) still splits into lines
- CRLF input
- LF input
- blank input — `""`, `"\n\n\n"`, `"\r\n\r\n"`, whitespace-only — all empty, which is what the call sites' fallbacks depend on
- fewer lines than the limit
- a trailing newline not displacing a real line or leaving a blank line
- the `lines:` limit at 1, 2, and above the available count

**Revert check.** With the helper body put back to `stderr.split(separator: "\n").suffix(lines).joined(separator: "\n")`, 5 of the 8 new tests fail with 7 recorded issues. The carriage-return test reported the bug verbatim — the tail came back as `"frame=   12 fps=0.0 … frame=   96 … [out#0/mp4 @ …] Error muxing a packet"`, one blob with the error text truncated. The CRLF test returned the whole dump starting at `ffmpeg version 6.1.1`. The three that still passed are the ones pinning behaviour this change preserves (LF input, sub-limit input, the line-count parameter). The helper was then restored and the suite re-run.

Full suite: **1118 tests pass** (1110 before). `swift build -Xswiftc -warnings-as-errors` clean; `make build` succeeds with no compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Correction after re-verification (2026-08-01)

Re-tested against the actual bundled ffmpeg (8.1.2) with stderr on a pipe, which
is how `SystemProcessRunner` captures it. Two claims above are too strong:

1. **The headline symptom is rarer than described.** On the common failure
   shapes — an encode error, an unwritable output path, a corrupt input — the
   old and new tails are **byte-identical**, because libx264's ~15 summary
   lines sit between the `\r`-packed progress blob and the error, so
   `.suffix(3)` never reaches the blob. Verified on three such runs.

   The blob only lands in the tail when ffmpeg dies abruptly mid-write with no
   encoder summary (reproduced with `ulimit -f`, SIGXFSZ): there the error text
   is glued to the progress line in the last component. Even then the new code
   still shows a progress line — it *separates* progress from error rather than
   removing the counter, so it delivers less than the title promises.

2. **The trailing-newline claim is wrong.** `split(separator:)` omits empty
   subsequences, so a trailing newline never consumed one of the three slots
   and never left a blank line. The blank-line filter is required by the new
   `components(separatedBy:)` spelling, which *does* produce empties — it is
   not a fix to the old behaviour.

**What remains solidly true, and why this is still worth merging:** the CRLF
half is real and verified — `"a\r\nb\r\nc\r\n".split(separator: "\n")`
returns the whole string as a single element, so the old code would show the
entire stderr dump on a host where ffmpeg writes CRLF. That is the
Windows/Linux port. Plus it dedupes the logic into a pure, tested helper that
was previously unreachable inside a `private` method.

Treat this as a portability fix with a small macOS readability win, not as a
live macOS bug fix.
