### PR TITLE
Enumerate installed fonts off the main thread at launch

### DIFF
--- a/ADBKit/Package.resolved
+++ b/ADBKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "376bd2b3a2f7b745cf30d45fac1dbcc14f5e0b2632064cce2002b85d8fe8feb2",
+  "originHash" : "1b66d3791e575d4154c15a002e08edc92895e7d1b933a38c1f869b9581a6dba6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -8,6 +8,51 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "70caa8dea43e2d273cd5ab78885d7eff01df550c",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "ee5b5705b0038f0c44646cde5fe972bb65387596",
+        "version" : "3.61.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -80,6 +125,15 @@
       "state" : {
         "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
         "version" : "1.7.4"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "state" : {
+        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
+        "version" : "1.13.0"
       }
     }
   ],

--- a/App/Sources/AppFont.swift
+++ b/App/Sources/AppFont.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreText
 import SwiftUI
 
 /// UserDefaults key for the app-wide font family (Settings ▸ Appearance).
@@ -88,37 +89,78 @@ extension Font {
     }
 }
 
-/// Installed font families, enumerated once and cached — `preload()` runs at
-/// launch so the Settings picker opens instantly instead of walking the font
-/// registry on first click.
+/// Installed font families, enumerated once and cached — `preload()` warms the
+/// cache off the main actor at launch so the Settings picker opens instantly and
+/// the font-registry walk never lands on the main thread.
 @MainActor
 enum FontCatalog {
     /// Fonts that ship with macOS, shortlisted at the top of the picker.
-    private static let curated: [String] = [
+    /// `nonisolated` so the pure `derive` can read it off the main actor.
+    private nonisolated static let curated: [String] = [
         "Avenir", "Avenir Next", "Charter", "Futura", "Georgia", "Gill Sans",
         "Helvetica Neue", "Menlo", "Monaco", "Optima", "Palatino", "Seravek",
         "SF Mono", "Times New Roman", "Verdana",
     ]
 
+    /// The three picker lists, derived together from one enumeration.
+    struct Lists: Sendable, Equatable {
+        var families: [String] = []
+        var standard: [String] = []
+        var other: [String] = []
+    }
+
+    private static var cached: Lists?
+
+    /// Cached lists, or an inline enumeration if something reads them before
+    /// `preload()` finishes. That fallback is the pre-fix behavior kept as a
+    /// backstop — correct, just slower — rather than a path worth relying on.
+    private static var lists: Lists {
+        if let cached { return cached }
+        let built = derive(from: enumerateRawFamilies())
+        cached = built
+        return built
+    }
+
     /// Every installed family (hidden system fonts excluded), sorted.
-    static let families: [String] = NSFontManager.shared.availableFontFamilies
-        .filter { !$0.hasPrefix(".") }
-        .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
-
+    static var families: [String] { lists.families }
     /// The curated shortlist, limited to families actually installed.
-    static let standardFamilies: [String] = {
+    static var standardFamilies: [String] { lists.standard }
+    static var otherFamilies: [String] { lists.other }
+
+    /// Warm the cache without ever touching the main thread.
+    ///
+    /// `CTFontManagerCopyAvailableFontFamilyNames` is documented thread-safe
+    /// where `NSFontManager` is not (and measured ~7x faster besides), so the
+    /// walk can move off the main actor. On a machine with a cold font registry
+    /// the old main-thread enumeration blocked launch long enough to trip the
+    /// 2 s hang detector (DROIDECTIVE-MAC-55).
+    static func preload() async {
+        guard cached == nil else { return }
+        cached = await Task.detached { derive(from: enumerateRawFamilies()) }.value
+    }
+
+    /// Raw family names from Core Text. `nonisolated` so `preload` can run it
+    /// off the main actor.
+    private nonisolated static func enumerateRawFamilies() -> [String] {
+        CTFontManagerCopyAvailableFontFamilyNames() as? [String] ?? []
+    }
+
+    /// Splits raw family names into the picker's three lists: hidden system
+    /// families (dot-prefixed) dropped, the rest collated the way the picker
+    /// lists them, and the curated shortlist narrowed to what is installed.
+    /// Pure, so the filter, collation, and split are pinned by tests instead of
+    /// eyeballed in the picker.
+    nonisolated static func derive(from raw: [String]) -> Lists {
+        let families = raw
+            .filter { !$0.hasPrefix(".") }
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
         let installed = Set(families)
-        return curated.filter { installed.contains($0) }
-    }()
-
-    static let otherFamilies: [String] = {
-        let standard = Set(standardFamilies)
-        return families.filter { !standard.contains($0) }
-    }()
-
-    /// Touch the cached lists so the enumeration cost is paid at launch.
-    static func preload() {
-        _ = standardFamilies
-        _ = otherFamilies
+        let standard = curated.filter { installed.contains($0) }
+        let standardSet = Set(standard)
+        return Lists(
+            families: families,
+            standard: standard,
+            other: families.filter { !standardSet.contains($0) }
+        )
     }
 }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -236,8 +236,9 @@ struct RootView: View {
         migrateDefaultsIfNeeded()
         applyStoredTheme()
         // Enumerate installed font families now so the Settings ▸ Appearance
-        // font picker opens instantly.
-        FontCatalog.preload()
+        // font picker opens instantly — off the main actor, since the walk
+        // itself is what stalled launch (DROIDECTIVE-MAC-55).
+        Task { await FontCatalog.preload() }
         // Watch the app's own CPU/RAM and report sustained spikes to telemetry
         // with the features open at the time (consent-gated in Telemetry).
         PerformanceMonitor.shared.start { [state] in

--- a/App/Tests/FontCatalogTests.swift
+++ b/App/Tests/FontCatalogTests.swift
@@ -1,0 +1,68 @@
+import Testing
+
+/// `FontCatalog.derive` turns Core Text's raw family names into the three lists
+/// Settings ▸ Appearance renders. It moved off the main actor to stop the font
+/// walk from stalling launch (DROIDECTIVE-MAC-55), so the filter, collation, and
+/// curated split are pinned here rather than eyeballed in the picker.
+@Suite struct FontCatalogTests {
+
+    /// Core Text reports hidden system families with a leading dot
+    /// (".AppleSystemUIFont"). They must never reach the picker.
+    @Test func hiddenSystemFamiliesAreDropped() {
+        let lists = FontCatalog.derive(from: [
+            ".AppleSystemUIFont", ".LastResort", "Georgia", "Verdana",
+        ])
+        #expect(lists.families == ["Georgia", "Verdana"])
+        #expect(!lists.families.contains { $0.hasPrefix(".") })
+        #expect(!lists.other.contains { $0.hasPrefix(".") })
+    }
+
+    /// The picker lists families the way a reader scans them, so collation is
+    /// case-insensitive. The input matters: a lowercase name must sort *before*
+    /// an uppercase one that follows it alphabetically, which is where an ASCII
+    /// sort diverges (it puts every capital ahead of every lowercase letter).
+    @Test func familiesCollateCaseInsensitively() {
+        let lists = FontCatalog.derive(from: ["Zapfino", "arial", "Baskerville"])
+        #expect(lists.families == ["arial", "Baskerville", "Zapfino"])
+    }
+
+    /// The shortlist keeps its curated order (a hand-picked reading order), not
+    /// the alphabetical order the full list uses.
+    @Test func curatedShortlistKeepsItsOwnOrderNotAlphabetical() {
+        let lists = FontCatalog.derive(from: ["Verdana", "Avenir", "Menlo", "Georgia"])
+        #expect(lists.standard == ["Avenir", "Georgia", "Menlo", "Verdana"])
+        #expect(lists.families == ["Avenir", "Georgia", "Menlo", "Verdana"])
+    }
+
+    /// A curated font the user hasn't got installed must not be offered.
+    @Test func curatedFamiliesThatAreNotInstalledAreOmitted() {
+        let lists = FontCatalog.derive(from: ["Georgia"])
+        #expect(lists.standard == ["Georgia"])
+        #expect(!lists.standard.contains("Seravek"))
+        #expect(!lists.standard.contains("SF Mono"))
+    }
+
+    /// `standard` and `other` partition `families` — every installed family is
+    /// offered exactly once, so nothing silently disappears from the picker.
+    @Test func standardAndOtherPartitionEveryFamily() {
+        let raw = [".Hidden", "Georgia", "Menlo", "Comic Sans MS", "Wingdings", "Avenir"]
+        let lists = FontCatalog.derive(from: raw)
+        #expect(Set(lists.standard).isDisjoint(with: Set(lists.other)))
+        #expect(Set(lists.standard).union(lists.other) == Set(lists.families))
+        #expect(lists.standard.count + lists.other.count == lists.families.count)
+        #expect(lists.other == ["Comic Sans MS", "Wingdings"])
+    }
+
+    /// A machine that reports nothing (or a Core Text cast that fails) yields
+    /// empty lists rather than tripping on an unwrap.
+    @Test func emptyInputYieldsEmptyLists() {
+        #expect(FontCatalog.derive(from: []) == FontCatalog.Lists())
+    }
+
+    /// Duplicate family names from Core Text must not duplicate picker rows in
+    /// the shortlist.
+    @Test func duplicateCuratedNamesAppearOnceInTheShortlist() {
+        let lists = FontCatalog.derive(from: ["Georgia", "Georgia", "Menlo"])
+        #expect(lists.standard == ["Georgia", "Menlo"])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -162,6 +162,8 @@ targets:
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/Root/PaneFreezePolicy.swift
+      # FontCatalog.derive — the picker's filter/collation/curated split.
+      - App/Sources/AppFont.swift
       # The id → detail-pane table FeatureDetailView switches over, so the
       # tests can check it against the registry.
       - App/Sources/FeatureDetail/FeatureDetailRoute.swift


### PR DESCRIPTION
Fixes DROIDECTIVE-MAC-55 (4 events / 2 users on 3.7.1).

`FontCatalog.families` was a main-actor `static let` backed by
`NSFontManager.shared.availableFontFamilies`, and `preload()` forced that walk on
the main thread during `performLaunchSetup`. On a machine with a cold font
registry it blocked long enough to trip the 2 s app-hang detector, with
`families` as the reported culprit.

## Change

Families now come from `CTFontManagerCopyAvailableFontFamilyNames`, which is
documented thread-safe where `NSFontManager` is not, so `preload()` can await it
from a detached task and the walk never lands on the main actor.

The three picker lists are derived together by a pure `derive(from:)`, which
makes the dot-prefix filter, the case-insensitive collation, and the curated
shortlist split testable without an OS query. Reading `families` before the
preload finishes still enumerates inline — the previous behavior, kept as a
backstop rather than a path to rely on.

## Verification

Compared both APIs on a real machine: identical 245-family lists, raw and
normalized and after the curated split, with Core Text at 13 ms against
NSFontManager's 91 ms warm, and the Core Text list identical from a background
thread.

`FontCatalogTests` covers the collation, the dot-prefix filter, curated order
(the shortlist keeps its hand-picked order, not alphabetical), uninstalled
curated fonts, the standard/other partition, duplicates, and empty input. Both
mutations were checked: removing the dot filter fails 2 tests, and swapping the
localized collation for an ASCII sort fails the collation test. The collation
case originally passed under both sorts, so its input was changed to one where
they actually diverge.

Also driven at the UI — Settings ▸ Appearance ▸ Font lists 248 items: the system
font, the curated shortlist in curated order, then the full alphabetical list.

AppTests 79/79; `make build` clean with warnings as errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)