### PR TITLE
Guard NSApp access during App.init() so keyless builds launch

### DIFF
--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -77,7 +77,11 @@ final class Telemetry {
                 PostHogSDK.shared.register(["app_active": active])
             }
         }
-        update(NSApp.isActive)
+        // `NSApp` is an implicitly-unwrapped global that stays nil until
+        // NSApplication exists, and this runs from `ADTApp.init()` — which
+        // predates it. Optional-chain the seed: no app yet means not active
+        // yet, and `didBecomeActiveNotification` corrects it at launch.
+        update(NSApp?.isActive ?? false)
         for (name, active) in [
             (NSApplication.didBecomeActiveNotification, true),
             (NSApplication.didResignActiveNotification, false),

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 # Optional telemetry keys for local builds. Create .env.telemetry (gitignored)
 # with SENTRY_DSN=... and POSTHOG_KEY=... to enable crash/analytics locally.
-# Without it both stay empty, so neither SDK starts — fine for development.
+# Without it both stay empty, so neither SDK starts. That is a genuinely
+# different startup path from a keyed build — `SentrySDK.start` is what first
+# creates the shared NSApplication — and CI compiles the keyless path without
+# ever launching it, so keyless-only launch bugs can hide there.
 -include .env.telemetry
 TELEMETRY := SENTRY_DSN="$(SENTRY_DSN)" POSTHOG_KEY="$(POSTHOG_KEY)"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -167,7 +167,11 @@ POSTHOG_KEY=phc_…
 ```
 
 `make build` / `make dmg` pick it up automatically. Without it, local builds run
-with telemetry disabled — fine for development.
+with telemetry disabled — fine for development, but note it is a different
+startup path from a keyed release build: `SentrySDK.start` is what first creates
+the shared `NSApplication`, so with empty keys nothing has created it by the time
+the rest of `Telemetry.start()` runs. CI's `build` job compiles that keyless path
+and never launches it.
 
 Both are client-side write keys, safe to ship in the binary. Users get a one-time
 privacy disclosure on first launch, managed afterward in Settings → Privacy.


### PR DESCRIPTION
## Use case

Launching the app from a local build — the default onboarding path, `make build && make run`.

## User impact

Not user-facing. Released builds are unaffected; the maintainer downloaded and ran v3.7.1 and it launches normally.

What is broken is a build made **without telemetry keys**: a fresh clone with no `.env.telemetry` builds fine and then dies in milliseconds on launch, before any window appears:

```
Droidective/Telemetry.swift:80: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
```

Reproduces in Debug and Release, launched via `open` and via direct exec. That is every new contributor and any dev who has not set up keys.

## The bug

`NSApp` is an implicitly-unwrapped `NSApplication!` global that stays nil until NSApplication exists. `Telemetry.swift:80` read `NSApp.isActive` to seed the `app_active` flag, on an unconditional chain that runs before there is an app: `ADTApp.init()` (`App/Sources/ADTApp.swift:233`) → `Telemetry.shared.start()` → `trackAppActivity()` → line 80. Introduced in d40fb85 ("Pace the JS console feed and make incidents self-explanatory"), present in the `v3.7.1` tag.

**Why it depends on the telemetry keys** — this is the part that explains everything else. `start()` calls `startSentry()` before `trackAppActivity()`. With a real DSN, `SentrySDK.start` touches `NSApplication` on macOS, which creates the instance and populates the `NSApp` global, so the seed reads a live app. With empty keys `startSentry()` no-ops on the `sentryConfigured` guard, `NSApp` is still nil, and the implicit unwrap traps. I verified both directions with a temporary probe logging `NSApp == nil` at that exact line:

| build | at line 80 |
|---|---|
| no keys (`make build`, no `.env.telemetry`) | `nsapp=nil` — traps |
| `SENTRY_DSN=https://…@127.0.0.1/1` | `nsapp=live` — fine |

So the crash lives only in the configuration where telemetry is off.

## The fix

```swift
update(NSApp?.isActive ?? false)
```

Optional-chaining the IUO instead of unwrapping it. That spelling is also semantically right: during `App.init()` the app genuinely is not active yet, and the two observers registered immediately below (`didBecomeActiveNotification` / `didResignActiveNotification`) own the flag from then on.

Not `NSApplication.shared`: forcing the instance to exist from `App.init()` changes app startup ordering, which is a bigger change than the bug.

**Evidence `app_active` still becomes true.** With the fix and empty keys, a plain `open` launch probed at the seed and in both observers:

```
07:05:55 app_active=false nsapp=nil    ← seed, App.init()
07:05:56 app_active=true  nsapp=live   ← didBecomeActiveNotification, 1s later
07:06:00 app_active=false nsapp=live   ← didResignActive (focus left the app)
```

The flag is not stuck at `false`; it is seeded false for about a second and then tracks reality.

## Verification

- **Debug** (`make build`, no keys): builds warning-free, launches via `open`, still running after 15s, window rendered (Device Info against a connected emulator).
- **Release** (`-configuration Release -derivedDataPath /tmp/droid-release-fix CODE_SIGNING_ALLOWED=NO`): builds, launches, still running after 34s, window present via AX.
- **Crash reports**: none. `~/Library/Logs/DiagnosticReports/Droidective*.ips` is empty after four launches (two instrumented, one clean Debug, one Release).
- **Tests**: ADBKit 1110 tests in 145 suites passed. AppTests 65 tests in 9 suites passed.

No regression test. `Telemetry.swift` imports Sentry and PostHog and references the App-layer `PerformanceMonitor.FeatureContext`, so compiling it into the AppTests logic bundle means adding both packages plus more sources to that target; and the trap is a call site reading a global the test cannot make nil — reproducing it needs the seed extracted into a pure helper, i.e. restructuring for a test that asserts `?? false`. The durable guard is a launch smoke check in CI, not a unit test.

## Why CI missed it

CI's `build` job compiles the app and never launches it. Worse, it compiles *exactly* the crashing configuration: it passes no `SENTRY_DSN`/`POSTHOG_KEY` on purpose (`.github/workflows/ci.yml:36`, and RELEASING.md says so — throwaway builds, and fork PRs cannot read secrets). The `release` job does pass the secrets (line 138), which is why the shipped DMG works. So the keyless path is built by every PR, shipped by none, and launched by nothing.

The `AppTests` bundle cannot catch it either — it is a logic bundle with no app host and never instantiates `ADTApp`.

Follow-up worth doing (not in this PR): a smoke step in the `build` job that launches the built app with no keys, waits a few seconds, and fails if the process is gone. That is the only check that would have caught this.

Also corrected here: the Makefile and RELEASING.md notes next to `.env.telemetry` said keyless builds are "fine for development" with no further caveat. They are fine again with this fix, but they are a distinct startup path that CI compiles and never runs — both places now say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
