### PR TITLE
Record the Mac microphone alongside device audio

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Mirror/MicrophoneCapture.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MicrophoneCapture.swift
@@ -1,0 +1,257 @@
+// Host microphone capture for recordings. Apple-only (AVFoundation capture +
+// CoreMedia timestamps) and deliberately confined to this one file, so the
+// Windows/Linux port gates it wholesale and swaps in its own input backend
+// behind the same chunk-callback shape.
+#if canImport(AVFoundation)
+import AVFoundation
+import CoreMedia
+import Foundation
+
+/// One delivery of microphone audio, already in the recorder's format.
+public struct MicrophoneChunk: Sendable {
+    /// Interleaved s16le PCM, 48 kHz, stereo — the same shape scrcpy sends, so
+    /// both sources meet in one format.
+    public let pcm: Data
+    /// Capture timestamp on the *host* clock, in seconds. `AudioTimeline`
+    /// translates it onto the device timeline the video is written on.
+    public let hostSeconds: Double
+    /// 0…1 signal level for the meter, computed here so the UI doesn't have to
+    /// touch the samples.
+    public let level: Float
+}
+
+/// Captures the Mac's microphone as 48 kHz stereo s16le PCM.
+///
+/// `AVCaptureAudioDataOutput.audioSettings` does the sample-rate and
+/// bit-depth conversion in the capture graph (a macOS-only capability), so the
+/// only conversion left here is the channel layout, which is pure and tested
+/// (`PCMSamples.stereo`).
+///
+/// `AVCaptureSession` isn't `Sendable` and both its configuration and its
+/// teardown block, so every touch of it is funnelled through one serial queue
+/// and the async entry points hop onto that queue rather than blocking a
+/// cooperative thread.
+public final class MicrophoneCapture: NSObject, @unchecked Sendable {
+    /// A selectable host input.
+    public struct Input: Sendable, Identifiable, Equatable {
+        public let id: String
+        public let name: String
+    }
+
+    public enum Authorization: Sendable, Equatable {
+        case notDetermined
+        case denied
+        case authorized
+    }
+
+    public enum CaptureError: Error, LocalizedError, Equatable {
+        case notAuthorized
+        case noInputDevice
+        case configurationFailed
+        case unsupportedFormat(sampleRate: Int, channels: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .notAuthorized:
+                return "Droidective doesn’t have microphone access."
+            case .noInputDevice:
+                return "No microphone is available."
+            case .configurationFailed:
+                return "Couldn’t start the microphone."
+            case let .unsupportedFormat(sampleRate, channels):
+                return "The microphone delivered \(sampleRate) Hz / \(channels)ch audio, "
+                    + "which can’t be mixed into the recording."
+            }
+        }
+    }
+
+    /// The rate everything downstream assumes: scrcpy's raw audio, the AAC
+    /// encoder, and the mixdown timeline all run at 48 kHz stereo.
+    public static let sampleRate = 48_000
+    public static let channelCount = 2
+
+    // MARK: - Device discovery
+
+    /// Every input the user can pick, default input first. Names come from the
+    /// system, so a picker can show them as-is.
+    public static func availableInputs() -> [Input] {
+        let discovered = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.microphone, .external],
+            mediaType: .audio,
+            position: .unspecified
+        ).devices
+        let defaultID = AVCaptureDevice.default(for: .audio)?.uniqueID
+        let inputs = discovered.map { Input(id: $0.uniqueID, name: $0.localizedName) }
+        guard let defaultID, let index = inputs.firstIndex(where: { $0.id == defaultID }) else {
+            return inputs
+        }
+        var ordered = inputs
+        ordered.insert(ordered.remove(at: index), at: 0)
+        return ordered
+    }
+
+    public static func authorization() -> Authorization {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized: return .authorized
+        case .notDetermined: return .notDetermined
+        default: return .denied
+        }
+    }
+
+    /// Show the system prompt (only ever shown once by macOS; a previously
+    /// denied app resolves immediately to false).
+    public static func requestAccess() async -> Bool {
+        await AVCaptureDevice.requestAccess(for: .audio)
+    }
+
+    // MARK: - Capture
+
+    private let deviceID: String?
+    private let queue = DispatchQueue(label: "com.rohindh.droidective.microphone")
+    private let session = AVCaptureSession()
+    private var onChunk: (@Sendable (MicrophoneChunk) -> Void)?
+    /// Set when a delivered buffer can't be used; reported once so a bad format
+    /// doesn't spam the log for every 10 ms of audio.
+    private var formatFailure: CaptureError?
+    private var running = false
+
+    /// - Parameter deviceID: an `Input.id`, or nil for the system default input.
+    public init(deviceID: String? = nil) {
+        self.deviceID = deviceID
+        super.init()
+    }
+
+    /// Build the graph and start delivering chunks. Throws if access was denied,
+    /// the device is gone, or the graph won't configure.
+    ///
+    /// A first-ever use prompts here rather than relying on the caller having
+    /// asked: recordings start from several places (the Screen Record screen,
+    /// the mirror's record button, a hotkey) and only one of them has a picker
+    /// to hang the request off.
+    public func start(onChunk: @escaping @Sendable (MicrophoneChunk) -> Void) async throws {
+        switch Self.authorization() {
+        case .authorized:
+            break
+        case .notDetermined:
+            guard await Self.requestAccess() else { throw CaptureError.notAuthorized }
+        case .denied:
+            throw CaptureError.notAuthorized
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            queue.async { [self] in
+                do {
+                    try configure(onChunk: onChunk)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    public func stop() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            queue.async { [self] in
+                if running { session.stopRunning() }
+                running = false
+                onChunk = nil
+                continuation.resume()
+            }
+        }
+    }
+
+    /// A format problem seen while capturing, if any — the recording continues
+    /// without microphone audio rather than failing outright.
+    public func failure() async -> CaptureError? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<CaptureError?, Never>) in
+            queue.async { [self] in continuation.resume(returning: formatFailure) }
+        }
+    }
+
+    private func configure(onChunk: @escaping @Sendable (MicrophoneChunk) -> Void) throws {
+        guard !running else { return }
+        let device = deviceID.flatMap { AVCaptureDevice(uniqueID: $0) }
+            ?? AVCaptureDevice.default(for: .audio)
+        guard let device else { throw CaptureError.noInputDevice }
+        guard let input = try? AVCaptureDeviceInput(device: device) else {
+            throw CaptureError.noInputDevice
+        }
+
+        session.beginConfiguration()
+        guard session.canAddInput(input) else {
+            session.commitConfiguration()
+            throw CaptureError.configurationFailed
+        }
+        session.addInput(input)
+
+        let output = AVCaptureAudioDataOutput()
+        // The capture graph converts to the recorder's rate and bit depth. The
+        // channel count is deliberately left to the device — a mono mic that
+        // can't be upmixed here would otherwise fail the whole graph — and
+        // `PCMSamples.stereo` squares it up.
+        output.audioSettings = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: Self.sampleRate,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        output.setSampleBufferDelegate(self, queue: queue)
+        guard session.canAddOutput(output) else {
+            session.commitConfiguration()
+            throw CaptureError.configurationFailed
+        }
+        session.addOutput(output)
+        session.commitConfiguration()
+
+        self.onChunk = onChunk
+        formatFailure = nil
+        session.startRunning()
+        running = true
+    }
+}
+
+extension MicrophoneCapture: AVCaptureAudioDataOutputSampleBufferDelegate {
+    public func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        // Called on `queue`, the same serial queue that owns the session.
+        guard let onChunk, formatFailure == nil else { return }
+        guard let format = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(format)?.pointee
+        else { return }
+
+        let channels = Int(asbd.mChannelsPerFrame)
+        guard Int(asbd.mSampleRate.rounded()) == Self.sampleRate, channels > 0 else {
+            formatFailure = .unsupportedFormat(
+                sampleRate: Int(asbd.mSampleRate.rounded()), channels: channels)
+            return
+        }
+        guard let data = Self.copyBytes(from: sampleBuffer) else { return }
+
+        let samples = PCMSamples.stereo(from: PCMSamples.decode(data), channels: channels)
+        guard !samples.isEmpty else { return }
+        onChunk(MicrophoneChunk(
+            pcm: PCMSamples.encode(samples),
+            hostSeconds: CMSampleBufferGetPresentationTimeStamp(sampleBuffer).seconds,
+            level: AudioLevel.rms(samples)))
+    }
+
+    private static func copyBytes(from sampleBuffer: CMSampleBuffer) -> Data? {
+        guard let block = CMSampleBufferGetDataBuffer(sampleBuffer) else { return nil }
+        let length = CMBlockBufferGetDataLength(block)
+        guard length > 0 else { return nil }
+        var bytes = [UInt8](repeating: 0, count: length)
+        let status = bytes.withUnsafeMutableBytes { raw -> OSStatus in
+            guard let base = raw.baseAddress else { return -1 }
+            return CMBlockBufferCopyDataBytes(
+                block, atOffset: 0, dataLength: length, destination: base)
+        }
+        guard status == kCMBlockBufferNoErr else { return nil }
+        return Data(bytes)
+    }
+}
+#endif

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MicrophoneCapture.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MicrophoneCapture.swift
@@ -81,7 +81,9 @@ public final class MicrophoneCapture: NSObject, @unchecked Sendable {
             position: .unspecified
         ).devices
         let defaultID = AVCaptureDevice.default(for: .audio)?.uniqueID
-        let inputs = discovered.map { Input(id: $0.uniqueID, name: $0.localizedName) }
+        let inputs = discovered
+            .map { Input(id: $0.uniqueID, name: $0.localizedName) }
+            .filter { RecordAudioInputs.isSelectable(name: $0.name, uniqueID: $0.id) }
         guard let defaultID, let index = inputs.firstIndex(where: { $0.id == defaultID }) else {
             return inputs
         }

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorRecorder.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorRecorder.swift
@@ -5,10 +5,13 @@ import Foundation
 
 /// Records the live mirror by passthrough-muxing the already-compressed H.264
 /// sample buffers into an `.mp4` (no re-encode, negligible cost — so the mirror
-/// stays fully live while recording). When the session carries device audio, a
-/// second track re-encodes the raw PCM to AAC alongside the video. The first
-/// appended video sample must be a key frame; `MirrorSession` gates on that, and
-/// the writer session starts on that frame's timestamp so audio shares the clock.
+/// stays fully live while recording). Audio rides alongside in a *single* AAC
+/// track fed by up to two sources — the device's own audio and the Mac's
+/// microphone — because players (QuickTime, browsers, chat apps) play only the
+/// first audio track, so two tracks would silently drop one source for whoever
+/// the clip is sent to. The first appended video sample must be a key frame;
+/// `MirrorSession` gates on that, and the writer session starts on that frame's
+/// timestamp, which is also the origin of the audio timeline.
 ///
 /// Only ever driven from `MirrorSession`'s serialized isolation (AVFoundation
 /// owns its own internal threading), so it's safe to hand across the actor's
