### PR TITLE
Stop the log tail and Settings from stalling the main thread

### DIFF
--- a/App/Sources/FeatureDetail/SelectableLogView.swift
+++ b/App/Sources/FeatureDetail/SelectableLogView.swift
@@ -42,7 +42,13 @@ struct SelectableLogView: NSViewRepresentable {
         // Head-trims measure the deleted height through the TextKit 1 layout
         // manager; touch it before any content lands so the view starts in
         // TextKit 1 instead of downgrading mid-stream.
-        _ = textView.layoutManager
+        //
+        // Non-contiguous layout is what keeps a long buffer affordable: regions
+        // that were never scrolled into carry an *estimated* height instead of
+        // being typeset, so an edit — and the tail scroll below — can read the
+        // document's total height without laying out every line
+        // (DROIDECTIVE-MAC-2Q).
+        textView.layoutManager?.allowsNonContiguousLayout = true
         textView.isEditable = false
         textView.isSelectable = true
         textView.drawsBackground = false
@@ -341,9 +347,28 @@ struct SelectableLogView: NSViewRepresentable {
             scrollView.reflectScrolledClipView(clip)
         }
 
+        /// Parks the viewport on the newest line of a bottom-anchored feed.
+        ///
+        /// Deliberately scrolls the clip view rather than calling
+        /// `scrollRangeToVisible` on the end of the storage. Asking the text
+        /// view to reveal the last character makes NSLayoutManager fill *every*
+        /// layout hole up to it, so a rebuild (filter change, order flip, a
+        /// cleared buffer) or a large append typeset the whole document on the
+        /// main thread — seconds of beachball on a long logcat, and the app's
+        /// single biggest hang (DROIDECTIVE-MAC-2Q, 67 events/9 users).
+        ///
+        /// The document's height already carries the estimate for unlaid
+        /// regions, and it is the very measure `measuredEdges` calls the
+        /// bottom — so the follow scroll and the edge state now agree instead
+        /// of one forcing layout the other never needed.
         private func scrollToBottom() {
-            guard let textView, let storage = textView.textStorage else { return }
-            textView.scrollRangeToVisible(NSRange(location: storage.length, length: 0))
+            guard let scrollView, let document = scrollView.documentView else { return }
+            let clip = scrollView.contentView
+            let bottom = TailGeometry(
+                contentHeight: document.frame.height, viewportHeight: clip.bounds.height
+            ).scrollRange
+            clip.scroll(to: NSPoint(x: clip.bounds.origin.x, y: bottom))
+            scrollView.reflectScrolledClipView(clip)
         }
 
         private func scrollToTop() {

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -108,9 +108,17 @@ struct GeneralSettingsView: View {
 
     /// True when the login item is registered (enabled, or pending the user's
     /// approval in System Settings).
-    private func loginItemRegistered() -> Bool {
-        let status = SMAppService.mainApp.status
-        return status == .enabled || status == .requiresApproval
+    ///
+    /// Runs off the main actor deliberately: `SMAppService.status` is a
+    /// synchronous round-trip to launchd, and on a cold or busy system it blocks
+    /// long enough to trip the 2 s hang detector — reading it from the General
+    /// tab's appearance stalled the whole app just for opening Settings
+    /// (DROIDECTIVE-MAC-4G).
+    private static func loginItemRegistered() async -> Bool {
+        await Task.detached {
+            let status = SMAppService.mainApp.status
+            return status == .enabled || status == .requiresApproval
+        }.value
     }
 
     /// Registers/unregisters the app as a macOS login item. The toggle is backed
@@ -136,7 +144,7 @@ struct GeneralSettingsView: View {
                     openAtLoginOn = enabled
                 } catch {
                     state.showToast(Toast(message: "Couldn't update Open at Login: \(error.localizedDescription)", ok: false))
-                    openAtLoginOn = loginItemRegistered()
+                    Task { openAtLoginOn = await Self.loginItemRegistered() }
                 }
             }
         )
@@ -275,7 +283,7 @@ struct GeneralSettingsView: View {
 
         }
         .formStyle(.grouped)
-        .onAppear { openAtLoginOn = loginItemRegistered() }
+        .task { openAtLoginOn = await Self.loginItemRegistered() }
     }
 }
 

--- a/App/Tests/TailGeometryTests.swift
+++ b/App/Tests/TailGeometryTests.swift
@@ -33,6 +33,18 @@ import Testing
         #expect(geo.scrollRange == 0)
     }
 
+    /// `scrollRange` doubles as the clip-view origin that parks a
+    /// bottom-anchored log on its newest line: `SelectableLogView.scrollToBottom`
+    /// reads it instead of asking TextKit to reveal the last character, which
+    /// typeset the whole buffer on the main thread (DROIDECTIVE-MAC-2Q). It must
+    /// clamp at zero — a negative origin would scroll above the document and
+    /// park the tail off-screen whenever the content is shorter than the pane.
+    @Test func scrollRangeIsTheBottomParkingOrigin() {
+        #expect(TailGeometry(contentHeight: 5000, viewportHeight: 600).scrollRange == 4400)
+        #expect(TailGeometry(contentHeight: 200, viewportHeight: 600).scrollRange == 0)
+        #expect(TailGeometry(contentHeight: 0, viewportHeight: 0).scrollRange == 0)
+    }
+
     // MARK: Newest edge (tail-follow) detection
 
     @Test func parkedAtOffsetZeroIsAtNewestEdge() {


### PR DESCRIPTION
Fixes two main-thread stalls that Sentry's app-hang detector reports on 3.7.1.

## Log tail — DROIDECTIVE-MAC-2Q (67 events, 9 users)

`SelectableLogView.scrollToBottom` revealed the end of the text storage with
`scrollRangeToVisible`. Revealing that character makes NSLayoutManager fill every
layout hole up to it, so a rebuild (filter change, order flip, cleared buffer) or
a large append typeset the entire logcat synchronously — the reported traces run
straight through `_NSFastFillAllLayoutHolesForGlyphRange` into the typesetter's
line breaking.

It now scrolls the clip view to the document's height, the way `scrollToTop`
already did, and reuses `TailGeometry.scrollRange` — the same measure
`measuredEdges` treats as the bottom, so the follow scroll and the edge state
read one source instead of one forcing layout the other never needed.
Non-contiguous layout is enabled so unlaid regions carry an estimated height
rather than being typeset; the `layoutManager` access that pinned the view to
TextKit 1 is preserved.

## Settings — DROIDECTIVE-MAC-4G

`GeneralSettingsView` read `SMAppService.mainApp.status` from `onAppear`. It is a
synchronous round-trip to launchd, so opening the General tab could block past
the 2 s hang threshold. It now reads off the main actor.

## Tests

`TailGeometryTests.scrollRangeIsTheBottomParkingOrigin` pins the semantic the
tail scroll now depends on, including the clamp at zero — without it a pane
taller than its content would scroll above the document. Verified by removing the
clamp and confirming the test fails.

AppTests 73/73; `make build` clean with warnings as errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)