### PR TITLE
Correct the cross-platform notes on the log readers and the API client

### DIFF
--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -40,12 +40,20 @@ stubbed — a platform that can't mirror simply doesn't expose the type:
 | `ConsoleLinkDetector` | returns no spans (corelibs has no `NSDataDetector`); a web UI linkifies in its own view layer |
 | `ProcessStats` (the watchdog's `proc_pid_rusage` sampling) | returns nil |
 | `HostNetwork.primaryIPv4` | `getifaddrs` on Linux; nil on Windows (GetAdaptersAddresses is a follow-up) |
+| `URLSessionTransport`'s TLS opt-out (API client) | compiles and runs, but `validateTLS: false` cannot be honoured — corelibs has no server-trust protection space — so its two delegate suites are Apple-scoped |
 
 Portable seams that changed shape:
 
-- `FileHandleLines` replaces Darwin-only `FileHandle.bytes.lines` for the
-  logcat and simulator-log streams: `readabilityHandler`-based (the same
-  non-blocking pattern as `SystemProcessRunner`), CRLF-tolerant, tested.
+- `FileHandleLines` supplies the logcat and simulator-log streams *off-Darwin*,
+  where `FileHandle.bytes.lines` does not exist: CRLF-tolerant, tested, and
+  backed by a dedicated blocking-read thread because corelibs never delivers
+  `readabilityHandler`'s empty EOF callback when the final data and the
+  writer's close arrive together. **Apple platforms deliberately keep
+  Foundation's own `bytes.lines`.** It is pull-driven, so a slow consumer
+  backpressures the pipe rather than queueing lines in an unbounded
+  `AsyncStream` buffer — and this is the live logcat feed, the most-used
+  surface in the shipping app. The rule the port follows: gate, don't replace;
+  a portability edit must leave the macOS path byte-identical.
 - SHA-256 digests come from CryptoKit on Apple platforms and swift-crypto's
   API-compatible `Crypto` elsewhere — the package's first dependency, linked
   only off-Apple.
@@ -109,3 +117,12 @@ stays with the scrcpy desktop app.
 - [ ] Windows: audit the process-spawning tests so `swift test` runs in CI
 - [ ] Windows: xz decode for frida assets; `HostNetwork` via GetAdaptersAddresses
 - [ ] Linux: interface ranking in `HostNetwork.pickPrimary` (en*/eth*/wl* over docker0/veth)
+- [ ] API client: portable expectations for `URLSessionTransport` so
+      `ApiTransportTests` / `ApiTransportLiveTests` run off-Darwin
+- [ ] A guard for corelibs-*unavailable* / *deprecated* Foundation symbols.
+      `PortabilityGuardTests` only catches Apple-only imports and a listed set
+      of traps, so it missed both API-client breaks
+      (`NSURLAuthenticationMethodServerTrust`,
+      `NSURLErrorFailingURLStringErrorKey`); only the real Linux compile found
+      them. Until that exists, `test-linux` is the only thing standing between
+      a new macOS feature and a broken port.


### PR DESCRIPTION
Documentation only — `docs/cross-platform.md` had drifted from what the default branch actually does after #224.

## What was wrong

The portable-seams section said `FileHandleLines` **replaces** `FileHandle.bytes.lines` for the logcat and simulator-log streams. It does not, and deliberately so: those two readers were re-gated during review, so **Apple platforms keep Foundation's own `bytes.lines`** and `FileHandleLines` sits on the `#else` branch.

That distinction is load-bearing rather than cosmetic. `bytes.lines` is pull-driven, so a slow consumer backpressures the pipe; the portable reader yields into an `AsyncStream` with the default **unbounded** buffering policy. On the live logcat feed — the most-used surface in the shipping app — those are different characteristics under a chatty stream. Anyone reading the old text would reasonably conclude macOS had already moved, and that moving other readers was equally free.

## Also recorded

- A table row for `URLSessionTransport`: it compiles off-Darwin, but `validateTLS: false` cannot be honoured there (corelibs has no server-trust protection space), which is why its two delegate suites are Apple-scoped.
- Two follow-ups. One is portable expectations for those suites. The other matters more: a guard for corelibs-*unavailable* and *deprecated* Foundation symbols. `PortabilityGuardTests` scans for Apple-only imports and a listed set of traps, so it missed both API-client breaks (`NSURLAuthenticationMethodServerTrust`, `NSURLErrorFailingURLStringErrorKey`) — only the real Linux compile caught them. Worth stating plainly that `test-linux` is currently the only thing standing between a new macOS feature and a broken port.

## Verification

Docs only, no code. Measured while writing this: **1554 tests on macOS, 1375 on Linux** — the Linux figure reproduced locally via `make test-linux` as well as in CI — and Windows compile-only.