@@ -16,15 +19,35 @@ import Foundation
 final class MirrorRecorder: @unchecked Sendable {
     enum RecorderError: Error { case cannotConfigure }
 
+    /// How far behind the newest sample the mixer commits audio, giving the
+    /// other source a moment to deliver its half of the same span. Only applies
+    /// when both sources are live; a single source is appended as it arrives.
+    private static let mixLagSeconds = 0.25
+
     private let writer: AVAssetWriter
     private let videoInput: AVAssetWriterInput
     private let audioInput: AVAssetWriterInput?
     private let audioFormat: CMAudioFormatDescription?
+    private let audioMode: RecordAudioMode
     private var started = false
 
-    /// - Parameter includeAudio: add an AAC audio track fed by `appendAudio`.
-    ///   Pass true only when the session actually supplies PCM (raw audio on).
-    init(url: URL, formatDescription: CMVideoFormatDescription, includeAudio: Bool) throws {
+    /// Set on the first appended video sample: the device-clock origin the
+    /// writer session opened on, paired with the host clock at that instant so
+    /// microphone timestamps can be translated onto the same timeline.
+    private var timeline: AudioTimeline?
+    /// Only used when both sources are on — a single source needs no mixing and
+    /// keeps the exact path it had before the microphone existed.
+    private var mixdown: PCMMixdown?
+    /// Newest frame either source has delivered, for the lagged mixer drain.
+    private var newestFrame: Int64 = 0
+    private var deviceMuted = false
+    private var microphoneMuted = false
+
+    /// - Parameter audio: which sources feed the AAC track. `.muted` writes no
+    ///   audio track at all. Pass a mode including `.device` only when the
+    ///   session actually supplies device PCM (raw audio on).
+    init(url: URL, formatDescription: CMVideoFormatDescription, audio: RecordAudioMode) throws {
+        audioMode = audio
         writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
         videoInput = AVAssetWriterInput(
             mediaType: .video, outputSettings: nil, sourceFormatHint: formatDescription)
@@ -32,7 +55,7 @@ final class MirrorRecorder: @unchecked Sendable {
         guard writer.canAdd(videoInput) else { throw RecorderError.cannotConfigure }
         writer.add(videoInput)
 
-        if includeAudio {
+        if audio.hasAudio {
             let settings: [String: Any] = [
                 AVFormatIDKey: kAudioFormatMPEG4AAC,
                 AVSampleRateKey: MirrorAudioPlayer.sampleRate,
@@ -54,22 +77,85 @@ final class MirrorRecorder: @unchecked Sendable {
     func append(_ sampleBuffer: CMSampleBuffer) {
         if !started {
             guard writer.startWriting() else { return }
-            writer.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+            let origin = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            writer.startSession(atSourceTime: origin)
             started = true
+            // The two clocks are anchored here, at the one instant both are
+            // known to refer to: the frame the file opens on.
+            timeline = AudioTimeline(
+                originDeviceSeconds: origin.seconds,
+                originHostSeconds: CMClockGetTime(CMClockGetHostTimeClock()).seconds,
+                sampleRate: Int(MirrorAudioPlayer.sampleRate))
+            if audioMode.mixesSources {
+                mixdown = PCMMixdown(
+                    sampleRate: Int(MirrorAudioPlayer.sampleRate),
+                    channels: Int(MirrorAudioPlayer.channelCount))
+            }
         }
         if videoInput.isReadyForMoreMediaData {
             videoInput.append(sampleBuffer)
         }
     }
 
-    /// Append one chunk of raw interleaved s16le PCM at `pts` (device clock). A
-    /// no-op until the video session has started, so audio shares the video's
-    /// timeline; a little leading audio before the first key frame is dropped.
-    func appendAudio(_ pcm: Data, pts: CMTime) {
-        guard started, let audioInput, let audioFormat, audioInput.isReadyForMoreMediaData,
+    /// Mute or unmute a source mid-recording. Muting silences the samples rather
+    /// than dropping them, so the track keeps one continuous timeline.
+    func setDeviceMuted(_ muted: Bool) { deviceMuted = muted }
+
+    func setMicrophoneMuted(_ muted: Bool) { microphoneMuted = muted }
+
+    /// One chunk of raw interleaved s16le PCM from the device at `pts` (device
+    /// clock). A no-op until the video session has started, so audio shares the
+    /// video's timeline; a little leading audio before the first key frame is
+    /// dropped.
+    func appendDeviceAudio(_ pcm: Data, pts: CMTime) {
+        guard audioMode.includesDevice, let timeline else { return }
+        ingest(deviceMuted ? PCMSamples.silenced(pcm) : pcm,
+               frame: timeline.frame(deviceSeconds: pts.seconds), pts: pts)
+    }
+
+    /// One chunk of microphone PCM stamped on the *host* clock, translated onto
+    /// the device timeline through the anchor taken when recording opened.
+    func appendMicrophoneAudio(_ pcm: Data, hostSeconds: Double) {
+        guard audioMode.includesMicrophone, let timeline else { return }
+        let frame = timeline.frame(hostSeconds: hostSeconds)
+        ingest(microphoneMuted ? PCMSamples.silenced(pcm) : pcm,
+               frame: frame, pts: Self.time(seconds: timeline.deviceSeconds(frame: frame)))
+    }
+
+    /// With one source the samples go straight to the track, exactly as they did
+    /// before the microphone existed — no buffering, no re-timestamping. With
+    /// two, they go through the mixdown instead and come back out summed.
+    private func ingest(_ pcm: Data, frame: Int64, pts: CMTime) {
+        guard started else { return }
+        guard mixdown != nil, let timeline else {
+            appendToTrack(pcm, pts: pts)
+            return
+        }
+        let samples = PCMSamples.decode(pcm)
+        guard !samples.isEmpty else { return }
+        mixdown?.add(samples: samples, at: frame)
+        newestFrame = max(newestFrame, frame + Int64(samples.count / Int(MirrorAudioPlayer.channelCount)))
+        let lagFrames = Int64(Self.mixLagSeconds * MirrorAudioPlayer.sampleRate)
+        if let chunk = mixdown?.drain(through: newestFrame - lagFrames) {
+            emit(chunk, timeline: timeline)
+        }
+    }
+
+    private func emit(_ chunk: PCMMixdown.Chunk, timeline: AudioTimeline) {
+        appendToTrack(
+            PCMSamples.encode(chunk.samples),
+            pts: Self.time(seconds: timeline.deviceSeconds(frame: chunk.startFrame)))
+    }
+
+    private func appendToTrack(_ pcm: Data, pts: CMTime) {
+        guard let audioInput, let audioFormat, audioInput.isReadyForMoreMediaData,
               let sampleBuffer = Self.audioSampleBuffer(pcm, pts: pts, format: audioFormat)
         else { return }
         audioInput.append(sampleBuffer)
+    }
+
+    private static func time(seconds: Double) -> CMTime {
+        CMTime(seconds: seconds, preferredTimescale: 1_000_000)
     }
 
     /// Finalize the container and return whether it completed. No-op cancel if
@@ -79,6 +165,8 @@ final class MirrorRecorder: @unchecked Sendable {
             writer.cancelWriting()
             return false
         }
+        // Commit whatever the mixer was still holding back for its lag window.
+        if let timeline, let tail = mixdown?.flush() { emit(tail, timeline: timeline) }
         videoInput.markAsFinished()
         audioInput?.markAsFinished()
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/MirrorSession.swift
@@ -58,6 +58,11 @@ public actor MirrorSession {
     /// Set by `startRecording` before the format is known; consumed when the
     /// config packet arrives to create the recorder in time for the first frame.
     private var pendingRecordURL: URL?
+    /// Which sources the armed/active recording mixes, already limited to what
+    /// this session can actually supply.
+    private var recordAudioMode: RecordAudioMode = .muted
+    private var deviceAudioMuted = false
+    private var microphoneMuted = false
 
     public init(adb: AdbClient, config: MirrorTransport.Configuration) {
         transport = MirrorTransport(adb: adb, config: config)
@@ -149,16 +154,44 @@ public actor MirrorSession {
     /// so a fresh session captures from that first frame rather than waiting for
     /// the next periodic key frame (seconds away). Appending always opens on a
     /// key frame so the file starts on a sync sample.
-    public func startRecording(to url: URL) throws {
+    ///
+    /// - Parameter audio: which sources to record. Device audio is dropped from
+    ///   the plan when the session never requested it, so an in-mirror recording
+    ///   can still take the microphone on a silent stream.
+    public func startRecording(to url: URL, audio: RecordAudioMode = .deviceOnly) throws {
         pendingRecordURL = url
+        recordAudioMode = audio.limited(deviceAudioAvailable: recordsAudio)
         if let formatDescription, recorder == nil {
             try activateRecorder(formatDescription: formatDescription, url: url)
         }
     }
 
+    /// What the armed recording ended up capturing — the requested mode after
+    /// the session's own capability is applied.
+    public func recordingAudioMode() -> RecordAudioMode { recordAudioMode }
+
+    /// One chunk of host microphone PCM (s16le, 48 kHz, stereo) stamped on the
+    /// host clock. Ignored unless a recording that wants the microphone is live.
+    public func appendMicrophoneAudio(_ pcm: Data, hostSeconds: Double) {
+        recorder?.appendMicrophoneAudio(pcm, hostSeconds: hostSeconds)
+    }
+
+    /// Silence either source in the file without stopping the capture. Applies
+    /// to the live recorder and is remembered for one created later in this
+    /// session.
+    public func setAudioMuted(device: Bool, microphone: Bool) {
+        deviceAudioMuted = device
+        microphoneMuted = microphone
+        recorder?.setDeviceMuted(device)
+        recorder?.setMicrophoneMuted(microphone)
+    }
+
     private func activateRecorder(formatDescription: CMVideoFormatDescription, url: URL) throws {
-        recorder = try MirrorRecorder(
-            url: url, formatDescription: formatDescription, includeAudio: recordsAudio)
+        let recorder = try MirrorRecorder(
+            url: url, formatDescription: formatDescription, audio: recordAudioMode)
+        recorder.setDeviceMuted(deviceAudioMuted)
+        recorder.setMicrophoneMuted(microphoneMuted)
+        self.recorder = recorder
         recorderStarted = false
         pendingRecordURL = nil
     }
@@ -274,7 +307,7 @@ public actor MirrorSession {
                         // timeline the writer session opened with.
                         if let recorder, recorderStarted {
                             let pts = CMTime(value: CMTimeValue(header.pts), timescale: 1_000_000)
-                            recorder.appendAudio(payload, pts: pts)
+                            recorder.appendDeviceAudio(payload, pts: pts)
                         }
                     }
                 }

--- a/ADBKit/Sources/ADBKit/Services/Mirror/PCMMixdown.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/PCMMixdown.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+// Deliberately free of Apple frameworks even though it sits in the Mirror
+// subsystem: the mixing math is the part most worth testing, and it stays
+// compilable (and tested) on the Windows/Linux port where the media stack
+// around it is gated out.
+
+/// Interleaved signed-16-bit little-endian PCM — the format scrcpy sends
+/// (`audio_codec=raw`) and the one the recorder's AAC encoder is fed.
+public enum PCMSamples {
+    /// Decode a little-endian s16 buffer. A trailing odd byte (a chunk split
+    /// mid-sample) is ignored rather than misread as a sample.
+    public static func decode(_ data: Data) -> [Int16] {
+        let count = data.count / 2
+        guard count > 0 else { return [] }
+        var samples = [Int16](repeating: 0, count: count)
+        // Explicit little-endian assembly, not a raw load: the wire format is
+        // fixed, so it must not follow the host's endianness.
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            for index in 0 ..< count {
+                let low = UInt16(raw[index * 2])
+                let high = UInt16(raw[index * 2 + 1])
+                samples[index] = Int16(bitPattern: low | (high << 8))
+            }
+        }
+        return samples
+    }
+
+    public static func encode(_ samples: [Int16]) -> Data {
+        var data = Data(count: samples.count * 2)
+        data.withUnsafeMutableBytes { (raw: UnsafeMutableRawBufferPointer) in
+            for (index, sample) in samples.enumerated() {
+                let bits = UInt16(bitPattern: sample)
+                raw[index * 2] = UInt8(bits & 0xff)
+                raw[index * 2 + 1] = UInt8(bits >> 8)
+            }
+        }
+        return data
+    }
+
+    /// Silence every sample — how a live mute is applied, so the track keeps a
+    /// continuous timeline instead of developing a hole.
+    public static func silenced(_ data: Data) -> Data {
+        Data(count: data.count)
+    }
+
+    /// Square an input's channel layout up to the stereo the recorder mixes in:
+    /// a mono mic is duplicated across both channels (rather than landing in the
+    /// left ear only), and a multi-channel interface is reduced to its first
+    /// two. A trailing partial frame is dropped.
+    public static func stereo(from samples: [Int16], channels: Int) -> [Int16] {
+        guard channels > 0 else { return [] }
+        let frames = samples.count / channels
+        guard channels != 2 else { return Array(samples.prefix(frames * 2)) }
+        var stereo = [Int16](repeating: 0, count: frames * 2)
+        for frame in 0 ..< frames {
+            let source = frame * channels
+            stereo[frame * 2] = samples[source]
+            stereo[frame * 2 + 1] = channels == 1 ? samples[source] : samples[source + 1]
+        }
+        return stereo
+    }
+}
+
+/// Maps the two clocks a recording sees onto one sample timeline.
+///
+/// Device audio is stamped in the device's clock (the same clock the video
+/// packets carry, which is what the writer session opens on); microphone
+/// samples arrive stamped in the *host's* clock. Anchoring both at the moment
+/// recording starts is what keeps narration from drifting away from the picture
+/// over a long take.
+public struct AudioTimeline: Sendable, Equatable {
+    /// Device-clock timestamp the writer session started on (seconds).
+    public let originDeviceSeconds: Double
+    /// Host-clock reading taken at that same instant (seconds).
+    public let originHostSeconds: Double
+    public let sampleRate: Int
+
+    public init(originDeviceSeconds: Double, originHostSeconds: Double, sampleRate: Int = 48_000) {
+        self.originDeviceSeconds = originDeviceSeconds
+        self.originHostSeconds = originHostSeconds
+        self.sampleRate = sampleRate
+    }
+
+    /// Frame index for a device-clock timestamp. Negative before the origin —
+    /// the mixer drops those, which is the leading audio that precedes the
+    /// first key frame.
+    public func frame(deviceSeconds: Double) -> Int64 {
+        frameCount(seconds: deviceSeconds - originDeviceSeconds)
+    }
+
+    /// Frame index for a host-clock timestamp, translated through the anchor.
+    public func frame(hostSeconds: Double) -> Int64 {
+        frameCount(seconds: hostSeconds - originHostSeconds)
+    }
+
+    /// The device-clock timestamp a frame index sits at — what an emitted chunk
+    /// is stamped with on its way into the writer.
+    public func deviceSeconds(frame: Int64) -> Double {
+        originDeviceSeconds + Double(frame) / Double(sampleRate)
+    }
+
+    private func frameCount(seconds: Double) -> Int64 {
+        let frames = (seconds * Double(sampleRate)).rounded()
+        // A non-finite or absurd timestamp (a corrupt packet header) must not
+        // trap the Int64 conversion; pin it to the origin instead.
+        guard frames.isFinite, frames > -9e18, frames < 9e18 else { return 0 }
+        return Int64(frames)
+    }
+}
+
+/// Sums two live PCM sources onto one timeline.
+///
+/// Each source calls `add` with its samples positioned by frame index; `drain`
+/// emits the contiguous run that is old enough to be considered complete.
+/// Whatever a source hasn't delivered for an emitted span reads as silence, so
+/// one source stalling (or being muted) never stalls the other — it just leaves
+/// the recording quieter.
+///
+/// Sums accumulate in `Int32` and are clamped once, on the way out: summing two
+/// full-scale sources clips rather than wrapping into a loud crackle.
+public struct PCMMixdown: Sendable, Equatable {
+    public struct Chunk: Sendable, Equatable {
+        public let startFrame: Int64
+        /// Interleaved samples, `channels` per frame.
+        public let samples: [Int16]
+
+        public init(startFrame: Int64, samples: [Int16]) {
+            self.startFrame = startFrame
+            self.samples = samples
+        }
+    }
+
+    public let sampleRate: Int
+    public let channels: Int
+    /// How far ahead of the emitted edge samples may be buffered before the
+    /// excess is dropped. Bounds memory when one source races ahead of a
+    /// stalled one (or ahead of a drain that never comes).
+    private let maxBufferedFrames: Int
+
+    /// Interleaved running sums for frames `[baseFrame, baseFrame + count/channels)`.
+    private var accumulator: [Int32] = []
+    /// First frame not yet emitted — the timeline's moving edge.
+    private var baseFrame: Int64 = 0
+    /// One past the newest frame any source has written.
+    private var highWaterFrame: Int64 = 0
+
+    public init(sampleRate: Int = 48_000, channels: Int = 2, maxBufferedSeconds: Double = 2) {
+        self.sampleRate = sampleRate
+        self.channels = channels
+        maxBufferedFrames = max(channels, Int(Double(sampleRate) * maxBufferedSeconds))
+    }
+
+    /// Frames written but not yet emitted.
+    public var bufferedFrames: Int { max(0, Int(highWaterFrame - baseFrame)) }
+
+    /// Mix one source's samples in at `frame`.
+    ///
+    /// Samples that fall before the emitted edge are dropped (they arrived too
+    /// late to be mixed), and samples beyond the buffering window are dropped
+    /// too — in both cases without shifting anything else, so a late or runaway
+    /// source can't push the other one out of sync.
+    public mutating func add(samples: [Int16], at frame: Int64) {
+        let frameCount = samples.count / channels
+        guard frameCount > 0 else { return }
+        let end = frame + Int64(frameCount)
+        guard end > baseFrame else { return }
+
+        let start = max(frame, baseFrame)
+        guard start < baseFrame + Int64(maxBufferedFrames) else { return }
+        let clampedEnd = min(end, baseFrame + Int64(maxBufferedFrames))
+        let skippedFrames = Int(start - frame)
+
+        let required = Int(clampedEnd - baseFrame) * channels
+        if accumulator.count < required {
+            accumulator.append(contentsOf: repeatElement(0, count: required - accumulator.count))
+        }
+        var destination = Int(start - baseFrame) * channels
+        var source = skippedFrames * channels
+        while destination < required {
+            accumulator[destination] += Int32(samples[source])
+            destination += 1
+            source += 1
+        }
+        highWaterFrame = max(highWaterFrame, clampedEnd)
+    }
+
+    /// Emit everything up to (not including) `frame` that has been written.
+    ///
+    /// Callers pass an edge that lags the newest sample seen, giving the other
+    /// source a moment to deliver its half of that span before it is committed.
+    public mutating func drain(through frame: Int64) -> Chunk? {
+        let end = min(frame, highWaterFrame)
+        guard end > baseFrame else { return nil }
+        let count = Int(end - baseFrame) * channels
+        var samples = [Int16](repeating: 0, count: count)
+        for index in 0 ..< count {
+            samples[index] = Int16(clamping: accumulator[index])
+        }
+        accumulator.removeFirst(count)
+        let chunk = Chunk(startFrame: baseFrame, samples: samples)
+        baseFrame = end
+        return chunk
+    }
+
+    /// Emit everything buffered, ignoring the lag — for finalizing a recording.
+    public mutating func flush() -> Chunk? { drain(through: highWaterFrame) }
+}
+
+/// Signal level for the microphone meter, as a 0…1 fraction of full scale.
+public enum AudioLevel {
+    public static func rms(_ samples: [Int16]) -> Float {
+        guard !samples.isEmpty else { return 0 }
+        var sum = 0.0
+        for sample in samples {
+            let value = Double(sample) / 32_768
+            sum += value * value
+        }
+        return Float(min(1, (sum / Double(samples.count)).squareRoot()))
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyServerParams.swift
+++ b/ADBKit/Sources/ADBKit/Services/Mirror/ScrcpyServerParams.swift
@@ -23,7 +23,19 @@ public struct ScrcpyServerParams: Sendable, Equatable {
     /// s16le, 48 kHz, stereo) so the client can play it without an Opus/AAC
     /// decoder; only consulted when `audio` is on.
     public var audioCodec: String
+    /// Which device-side source the server captures: its playback ("output",
+    /// the server's default) or the device's own microphone ("mic"). One
+    /// session carries one source — scrcpy captures a single audio stream — so
+    /// this is a choice, not a set. Only consulted when `audio` is on.
+    public var audioSource: AudioSource
     public var control: Bool
+
+    /// scrcpy's `audio_source` values. The server accepts several mic variants;
+    /// these are the two the recorder offers.
+    public enum AudioSource: String, Sendable, Equatable, CaseIterable {
+        case output
+        case microphone = "mic"
+    }
     /// Longest side in px (0 = device size).
     public var maxSize: Int
     /// Video bit-rate in bits/sec (0 = server default, ~8 Mbps).
@@ -43,6 +55,7 @@ public struct ScrcpyServerParams: Sendable, Equatable {
         video: Bool = true,
         audio: Bool = false,
         audioCodec: String = "raw",
+        audioSource: AudioSource = .output,
         control: Bool = false,
         maxSize: Int = 0,
         videoBitRate: Int = 0,
@@ -55,6 +68,7 @@ public struct ScrcpyServerParams: Sendable, Equatable {
         self.video = video
         self.audio = audio
         self.audioCodec = audioCodec
+        self.audioSource = audioSource
         self.control = control
         self.maxSize = maxSize
         self.videoBitRate = videoBitRate
@@ -80,6 +94,8 @@ public struct ScrcpyServerParams: Sendable, Equatable {
             // The server's default audio codec is Opus; request the configured
             // one (raw PCM) so the client plays it without bundling a decoder.
             if audioCodec != "opus" { params.append("audio_codec=\(audioCodec)") }
+            // `output` is the server's default, so it's left unsaid.
+            if audioSource != .output { params.append("audio_source=\(audioSource.rawValue)") }
         } else {
             params.append("audio=false")
         }

--- a/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
@@ -38,11 +38,37 @@ public actor ScreenRecorder {
     /// only single-segment (never-paused) recordings are supported.
     private let ffmpegPath: String?
 
+    /// What the recording is capturing right now, for the UI's mute controls
+    /// and level meter.
+    public struct AudioStatus: Sendable, Equatable {
+        public let mode: RecordAudioMode
+        public let deviceMuted: Bool
+        public let microphoneMuted: Bool
+        /// 0…1 level of the last microphone chunk; 0 when the mic isn't running.
+        public let microphoneLevel: Float
+        /// Why the microphone isn't contributing, if it isn't. The recording
+        /// keeps going without it rather than failing.
+        public let microphoneFailure: String?
+    }
+
     private var session: MirrorSession?
     private var currentURL: URL?
     private var segments: [URL] = []
     private var serial = ""
     private var options = ScreenRecordOptions()
+
+    /// The microphone runs per segment: it starts with a segment and stops on
+    /// pause, so a paused recording doesn't hold the mic open (and doesn't keep
+    /// the system's recording indicator lit).
+    private var microphone: MicrophoneCapture?
+    private var microphonePump: Task<Void, Never>?
+    private var microphoneSink: AsyncStream<MicrophoneChunk>.Continuation?
+    private var microphoneLevel: Float = 0
+    private var microphoneFailure: String?
+    /// Mute state survives pause/resume, so each new segment starts out matching
+    /// what the user last chose.
+    private var deviceMuted = false
+    private var microphoneMuted = false
 
     public init(client: AdbClient, server: ScrcpyServerInfo, ffmpegPath: String? = nil) {
         self.client = client
@@ -62,6 +88,24 @@ public actor ScreenRecorder {
     /// latest without a second device connection or draining the record stream.
     public func previewFrame() async -> MirrorSession.Snapshot? {
         await session?.snapshot()
+    }
+
+    public func audioStatus() -> AudioStatus {
+        AudioStatus(
+            mode: options.audio.mode,
+            deviceMuted: deviceMuted,
+            microphoneMuted: microphoneMuted,
+            microphoneLevel: microphoneMuted ? 0 : microphoneLevel,
+            microphoneFailure: microphoneFailure)
+    }
+
+    /// Silence either source mid-recording. The capture keeps running — muted
+    /// samples are written as silence — so unmuting is instant and the audio
+    /// track keeps one continuous timeline.
+    public func setMuted(device: Bool, microphone: Bool) async {
+        deviceMuted = device
+        microphoneMuted = microphone
+        await session?.setAudioMuted(device: device, microphone: microphone)
     }
 
     public func start(serial: String, options: ScreenRecordOptions = ScreenRecordOptions()) async throws {
@@ -114,6 +158,7 @@ public actor ScreenRecorder {
 
     /// Abort and discard everything (view dismissed / app quit).
     public func abort() async {
+        await stopMicrophone()
         if let session { await session.stop() }
         let leftovers = segments + [currentURL].compactMap { $0 }
         session = nil
@@ -127,7 +172,7 @@ public actor ScreenRecorder {
     private func startSegment() async throws {
         let params = ScrcpyServerParams(
             scid: UInt32.random(in: 1 ... 0x7fff_ffff),
-            audio: options.captureAudio,
+            audio: options.audio.mode.includesDevice,
             control: false,
             maxSize: options.maxSize,
             videoBitRate: options.bitRateMbps > 0 ? options.bitRateMbps * 1_000_000 : 0,
@@ -143,22 +188,81 @@ public actor ScreenRecorder {
         let temp = Self.tempURL(ext: "mp4")
         // Arm recording up front; the session creates the recorder when the config
         // packet lands so this segment captures from its first key frame.
-        try await session.startRecording(to: temp)
+        await session.setAudioMuted(device: deviceMuted, microphone: microphoneMuted)
+        try await session.startRecording(to: temp, audio: options.audio.mode)
         guard await Self.waitUntilStreaming(session: session) else {
             await session.stop()
             throw RecordingError.startFailed("Couldn’t get video from the device.")
         }
         self.session = session
         self.currentURL = temp
+        await startMicrophone(feeding: session)
     }
 
     private func finalizeSegment() async {
         guard let session, let currentURL else { return }
         self.session = nil
         self.currentURL = nil
+        await stopMicrophone()
         _ = try? await session.stopRecording(url: currentURL)
         await session.stop()
         segments.append(currentURL)
+    }
+
+    // MARK: - Microphone
+
+    /// Bring the host microphone up for this segment and pump its chunks into
+    /// the session. A microphone that won't start (unplugged, access revoked)
+    /// is reported through `audioStatus()` and the recording continues without
+    /// it — losing the narration is better than losing the take.
+    private func startMicrophone(feeding session: MirrorSession) async {
+        guard options.audio.mode.includesMicrophone else { return }
+        let capture = MicrophoneCapture(deviceID: options.audio.microphoneDeviceID)
+        // A stream rather than a Task per chunk: chunks must reach the writer in
+        // order, and separate Tasks carry no ordering guarantee.
+        let (stream, sink) = AsyncStream.makeStream(
+            of: MicrophoneChunk.self, bufferingPolicy: .bufferingNewest(200))
+        do {
+            try await capture.start { sink.yield($0) }
+        } catch {
+            sink.finish()
+            microphoneFailure = Self.message(for: error)
+            return
+        }
+        microphone = capture
+        microphoneSink = sink
+        microphoneFailure = nil
+        microphonePump = Task { [weak self] in
+            for await chunk in stream {
+                await self?.deliver(chunk, to: session)
+            }
+        }
+    }
+
+    private func deliver(_ chunk: MicrophoneChunk, to session: MirrorSession) async {
+        microphoneLevel = chunk.level
+        await session.appendMicrophoneAudio(chunk.pcm, hostSeconds: chunk.hostSeconds)
+    }
+
+    private func stopMicrophone() async {
+        microphonePump?.cancel()
+        microphonePump = nil
+        microphoneSink?.finish()
+        microphoneSink = nil
+        if let microphone {
+            // A format the graph couldn't deliver only shows up while capturing,
+            // so it's collected on the way out.
+            if microphoneFailure == nil, let failure = await microphone.failure() {
+                microphoneFailure = failure.errorDescription
+            }
+            await microphone.stop()
+        }
+        microphone = nil
+        microphoneLevel = 0
+    }
+
+    private static func message(for error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     private static func waitUntilStreaming(session: MirrorSession) async -> Bool {

--- a/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenRecorder.swift
@@ -42,6 +42,9 @@ public actor ScreenRecorder {
     /// and level meter.
     public struct AudioStatus: Sendable, Equatable {
         public let mode: RecordAudioMode
+        /// What the device half of the recording is: its playback, its own
+        /// microphone, or nothing.
+        public let deviceSource: DeviceAudioSource
         public let deviceMuted: Bool
         public let microphoneMuted: Bool
         /// 0…1 level of the last microphone chunk; 0 when the mic isn't running.
@@ -93,6 +96,7 @@ public actor ScreenRecorder {
     public func audioStatus() -> AudioStatus {
         AudioStatus(
             mode: options.audio.mode,
+            deviceSource: options.audio.deviceSource,
             deviceMuted: deviceMuted,
             microphoneMuted: microphoneMuted,
             microphoneLevel: microphoneMuted ? 0 : microphoneLevel,
@@ -172,7 +176,8 @@ public actor ScreenRecorder {
     private func startSegment() async throws {
         let params = ScrcpyServerParams(
             scid: UInt32.random(in: 1 ... 0x7fff_ffff),
-            audio: options.audio.mode.includesDevice,
+            audio: options.audio.deviceSource.isOn,
+            audioSource: options.audio.deviceSource.scrcpySource,
             control: false,
             maxSize: options.maxSize,
             videoBitRate: options.bitRateMbps > 0 ? options.bitRateMbps * 1_000_000 : 0,

--- a/ADBKit/Sources/ADBKit/Services/ScreenTools.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenTools.swift
@@ -64,17 +64,89 @@ public enum RecordAudioMode: String, Sendable, Equatable, Codable, CaseIterable 
     }
 }
 
-/// The audio half of `ScreenRecordOptions`: what to capture, and which host
-/// input to capture the microphone from.
+/// What the device contributes to a recording. scrcpy captures **one** audio
+/// stream per session, so the device's playback and its own microphone are
+/// alternatives, not a pair — picking `microphone` records what the phone
+/// hears (the room, a call's uplink) instead of what it plays.
+public enum DeviceAudioSource: String, Sendable, Equatable, Codable, CaseIterable {
+    case off
+    case playback
+    case microphone
+
+    public var isOn: Bool { self != .off }
+
+    public var title: String {
+        switch self {
+        case .off: return "Off"
+        case .playback: return "Device playback"
+        case .microphone: return "Device microphone"
+        }
+    }
+
+    /// SF Symbol *name* — ADBKit stays UI-free, so this is a string.
+    public var symbolName: String {
+        switch self {
+        case .off: return "speaker.slash.fill"
+        case .playback: return "speaker.wave.2.fill"
+        case .microphone: return "mic.and.signal.meter.fill"
+        }
+    }
+
+    var scrcpySource: ScrcpyServerParams.AudioSource {
+        self == .microphone ? .microphone : .output
+    }
+}
+
+/// Which host inputs are worth offering in a picker.
+public enum RecordAudioInputs {
+    /// Core Audio's own scratch devices — the aggregate macOS builds around the
+    /// current default input (`CADefaultDeviceAggregate-…`) and the tap/loopback
+    /// shims some apps install — are implementation details, not microphones
+    /// anyone means to pick. Hiding them keeps the list to real hardware.
+    public static func isSelectable(name: String, uniqueID: String) -> Bool {
+        let hidden = ["CADefaultDeviceAggregate", "CATapAggregateDevice", "AMS2_Aggregate"]
+        return !hidden.contains { name.hasPrefix($0) || uniqueID.hasPrefix($0) }
+    }
+}
+
+/// The audio half of `ScreenRecordOptions`: what the device contributes, and
+/// which host input (if any) is mixed in alongside it.
 public struct RecordAudioOptions: Sendable, Equatable, Codable {
-    public var mode: RecordAudioMode
+    /// The device's own contribution — its playback, its microphone, or
+    /// nothing.
+    public var deviceSource: DeviceAudioSource
+    /// Whether the Mac's microphone is mixed in.
+    public var usesHostMicrophone: Bool
     /// Host input device id (an `AVCaptureDevice.uniqueID`), or nil for the
-    /// system default input. Ignored when the mode excludes the microphone.
+    /// system default input. Ignored when the host microphone is off.
     public var microphoneDeviceID: String?
 
-    public init(mode: RecordAudioMode = .deviceOnly, microphoneDeviceID: String? = nil) {
-        self.mode = mode
+    public init(
+        deviceSource: DeviceAudioSource = .playback,
+        usesHostMicrophone: Bool = false,
+        microphoneDeviceID: String? = nil
+    ) {
+        self.deviceSource = deviceSource
+        self.usesHostMicrophone = usesHostMicrophone
         self.microphoneDeviceID = microphoneDeviceID
+    }
+
+    /// Which sources the mixer has to reconcile — the device stream (whatever
+    /// it carries) and the host microphone.
+    public var mode: RecordAudioMode {
+        .mode(device: deviceSource.isOn, microphone: usesHostMicrophone)
+    }
+
+    /// One line naming exactly what a recording will capture, for the UI to
+    /// show before the user commits to a take.
+    public func summary(microphoneName: String?) -> String {
+        let host = microphoneName ?? "the Mac's microphone"
+        switch (deviceSource, usesHostMicrophone) {
+        case (.off, false): return "No audio"
+        case (.off, true): return host
+        case (let source, false): return source.title
+        case (let source, true): return "\(source.title) + \(host)"
+        }
     }
 }
 

--- a/ADBKit/Sources/ADBKit/Services/ScreenTools.swift
+++ b/ADBKit/Sources/ADBKit/Services/ScreenTools.swift
@@ -1,5 +1,83 @@
 import Foundation
 
+/// Which audio a recording captures. The device's own audio arrives over the
+/// scrcpy stream (Android 11+); the microphone is a host input. When both are
+/// on they are summed into one AAC track so the file plays everywhere — see
+/// `PCMMixdown`.
+public enum RecordAudioMode: String, Sendable, Equatable, Codable, CaseIterable {
+    case deviceAndMicrophone
+    case deviceOnly
+    case microphoneOnly
+    case muted
+
+    public var includesDevice: Bool {
+        self == .deviceAndMicrophone || self == .deviceOnly
+    }
+
+    public var includesMicrophone: Bool {
+        self == .deviceAndMicrophone || self == .microphoneOnly
+    }
+
+    /// Both sources feed one track, so their samples must be summed on a shared
+    /// timeline rather than appended as they arrive.
+    public var mixesSources: Bool { includesDevice && includesMicrophone }
+
+    /// Whether the recording carries an audio track at all.
+    public var hasAudio: Bool { self != .muted }
+
+    public static func mode(device: Bool, microphone: Bool) -> RecordAudioMode {
+        switch (device, microphone) {
+        case (true, true): return .deviceAndMicrophone
+        case (true, false): return .deviceOnly
+        case (false, true): return .microphoneOnly
+        case (false, false): return .muted
+        }
+    }
+
+    /// The mode actually achievable when the session never asked the device for
+    /// audio: an in-mirror recording can only record what its stream carries.
+    public func limited(deviceAudioAvailable: Bool) -> RecordAudioMode {
+        deviceAudioAvailable
+            ? self
+            : Self.mode(device: false, microphone: includesMicrophone)
+    }
+
+    /// UI label. It lives here so the picker and the recorder can't drift apart.
+    public var title: String {
+        switch self {
+        case .deviceAndMicrophone: return "Device + Microphone"
+        case .deviceOnly: return "Device only"
+        case .microphoneOnly: return "Microphone only"
+        case .muted: return "No audio"
+        }
+    }
+
+    /// SF Symbol *name* — ADBKit stays UI-free, so this is a string, like the
+    /// feature icons.
+    public var symbolName: String {
+        switch self {
+        case .deviceAndMicrophone: return "waveform.badge.mic"
+        case .deviceOnly: return "speaker.wave.2.fill"
+        case .microphoneOnly: return "mic.fill"
+        case .muted: return "speaker.slash.fill"
+        }
+    }
+}
+
+/// The audio half of `ScreenRecordOptions`: what to capture, and which host
+/// input to capture the microphone from.
+public struct RecordAudioOptions: Sendable, Equatable, Codable {
+    public var mode: RecordAudioMode
+    /// Host input device id (an `AVCaptureDevice.uniqueID`), or nil for the
+    /// system default input. Ignored when the mode excludes the microphone.
+    public var microphoneDeviceID: String?
+
+    public init(mode: RecordAudioMode = .deviceOnly, microphoneDeviceID: String? = nil) {
+        self.mode = mode
+        self.microphoneDeviceID = microphoneDeviceID
+    }
+}
+
 /// Screen-recording options. The recorder maps these onto `ScrcpyServerParams`
 /// for the in-app scrcpy client (bundled server) — no external scrcpy process.
 /// `timeLimitSeconds` is enforced by the recording UI (the server has no
@@ -11,8 +89,9 @@ public struct ScreenRecordOptions: Sendable, Equatable {
     public var bitRateMbps: Int
     /// Frame-rate cap (0 = unlimited) → `max_fps`.
     public var maxFps: Int
-    /// Capture device audio (Android 11+; falls back to video-only otherwise).
-    public var captureAudio: Bool
+    /// What to capture: device audio (Android 11+; falls back to video-only
+    /// otherwise), the Mac's microphone, both, or neither.
+    public var audio: RecordAudioOptions
     /// Stop after N seconds (0 = unlimited); enforced by the UI.
     public var timeLimitSeconds: Int
 
@@ -20,13 +99,13 @@ public struct ScreenRecordOptions: Sendable, Equatable {
         maxSize: Int = 0,
         bitRateMbps: Int = 0,
         maxFps: Int = 0,
-        captureAudio: Bool = true,
+        audio: RecordAudioOptions = RecordAudioOptions(),
         timeLimitSeconds: Int = 0
     ) {
         self.maxSize = maxSize
         self.bitRateMbps = bitRateMbps
         self.maxFps = maxFps
-        self.captureAudio = captureAudio
+        self.audio = audio
         self.timeLimitSeconds = timeLimitSeconds
     }
 }

--- a/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
@@ -53,7 +53,7 @@ import Testing
         try await recorder.start(
             serial: serial,
             options: ScreenRecordOptions(
-                maxSize: 800, audio: RecordAudioOptions(mode: .deviceOnly)))
+                maxSize: 800, audio: RecordAudioOptions(deviceSource: .playback)))
         try await Task.sleep(for: .seconds(3))
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorPlusRecordLiveTests.swift
@@ -51,7 +51,9 @@ import Testing
         // Now record via a SECOND session while the display session keeps streaming.
         let recorder = ScreenRecorder(client: adb, server: server)
         try await recorder.start(
-            serial: serial, options: ScreenRecordOptions(maxSize: 800, captureAudio: true))
+            serial: serial,
+            options: ScreenRecordOptions(
+                maxSize: 800, audio: RecordAudioOptions(mode: .deviceOnly)))
         try await Task.sleep(for: .seconds(3))
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/ADBKit/Tests/ADBKitTests/PCMMixdownTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PCMMixdownTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+@Suite struct PCMSamplesTests {
+    @Test func decodesLittleEndianRegardlessOfHost() {
+        #expect(PCMSamples.decode(Data([0x00, 0x80])) == [Int16.min])
+        #expect(PCMSamples.decode(Data([0xff, 0x7f])) == [Int16.max])
+        #expect(PCMSamples.decode(Data([0x01, 0x00, 0xff, 0xff])) == [1, -1])
+    }
+
+    @Test func roundTripsThroughEncode() {
+        let samples: [Int16] = [0, 1, -1, 1234, -4321, Int16.max, Int16.min]
+        #expect(PCMSamples.decode(PCMSamples.encode(samples)) == samples)
+    }
+
+    @Test func ignoresATrailingHalfSample() {
+        // A chunk boundary can split a sample; the odd byte must be dropped,
+        // not paired with a zero into a bogus value.
+        #expect(PCMSamples.decode(Data([0x01, 0x00, 0x02])) == [1])
+        #expect(PCMSamples.decode(Data([0x7f])) == [])
+        #expect(PCMSamples.decode(Data()) == [])
+    }
+
+    @Test func monoInputIsDuplicatedAcrossBothChannels() {
+        // A mono USB mic must not end up in the left ear only.
+        #expect(PCMSamples.stereo(from: [5, -7], channels: 1) == [5, 5, -7, -7])
+    }
+
+    @Test func stereoInputPassesThroughAndMultiChannelKeepsTheFirstPair() {
+        #expect(PCMSamples.stereo(from: [1, 2, 3, 4], channels: 2) == [1, 2, 3, 4])
+        #expect(PCMSamples.stereo(from: [1, 2, 3, 4, 5, 6], channels: 3) == [1, 2, 4, 5])
+    }
+
+    @Test func partialTrailingFramesAreDroppedNotPaddedWithSilence() {
+        #expect(PCMSamples.stereo(from: [1, 2, 3], channels: 2) == [1, 2])
+        #expect(PCMSamples.stereo(from: [1, 2], channels: 3) == [])
+        #expect(PCMSamples.stereo(from: [1, 2], channels: 0) == [])
+    }
+
+    @Test func silencingKeepsTheLengthSoTheTimelineDoesNotShift() {
+        let data = PCMSamples.encode([500, -500, 32_000])
+        let silent = PCMSamples.silenced(data)
+        #expect(silent.count == data.count)
+        #expect(PCMSamples.decode(silent) == [0, 0, 0])
+    }
+}
+
+@Suite struct AudioTimelineTests {
+    private let timeline = AudioTimeline(
+        originDeviceSeconds: 10, originHostSeconds: 100, sampleRate: 48_000)
+
+    @Test func deviceTimestampsCountFromTheOrigin() {
+        #expect(timeline.frame(deviceSeconds: 10) == 0)
+        #expect(timeline.frame(deviceSeconds: 11) == 48_000)
+        #expect(timeline.frame(deviceSeconds: 10.5) == 24_000)
+    }
+
+    @Test func hostTimestampsTranslateThroughTheAnchor() {
+        // The two clocks read 90 seconds apart; the same instant must land on
+        // the same frame from either side.
+        #expect(timeline.frame(hostSeconds: 100) == 0)
+        #expect(timeline.frame(hostSeconds: 100.5) == timeline.frame(deviceSeconds: 10.5))
+        #expect(timeline.frame(hostSeconds: 101) == 48_000)
+    }
+
+    @Test func audioBeforeTheOriginIsNegativeNotWrapped() {
+        #expect(timeline.frame(deviceSeconds: 9.5) == -24_000)
+        #expect(timeline.frame(hostSeconds: 99.5) == -24_000)
+    }
+
+    @Test func framesConvertBackToDeviceSeconds() {
+        #expect(timeline.deviceSeconds(frame: 0) == 10)
+        #expect(timeline.deviceSeconds(frame: 48_000) == 11)
+        #expect(abs(timeline.deviceSeconds(frame: 24_000) - 10.5) < 0.000_001)
+    }
+
+    @Test func nonFiniteOrAbsurdTimestampsPinToTheOriginInsteadOfTrapping() {
+        #expect(timeline.frame(deviceSeconds: .nan) == 0)
+        #expect(timeline.frame(deviceSeconds: .infinity) == 0)
+        #expect(timeline.frame(hostSeconds: -.infinity) == 0)
+        #expect(timeline.frame(deviceSeconds: 1e300) == 0)
+    }
+}
+
+@Suite struct PCMMixdownTests {
+    /// One stereo frame of a constant value, `frames` long.
+    private func tone(_ value: Int16, frames: Int) -> [Int16] {
+        [Int16](repeating: value, count: frames * 2)
+    }
+
+    @Test func aLoneSourcePassesThroughUnchanged() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(1_000, frames: 4), at: 0)
+        let chunk = mixdown.drain(through: 4)
+        #expect(chunk?.startFrame == 0)
+        #expect(chunk?.samples == tone(1_000, frames: 4))
+    }
+
+    @Test func alignedSourcesSum() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(1_000, frames: 4), at: 0)
+        mixdown.add(samples: tone(250, frames: 4), at: 0)
+        #expect(mixdown.drain(through: 4)?.samples == tone(1_250, frames: 4))
+    }
+
+    @Test func aLateStartingSourceOnlyMixesFromWhereItBegins() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(1_000, frames: 4), at: 0)
+        // The mic joins two frames in — narration starting after the recording.
+        mixdown.add(samples: tone(500, frames: 2), at: 2)
+        let samples = mixdown.drain(through: 4)?.samples
+        #expect(samples == tone(1_000, frames: 2) + tone(1_500, frames: 2))
+    }
+
+    @Test func gapsInASourceReadAsSilenceNotAsAShift() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(700, frames: 2), at: 0)
+        // Frames 2–3 never arrive from either source; frame 4 does.
+        mixdown.add(samples: tone(700, frames: 1), at: 4)
+        let chunk = mixdown.drain(through: 5)
+        #expect(chunk?.samples == tone(700, frames: 2) + tone(0, frames: 2) + tone(700, frames: 1))
+    }
+
+    /// What the in-recording mute chips promise: silencing one source leaves
+    /// the other one untouched, and the timeline doesn't shift (mute writes
+    /// silence rather than dropping samples).
+    @Test func mutingOneSourceLeavesTheOtherAudible() {
+        var mixdown = PCMMixdown()
+        let muted = PCMSamples.decode(PCMSamples.silenced(PCMSamples.encode(tone(9_000, frames: 4))))
+        mixdown.add(samples: muted, at: 0)
+        mixdown.add(samples: tone(1_200, frames: 4), at: 0)
+        let chunk = mixdown.drain(through: 4)
+        #expect(chunk?.startFrame == 0)
+        #expect(chunk?.samples == tone(1_200, frames: 4))
+    }
+
+    @Test func mutingBothSourcesWritesSilenceNotAGap() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(0, frames: 3), at: 0)
+        mixdown.add(samples: tone(0, frames: 3), at: 0)
+        let chunk = mixdown.drain(through: 3)
+        // Three frames of silence, so the next chunk still lands at frame 3.
+        #expect(chunk?.samples == tone(0, frames: 3))
+        mixdown.add(samples: tone(500, frames: 1), at: 3)
+        #expect(mixdown.drain(through: 4)?.startFrame == 3)
+    }
+
+    @Test func summedFullScaleSourcesClipRatherThanWrap() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(Int16.max, frames: 2), at: 0)
+        mixdown.add(samples: tone(Int16.max, frames: 2), at: 0)
+        #expect(mixdown.drain(through: 2)?.samples == tone(Int16.max, frames: 2))
+
+        var negative = PCMMixdown()
+        negative.add(samples: tone(Int16.min, frames: 2), at: 0)
+        negative.add(samples: tone(Int16.min, frames: 2), at: 0)
+        #expect(negative.drain(through: 2)?.samples == tone(Int16.min, frames: 2))
+    }
+
+    @Test func drainNeverRunsAheadOfWhatWasWritten() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(100, frames: 3), at: 0)
+        // Asked for 10 frames, only 3 exist: emit those, and don't advance past
+        // them (frames 3+ may still arrive).
+        let chunk = mixdown.drain(through: 10)
+        #expect(chunk?.samples.count == 3 * 2)
+        #expect(mixdown.drain(through: 10) == nil)
+
+        mixdown.add(samples: tone(100, frames: 1), at: 3)
+        #expect(mixdown.drain(through: 10)?.startFrame == 3)
+    }
+
+    @Test func nothingBufferedDrainsToNil() {
+        var mixdown = PCMMixdown()
+        #expect(mixdown.drain(through: 100) == nil)
+        #expect(mixdown.flush() == nil)
+        mixdown.add(samples: [], at: 0)
+        #expect(mixdown.drain(through: 100) == nil)
+    }
+
+    @Test func samplesArrivingAfterTheirSpanWasEmittedAreDropped() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(1_000, frames: 4), at: 0)
+        _ = mixdown.drain(through: 4)
+        // A straggler for frames 0–1: too late to mix, and it must not be
+        // re-emitted at the new edge (which would duplicate audio).
+        mixdown.add(samples: tone(9_000, frames: 2), at: 0)
+        #expect(mixdown.drain(through: 10) == nil)
+
+        // The part of a straddling chunk that is still ahead of the edge is kept.
+        mixdown.add(samples: tone(300, frames: 6), at: 2)
+        let chunk = mixdown.drain(through: 8)
+        #expect(chunk?.startFrame == 4)
+        #expect(chunk?.samples == tone(300, frames: 4))
+    }
+
+    @Test func aRunawaySourceCannotGrowTheBufferWithoutBound() {
+        var mixdown = PCMMixdown(sampleRate: 48_000, channels: 2, maxBufferedSeconds: 0.5)
+        mixdown.add(samples: tone(500, frames: 48_000), at: 0)
+        #expect(mixdown.bufferedFrames == 24_000)
+        // Far beyond the window: dropped outright rather than allocating a
+        // multi-minute gap of silence.
+        mixdown.add(samples: tone(500, frames: 10), at: 5_000_000)
+        #expect(mixdown.bufferedFrames == 24_000)
+    }
+
+    @Test func flushEmitsTheTailThenNothing() {
+        var mixdown = PCMMixdown()
+        mixdown.add(samples: tone(400, frames: 5), at: 0)
+        _ = mixdown.drain(through: 2)
+        let tail = mixdown.flush()
+        #expect(tail?.startFrame == 2)
+        #expect(tail?.samples == tone(400, frames: 3))
+        #expect(mixdown.flush() == nil)
+    }
+
+    @Test func monoAndOtherLayoutsCountFramesByChannel() {
+        var mixdown = PCMMixdown(sampleRate: 48_000, channels: 1)
+        mixdown.add(samples: [10, 20, 30], at: 0)
+        mixdown.add(samples: [1, 2, 3], at: 0)
+        #expect(mixdown.drain(through: 3)?.samples == [11, 22, 33])
+    }
+}
+
+@Suite struct AudioLevelTests {
+    @Test func silenceReadsZeroAndFullScaleReadsOne() {
+        #expect(AudioLevel.rms([0, 0, 0]) == 0)
+        #expect(AudioLevel.rms([]) == 0)
+        #expect(abs(AudioLevel.rms([Int16.max, Int16.max]) - 1) < 0.001)
+        #expect(AudioLevel.rms([Int16.min, Int16.min]) == 1)
+    }
+
+    @Test func quietSignalsSitBetween() {
+        let level = AudioLevel.rms([3_276, -3_276, 3_276, -3_276])
+        #expect(level > 0.09 && level < 0.11)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/RecordAudioOptionsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/RecordAudioOptionsTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+/// The recording's audio shape: what the device contributes (one stream —
+/// playback *or* its own mic) and whether the Mac's microphone is mixed in.
+@Suite struct RecordAudioOptionsTests {
+    @Test func theDeviceHalfMapsOntoScrcpysAudioSource() {
+        #expect(DeviceAudioSource.playback.scrcpySource == .output)
+        #expect(DeviceAudioSource.microphone.scrcpySource == .microphone)
+        // Off never reaches the server as a source — the stream is simply not
+        // requested — but it must not claim to be the microphone either.
+        #expect(DeviceAudioSource.off.scrcpySource == .output)
+        #expect(!DeviceAudioSource.off.isOn)
+        #expect(DeviceAudioSource.playback.isOn && DeviceAudioSource.microphone.isOn)
+    }
+
+    @Test func theMixerSeesTwoSourcesOnlyWhenBothSidesAreOn() {
+        #expect(RecordAudioOptions(deviceSource: .off, usesHostMicrophone: false).mode == .muted)
+        #expect(RecordAudioOptions(deviceSource: .playback, usesHostMicrophone: false).mode
+            == .deviceOnly)
+        #expect(RecordAudioOptions(deviceSource: .off, usesHostMicrophone: true).mode
+            == .microphoneOnly)
+        // The device's own mic is still "the device side" as far as mixing goes.
+        #expect(RecordAudioOptions(deviceSource: .microphone, usesHostMicrophone: true).mode
+            == .deviceAndMicrophone)
+        #expect(RecordAudioOptions(deviceSource: .microphone, usesHostMicrophone: true).mode
+            .mixesSources)
+    }
+
+    @Test func theSummaryNamesEveryCombination() {
+        #expect(RecordAudioOptions(deviceSource: .off, usesHostMicrophone: false)
+            .summary(microphoneName: "MacBook Pro Microphone") == "No audio")
+        #expect(RecordAudioOptions(deviceSource: .playback, usesHostMicrophone: false)
+            .summary(microphoneName: "MacBook Pro Microphone") == "Device playback")
+        #expect(RecordAudioOptions(deviceSource: .off, usesHostMicrophone: true)
+            .summary(microphoneName: "MacBook Pro Microphone") == "MacBook Pro Microphone")
+        #expect(RecordAudioOptions(deviceSource: .microphone, usesHostMicrophone: true)
+            .summary(microphoneName: "Podcast Mic") == "Device microphone + Podcast Mic")
+    }
+
+    @Test func theSummaryStillReadsWithoutAnInputName() {
+        #expect(RecordAudioOptions(deviceSource: .playback, usesHostMicrophone: true)
+            .summary(microphoneName: nil) == "Device playback + the Mac's microphone")
+    }
+
+    @Test func coreAudiosOwnScratchDevicesAreNotOfferedAsMicrophones() {
+        // The aggregate macOS builds around the default input is not something
+        // anyone means to pick — it shows up as "CADefaultDeviceAggregate-87116-0".
+        #expect(!RecordAudioInputs.isSelectable(
+            name: "CADefaultDeviceAggregate-87116-0", uniqueID: "CADefaultDeviceAggregate-87116-0"))
+        #expect(!RecordAudioInputs.isSelectable(name: "CATapAggregateDevice-1", uniqueID: "x"))
+        #expect(!RecordAudioInputs.isSelectable(name: "anything", uniqueID: "AMS2_Aggregate-9"))
+    }
+
+    @Test func realMicrophonesStayInTheList() {
+        #expect(RecordAudioInputs.isSelectable(
+            name: "MacBook Pro Microphone", uniqueID: "BuiltInMicrophoneDevice"))
+        #expect(RecordAudioInputs.isSelectable(
+            name: "Scarlett Solo USB", uniqueID: "AppleUSBAudioEngine:Focusrite"))
+        // A name that merely *contains* the marker is still a real device.
+        #expect(RecordAudioInputs.isSelectable(
+            name: "My CADefaultDeviceAggregate Clone", uniqueID: "usb-9"))
+    }
+
+    @Test func optionsRoundTripThroughCodable() throws {
+        let options = RecordAudioOptions(
+            deviceSource: .microphone, usesHostMicrophone: true, microphoneDeviceID: "usb-1")
+        let data = try JSONEncoder().encode(options)
+        #expect(try JSONDecoder().decode(RecordAudioOptions.self, from: data) == options)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ScrcpyServerParamsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScrcpyServerParamsTests.swift
@@ -37,6 +37,23 @@ import Testing
         #expect(!params.parameters().contains("control=false"))
     }
 
+    @Test func theDeviceMicrophoneIsRequestedWithAudioSource() {
+        let mic = ScrcpyServerParams(
+            scid: 0x0000_0001, audio: true, audioSource: .microphone)
+        #expect(mic.parameters().contains("audio_source=mic"))
+        // The server's default source is `output`, so it stays unsaid.
+        let playback = ScrcpyServerParams(scid: 0x0000_0001, audio: true, audioSource: .output)
+        #expect(!playback.parameters().contains(where: { $0.hasPrefix("audio_source=") }))
+    }
+
+    @Test func audioSourceIsNotSentWhenAudioIsOff() {
+        // A source without a stream would be a contradiction the server has to
+        // parse; audio=false is the whole statement.
+        let params = ScrcpyServerParams(scid: 1, audio: false, audioSource: .microphone)
+        #expect(!params.parameters().contains(where: { $0.hasPrefix("audio_source=") }))
+        #expect(params.parameters().contains("audio=false"))
+    }
+
     @Test func audioEnabledRequestsRawPcm() {
         // audio on => no audio=false, and the non-default raw codec is requested.
         let params = ScrcpyServerParams(

--- a/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
@@ -27,7 +27,9 @@ import Testing
 
         let recorder = ScreenRecorder(client: adb, server: server)
         try await recorder.start(
-            serial: serial, options: ScreenRecordOptions(maxSize: 800, captureAudio: true))
+            serial: serial,
+            options: ScreenRecordOptions(
+                maxSize: 800, audio: RecordAudioOptions(mode: .deviceOnly)))
         try await Task.sleep(for: .seconds(3))
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ScreenRecorderLiveTests.swift
@@ -29,7 +29,7 @@ import Testing
         try await recorder.start(
             serial: serial,
             options: ScreenRecordOptions(
-                maxSize: 800, audio: RecordAudioOptions(mode: .deviceOnly)))
+                maxSize: 800, audio: RecordAudioOptions(deviceSource: .playback)))
         try await Task.sleep(for: .seconds(3))
         let url = try await recorder.stop()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -316,11 +316,21 @@ final class MirrorViewModel {
         let recorder = ScreenRecorder(
             client: adb, server: server, ffmpegPath: BundledTools.ffmpegPath())
         do {
+            // The same audio choice the Screen Record screen uses, so a clip
+            // taken from the mirror captures what the user set up there.
             try await recorder.start(
-                serial: serial, options: ScreenRecordOptions(maxSize: 1280, captureAudio: true))
+                serial: serial,
+                options: ScreenRecordOptions(
+                    maxSize: 1280, audio: RecordAudioPreference.options(from: .standard)))
             screenRecorder = recorder
             isRecording = true
             isPaused = false
+            // The mirror has no mute chips to show this on, so a microphone
+            // that wouldn't start is reported once instead of going unnoticed
+            // until playback.
+            if let failure = await recorder.audioStatus().microphoneFailure {
+                recordingError = failure
+            }
         } catch {
             recordingError = error.localizedDescription
         }

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -65,6 +65,10 @@ final class MirrorViewModel {
     /// to record on the live session can't get a key frame mid-stream — the
     /// encoder emits them rarely.)
     private var screenRecorder: ScreenRecorder?
+    /// What the running recording captures, so the bar's audio menu can show
+    /// it and offer live mutes. Read at start and after each mute; nothing
+    /// else changes it, so it needs no polling.
+    private(set) var recordAudioStatus: ScreenRecorder.AudioStatus?
     private var sendControl: (@Sendable (ScrcpyControlMessage) -> Void)?
     /// Whether to request device audio. Off by default (the toggle in the
     /// control bar opts in). Cleared after one failed start so the mirror
@@ -325,10 +329,11 @@ final class MirrorViewModel {
             screenRecorder = recorder
             isRecording = true
             isPaused = false
+            recordAudioStatus = await recorder.audioStatus()
             // The mirror has no mute chips to show this on, so a microphone
             // that wouldn't start is reported once instead of going unnoticed
             // until playback.
-            if let failure = await recorder.audioStatus().microphoneFailure {
+            if let failure = recordAudioStatus?.microphoneFailure {
                 recordingError = failure
             }
         } catch {
@@ -341,8 +346,17 @@ final class MirrorViewModel {
         screenRecorder = nil
         isRecording = false
         isPaused = false
+        recordAudioStatus = nil
         // Stopping returns the finished temp file; the view prompts discard/save/edit.
         if let url = try? await recorder.stop() { pendingRecording = url }
+    }
+
+    /// Silence either source mid-recording, from the bar's audio menu. The
+    /// capture keeps running, so unmuting is instant.
+    func setRecordMuted(device: Bool, microphone: Bool) async {
+        guard let recorder = screenRecorder else { return }
+        await recorder.setMuted(device: device, microphone: microphone)
+        recordAudioStatus = await recorder.audioStatus()
     }
 
     /// Stop recording for a "Stop & save" leave and return the finished file
@@ -352,6 +366,7 @@ final class MirrorViewModel {
         screenRecorder = nil
         isRecording = false
         isPaused = false
+        recordAudioStatus = nil
         return try? await recorder.stop()
     }
 

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
@@ -1,48 +1,43 @@
 import ADBKit
 import SwiftUI
 
-/// Asking for microphone access at the moment the user opts in — from the
-/// Screen Record picker or the mirror's ⋯ menu — so the system prompt lands on
-/// a deliberate choice instead of surprising them when a recording starts.
+/// Asking for microphone access at the moment the user opts in, so the system
+/// prompt lands on a deliberate choice instead of surprising them when a
+/// recording starts.
 enum MicrophoneAccess {
     @discardableResult
-    static func requestIfNeeded(for mode: RecordAudioMode) async -> MicrophoneCapture.Authorization {
-        guard mode.includesMicrophone,
-              MicrophoneCapture.authorization() == .notDetermined
-        else { return MicrophoneCapture.authorization() }
+    static func requestIfNeeded(forHostMicrophone on: Bool) async
+        -> MicrophoneCapture.Authorization {
+        guard on, MicrophoneCapture.authorization() == .notDetermined else {
+            return MicrophoneCapture.authorization()
+        }
         _ = await MicrophoneCapture.requestAccess()
         return MicrophoneCapture.authorization()
     }
+
+    /// macOS only ever prompts once, so a denied app can only be fixed here.
+    static func openSettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+        else { return }
+        NSWorkspace.shared.open(url)
+    }
 }
 
-/// The audio choice on the Screen Record screen: two switches — the device's
-/// own sound, and the Mac's microphone — because that's what the recording
-/// actually has, and either can be on without the other. When the microphone
-/// is on it gains an input picker and a level check, so you know it's hearing
-/// you before you hit Record.
+/// The recording's audio, as two independent dropdowns:
+///
+/// - **Device audio** — off, the device's playback, or the device's own
+///   microphone. scrcpy carries one device stream per session, so these are
+///   alternatives rather than a set.
+/// - **Microphone** — off, the Mac's default input, or a named input.
+///
+/// Any pairing works, and the summary line spells out the result so nobody has
+/// to hold the combination in their head.
 struct RecordAudioOptionsRow: View {
-    @Binding var mode: RecordAudioMode
+    @Binding var deviceSource: DeviceAudioSource
+    @Binding var usesHostMicrophone: Bool
     /// An `AVCaptureDevice.uniqueID`, or empty for the system default input.
     @Binding var inputID: String
-
-    private var deviceAudio: Binding<Bool> {
-        Binding(
-            get: { mode.includesDevice },
-            set: { mode = .mode(device: $0, microphone: mode.includesMicrophone) })
-    }
-
-    /// Off, the system default, or a named input — picking an input is what
-    /// turns the microphone on, so there's one control instead of two.
-    private var microphoneChoice: Binding<MicrophoneChoice> {
-        Binding(
-            get: { RecordAudioPreference.microphoneChoice(mode: mode, inputID: inputID) },
-            set: { choice in
-                let applied = RecordAudioPreference.applying(
-                    choice, mode: mode, inputID: inputID)
-                mode = applied.mode
-                inputID = applied.inputID
-            })
-    }
 
     @State private var inputs: [MicrophoneCapture.Input] = []
     @State private var authorization = MicrophoneCapture.authorization()
@@ -51,17 +46,38 @@ struct RecordAudioOptionsRow: View {
     @State private var testTask: Task<Void, Never>?
     @State private var micError: String?
 
+    /// What the current pairing will record, in words.
+    var summary: String {
+        RecordAudioOptions(
+            deviceSource: deviceSource,
+            usesHostMicrophone: usesHostMicrophone,
+            microphoneDeviceID: inputID.isEmpty ? nil : inputID
+        ).summary(microphoneName: usesHostMicrophone ? selectedInputName : nil)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            Toggle(isOn: devicePlayback) {
+                rowLabel(
+                    "Device audio",
+                    subtitle: "The sound the app itself plays (Android 11+)")
+            }
+            Toggle(isOn: deviceMicrophone) {
+                rowLabel(
+                    "Device microphone",
+                    subtitle: "What the phone's own mic hears")
+            }
+            if deviceSource == .microphone {
+                Text("The device sends one audio stream, so its mic replaces its playback.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .transition(.opacity)
+            }
             labeledRow(
-                "Device audio",
-                subtitle: "The app's own sound, from the device (Android 11+)"
-            ) { deviceAudioPicker }
-            labeledRow(
-                "Microphone",
-                subtitle: "Your voice, from the Mac — narrate what you're showing"
+                "Mac microphone",
+                subtitle: "Your voice — narrate what you're showing"
             ) { microphonePicker }
-            if mode.includesMicrophone {
+            if usesHostMicrophone {
                 levelCheckRow
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
@@ -70,41 +86,46 @@ struct RecordAudioOptionsRow: View {
                     .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.15), value: mode)
+        .animation(.easeInOut(duration: 0.15), value: usesHostMicrophone)
+        .animation(.easeInOut(duration: 0.15), value: deviceSource)
         .animation(.easeInOut(duration: 0.15), value: authorization)
         .onAppear { refreshInputs() }
         .onDisappear { stopTest() }
-        .onChange(of: mode) { _, new in modeChanged(to: new) }
+        .onChange(of: usesHostMicrophone) { _, on in microphoneToggled(on) }
         .onChange(of: inputID) { _, _ in if isTesting { restartTest() } }
     }
 
-    private func labeledRow(
-        _ title: String, subtitle: String, @ViewBuilder _ control: () -> some View
-    ) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(title)
-                Text(subtitle)
-                    .font(.app(.footnote))
-                    .foregroundStyle(.textMuted)
-            }
-            Spacer(minLength: 12)
-            control()
-        }
+    /// The device's playback and its own microphone are one checkbox each, but
+    /// scrcpy carries a single device stream — so ticking one unticks the
+    /// other, with a line of text saying why rather than a silently ignored
+    /// setting.
+    private var devicePlayback: Binding<Bool> {
+        Binding(
+            get: { deviceSource == .playback },
+            set: { deviceSource = $0 ? .playback : .off })
     }
 
-    private var deviceAudioPicker: some View {
-        Picker("", selection: deviceAudio) {
-            Text("On").tag(true)
-            Text("Off").tag(false)
+    private var deviceMicrophone: Binding<Bool> {
+        Binding(
+            get: { deviceSource == .microphone },
+            set: { deviceSource = $0 ? .microphone : .off })
+    }
+
+    private func rowLabel(_ title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(title)
+            Text(subtitle)
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
         }
-        .labelsHidden().pickerStyle(.menu).fixedSize()
     }
 
     private var microphonePicker: some View {
+        // No `Divider()` in here: a divider inside a Picker breaks tag matching,
+        // and SwiftUI then *writes back* a coerced selection — which silently
+        // turned the microphone on at launch.
         Picker("", selection: microphoneChoice) {
             Text("Off").tag(MicrophoneChoice.off)
-            Divider()
             Text("System default").tag(MicrophoneChoice.systemDefault)
             ForEach(inputs) { input in
                 Text(input.name).tag(MicrophoneChoice.input(input.id))
@@ -113,6 +134,24 @@ struct RecordAudioOptionsRow: View {
         .labelsHidden().pickerStyle(.menu)
         .frame(maxWidth: 210)
         .disabled(authorization == .denied)
+    }
+
+    private var microphoneChoice: Binding<MicrophoneChoice> {
+        Binding(
+            get: {
+                RecordAudioPreference.microphoneChoice(
+                    usesHostMicrophone: usesHostMicrophone, inputID: inputID)
+            },
+            set: { choice in
+                let applied = RecordAudioPreference.applying(choice, inputID: inputID)
+                usesHostMicrophone = applied.usesHostMicrophone
+                inputID = applied.inputID
+            })
+    }
+
+    private var selectedInputName: String {
+        guard !inputID.isEmpty else { return inputs.first?.name ?? "System default" }
+        return inputs.first(where: { $0.id == inputID })?.name ?? "Selected input"
     }
 
     /// Hear the chosen input before committing to a take.
@@ -131,10 +170,25 @@ struct RecordAudioOptionsRow: View {
         }
     }
 
+    private func labeledRow(
+        _ title: String, subtitle: String, @ViewBuilder _ control: () -> some View
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                Text(subtitle)
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+            }
+            Spacer(minLength: 12)
+            control()
+        }
+    }
+
     /// Whichever of the two problems is worth saying out loud: no access, or an
     /// input that wouldn't start.
     private var warning: String? {
-        guard mode.includesMicrophone else { return nil }
+        guard usesHostMicrophone else { return nil }
         if authorization == .denied {
             return "Microphone access is off, so the recording won’t have mic audio."
         }
@@ -150,7 +204,7 @@ struct RecordAudioOptionsRow: View {
                 .foregroundStyle(.textMuted)
                 .fixedSize(horizontal: false, vertical: true)
             if authorization == .denied {
-                Button("Open Settings") { openMicrophoneSettings() }
+                Button("Open Settings") { MicrophoneAccess.openSettings() }
                     .buttonStyle(.link)
                     .font(.app(.footnote))
             }
@@ -159,15 +213,15 @@ struct RecordAudioOptionsRow: View {
 
     // MARK: - Access and inputs
 
-    private func modeChanged(to mode: RecordAudioMode) {
+    private func microphoneToggled(_ on: Bool) {
         micError = nil
-        guard mode.includesMicrophone else {
+        guard on else {
             stopTest()
             return
         }
         refreshInputs()
         Task { @MainActor in
-            authorization = await MicrophoneAccess.requestIfNeeded(for: mode)
+            authorization = await MicrophoneAccess.requestIfNeeded(forHostMicrophone: true)
         }
     }
 
@@ -177,13 +231,6 @@ struct RecordAudioOptionsRow: View {
         // The chosen input can vanish (a headset unplugged between recordings);
         // fall back to the system default rather than failing at Record time.
         if !inputID.isEmpty, !inputs.contains(where: { $0.id == inputID }) { inputID = "" }
-    }
-
-    private func openMicrophoneSettings() {
-        guard let url = URL(
-            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-        else { return }
-        NSWorkspace.shared.open(url)
     }
 
     // MARK: - Level check
@@ -274,8 +321,8 @@ struct RecordAudioMuteChips: View {
         HStack(spacing: 8) {
             if status.mode.includesDevice {
                 chip(
-                    title: "Device",
-                    symbol: "speaker.wave.2.fill",
+                    title: status.deviceSource == .microphone ? "Device mic" : "Device",
+                    symbol: status.deviceSource.symbolName,
                     mutedSymbol: "speaker.slash.fill",
                     isMuted: status.deviceMuted,
                     level: nil

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
@@ -31,10 +31,17 @@ struct RecordAudioOptionsRow: View {
             set: { mode = .mode(device: $0, microphone: mode.includesMicrophone) })
     }
 
-    private var microphone: Binding<Bool> {
+    /// Off, the system default, or a named input — picking an input is what
+    /// turns the microphone on, so there's one control instead of two.
+    private var microphoneChoice: Binding<MicrophoneChoice> {
         Binding(
-            get: { mode.includesMicrophone },
-            set: { mode = .mode(device: mode.includesDevice, microphone: $0) })
+            get: { RecordAudioPreference.microphoneChoice(mode: mode, inputID: inputID) },
+            set: { choice in
+                let applied = RecordAudioPreference.applying(
+                    choice, mode: mode, inputID: inputID)
+                mode = applied.mode
+                inputID = applied.inputID
+            })
     }
 
     @State private var inputs: [MicrophoneCapture.Input] = []
@@ -46,16 +53,16 @@ struct RecordAudioOptionsRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            SwitchRow(
+            labeledRow(
                 "Device audio",
-                subtitle: "The app's own sound, from the device (Android 11+)",
-                isOn: deviceAudio)
-            SwitchRow(
+                subtitle: "The app's own sound, from the device (Android 11+)"
+            ) { deviceAudioPicker }
+            labeledRow(
                 "Microphone",
-                subtitle: "Your voice, from the Mac — narrate what you're showing",
-                isOn: microphone)
+                subtitle: "Your voice, from the Mac — narrate what you're showing"
+            ) { microphonePicker }
             if mode.includesMicrophone {
-                microphoneRow
+                levelCheckRow
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
             if let message = warning {
@@ -71,25 +78,50 @@ struct RecordAudioOptionsRow: View {
         .onChange(of: inputID) { _, _ in if isTesting { restartTest() } }
     }
 
-    private var microphoneRow: some View {
-        HStack(spacing: 8) {
-            Text("Input")
-                .font(.app(.callout))
-                .foregroundStyle(.textMuted)
-            Picker("", selection: $inputID) {
-                Text("System default").tag("")
-                ForEach(inputs) { input in
-                    Text(input.name).tag(input.id)
-                }
+    private func labeledRow(
+        _ title: String, subtitle: String, @ViewBuilder _ control: () -> some View
+    ) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                Text(subtitle)
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
             }
-            .labelsHidden().pickerStyle(.menu)
-            .frame(maxWidth: 190)
-            .disabled(authorization == .denied)
+            Spacer(minLength: 12)
+            control()
+        }
+    }
 
+    private var deviceAudioPicker: some View {
+        Picker("", selection: deviceAudio) {
+            Text("On").tag(true)
+            Text("Off").tag(false)
+        }
+        .labelsHidden().pickerStyle(.menu).fixedSize()
+    }
+
+    private var microphonePicker: some View {
+        Picker("", selection: microphoneChoice) {
+            Text("Off").tag(MicrophoneChoice.off)
+            Divider()
+            Text("System default").tag(MicrophoneChoice.systemDefault)
+            ForEach(inputs) { input in
+                Text(input.name).tag(MicrophoneChoice.input(input.id))
+            }
+        }
+        .labelsHidden().pickerStyle(.menu)
+        .frame(maxWidth: 210)
+        .disabled(authorization == .denied)
+    }
+
+    /// Hear the chosen input before committing to a take.
+    private var levelCheckRow: some View {
+        HStack(spacing: 8) {
+            Spacer(minLength: 0)
             AudioLevelMeter(level: level)
                 .frame(width: 62)
                 .opacity(isTesting ? 1 : 0.35)
-
             Button(isTesting ? "Stop" : "Test") {
                 isTesting ? stopTest() : startTest()
             }

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
@@ -15,13 +15,27 @@ enum MicrophoneAccess {
     }
 }
 
-/// The audio choice on the Screen Record screen: one picker for what to
-/// capture, and — only when the microphone is part of it — the input to use,
-/// with a level check so you know it's hearing you before you hit Record.
+/// The audio choice on the Screen Record screen: two switches — the device's
+/// own sound, and the Mac's microphone — because that's what the recording
+/// actually has, and either can be on without the other. When the microphone
+/// is on it gains an input picker and a level check, so you know it's hearing
+/// you before you hit Record.
 struct RecordAudioOptionsRow: View {
     @Binding var mode: RecordAudioMode
     /// An `AVCaptureDevice.uniqueID`, or empty for the system default input.
     @Binding var inputID: String
+
+    private var deviceAudio: Binding<Bool> {
+        Binding(
+            get: { mode.includesDevice },
+            set: { mode = .mode(device: $0, microphone: mode.includesMicrophone) })
+    }
+
+    private var microphone: Binding<Bool> {
+        Binding(
+            get: { mode.includesMicrophone },
+            set: { mode = .mode(device: mode.includesDevice, microphone: $0) })
+    }
 
     @State private var inputs: [MicrophoneCapture.Input] = []
     @State private var authorization = MicrophoneCapture.authorization()
@@ -31,20 +45,18 @@ struct RecordAudioOptionsRow: View {
     @State private var micError: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text("Audio")
-                Spacer()
-                modePicker
-            }
+        VStack(alignment: .leading, spacing: 12) {
+            SwitchRow(
+                "Device audio",
+                subtitle: "The app's own sound, from the device (Android 11+)",
+                isOn: deviceAudio)
+            SwitchRow(
+                "Microphone",
+                subtitle: "Your voice, from the Mac — narrate what you're showing",
+                isOn: microphone)
             if mode.includesMicrophone {
                 microphoneRow
                     .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-            if mode.includesDevice {
-                Text("Device audio needs Android 11 or newer.")
-                    .font(.app(.footnote))
-                    .foregroundStyle(.textMuted)
             }
             if let message = warning {
                 warningRow(message)
@@ -57,15 +69,6 @@ struct RecordAudioOptionsRow: View {
         .onDisappear { stopTest() }
         .onChange(of: mode) { _, new in modeChanged(to: new) }
         .onChange(of: inputID) { _, _ in if isTesting { restartTest() } }
-    }
-
-    private var modePicker: some View {
-        Picker("", selection: $mode) {
-            ForEach(RecordAudioMode.allCases, id: \.self) { option in
-                Label(option.title, systemImage: option.symbolName).tag(option)
-            }
-        }
-        .labelsHidden().pickerStyle(.menu).fixedSize()
     }
 
     private var microphoneRow: some View {

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioControls.swift
@@ -1,0 +1,295 @@
+import ADBKit
+import SwiftUI
+
+/// Asking for microphone access at the moment the user opts in — from the
+/// Screen Record picker or the mirror's ⋯ menu — so the system prompt lands on
+/// a deliberate choice instead of surprising them when a recording starts.
+enum MicrophoneAccess {
+    @discardableResult
+    static func requestIfNeeded(for mode: RecordAudioMode) async -> MicrophoneCapture.Authorization {
+        guard mode.includesMicrophone,
+              MicrophoneCapture.authorization() == .notDetermined
+        else { return MicrophoneCapture.authorization() }
+        _ = await MicrophoneCapture.requestAccess()
+        return MicrophoneCapture.authorization()
+    }
+}
+
+/// The audio choice on the Screen Record screen: one picker for what to
+/// capture, and — only when the microphone is part of it — the input to use,
+/// with a level check so you know it's hearing you before you hit Record.
+struct RecordAudioOptionsRow: View {
+    @Binding var mode: RecordAudioMode
+    /// An `AVCaptureDevice.uniqueID`, or empty for the system default input.
+    @Binding var inputID: String
+
+    @State private var inputs: [MicrophoneCapture.Input] = []
+    @State private var authorization = MicrophoneCapture.authorization()
+    @State private var level: Float = 0
+    @State private var isTesting = false
+    @State private var testTask: Task<Void, Never>?
+    @State private var micError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Audio")
+                Spacer()
+                modePicker
+            }
+            if mode.includesMicrophone {
+                microphoneRow
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+            if mode.includesDevice {
+                Text("Device audio needs Android 11 or newer.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+            }
+            if let message = warning {
+                warningRow(message)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.15), value: mode)
+        .animation(.easeInOut(duration: 0.15), value: authorization)
+        .onAppear { refreshInputs() }
+        .onDisappear { stopTest() }
+        .onChange(of: mode) { _, new in modeChanged(to: new) }
+        .onChange(of: inputID) { _, _ in if isTesting { restartTest() } }
+    }
+
+    private var modePicker: some View {
+        Picker("", selection: $mode) {
+            ForEach(RecordAudioMode.allCases, id: \.self) { option in
+                Label(option.title, systemImage: option.symbolName).tag(option)
+            }
+        }
+        .labelsHidden().pickerStyle(.menu).fixedSize()
+    }
+
+    private var microphoneRow: some View {
+        HStack(spacing: 8) {
+            Text("Input")
+                .font(.app(.callout))
+                .foregroundStyle(.textMuted)
+            Picker("", selection: $inputID) {
+                Text("System default").tag("")
+                ForEach(inputs) { input in
+                    Text(input.name).tag(input.id)
+                }
+            }
+            .labelsHidden().pickerStyle(.menu)
+            .frame(maxWidth: 190)
+            .disabled(authorization == .denied)
+
+            AudioLevelMeter(level: level)
+                .frame(width: 62)
+                .opacity(isTesting ? 1 : 0.35)
+
+            Button(isTesting ? "Stop" : "Test") {
+                isTesting ? stopTest() : startTest()
+            }
+            .controlSize(.small)
+            .disabled(authorization == .denied)
+            .help("Listen to the selected input without recording")
+        }
+    }
+
+    /// Whichever of the two problems is worth saying out loud: no access, or an
+    /// input that wouldn't start.
+    private var warning: String? {
+        guard mode.includesMicrophone else { return nil }
+        if authorization == .denied {
+            return "Microphone access is off, so the recording won’t have mic audio."
+        }
+        return micError
+    }
+
+    private func warningRow(_ message: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.app(.footnote))
+                .foregroundStyle(.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
+            if authorization == .denied {
+                Button("Open Settings") { openMicrophoneSettings() }
+                    .buttonStyle(.link)
+                    .font(.app(.footnote))
+            }
+        }
+    }
+
+    // MARK: - Access and inputs
+
+    private func modeChanged(to mode: RecordAudioMode) {
+        micError = nil
+        guard mode.includesMicrophone else {
+            stopTest()
+            return
+        }
+        refreshInputs()
+        Task { @MainActor in
+            authorization = await MicrophoneAccess.requestIfNeeded(for: mode)
+        }
+    }
+
+    private func refreshInputs() {
+        authorization = MicrophoneCapture.authorization()
+        inputs = MicrophoneCapture.availableInputs()
+        // The chosen input can vanish (a headset unplugged between recordings);
+        // fall back to the system default rather than failing at Record time.
+        if !inputID.isEmpty, !inputs.contains(where: { $0.id == inputID }) { inputID = "" }
+    }
+
+    private func openMicrophoneSettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+        else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Level check
+
+    private func startTest() {
+        stopTest()
+        isTesting = true
+        micError = nil
+        let deviceID = inputID.isEmpty ? nil : inputID
+        testTask = Task { @MainActor in
+            let capture = MicrophoneCapture(deviceID: deviceID)
+            // bufferingNewest(1): a meter only ever wants the newest level.
+            let (levels, sink) = AsyncStream.makeStream(
+                of: Float.self, bufferingPolicy: .bufferingNewest(1))
+            do {
+                try await capture.start { sink.yield($0.level) }
+            } catch {
+                micError = (error as? LocalizedError)?.errorDescription
+                    ?? error.localizedDescription
+                isTesting = false
+                sink.finish()
+                return
+            }
+            // A forgotten test must not hold the microphone open indefinitely.
+            let timeout = Task { try? await Task.sleep(for: .seconds(30)); sink.finish() }
+            for await value in levels { level = value }
+            timeout.cancel()
+            await capture.stop()
+            if let failure = await capture.failure() { micError = failure.errorDescription }
+            level = 0
+            isTesting = false
+        }
+    }
+
+    private func stopTest() {
+        testTask?.cancel()
+        testTask = nil
+        isTesting = false
+        level = 0
+    }
+
+    private func restartTest() {
+        stopTest()
+        startTest()
+    }
+}
+
+/// A segmented input meter. Speech RMS sits low (roughly 0.05–0.2 of full
+/// scale), so the segments follow a square-root curve — a linear bar would look
+/// dead for a perfectly good signal — and the top two turn orange as a clipping
+/// warning.
+struct AudioLevelMeter: View {
+    let level: Float
+    var segments = 10
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(0 ..< segments, id: \.self) { index in
+                Capsule()
+                    .fill(isLit(index) ? color(index) : Color.primary.opacity(0.12))
+                    .frame(height: 9)
+            }
+        }
+        .animation(.linear(duration: 0.08), value: level)
+        .accessibilityLabel("Microphone level")
+        .accessibilityValue("\(Int(scaled * 100)) percent")
+    }
+
+    private var scaled: Float { min(1, level.squareRoot() * 1.25) }
+
+    private func isLit(_ index: Int) -> Bool {
+        scaled * Float(segments) >= Float(index) + 0.5
+    }
+
+    private func color(_ index: Int) -> Color {
+        index >= segments - 2 ? .orange : .brandAccent
+    }
+}
+
+/// The mute controls shown while recording — one chip per source that's being
+/// captured. Muting writes silence rather than stopping the capture, so the
+/// chips stay live and unmuting is instant.
+struct RecordAudioMuteChips: View {
+    let status: ScreenRecorder.AudioStatus
+    let setMuted: (_ device: Bool, _ microphone: Bool) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if status.mode.includesDevice {
+                chip(
+                    title: "Device",
+                    symbol: "speaker.wave.2.fill",
+                    mutedSymbol: "speaker.slash.fill",
+                    isMuted: status.deviceMuted,
+                    level: nil
+                ) { setMuted(!status.deviceMuted, status.microphoneMuted) }
+            }
+            if status.mode.includesMicrophone {
+                chip(
+                    title: "Mic",
+                    symbol: "mic.fill",
+                    mutedSymbol: "mic.slash.fill",
+                    isMuted: status.microphoneMuted,
+                    level: status.microphoneFailure == nil ? status.microphoneLevel : nil
+                ) { setMuted(status.deviceMuted, !status.microphoneMuted) }
+            }
+            if let failure = status.microphoneFailure {
+                Label(failure, systemImage: "exclamationmark.triangle.fill")
+                    .font(.app(.caption))
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private func chip(
+        title: String,
+        symbol: String,
+        mutedSymbol: String,
+        isMuted: Bool,
+        level: Float?,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: isMuted ? mutedSymbol : symbol)
+                    .font(.app(.caption).weight(.semibold))
+                Text(title).font(.app(.caption))
+                if let level, !isMuted {
+                    AudioLevelMeter(level: level, segments: 5).frame(width: 30)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                Capsule().fill(isMuted ? Color.primary.opacity(0.08) : Color.brandAccent.opacity(0.16)))
+            .overlay(Capsule().strokeBorder(.borderSubtle))
+            .foregroundStyle(isMuted ? Color.secondary : Color.primary)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help(isMuted ? "Unmute \(title.lowercased())" : "Mute \(title.lowercased())")
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
@@ -1,6 +1,15 @@
 import ADBKit
 import Foundation
 
+/// One microphone dropdown instead of a switch plus an input picker: off, the
+/// system default, or a named input. Picking an input *is* turning the
+/// microphone on, which is one decision rather than two.
+enum MicrophoneChoice: Hashable, Sendable {
+    case off
+    case systemDefault
+    case input(String)
+}
+
 /// Where the recording-audio choice lives, shared by the Screen Record screen
 /// and the mirror's record button so both capture the same way.
 enum RecordAudioPreference {
@@ -22,6 +31,29 @@ enum RecordAudioPreference {
     static func inheritedMode(from defaults: UserDefaults) -> RecordAudioMode {
         guard defaults.object(forKey: legacyModeKey) != nil else { return .deviceOnly }
         return defaults.bool(forKey: legacyModeKey) ? .deviceOnly : .muted
+    }
+
+    /// What the microphone dropdown shows for the stored settings.
+    static func microphoneChoice(mode: RecordAudioMode, inputID: String) -> MicrophoneChoice {
+        guard mode.includesMicrophone else { return .off }
+        return inputID.isEmpty ? .systemDefault : .input(inputID)
+    }
+
+    /// The settings a dropdown pick implies. Device audio is untouched — the
+    /// two sources are independent — and turning the microphone off *keeps* the
+    /// chosen input, so switching it back on doesn't lose the choice.
+    static func applying(
+        _ choice: MicrophoneChoice, mode: RecordAudioMode, inputID: String
+    ) -> (mode: RecordAudioMode, inputID: String) {
+        let device = mode.includesDevice
+        switch choice {
+        case .off:
+            return (.mode(device: device, microphone: false), inputID)
+        case .systemDefault:
+            return (.mode(device: device, microphone: true), "")
+        case let .input(id):
+            return (.mode(device: device, microphone: true), id)
+        }
     }
 
     /// Fold the old key into the new one, once, and drop it.

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
@@ -1,0 +1,35 @@
+import ADBKit
+import Foundation
+
+/// Where the recording-audio choice lives, shared by the Screen Record screen
+/// and the mirror's record button so both capture the same way.
+enum RecordAudioPreference {
+    static let modeKey = "recAudioMode"
+    static let inputKey = "recMicInput"
+    /// The pre-microphone key: one "capture device audio" switch.
+    static let legacyModeKey = "recCaptureAudio"
+
+    static func options(from defaults: UserDefaults) -> RecordAudioOptions {
+        let stored = defaults.string(forKey: modeKey).flatMap(RecordAudioMode.init(rawValue:))
+        let input = defaults.string(forKey: inputKey) ?? ""
+        return RecordAudioOptions(
+            mode: stored ?? inheritedMode(from: defaults),
+            microphoneDeviceID: input.isEmpty ? nil : input)
+    }
+
+    /// Carry the old single switch forward: someone who had device audio turned
+    /// off keeps recording silently instead of silently regaining audio.
+    static func inheritedMode(from defaults: UserDefaults) -> RecordAudioMode {
+        guard defaults.object(forKey: legacyModeKey) != nil else { return .deviceOnly }
+        return defaults.bool(forKey: legacyModeKey) ? .deviceOnly : .muted
+    }
+
+    /// Fold the old key into the new one, once, and drop it.
+    static func migrate(_ defaults: UserDefaults) {
+        guard defaults.object(forKey: legacyModeKey) != nil else { return }
+        if defaults.string(forKey: modeKey) == nil {
+            defaults.set(options(from: defaults).mode.rawValue, forKey: modeKey)
+        }
+        defaults.removeObject(forKey: legacyModeKey)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
@@ -11,57 +11,81 @@ enum MicrophoneChoice: Hashable, Sendable {
 }
 
 /// Where the recording-audio choice lives, shared by the Screen Record screen
-/// and the mirror's record button so both capture the same way.
+/// and the mirror's recording sheet so both capture the same way.
+///
+/// Two stored values, one per dropdown: what the device contributes (its
+/// playback, its own microphone, or nothing) and which Mac input is mixed in.
 enum RecordAudioPreference {
-    static let modeKey = "recAudioMode"
+    static let deviceKey = "recDeviceAudio"
+    static let hostMicKey = "recHostMic"
     static let inputKey = "recMicInput"
-    /// The pre-microphone key: one "capture device audio" switch.
-    static let legacyModeKey = "recCaptureAudio"
+    /// Superseded keys, read once by `migrate`: the original single "capture
+    /// device audio" switch, and the four-way mode that replaced it.
+    static let legacySwitchKey = "recCaptureAudio"
+    static let legacyModeKey = "recAudioMode"
 
     static func options(from defaults: UserDefaults) -> RecordAudioOptions {
-        let stored = defaults.string(forKey: modeKey).flatMap(RecordAudioMode.init(rawValue:))
         let input = defaults.string(forKey: inputKey) ?? ""
         return RecordAudioOptions(
-            mode: stored ?? inheritedMode(from: defaults),
+            deviceSource: deviceSource(from: defaults),
+            usesHostMicrophone: usesHostMicrophone(from: defaults),
             microphoneDeviceID: input.isEmpty ? nil : input)
     }
 
-    /// Carry the old single switch forward: someone who had device audio turned
-    /// off keeps recording silently instead of silently regaining audio.
-    static func inheritedMode(from defaults: UserDefaults) -> RecordAudioMode {
-        guard defaults.object(forKey: legacyModeKey) != nil else { return .deviceOnly }
-        return defaults.bool(forKey: legacyModeKey) ? .deviceOnly : .muted
+    static func deviceSource(from defaults: UserDefaults) -> DeviceAudioSource {
+        if let stored = defaults.string(forKey: deviceKey),
+           let source = DeviceAudioSource(rawValue: stored) {
+            return source
+        }
+        return inheritedMode(from: defaults).includesDevice ? .playback : .off
     }
 
+    static func usesHostMicrophone(from defaults: UserDefaults) -> Bool {
+        if defaults.object(forKey: hostMicKey) != nil { return defaults.bool(forKey: hostMicKey) }
+        return inheritedMode(from: defaults).includesMicrophone
+    }
+
+    /// Carry a superseded setting forward: someone who had audio turned off
+    /// keeps recording silently instead of silently regaining it.
+    static func inheritedMode(from defaults: UserDefaults) -> RecordAudioMode {
+        if let stored = defaults.string(forKey: legacyModeKey),
+           let mode = RecordAudioMode(rawValue: stored) {
+            return mode
+        }
+        guard defaults.object(forKey: legacySwitchKey) != nil else { return .deviceOnly }
+        return defaults.bool(forKey: legacySwitchKey) ? .deviceOnly : .muted
+    }
+
+    /// Fold the superseded keys into the current pair, once, and drop them.
+    static func migrate(_ defaults: UserDefaults) {
+        let superseded = [legacySwitchKey, legacyModeKey]
+        guard superseded.contains(where: { defaults.object(forKey: $0) != nil }) else { return }
+        if defaults.string(forKey: deviceKey) == nil {
+            defaults.set(deviceSource(from: defaults).rawValue, forKey: deviceKey)
+        }
+        if defaults.object(forKey: hostMicKey) == nil {
+            defaults.set(usesHostMicrophone(from: defaults), forKey: hostMicKey)
+        }
+        superseded.forEach { defaults.removeObject(forKey: $0) }
+    }
+
+    // MARK: - The microphone dropdown
+
     /// What the microphone dropdown shows for the stored settings.
-    static func microphoneChoice(mode: RecordAudioMode, inputID: String) -> MicrophoneChoice {
-        guard mode.includesMicrophone else { return .off }
+    static func microphoneChoice(usesHostMicrophone: Bool, inputID: String) -> MicrophoneChoice {
+        guard usesHostMicrophone else { return .off }
         return inputID.isEmpty ? .systemDefault : .input(inputID)
     }
 
-    /// The settings a dropdown pick implies. Device audio is untouched — the
-    /// two sources are independent — and turning the microphone off *keeps* the
-    /// chosen input, so switching it back on doesn't lose the choice.
+    /// The settings a dropdown pick implies. Turning the microphone off *keeps*
+    /// the chosen input, so switching it back on doesn't lose the choice.
     static func applying(
-        _ choice: MicrophoneChoice, mode: RecordAudioMode, inputID: String
-    ) -> (mode: RecordAudioMode, inputID: String) {
-        let device = mode.includesDevice
+        _ choice: MicrophoneChoice, inputID: String
+    ) -> (usesHostMicrophone: Bool, inputID: String) {
         switch choice {
-        case .off:
-            return (.mode(device: device, microphone: false), inputID)
-        case .systemDefault:
-            return (.mode(device: device, microphone: true), "")
-        case let .input(id):
-            return (.mode(device: device, microphone: true), id)
+        case .off: return (false, inputID)
+        case .systemDefault: return (true, "")
+        case let .input(id): return (true, id)
         }
-    }
-
-    /// Fold the old key into the new one, once, and drop it.
-    static func migrate(_ defaults: UserDefaults) {
-        guard defaults.object(forKey: legacyModeKey) != nil else { return }
-        if defaults.string(forKey: modeKey) == nil {
-            defaults.set(options(from: defaults).mode.rawValue, forKey: modeKey)
-        }
-        defaults.removeObject(forKey: legacyModeKey)
     }
 }

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioSheet.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioSheet.swift
@@ -14,9 +14,12 @@ struct RecordAudioSheet: View {
     @AppStorage(RecordAudioPreference.inputKey) private var inputID = ""
 
     @Environment(\.dismiss) private var dismiss
-    /// Nil when the mirror can't record right now (not streaming); the sheet
-    /// then only edits the settings.
-    let start: (() -> Void)?
+    /// Starts a take. Present even when it can't run right now — the button is
+    /// disabled with a reason instead of vanishing, because a control that
+    /// silently isn't there reads as a broken one.
+    let start: () -> Void
+    /// Why recording is unavailable, or nil when it's ready.
+    let blockedReason: String?
 
     private var deviceSource: Binding<DeviceAudioSource> {
         Binding(
@@ -36,21 +39,27 @@ struct RecordAudioSheet: View {
             controls
 
             HStack {
-                summaryLabel
+                VStack(alignment: .leading, spacing: 2) {
+                    summaryLabel
+                    if let blockedReason {
+                        Text(blockedReason)
+                            .font(.app(.footnote))
+                            .foregroundStyle(.orange)
+                    }
+                }
                 Spacer(minLength: 12)
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
-                if let start {
-                    Button {
-                        dismiss()
-                        start()
-                    } label: {
-                        Label("Start Recording", systemImage: "record.circle")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.red)
-                    .keyboardShortcut(.defaultAction)
+                Button {
+                    dismiss()
+                    start()
+                } label: {
+                    Label("Start Recording", systemImage: "record.circle")
                 }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .keyboardShortcut(.defaultAction)
+                .disabled(blockedReason != nil)
             }
         }
         .padding(20)

--- a/App/Sources/FeatureDetail/Views/Record/RecordAudioSheet.swift
+++ b/App/Sources/FeatureDetail/Views/Record/RecordAudioSheet.swift
@@ -1,0 +1,81 @@
+import ADBKit
+import SwiftUI
+
+/// The mirror's recording setup: pick what the recording captures, hear the
+/// microphone, then start the take from the same place.
+///
+/// A sheet rather than more buttons on the mirror bar — the bar is already
+/// eleven controls wide, and the audio combination is something you set up
+/// once and then check, which reads badly as a row of icons.
+struct RecordAudioSheet: View {
+    @AppStorage(RecordAudioPreference.deviceKey) private var deviceSourceRaw =
+        DeviceAudioSource.playback.rawValue
+    @AppStorage(RecordAudioPreference.hostMicKey) private var usesHostMicrophone = false
+    @AppStorage(RecordAudioPreference.inputKey) private var inputID = ""
+
+    @Environment(\.dismiss) private var dismiss
+    /// Nil when the mirror can't record right now (not streaming); the sheet
+    /// then only edits the settings.
+    let start: (() -> Void)?
+
+    private var deviceSource: Binding<DeviceAudioSource> {
+        Binding(
+            get: { DeviceAudioSource(rawValue: deviceSourceRaw) ?? .playback },
+            set: { deviceSourceRaw = $0.rawValue })
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Recording audio").font(.app(.title3).weight(.semibold))
+                Text("Mixed into one track, so the clip plays everywhere.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+            }
+
+            controls
+
+            HStack {
+                summaryLabel
+                Spacer(minLength: 12)
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                if let start {
+                    Button {
+                        dismiss()
+                        start()
+                    } label: {
+                        Label("Start Recording", systemImage: "record.circle")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+                    .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+
+    private var controls: some View {
+        RecordAudioOptionsRow(
+            deviceSource: deviceSource,
+            usesHostMicrophone: $usesHostMicrophone,
+            inputID: $inputID)
+    }
+
+    /// Spells out the resulting combination, so "what will this capture?" is
+    /// answered on the sheet rather than after playback.
+    private var summaryLabel: some View {
+        let options = RecordAudioOptions(
+            deviceSource: deviceSource.wrappedValue,
+            usesHostMicrophone: usesHostMicrophone,
+            microphoneDeviceID: inputID.isEmpty ? nil : inputID)
+        return Label(
+            options.summary(microphoneName: nil),
+            systemImage: options.mode.hasAudio ? "waveform" : "speaker.slash.fill")
+            .font(.app(.footnote))
+            .foregroundStyle(.textMuted)
+            .lineLimit(2)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -247,6 +247,8 @@ private struct MirrorStage: View {
     @AppStorage(mirrorShowTouchesKey) private var showTouches = false
     @AppStorage(RecordAudioPreference.modeKey) private var recordAudioModeRaw =
         RecordAudioMode.deviceOnly.rawValue
+    @AppStorage(RecordAudioPreference.inputKey) private var micInputID = ""
+    @State private var micInputs: [MicrophoneCapture.Input] = []
     /// Reconnect the current device in place (the stopped/failed cards' button).
     let onReconnect: () -> Void
     /// Move the mirror to its own window; nil when already hosted in one.
@@ -343,27 +345,109 @@ private struct MirrorStage: View {
         Toggle("Stream audio (restarts mirror)", isOn: $includeAudio)
             .disabled(model.isRecording)
         Toggle("Show touches", isOn: $showTouches)
-        // What a recording started from this bar captures — the same stored
-        // choice the Screen Record screen uses. Locked mid-recording: the
-        // sources are fixed when the capture opens.
-        Picker("Recording audio", selection: recordAudioMode) {
-            ForEach(RecordAudioMode.allCases, id: \.self) { option in
-                Label(option.title, systemImage: option.symbolName).tag(option)
+        // Which mic to record from is a set-once setting — the on/off that
+        // matters per take is the bar button.
+        if storedMode.includesMicrophone {
+            Picker("Microphone input", selection: $micInputID) {
+                Text("System default").tag("")
+                ForEach(micInputs) { input in
+                    Text(input.name).tag(input.id)
+                }
             }
+            .disabled(model.isRecording)
         }
-        .disabled(model.isRecording)
     }
 
-    /// Choosing a microphone mode here asks for access straight away — this
-    /// menu is the only audio control the mirror has, so the prompt can't wait
-    /// for a picker the user may never open.
-    private var recordAudioMode: Binding<RecordAudioMode> {
-        Binding(
-            get: { RecordAudioMode(rawValue: recordAudioModeRaw) ?? .deviceOnly },
-            set: { mode in
-                recordAudioModeRaw = mode.rawValue
-                Task { await MicrophoneAccess.requestIfNeeded(for: mode) }
-            })
+    /// The recording's two audio sources, as two plain on/off buttons beside
+    /// the record button: the device's own sound, and the Mac's microphone.
+    /// Both, either, or neither — no mode list to read. During a take the same
+    /// two buttons mute and unmute what's being captured.
+    private func audioSourceButtons(buttonWidth: CGFloat) -> some View {
+        Group {
+            // A waveform, not a speaker: the volume cluster two buttons along
+            // already owns the speaker icons (its mute is literally
+            // `speaker.slash.fill`), and two speakers meaning different things
+            // in one bar is exactly the confusion to avoid.
+            audioSourceButton(
+                on: "waveform", off: "waveform.slash",
+                isOn: deviceAudioOn, width: buttonWidth,
+                enabled: !model.isRecording || recordingCarries(\.includesDevice),
+                help: deviceAudioOn
+                    ? (model.isRecording ? "Mute the device's audio" : "Device audio on (Android 11+)")
+                    : (model.isRecording ? "Unmute the device's audio" : "Device audio off")
+            ) { setDeviceAudio(!deviceAudioOn) }
+
+            audioSourceButton(
+                on: "mic.fill", off: "mic.slash.fill",
+                isOn: microphoneOn, width: buttonWidth,
+                enabled: !model.isRecording || recordingCarries(\.includesMicrophone),
+                help: microphoneOn
+                    ? (model.isRecording ? "Mute your microphone" : "Microphone on")
+                    : (model.isRecording ? "Unmute your microphone" : "Microphone off")
+            ) { setMicrophone(!microphoneOn) }
+        }
+        // Inputs come and go with headsets; refresh where the ⋯ menu's picker
+        // will read them.
+        .onAppear { micInputs = MicrophoneCapture.availableInputs() }
+    }
+
+    private func audioSourceButton(
+        on: String, off: String, isOn: Bool, width: CGFloat, enabled: Bool, help: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        navButton(
+            isOn ? on : off,
+            tint: isOn ? .primary : .textMuted,
+            width: width,
+            help: enabled ? help : "Not part of this recording",
+            action: action
+        )
+        .disabled(!enabled)
+    }
+
+    /// Before a take these read the stored choice; during one they read what
+    /// the recorder is actually capturing, so a muted source shows as off.
+    private var deviceAudioOn: Bool {
+        guard model.isRecording, let status = model.recordAudioStatus else {
+            return storedMode.includesDevice
+        }
+        return status.mode.includesDevice && !status.deviceMuted
+    }
+
+    private var microphoneOn: Bool {
+        guard model.isRecording, let status = model.recordAudioStatus else {
+            return storedMode.includesMicrophone
+        }
+        return status.mode.includesMicrophone && !status.microphoneMuted
+    }
+
+    private func recordingCarries(_ path: KeyPath<RecordAudioMode, Bool>) -> Bool {
+        model.recordAudioStatus?.mode[keyPath: path] ?? false
+    }
+
+    private var storedMode: RecordAudioMode {
+        RecordAudioMode(rawValue: recordAudioModeRaw) ?? .deviceOnly
+    }
+
+    private func setDeviceAudio(_ on: Bool) {
+        guard !model.isRecording else {
+            Task { await model.setRecordMuted(device: !on, microphone: !microphoneOn) }
+            return
+        }
+        recordAudioModeRaw = RecordAudioMode
+            .mode(device: on, microphone: storedMode.includesMicrophone).rawValue
+    }
+
+    /// Turning the microphone on asks for access straight away, so the system
+    /// prompt lands on the choice instead of on the first recording.
+    private func setMicrophone(_ on: Bool) {
+        guard !model.isRecording else {
+            Task { await model.setRecordMuted(device: !deviceAudioOn, microphone: !on) }
+            return
+        }
+        let mode = RecordAudioMode.mode(device: storedMode.includesDevice, microphone: on)
+        recordAudioModeRaw = mode.rawValue
+        Task { await MicrophoneAccess.requestIfNeeded(for: mode) }
     }
 
     private var optionsMenu: some View {
@@ -429,6 +513,8 @@ private struct MirrorStage: View {
         navButton("camera", width: buttonWidth, help: "Screenshot — edit in place") {
             Task { await model.takeScreenshot() }
         }
+
+        audioSourceButtons(buttonWidth: buttonWidth)
 
         if model.isRecording {
             navButton(

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -345,64 +345,14 @@ private struct MirrorStage: View {
         Toggle("Stream audio (restarts mirror)", isOn: $includeAudio)
             .disabled(model.isRecording)
         Toggle("Show touches", isOn: $showTouches)
-        // Which mic to record from is a set-once setting — the on/off that
-        // matters per take is the bar button.
-        if storedMode.includesMicrophone {
-            Picker("Microphone input", selection: $micInputID) {
-                Text("System default").tag("")
-                ForEach(micInputs) { input in
-                    Text(input.name).tag(input.id)
-                }
-            }
-            .disabled(model.isRecording)
-        }
     }
 
-    /// The recording's two audio sources, as two plain on/off buttons beside
-    /// the record button: the device's own sound, and the Mac's microphone.
-    /// Both, either, or neither — no mode list to read. During a take the same
-    /// two buttons mute and unmute what's being captured.
-    private func audioSourceButtons(buttonWidth: CGFloat) -> some View {
-        Group {
-            // A waveform, not a speaker: the volume cluster two buttons along
-            // already owns the speaker icons (its mute is literally
-            // `speaker.slash.fill`), and two speakers meaning different things
-            // in one bar is exactly the confusion to avoid.
-            audioSourceButton(
-                on: "waveform", off: "waveform.slash",
-                isOn: deviceAudioOn, width: buttonWidth,
-                enabled: !model.isRecording || recordingCarries(\.includesDevice),
-                help: deviceAudioOn
-                    ? (model.isRecording ? "Mute the device's audio" : "Device audio on (Android 11+)")
-                    : (model.isRecording ? "Unmute the device's audio" : "Device audio off")
-            ) { setDeviceAudio(!deviceAudioOn) }
-
-            audioSourceButton(
-                on: "mic.fill", off: "mic.slash.fill",
-                isOn: microphoneOn, width: buttonWidth,
-                enabled: !model.isRecording || recordingCarries(\.includesMicrophone),
-                help: microphoneOn
-                    ? (model.isRecording ? "Mute your microphone" : "Microphone on")
-                    : (model.isRecording ? "Unmute your microphone" : "Microphone off")
-            ) { setMicrophone(!microphoneOn) }
-        }
-        // Inputs come and go with headsets; refresh where the ⋯ menu's picker
-        // will read them.
-        .onAppear { micInputs = MicrophoneCapture.availableInputs() }
+    private var deviceAudioBinding: Binding<Bool> {
+        Binding(get: { deviceAudioOn }, set: { setDeviceAudio($0) })
     }
 
-    private func audioSourceButton(
-        on: String, off: String, isOn: Bool, width: CGFloat, enabled: Bool, help: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        navButton(
-            isOn ? on : off,
-            tint: isOn ? .primary : .textMuted,
-            width: width,
-            help: enabled ? help : "Not part of this recording",
-            action: action
-        )
-        .disabled(!enabled)
+    private var microphoneBinding: Binding<Bool> {
+        Binding(get: { microphoneOn }, set: { setMicrophone($0) })
     }
 
     /// Before a take these read the stored choice; during one they read what
@@ -514,8 +464,6 @@ private struct MirrorStage: View {
             Task { await model.takeScreenshot() }
         }
 
-        audioSourceButtons(buttonWidth: buttonWidth)
-
         if model.isRecording {
             navButton(
                 model.isPaused ? "play.fill" : "pause.fill",
@@ -524,12 +472,59 @@ private struct MirrorStage: View {
             ) {
                 Task { model.isPaused ? await model.resumeRecording() : await model.pauseRecording() }
             }
-            navButton("stop.circle.fill", tint: .red, width: buttonWidth, help: "Stop recording") {
+            recordSplitButton(
+                symbol: "stop.circle.fill", tint: .red,
+                help: "Stop recording — the arrow mutes either source"
+            ) {
                 Task { await model.stopRecording() }
             }
         } else {
-            navButton("record.circle", width: buttonWidth, help: "Record — keep mirroring") {
+            recordSplitButton(
+                symbol: "record.circle", tint: nil,
+                help: "Record — keep mirroring; the arrow picks the audio"
+            ) {
                 Task { await model.startRecording() }
+            }
+        }
+    }
+
+    /// Recording and its audio as one control: the button records (or stops),
+    /// and the arrow beside it turns device audio and the microphone on or off
+    /// — before a take, and as mutes during one. Everything about the recording
+    /// hangs off the record button, so there's nothing to hunt for.
+    private func recordSplitButton(
+        symbol: String, tint: Color?, help: String, action: @escaping () -> Void
+    ) -> some View {
+        Menu {
+            recordAudioItems
+        } label: {
+            Image(systemName: symbol)
+                .font(.app(.title3))
+                .foregroundStyle(tint ?? .primary)
+        } primaryAction: {
+            action()
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(help)
+        .onAppear { micInputs = MicrophoneCapture.availableInputs() }
+    }
+
+    /// Two independent on/off items — device audio and the microphone — which
+    /// between them cover both, either, and neither. During a take they mute
+    /// and unmute instead, and a source this recording never included is
+    /// disabled rather than silently doing nothing.
+    @ViewBuilder private var recordAudioItems: some View {
+        Toggle("Device audio", isOn: deviceAudioBinding)
+            .disabled(model.isRecording && !recordingCarries(\.includesDevice))
+        Toggle("Microphone", isOn: microphoneBinding)
+            .disabled(model.isRecording && !recordingCarries(\.includesMicrophone))
+        if storedMode.includesMicrophone, !model.isRecording {
+            Picker("Microphone input", selection: $micInputID) {
+                Text("System default").tag("")
+                ForEach(micInputs) { input in
+                    Text(input.name).tag(input.id)
+                }
             }
         }
     }

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -245,10 +245,8 @@ private struct MirrorStage: View {
     @Bindable var model: MirrorViewModel
     @AppStorage(mirrorIncludeAudioKey) private var includeAudio = false
     @AppStorage(mirrorShowTouchesKey) private var showTouches = false
-    @AppStorage(RecordAudioPreference.modeKey) private var recordAudioModeRaw =
-        RecordAudioMode.deviceOnly.rawValue
-    @AppStorage(RecordAudioPreference.inputKey) private var micInputID = ""
-    @State private var micInputs: [MicrophoneCapture.Input] = []
+    /// The recording-audio sheet: pick the combination, hear the mic, start.
+    @State private var showAudioSheet = false
     /// Reconnect the current device in place (the stopped/failed cards' button).
     let onReconnect: () -> Void
     /// Move the mirror to its own window; nil when already hosted in one.
@@ -282,6 +280,14 @@ private struct MirrorStage: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             controlBar
+        }
+        .sheet(isPresented: $showAudioSheet) {
+            // Start is offered only when a recording could actually begin; from
+            // a stopped/failed mirror the sheet just edits the settings.
+            RecordAudioSheet(
+                start: model.status == .streaming && !model.isRecording
+                    ? { Task { await model.startRecording() } }
+                    : nil)
         }
     }
 
@@ -345,59 +351,6 @@ private struct MirrorStage: View {
         Toggle("Stream audio (restarts mirror)", isOn: $includeAudio)
             .disabled(model.isRecording)
         Toggle("Show touches", isOn: $showTouches)
-    }
-
-    private var deviceAudioBinding: Binding<Bool> {
-        Binding(get: { deviceAudioOn }, set: { setDeviceAudio($0) })
-    }
-
-    private var microphoneBinding: Binding<Bool> {
-        Binding(get: { microphoneOn }, set: { setMicrophone($0) })
-    }
-
-    /// Before a take these read the stored choice; during one they read what
-    /// the recorder is actually capturing, so a muted source shows as off.
-    private var deviceAudioOn: Bool {
-        guard model.isRecording, let status = model.recordAudioStatus else {
-            return storedMode.includesDevice
-        }
-        return status.mode.includesDevice && !status.deviceMuted
-    }
-
-    private var microphoneOn: Bool {
-        guard model.isRecording, let status = model.recordAudioStatus else {
-            return storedMode.includesMicrophone
-        }
-        return status.mode.includesMicrophone && !status.microphoneMuted
-    }
-
-    private func recordingCarries(_ path: KeyPath<RecordAudioMode, Bool>) -> Bool {
-        model.recordAudioStatus?.mode[keyPath: path] ?? false
-    }
-
-    private var storedMode: RecordAudioMode {
-        RecordAudioMode(rawValue: recordAudioModeRaw) ?? .deviceOnly
-    }
-
-    private func setDeviceAudio(_ on: Bool) {
-        guard !model.isRecording else {
-            Task { await model.setRecordMuted(device: !on, microphone: !microphoneOn) }
-            return
-        }
-        recordAudioModeRaw = RecordAudioMode
-            .mode(device: on, microphone: storedMode.includesMicrophone).rawValue
-    }
-
-    /// Turning the microphone on asks for access straight away, so the system
-    /// prompt lands on the choice instead of on the first recording.
-    private func setMicrophone(_ on: Bool) {
-        guard !model.isRecording else {
-            Task { await model.setRecordMuted(device: !deviceAudioOn, microphone: !on) }
-            return
-        }
-        let mode = RecordAudioMode.mode(device: storedMode.includesDevice, microphone: on)
-        recordAudioModeRaw = mode.rawValue
-        Task { await MicrophoneAccess.requestIfNeeded(for: mode) }
     }
 
     private var optionsMenu: some View {
@@ -472,61 +425,89 @@ private struct MirrorStage: View {
             ) {
                 Task { model.isPaused ? await model.resumeRecording() : await model.pauseRecording() }
             }
-            recordSplitButton(
-                symbol: "stop.circle.fill", tint: .red,
-                help: "Stop recording — the arrow mutes either source"
-            ) {
+            navButton("stop.circle.fill", tint: .red, width: buttonWidth, help: "Stop recording") {
                 Task { await model.stopRecording() }
             }
+            liveAudioMenu
         } else {
-            recordSplitButton(
-                symbol: "record.circle", tint: nil,
-                help: "Record — keep mirroring; the arrow picks the audio"
-            ) {
-                Task { await model.startRecording() }
-            }
+            recordControl(buttonWidth: buttonWidth)
         }
     }
 
-    /// Recording and its audio as one control: the button records (or stops),
-    /// and the arrow beside it turns device audio and the microphone on or off
-    /// — before a take, and as mutes during one. Everything about the recording
-    /// hangs off the record button, so there's nothing to hunt for.
-    private func recordSplitButton(
-        symbol: String, tint: Color?, help: String, action: @escaping () -> Void
-    ) -> some View {
+    /// Record, plus a chevron opening the audio sheet — set the combination,
+    /// hear the microphone, and start the take from there. One control on the
+    /// bar, and the options get a panel of their own instead of a row of icons
+    /// or a menu that can't show what it's doing.
+    private func recordControl(buttonWidth: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            navButton("record.circle", width: buttonWidth, help: "Record — keep mirroring") {
+                Task { await model.startRecording() }
+            }
+            Button {
+                showAudioSheet = true
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.app(.caption2).weight(.semibold))
+                    .frame(width: 16, height: 30)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Recording audio — device playback or mic, plus the Mac's mic")
+        }
+    }
+
+    /// Mid-take the sources are fixed (the capture opened on them), so all
+    /// that's left is silencing them.
+    private var liveAudioMenu: some View {
         Menu {
-            recordAudioItems
+            if let status = model.recordAudioStatus, status.mode.hasAudio {
+                if status.mode.includesDevice {
+                    Toggle(
+                        status.deviceSource == .microphone ? "Device microphone" : "Device audio",
+                        isOn: Binding(
+                            get: { !status.deviceMuted },
+                            set: { on in
+                                Task {
+                                    await model.setRecordMuted(
+                                        device: !on, microphone: status.microphoneMuted)
+                                }
+                            }))
+                }
+                if status.mode.includesMicrophone {
+                    Toggle("Microphone", isOn: Binding(
+                        get: { !status.microphoneMuted },
+                        set: { on in
+                            Task {
+                                await model.setRecordMuted(
+                                    device: status.deviceMuted, microphone: !on)
+                            }
+                        }))
+                }
+            } else {
+                Text("This recording has no audio")
+            }
         } label: {
-            Image(systemName: symbol)
+            Image(systemName: liveAudioSymbol)
                 .font(.app(.title3))
-                .foregroundStyle(tint ?? .primary)
-        } primaryAction: {
-            action()
+                .foregroundStyle(anySourceMuted ? Color.orange : .primary)
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
-        .help(help)
-        .onAppear { micInputs = MicrophoneCapture.availableInputs() }
+        .help("Mute or unmute what's being recorded")
     }
 
-    /// Two independent on/off items — device audio and the microphone — which
-    /// between them cover both, either, and neither. During a take they mute
-    /// and unmute instead, and a source this recording never included is
-    /// disabled rather than silently doing nothing.
-    @ViewBuilder private var recordAudioItems: some View {
-        Toggle("Device audio", isOn: deviceAudioBinding)
-            .disabled(model.isRecording && !recordingCarries(\.includesDevice))
-        Toggle("Microphone", isOn: microphoneBinding)
-            .disabled(model.isRecording && !recordingCarries(\.includesMicrophone))
-        if storedMode.includesMicrophone, !model.isRecording {
-            Picker("Microphone input", selection: $micInputID) {
-                Text("System default").tag("")
-                ForEach(micInputs) { input in
-                    Text(input.name).tag(input.id)
-                }
-            }
-        }
+    private var liveAudioSymbol: String {
+        guard let status = model.recordAudioStatus else { return "waveform" }
+        let device = status.mode.includesDevice && !status.deviceMuted
+        let microphone = status.mode.includesMicrophone && !status.microphoneMuted
+        if !device, !microphone { return "speaker.slash.fill" }
+        return microphone ? "mic.fill" : status.deviceSource.symbolName
+    }
+
+    private var anySourceMuted: Bool {
+        guard let status = model.recordAudioStatus else { return false }
+        return (status.mode.includesDevice && status.deviceMuted)
+            || (status.mode.includesMicrophone && status.microphoneMuted)
     }
 
     private func navButton(

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -245,6 +245,8 @@ private struct MirrorStage: View {
     @Bindable var model: MirrorViewModel
     @AppStorage(mirrorIncludeAudioKey) private var includeAudio = false
     @AppStorage(mirrorShowTouchesKey) private var showTouches = false
+    @AppStorage(RecordAudioPreference.modeKey) private var recordAudioModeRaw =
+        RecordAudioMode.deviceOnly.rawValue
     /// Reconnect the current device in place (the stopped/failed cards' button).
     let onReconnect: () -> Void
     /// Move the mirror to its own window; nil when already hosted in one.
@@ -341,6 +343,27 @@ private struct MirrorStage: View {
         Toggle("Stream audio (restarts mirror)", isOn: $includeAudio)
             .disabled(model.isRecording)
         Toggle("Show touches", isOn: $showTouches)
+        // What a recording started from this bar captures — the same stored
+        // choice the Screen Record screen uses. Locked mid-recording: the
+        // sources are fixed when the capture opens.
+        Picker("Recording audio", selection: recordAudioMode) {
+            ForEach(RecordAudioMode.allCases, id: \.self) { option in
+                Label(option.title, systemImage: option.symbolName).tag(option)
+            }
+        }
+        .disabled(model.isRecording)
+    }
+
+    /// Choosing a microphone mode here asks for access straight away — this
+    /// menu is the only audio control the mirror has, so the prompt can't wait
+    /// for a picker the user may never open.
+    private var recordAudioMode: Binding<RecordAudioMode> {
+        Binding(
+            get: { RecordAudioMode(rawValue: recordAudioModeRaw) ?? .deviceOnly },
+            set: { mode in
+                recordAudioModeRaw = mode.rawValue
+                Task { await MicrophoneAccess.requestIfNeeded(for: mode) }
+            })
     }
 
     private var optionsMenu: some View {

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -282,12 +282,9 @@ private struct MirrorStage: View {
             controlBar
         }
         .sheet(isPresented: $showAudioSheet) {
-            // Start is offered only when a recording could actually begin; from
-            // a stopped/failed mirror the sheet just edits the settings.
             RecordAudioSheet(
-                start: model.status == .streaming && !model.isRecording
-                    ? { Task { await model.startRecording() } }
-                    : nil)
+                start: { Task { await model.startRecording() } },
+                blockedReason: recordingBlockedReason)
         }
     }
 
@@ -454,6 +451,13 @@ private struct MirrorStage: View {
             .buttonStyle(.plain)
             .help("Recording audio — device playback or mic, plus the Mac's mic")
         }
+    }
+
+    /// Why the sheet's Start Recording can't run, or nil when it can.
+    private var recordingBlockedReason: String? {
+        if model.isRecording { return "A recording is already running." }
+        guard model.status == .streaming else { return "The mirror isn’t streaming yet." }
+        return nil
     }
 
     /// Mid-take the sources are fixed (the capture opened on them), so all

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -48,22 +48,24 @@ struct ScreenRecordView: View {
     @AppStorage("recMaxSize") private var maxSize = 0
     @AppStorage("recBitRate") private var bitRateMbps = 0
     @AppStorage("recMaxFps") private var maxFps = 0
-    @AppStorage(RecordAudioPreference.modeKey) private var audioModeRaw =
-        RecordAudioMode.deviceOnly.rawValue
+    @AppStorage(RecordAudioPreference.deviceKey) private var deviceSourceRaw =
+        DeviceAudioSource.playback.rawValue
+    @AppStorage(RecordAudioPreference.hostMicKey) private var usesHostMicrophone = false
     @AppStorage(RecordAudioPreference.inputKey) private var micInputID = ""
     @AppStorage("recTimeLimit") private var timeLimit = 0
 
-    private var audioMode: Binding<RecordAudioMode> {
+    private var deviceSource: Binding<DeviceAudioSource> {
         Binding(
-            get: { RecordAudioMode(rawValue: audioModeRaw) ?? .deviceOnly },
-            set: { audioModeRaw = $0.rawValue })
+            get: { DeviceAudioSource(rawValue: deviceSourceRaw) ?? .playback },
+            set: { deviceSourceRaw = $0.rawValue })
     }
 
     private var recordOptions: ScreenRecordOptions {
         ScreenRecordOptions(
             maxSize: maxSize, bitRateMbps: bitRateMbps, maxFps: maxFps,
             audio: RecordAudioOptions(
-                mode: audioMode.wrappedValue,
+                deviceSource: deviceSource.wrappedValue,
+                usesHostMicrophone: usesHostMicrophone,
                 microphoneDeviceID: micInputID.isEmpty ? nil : micInputID),
             timeLimitSeconds: timeLimit
         )
@@ -262,7 +264,10 @@ struct ScreenRecordView: View {
         GroupBox {
             VStack(alignment: .leading, spacing: 14) {
                 labeledRow("Resolution") { resolutionPicker }
-                RecordAudioOptionsRow(mode: audioMode, inputID: $micInputID)
+                RecordAudioOptionsRow(
+                    deviceSource: deviceSource,
+                    usesHostMicrophone: $usesHostMicrophone,
+                    inputID: $micInputID)
                 Button {
                     withAnimation(.easeInOut(duration: 0.15)) { showAdvanced.toggle() }
                 } label: {

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -41,16 +41,31 @@ struct ScreenRecordView: View {
     /// Reused across the preview poll — a fresh `CIContext` per frame is costly.
     @State private var previewContext = CIContext()
 
+    /// What the live recording is capturing, polled alongside the preview so the
+    /// mute chips and mic meter track the recorder without a second timer.
+    @State private var audioStatus: ScreenRecorder.AudioStatus?
+
     @AppStorage("recMaxSize") private var maxSize = 0
     @AppStorage("recBitRate") private var bitRateMbps = 0
     @AppStorage("recMaxFps") private var maxFps = 0
-    @AppStorage("recCaptureAudio") private var captureAudio = true
+    @AppStorage(RecordAudioPreference.modeKey) private var audioModeRaw =
+        RecordAudioMode.deviceOnly.rawValue
+    @AppStorage(RecordAudioPreference.inputKey) private var micInputID = ""
     @AppStorage("recTimeLimit") private var timeLimit = 0
+
+    private var audioMode: Binding<RecordAudioMode> {
+        Binding(
+            get: { RecordAudioMode(rawValue: audioModeRaw) ?? .deviceOnly },
+            set: { audioModeRaw = $0.rawValue })
+    }
 
     private var recordOptions: ScreenRecordOptions {
         ScreenRecordOptions(
             maxSize: maxSize, bitRateMbps: bitRateMbps, maxFps: maxFps,
-            captureAudio: captureAudio, timeLimitSeconds: timeLimit
+            audio: RecordAudioOptions(
+                mode: audioMode.wrappedValue,
+                microphoneDeviceID: micInputID.isEmpty ? nil : micInputID),
+            timeLimitSeconds: timeLimit
         )
     }
 
@@ -67,6 +82,7 @@ struct ScreenRecordView: View {
             }
         }
         .recordingDecision(url: $decisionURL) { recordedURL = $0 }
+        .onAppear { RecordAudioPreference.migrate(.standard) }
         .onChange(of: state.devices) {
             guard isRecording, !isStopping, !deviceLost, let recordingSerial,
                   !state.devices.contains(where: { $0.serial == recordingSerial && $0.isReady })
@@ -141,6 +157,11 @@ struct ScreenRecordView: View {
                 }
             }
 
+            if isRecording, let audioStatus, audioStatus.mode.hasAudio {
+                RecordAudioMuteChips(status: audioStatus) { device, microphone in
+                    Task { await recorder?.setMuted(device: device, microphone: microphone) }
+                }
+            }
             recordControlButtons
             hints
         }
@@ -241,7 +262,7 @@ struct ScreenRecordView: View {
         GroupBox {
             VStack(alignment: .leading, spacing: 14) {
                 labeledRow("Resolution") { resolutionPicker }
-                SwitchRow("Capture audio (Android 11+)", isOn: $captureAudio)
+                RecordAudioOptionsRow(mode: audioMode, inputID: $micInputID)
                 Button {
                     withAnimation(.easeInOut(duration: 0.15)) { showAdvanced.toggle() }
                 } label: {
@@ -451,6 +472,7 @@ struct ScreenRecordView: View {
                    let image = MirrorImage.nsImage(from: snap.imageBuffer, context: context) {
                     previewImage = image
                 }
+                audioStatus = await recorder.audioStatus()
                 try? await Task.sleep(for: .milliseconds(90))
             }
         }
@@ -460,6 +482,7 @@ struct ScreenRecordView: View {
         previewTask?.cancel()
         previewTask = nil
         previewImage = nil
+        audioStatus = nil
     }
 
     /// The server has no time-limit knob, so the UI stops the recording after the

--- a/App/Tests/RecordAudioPreferenceTests.swift
+++ b/App/Tests/RecordAudioPreferenceTests.swift
@@ -1,0 +1,93 @@
+import ADBKit
+import Foundation
+import Testing
+
+/// The bundle compiles `RecordAudioPreference.swift` directly (see project.yml),
+/// so there is no app module to import.
+@Suite struct RecordAudioPreferenceTests {
+    /// A defaults store of its own per test — the suite must not read or write
+    /// the developer's real preferences.
+    private func makeDefaults(_ values: [String: Any] = [:]) -> UserDefaults {
+        let suiteName = "RecordAudioPreferenceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("a fresh suite name always opens")
+        }
+        for (key, value) in values { defaults.set(value, forKey: key) }
+        return defaults
+    }
+
+    @Test func aFreshInstallRecordsDeviceAudioOnly() {
+        let options = RecordAudioPreference.options(from: makeDefaults())
+        #expect(options.mode == .deviceOnly)
+        #expect(options.microphoneDeviceID == nil)
+    }
+
+    @Test func theStoredModeAndInputAreReadBack() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.modeKey: RecordAudioMode.deviceAndMicrophone.rawValue,
+            RecordAudioPreference.inputKey: "AppleUSBAudioEngine:Focusrite",
+        ])
+        let options = RecordAudioPreference.options(from: defaults)
+        #expect(options.mode == .deviceAndMicrophone)
+        #expect(options.microphoneDeviceID == "AppleUSBAudioEngine:Focusrite")
+    }
+
+    @Test func anEmptyInputMeansTheSystemDefaultNotADeviceNamedEmpty() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.modeKey: RecordAudioMode.microphoneOnly.rawValue,
+            RecordAudioPreference.inputKey: "",
+        ])
+        #expect(RecordAudioPreference.options(from: defaults).microphoneDeviceID == nil)
+    }
+
+    @Test func anUnknownStoredModeFallsBackInsteadOfLosingAudio() {
+        let defaults = makeDefaults([RecordAudioPreference.modeKey: "quadraphonic"])
+        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceOnly)
+    }
+
+    @Test func theOldSingleSwitchCarriesForward() {
+        // Someone who had "capture audio" off must stay silent, not silently
+        // start recording device audio again.
+        let off = makeDefaults([RecordAudioPreference.legacyModeKey: false])
+        #expect(RecordAudioPreference.options(from: off).mode == .muted)
+
+        let on = makeDefaults([RecordAudioPreference.legacyModeKey: true])
+        #expect(RecordAudioPreference.options(from: on).mode == .deviceOnly)
+    }
+
+    @Test func anExplicitChoiceWinsOverTheOldSwitch() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.legacyModeKey: false,
+            RecordAudioPreference.modeKey: RecordAudioMode.deviceAndMicrophone.rawValue,
+        ])
+        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceAndMicrophone)
+    }
+
+    @Test func migrationWritesTheNewKeyAndDropsTheOldOne() {
+        let defaults = makeDefaults([RecordAudioPreference.legacyModeKey: false])
+        RecordAudioPreference.migrate(defaults)
+        #expect(defaults.string(forKey: RecordAudioPreference.modeKey)
+            == RecordAudioMode.muted.rawValue)
+        #expect(defaults.object(forKey: RecordAudioPreference.legacyModeKey) == nil)
+        // Idempotent: running again on the migrated store changes nothing.
+        RecordAudioPreference.migrate(defaults)
+        #expect(RecordAudioPreference.options(from: defaults).mode == .muted)
+    }
+
+    @Test func migrationLeavesAStoreThatNeverHadTheOldKeyAlone() {
+        let defaults = makeDefaults()
+        RecordAudioPreference.migrate(defaults)
+        #expect(defaults.string(forKey: RecordAudioPreference.modeKey) == nil)
+        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceOnly)
+    }
+
+    @Test func migrationKeepsAnExplicitChoiceWhileDroppingTheOldKey() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.legacyModeKey: false,
+            RecordAudioPreference.modeKey: RecordAudioMode.microphoneOnly.rawValue,
+        ])
+        RecordAudioPreference.migrate(defaults)
+        #expect(RecordAudioPreference.options(from: defaults).mode == .microphoneOnly)
+        #expect(defaults.object(forKey: RecordAudioPreference.legacyModeKey) == nil)
+    }
+}

--- a/App/Tests/RecordAudioPreferenceTests.swift
+++ b/App/Tests/RecordAudioPreferenceTests.swift
@@ -63,6 +63,51 @@ import Testing
         #expect(RecordAudioPreference.options(from: defaults).mode == .deviceAndMicrophone)
     }
 
+    // MARK: - The microphone dropdown
+
+    @Test func theDropdownShowsWhatIsStored() {
+        #expect(RecordAudioPreference.microphoneChoice(mode: .deviceOnly, inputID: "") == .off)
+        // An input is remembered while off, but off is still what's shown.
+        #expect(RecordAudioPreference.microphoneChoice(mode: .muted, inputID: "usb-1") == .off)
+        #expect(RecordAudioPreference.microphoneChoice(mode: .microphoneOnly, inputID: "")
+            == .systemDefault)
+        #expect(RecordAudioPreference.microphoneChoice(mode: .deviceAndMicrophone, inputID: "usb-1")
+            == .input("usb-1"))
+    }
+
+    @Test func pickingAnInputTurnsTheMicrophoneOnAndLeavesDeviceAudioAlone() {
+        let on = RecordAudioPreference.applying(.input("usb-1"), mode: .deviceOnly, inputID: "")
+        #expect(on.mode == .deviceAndMicrophone)
+        #expect(on.inputID == "usb-1")
+
+        let micOnly = RecordAudioPreference.applying(.systemDefault, mode: .muted, inputID: "usb-1")
+        #expect(micOnly.mode == .microphoneOnly)
+        // "System default" means exactly that — the named input is cleared.
+        #expect(micOnly.inputID == "")
+    }
+
+    @Test func turningTheMicrophoneOffKeepsTheChosenInputForNextTime() {
+        let off = RecordAudioPreference.applying(
+            .off, mode: .deviceAndMicrophone, inputID: "usb-1")
+        #expect(off.mode == .deviceOnly)
+        #expect(off.inputID == "usb-1")
+        // Device audio off stays off, too.
+        #expect(RecordAudioPreference.applying(.off, mode: .microphoneOnly, inputID: "").mode
+            == .muted)
+    }
+
+    @Test func theDropdownRoundTripsThroughEveryState() {
+        for (mode, input) in [
+            (RecordAudioMode.muted, ""), (.deviceOnly, ""), (.microphoneOnly, ""),
+            (.deviceAndMicrophone, "usb-1"),
+        ] as [(RecordAudioMode, String)] {
+            let choice = RecordAudioPreference.microphoneChoice(mode: mode, inputID: input)
+            let applied = RecordAudioPreference.applying(choice, mode: mode, inputID: input)
+            #expect(applied.mode == mode)
+            #expect(applied.inputID == input)
+        }
+    }
+
     @Test func migrationWritesTheNewKeyAndDropsTheOldOne() {
         let defaults = makeDefaults([RecordAudioPreference.legacyModeKey: false])
         RecordAudioPreference.migrate(defaults)

--- a/App/Tests/RecordAudioPreferenceTests.swift
+++ b/App/Tests/RecordAudioPreferenceTests.swift
@@ -16,123 +16,136 @@ import Testing
         return defaults
     }
 
-    @Test func aFreshInstallRecordsDeviceAudioOnly() {
+    @Test func aFreshInstallRecordsTheDevicesPlaybackOnly() {
         let options = RecordAudioPreference.options(from: makeDefaults())
-        #expect(options.mode == .deviceOnly)
+        #expect(options.deviceSource == .playback)
+        #expect(!options.usesHostMicrophone)
         #expect(options.microphoneDeviceID == nil)
+        #expect(options.mode == .deviceOnly)
     }
 
-    @Test func theStoredModeAndInputAreReadBack() {
+    @Test func bothDropdownsAreReadBack() {
         let defaults = makeDefaults([
-            RecordAudioPreference.modeKey: RecordAudioMode.deviceAndMicrophone.rawValue,
+            RecordAudioPreference.deviceKey: DeviceAudioSource.microphone.rawValue,
+            RecordAudioPreference.hostMicKey: true,
             RecordAudioPreference.inputKey: "AppleUSBAudioEngine:Focusrite",
         ])
         let options = RecordAudioPreference.options(from: defaults)
-        #expect(options.mode == .deviceAndMicrophone)
+        #expect(options.deviceSource == .microphone)
+        #expect(options.usesHostMicrophone)
         #expect(options.microphoneDeviceID == "AppleUSBAudioEngine:Focusrite")
+        // Device mic + Mac mic is still two sources to mix.
+        #expect(options.mode == .deviceAndMicrophone)
     }
 
     @Test func anEmptyInputMeansTheSystemDefaultNotADeviceNamedEmpty() {
         let defaults = makeDefaults([
-            RecordAudioPreference.modeKey: RecordAudioMode.microphoneOnly.rawValue,
+            RecordAudioPreference.hostMicKey: true,
             RecordAudioPreference.inputKey: "",
         ])
         #expect(RecordAudioPreference.options(from: defaults).microphoneDeviceID == nil)
     }
 
-    @Test func anUnknownStoredModeFallsBackInsteadOfLosingAudio() {
-        let defaults = makeDefaults([RecordAudioPreference.modeKey: "quadraphonic"])
-        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceOnly)
+    @Test func anUnknownStoredSourceFallsBackInsteadOfLosingAudio() {
+        let defaults = makeDefaults([RecordAudioPreference.deviceKey: "quadraphonic"])
+        #expect(RecordAudioPreference.options(from: defaults).deviceSource == .playback)
     }
 
-    @Test func theOldSingleSwitchCarriesForward() {
+    // MARK: - Superseded settings
+
+    @Test func theOriginalSingleSwitchCarriesForward() {
         // Someone who had "capture audio" off must stay silent, not silently
         // start recording device audio again.
-        let off = makeDefaults([RecordAudioPreference.legacyModeKey: false])
-        #expect(RecordAudioPreference.options(from: off).mode == .muted)
+        let off = makeDefaults([RecordAudioPreference.legacySwitchKey: false])
+        #expect(RecordAudioPreference.options(from: off).deviceSource == .off)
+        #expect(!RecordAudioPreference.options(from: off).usesHostMicrophone)
 
-        let on = makeDefaults([RecordAudioPreference.legacyModeKey: true])
-        #expect(RecordAudioPreference.options(from: on).mode == .deviceOnly)
+        let on = makeDefaults([RecordAudioPreference.legacySwitchKey: true])
+        #expect(RecordAudioPreference.options(from: on).deviceSource == .playback)
     }
 
-    @Test func anExplicitChoiceWinsOverTheOldSwitch() {
+    @Test func theFourWayModeCarriesForwardToBothDropdowns() {
         let defaults = makeDefaults([
-            RecordAudioPreference.legacyModeKey: false,
-            RecordAudioPreference.modeKey: RecordAudioMode.deviceAndMicrophone.rawValue,
+            RecordAudioPreference.legacyModeKey: RecordAudioMode.microphoneOnly.rawValue,
         ])
-        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceAndMicrophone)
+        let options = RecordAudioPreference.options(from: defaults)
+        #expect(options.deviceSource == .off)
+        #expect(options.usesHostMicrophone)
+    }
+
+    @Test func anExplicitChoiceWinsOverASupersededOne() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.legacyModeKey: RecordAudioMode.muted.rawValue,
+            RecordAudioPreference.deviceKey: DeviceAudioSource.microphone.rawValue,
+            RecordAudioPreference.hostMicKey: true,
+        ])
+        let options = RecordAudioPreference.options(from: defaults)
+        #expect(options.deviceSource == .microphone)
+        #expect(options.usesHostMicrophone)
+    }
+
+    @Test func migrationWritesTheNewKeysAndDropsTheOldOnes() {
+        let defaults = makeDefaults([
+            RecordAudioPreference.legacyModeKey: RecordAudioMode.microphoneOnly.rawValue,
+        ])
+        RecordAudioPreference.migrate(defaults)
+        #expect(defaults.string(forKey: RecordAudioPreference.deviceKey)
+            == DeviceAudioSource.off.rawValue)
+        #expect(defaults.bool(forKey: RecordAudioPreference.hostMicKey))
+        #expect(defaults.object(forKey: RecordAudioPreference.legacyModeKey) == nil)
+        #expect(defaults.object(forKey: RecordAudioPreference.legacySwitchKey) == nil)
+        // Idempotent: running again on the migrated store changes nothing.
+        RecordAudioPreference.migrate(defaults)
+        let options = RecordAudioPreference.options(from: defaults)
+        #expect(options.deviceSource == .off)
+        #expect(options.usesHostMicrophone)
+    }
+
+    @Test func migrationLeavesAStoreThatNeverHadTheOldKeysAlone() {
+        let defaults = makeDefaults()
+        RecordAudioPreference.migrate(defaults)
+        #expect(defaults.string(forKey: RecordAudioPreference.deviceKey) == nil)
+        #expect(RecordAudioPreference.options(from: defaults).deviceSource == .playback)
     }
 
     // MARK: - The microphone dropdown
 
     @Test func theDropdownShowsWhatIsStored() {
-        #expect(RecordAudioPreference.microphoneChoice(mode: .deviceOnly, inputID: "") == .off)
+        #expect(RecordAudioPreference.microphoneChoice(usesHostMicrophone: false, inputID: "")
+            == .off)
         // An input is remembered while off, but off is still what's shown.
-        #expect(RecordAudioPreference.microphoneChoice(mode: .muted, inputID: "usb-1") == .off)
-        #expect(RecordAudioPreference.microphoneChoice(mode: .microphoneOnly, inputID: "")
+        #expect(RecordAudioPreference.microphoneChoice(usesHostMicrophone: false, inputID: "usb-1")
+            == .off)
+        #expect(RecordAudioPreference.microphoneChoice(usesHostMicrophone: true, inputID: "")
             == .systemDefault)
-        #expect(RecordAudioPreference.microphoneChoice(mode: .deviceAndMicrophone, inputID: "usb-1")
+        #expect(RecordAudioPreference.microphoneChoice(usesHostMicrophone: true, inputID: "usb-1")
             == .input("usb-1"))
     }
 
-    @Test func pickingAnInputTurnsTheMicrophoneOnAndLeavesDeviceAudioAlone() {
-        let on = RecordAudioPreference.applying(.input("usb-1"), mode: .deviceOnly, inputID: "")
-        #expect(on.mode == .deviceAndMicrophone)
-        #expect(on.inputID == "usb-1")
+    @Test func pickingAnInputTurnsTheMicrophoneOn() {
+        let named = RecordAudioPreference.applying(.input("usb-1"), inputID: "")
+        #expect(named.usesHostMicrophone)
+        #expect(named.inputID == "usb-1")
 
-        let micOnly = RecordAudioPreference.applying(.systemDefault, mode: .muted, inputID: "usb-1")
-        #expect(micOnly.mode == .microphoneOnly)
+        let systemDefault = RecordAudioPreference.applying(.systemDefault, inputID: "usb-1")
+        #expect(systemDefault.usesHostMicrophone)
         // "System default" means exactly that — the named input is cleared.
-        #expect(micOnly.inputID == "")
+        #expect(systemDefault.inputID == "")
     }
 
     @Test func turningTheMicrophoneOffKeepsTheChosenInputForNextTime() {
-        let off = RecordAudioPreference.applying(
-            .off, mode: .deviceAndMicrophone, inputID: "usb-1")
-        #expect(off.mode == .deviceOnly)
+        let off = RecordAudioPreference.applying(.off, inputID: "usb-1")
+        #expect(!off.usesHostMicrophone)
         #expect(off.inputID == "usb-1")
-        // Device audio off stays off, too.
-        #expect(RecordAudioPreference.applying(.off, mode: .microphoneOnly, inputID: "").mode
-            == .muted)
     }
 
     @Test func theDropdownRoundTripsThroughEveryState() {
-        for (mode, input) in [
-            (RecordAudioMode.muted, ""), (.deviceOnly, ""), (.microphoneOnly, ""),
-            (.deviceAndMicrophone, "usb-1"),
-        ] as [(RecordAudioMode, String)] {
-            let choice = RecordAudioPreference.microphoneChoice(mode: mode, inputID: input)
-            let applied = RecordAudioPreference.applying(choice, mode: mode, inputID: input)
-            #expect(applied.mode == mode)
+        for (on, input) in [(false, ""), (true, ""), (true, "usb-1"), (false, "usb-1")] {
+            let choice = RecordAudioPreference.microphoneChoice(
+                usesHostMicrophone: on, inputID: input)
+            let applied = RecordAudioPreference.applying(choice, inputID: input)
+            #expect(applied.usesHostMicrophone == on)
             #expect(applied.inputID == input)
         }
-    }
-
-    @Test func migrationWritesTheNewKeyAndDropsTheOldOne() {
-        let defaults = makeDefaults([RecordAudioPreference.legacyModeKey: false])
-        RecordAudioPreference.migrate(defaults)
-        #expect(defaults.string(forKey: RecordAudioPreference.modeKey)
-            == RecordAudioMode.muted.rawValue)
-        #expect(defaults.object(forKey: RecordAudioPreference.legacyModeKey) == nil)
-        // Idempotent: running again on the migrated store changes nothing.
-        RecordAudioPreference.migrate(defaults)
-        #expect(RecordAudioPreference.options(from: defaults).mode == .muted)
-    }
-
-    @Test func migrationLeavesAStoreThatNeverHadTheOldKeyAlone() {
-        let defaults = makeDefaults()
-        RecordAudioPreference.migrate(defaults)
-        #expect(defaults.string(forKey: RecordAudioPreference.modeKey) == nil)
-        #expect(RecordAudioPreference.options(from: defaults).mode == .deviceOnly)
-    }
-
-    @Test func migrationKeepsAnExplicitChoiceWhileDroppingTheOldKey() {
-        let defaults = makeDefaults([
-            RecordAudioPreference.legacyModeKey: false,
-            RecordAudioPreference.modeKey: RecordAudioMode.microphoneOnly.rawValue,
-        ])
-        RecordAudioPreference.migrate(defaults)
-        #expect(RecordAudioPreference.options(from: defaults).mode == .microphoneOnly)
-        #expect(defaults.object(forKey: RecordAudioPreference.legacyModeKey) == nil)
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1482 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1491 tests, keep green
 make test-app      # the AppTests logic bundle — 93 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)
@@ -410,22 +410,27 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   bundle compiles that file standalone (and links ADBKit for it). JS Console
   keeps its Chrome-dark hue at the card step; CodeMirror webviews stay opaque.
 - **Recording audio is one AAC track fed by up to two sources.** A recording
-  captures device audio (scrcpy, Android 11+), the Mac's microphone, both, or
-  neither — `RecordAudioMode` in ScreenTools, persisted by the App-layer
-  `RecordAudioPreference` (`recAudioMode`/`recMicInput`). **The two sources are
-  always two independent on/off controls, never a mode list** — the four
-  combinations fall out of them. Two surfaces, shaped to their context:
-  - **Mirror bar**: everything hangs off *one* control — a record split button
-    (`Menu … primaryAction:`, the project's Restart-button idiom). The button
-    records; the arrow toggles Device audio / Microphone and picks the mic
-    input. Mid-take the pair becomes Stop + the same arrow, whose toggles now
-    mute and unmute; a source the recording never included is disabled, not
-    hidden. Nothing recording-related lives in ⋯ (it started there and nobody
-    found it).
-  - **Screen Record screen**: one dropdown each — Device audio (On/Off) and
-    Microphone (Off / System default / a named input, so picking an input *is*
-    turning it on: `MicrophoneChoice` + its round-trip tests). Mid-take the two
-    mute chips sit over the live preview.
+  captures the device's audio, the Mac's microphone, both, or neither —
+  `RecordAudioOptions`/`DeviceAudioSource` in ScreenTools, persisted by the
+  App-layer `RecordAudioPreference` (`recDeviceAudio`/`recHostMic`/
+  `recMicInput`, with migrations from the superseded `recCaptureAudio` and
+  `recAudioMode`). The device side is **playback *or* its own microphone, never
+  both**: scrcpy carries one device stream per session
+  (`ScrcpyServerParams.audioSource` → `audio_source=mic`), so the two
+  checkboxes are mutually exclusive and say so in a line of text rather than
+  silently ignoring one. The same three controls — Device audio, Device
+  microphone, Mac microphone (Off / System default / a named input) — appear on
+  the Screen Record screen inline and in the mirror's `RecordAudioSheet`, which
+  the chevron beside the mirror's record button opens: set the combination,
+  hear the mic on the level meter, and Start Recording from the sheet. Mid-take
+  the mirror bar shows a mute menu and the Screen Record screen its two mute
+  chips.
+  - **Two Picker traps live here.** A `Divider()` inside a `Picker` breaks tag
+    matching and SwiftUI then *writes back* a coerced selection — that silently
+    switched the microphone on at launch. And Core Audio's scratch devices
+    (`CADefaultDeviceAggregate-…`, tap aggregates) show up in
+    `AVCaptureDevice.DiscoverySession` and must be filtered out
+    (`RecordAudioInputs.isSelectable`) or they appear as pickable "microphones".
   Both sources land in **one** track, never two: players (QuickTime, browsers,
   chat apps) play only the first audio track, so a second one is silently lost
   for whoever the clip is sent to. With one source the samples go straight to
@@ -742,7 +747,7 @@ jadx/apktool, recompile, and sign — with keystore creation) plus Frida setup, 
 custom accent color, launching emulators from the device bar, per-feature
 connect-a-device empty states, a live-preview hotkey recorder, and a Settings
 split into Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 1482 ADBKit + 93
+Application Support and are sized/removable in Settings); 1491 ADBKit + 93
 AppTests green (macOS — the suite also runs on Linux in CI, minus the
 Darwin-gated files);
 builds clean with zero warnings (enforced as errors in CI). Verified live against a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,8 +412,17 @@ table) is in `docs/reactotron-mcp-analysis.md`.
 - **Recording audio is one AAC track fed by up to two sources.** A recording
   captures device audio (scrcpy, Android 11+), the Mac's microphone, both, or
   neither — `RecordAudioMode` in ScreenTools, persisted by the App-layer
-  `RecordAudioPreference` (`recAudioMode`/`recMicInput`) and shared by the
-  Screen Record screen's Audio picker and the mirror bar's ⋯ ▸ Recording audio.
+  `RecordAudioPreference` (`recAudioMode`/`recMicInput`). **Two independent
+  on/off controls, never a mode list** — a Device audio switch and a
+  Microphone switch on the Screen Record screen, and the matching pair of
+  buttons beside the mirror bar's record button (waveform + mic; the four
+  combinations fall out of the two). Mid-take the pair keeps the same two-way
+  shape: the mirror's buttons switch to mute/unmute (a source the recording
+  never included is disabled, not hidden), and the Screen Record screen shows
+  the two mute chips over the live preview. The mirror's device-audio icon is a **waveform, not a speaker**: the
+  volume cluster two buttons along already owns the speaker icons (its mute is
+  `speaker.slash.fill`). Which mic to use is a set-once picker — Input on the
+  Screen Record screen, ⋯ ▸ Microphone input in the mirror.
   Both sources land in **one** track, never two: players (QuickTime, browsers,
   chat apps) play only the first audio track, so a second one is silently lost
   for whoever the clip is sent to. With one source the samples go straight to
@@ -421,9 +430,8 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   portable, tested) on a shared timeline, because the device stamps its audio
   in the device clock and the mic in the host clock — `AudioTimeline` anchors
   the two at the frame the file opens on, or narration drifts over a long take.
-  Mute (the chips on the recording screen) writes *silence* rather than
-  dropping samples, so the track keeps one continuous timeline and unmuting is
-  instant. `MicrophoneCapture` (Apple-gated, its own file) requests access
+  Mute writes *silence* rather than dropping samples, so the track keeps one
+  continuous timeline and unmuting is instant. `MicrophoneCapture` (Apple-gated, its own file) requests access
   itself when the status is undetermined — recordings start from several places
   and only one has a picker — and a mic that won't start is surfaced through
   `ScreenRecorder.audioStatus()` while the recording keeps going: losing the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ opening it — verify those by hand.
 
 ```
 make test          # ADBKit unit tests (cd ADBKit && swift test) — 1482 tests, keep green
-make test-app      # the AppTests logic bundle — 89 tests
+make test-app      # the AppTests logic bundle — 93 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)
 make test-emulator # tier 3: the device-dependent suites against a real emulator
@@ -412,17 +412,20 @@ table) is in `docs/reactotron-mcp-analysis.md`.
 - **Recording audio is one AAC track fed by up to two sources.** A recording
   captures device audio (scrcpy, Android 11+), the Mac's microphone, both, or
   neither — `RecordAudioMode` in ScreenTools, persisted by the App-layer
-  `RecordAudioPreference` (`recAudioMode`/`recMicInput`). **Two independent
-  on/off controls, never a mode list** — a Device audio switch and a
-  Microphone switch on the Screen Record screen, and the matching pair of
-  buttons beside the mirror bar's record button (waveform + mic; the four
-  combinations fall out of the two). Mid-take the pair keeps the same two-way
-  shape: the mirror's buttons switch to mute/unmute (a source the recording
-  never included is disabled, not hidden), and the Screen Record screen shows
-  the two mute chips over the live preview. The mirror's device-audio icon is a **waveform, not a speaker**: the
-  volume cluster two buttons along already owns the speaker icons (its mute is
-  `speaker.slash.fill`). Which mic to use is a set-once picker — Input on the
-  Screen Record screen, ⋯ ▸ Microphone input in the mirror.
+  `RecordAudioPreference` (`recAudioMode`/`recMicInput`). **The two sources are
+  always two independent on/off controls, never a mode list** — the four
+  combinations fall out of them. Two surfaces, shaped to their context:
+  - **Mirror bar**: everything hangs off *one* control — a record split button
+    (`Menu … primaryAction:`, the project's Restart-button idiom). The button
+    records; the arrow toggles Device audio / Microphone and picks the mic
+    input. Mid-take the pair becomes Stop + the same arrow, whose toggles now
+    mute and unmute; a source the recording never included is disabled, not
+    hidden. Nothing recording-related lives in ⋯ (it started there and nobody
+    found it).
+  - **Screen Record screen**: one dropdown each — Device audio (On/Off) and
+    Microphone (Off / System default / a named input, so picking an input *is*
+    turning it on: `MicrophoneChoice` + its round-trip tests). Mid-take the two
+    mute chips sit over the live preview.
   Both sources land in **one** track, never two: players (QuickTime, browsers,
   chat apps) play only the first audio track, so a second one is silently lost
   for whoever the clip is sent to. With one source the samples go straight to
@@ -739,7 +742,7 @@ jadx/apktool, recompile, and sign — with keystore creation) plus Frida setup, 
 custom accent color, launching emulators from the device bar, per-feature
 connect-a-device empty states, a live-preview hotkey recorder, and a Settings
 split into Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 1482 ADBKit + 89
+Application Support and are sized/removable in Settings); 1482 ADBKit + 93
 AppTests green (macOS — the suite also runs on Linux in CI, minus the
 Darwin-gated files);
 builds clean with zero warnings (enforced as errors in CI). Verified live against a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,8 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1157 tests, keep green
-make test-app      # the AppTests logic bundle — 67 tests
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1482 tests, keep green
+make test-app      # the AppTests logic bundle — 89 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)
 make test-emulator # tier 3: the device-dependent suites against a real emulator
@@ -156,7 +156,9 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
 - `Services/`: one per domain — TextInput, AppControl, AppInspection (perms/
   info/meminfo/sandbox), AppsExplorer, FileExplorer, Overrides, ScreenCapture,
   ScreenRecorder (records through a headless `MirrorSession` on the bundled
-  scrcpy server — no desktop scrcpy), Crash, BugReport, Connection (wireless),
+  scrcpy server — no desktop scrcpy; it also owns the microphone's
+  per-segment lifecycle — see the recording-audio convention),
+  Crash, BugReport, Connection (wireless),
   CustomCommand (one free-typed line; a leading `adb` token infers the adb
   kind → tokenized argv, never a shell; anything else — multi-line included —
   runs through `zsh -lc`, deliberately not device-scoped — `{serial}` targets
@@ -178,7 +180,7 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   console history on reconnects). No adb path (Metro runs on the Mac); the
   device only needs `adb reverse tcp:<metroPort>` to reach the dev server.
   `ScreenTools` holds the
-  `ScreenRecordOptions` struct. **Bundled binaries** (scrcpy-server, a static
+  `ScreenRecordOptions` struct and `RecordAudioMode`/`RecordAudioOptions`. **Bundled binaries** (scrcpy-server, a static
   GPLv3 ffmpeg, and the Apache-2.0 bundletool + uber-apk-signer jars — the
   jars are factory-seeded into the managed-tool store at launch so
   Settings ▸ Tools can upgrade them) live in `App/Resources/`, resolved by the
@@ -407,6 +409,25 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   `\.windowOpacity` is declared in Theme.swift because the AppTests logic
   bundle compiles that file standalone (and links ADBKit for it). JS Console
   keeps its Chrome-dark hue at the card step; CodeMirror webviews stay opaque.
+- **Recording audio is one AAC track fed by up to two sources.** A recording
+  captures device audio (scrcpy, Android 11+), the Mac's microphone, both, or
+  neither — `RecordAudioMode` in ScreenTools, persisted by the App-layer
+  `RecordAudioPreference` (`recAudioMode`/`recMicInput`) and shared by the
+  Screen Record screen's Audio picker and the mirror bar's ⋯ ▸ Recording audio.
+  Both sources land in **one** track, never two: players (QuickTime, browsers,
+  chat apps) play only the first audio track, so a second one is silently lost
+  for whoever the clip is sent to. With one source the samples go straight to
+  the writer exactly as before; with two they meet in `PCMMixdown` (pure,
+  portable, tested) on a shared timeline, because the device stamps its audio
+  in the device clock and the mic in the host clock — `AudioTimeline` anchors
+  the two at the frame the file opens on, or narration drifts over a long take.
+  Mute (the chips on the recording screen) writes *silence* rather than
+  dropping samples, so the track keeps one continuous timeline and unmuting is
+  instant. `MicrophoneCapture` (Apple-gated, its own file) requests access
+  itself when the status is undetermined — recordings start from several places
+  and only one has a picker — and a mic that won't start is surfaced through
+  `ScreenRecorder.audioStatus()` while the recording keeps going: losing the
+  narration beats losing the take.
 - **Sparkle never starts in Debug builds** (`SparkleUpdater.updaterAllowed`).
   Silent staging + install-on-quit replaces the bundle at the app's own path —
   a dev build sharing the release bundle id gets the RELEASE app installed
@@ -710,7 +731,7 @@ jadx/apktool, recompile, and sign — with keystore creation) plus Frida setup, 
 custom accent color, launching emulators from the device bar, per-feature
 connect-a-device empty states, a live-preview hotkey recorder, and a Settings
 split into Appearance/Privacy; managed tools download from GitHub releases into
-Application Support and are sized/removable in Settings); 1157 ADBKit + 67
+Application Support and are sized/removable in Settings); 1482 ADBKit + 89
 AppTests green (macOS — the suite also runs on Linux in CI, minus the
 Darwin-gated files);
 builds clean with zero warnings (enforced as errors in CI). Verified live against a

--- a/project.yml
+++ b/project.yml
@@ -75,6 +75,11 @@ targets:
         LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
         LSApplicationCategoryType: public.app-category.developer-tools
         NSHumanReadableCopyright: "© 2026 Rohindh R"
+        # Screen recordings can mix in the Mac's microphone (Screen Record ▸
+        # Audio). macOS shows this the first time that's switched on.
+        NSMicrophoneUsageDescription:
+          "Droidective records your microphone into screen recordings when you
+          choose to include it, so you can narrate what the device is doing."
         SentryDSN: $(SENTRY_DSN)
         PostHogKey: $(POSTHOG_KEY)
         SUFeedURL: https://droidective.com/appcast.xml
@@ -170,6 +175,9 @@ targets:
       # tests can check it against the registry.
       - App/Sources/FeatureDetail/FeatureDetailRoute.swift
       - App/Sources/FeatureDetail/Views/Mirror/MirrorTabPolicy.swift
+      # The persisted recording-audio choice, incl. the pre-microphone
+      # single-switch migration.
+      - App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
       - App/Sources/FeatureDetail/Views/TourPaging.swift
       - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
       - App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift


### PR DESCRIPTION
Screen recordings can now carry the Mac's microphone alongside the device's audio, so a bug repro can be narrated while it's captured.

## What a recording can capture

Three controls, on the Screen Record screen and in the mirror's recording sheet:

- **Device audio** — the sound the app itself plays (scrcpy, Android 11+).
- **Device microphone** — what the phone's own mic hears (`audio_source=mic`). scrcpy carries one device stream per session, so this and playback are mutually exclusive; the UI says so rather than ignoring one of them.
- **Mac microphone** — off, the system default, or a named input, with a level meter and a Test button to hear it before recording.

Any pairing works, and both halves land in **one** AAC track. Two tracks would be silently lossy: QuickTime, browsers and chat apps play only the first one.

## How the two sources meet

`PCMMixdown` sums them on a shared sample timeline — pure, portable and unit-tested, so it runs on the Linux port too. The device stamps its audio in the device clock and the Mac's mic in the host clock, so `AudioTimeline` anchors the two at the frame the file opens on; without that, narration drifts away from the picture over a long take. Sums accumulate in `Int32` and clamp once on the way out, so two loud sources clip instead of wrapping.

With a single source the samples still go straight to the writer exactly as before — the mixer only engages when there are two.

Mute (the chips on the Screen Record screen, the menu in the mirror bar) writes *silence* rather than dropping samples, so the track keeps one continuous timeline and unmuting is instant.

## Failure handling

`MicrophoneCapture` requests access itself when the status is undetermined — recordings start from several places and only one has a picker. A microphone that won't start (unplugged, access revoked, an unusable format) is reported through `ScreenRecorder.audioStatus()` and the recording keeps going: losing the narration beats losing the take.

## Layers

- **ADBKit**: `RecordAudioOptions`/`DeviceAudioSource` in ScreenTools, `PCMMixdown`/`AudioTimeline`/`PCMSamples`/`AudioLevel` (portable), `MicrophoneCapture` (`#if canImport(AVFoundation)`, its own file so the port gates it wholesale), `ScrcpyServerParams.audioSource`, and the microphone's per-segment lifecycle in `ScreenRecorder`.
- **App**: `RecordAudioOptionsRow`, `RecordAudioSheet`, `RecordAudioPreference` (persistence + migrations from the shipped `recCaptureAudio` switch), mute chips, and the mirror bar's record chevron.

## Two bugs found while testing this

- A `Divider()` inside the microphone `Picker` broke SwiftUI's tag matching, so it wrote back a coerced selection — the microphone switched itself on at launch.
- Core Audio's scratch aggregates (`CADefaultDeviceAggregate-…`) were being offered as pickable microphones; `RecordAudioInputs.isSelectable` filters them.

## Verification

`make verify` green — 1491 ADBKit + 99 ReactotronMCP + 93 AppTests, zero warnings. `make test-linux` green (1402), including the four new audio suites, so the mixing core still builds and passes off-Apple.

Checked live against an emulator: recording from both the Screen Record screen and the mirror sheet, the mic-denied path (recording continues, warning shown), mute chips, and the resulting file — one AAC stereo track whose levels show room tone then speech, confirming the microphone genuinely reaches the file.
