### PR TITLE
Fix terminal scrolling in full-screen and streaming programs

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/TerminalScrollPin.swift
+++ b/ADBKit/Sources/ADBKit/Features/TerminalScrollPin.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Keeps a terminal's viewport where the user parked it while the program
+/// underneath keeps writing.
+///
+/// SwiftTerm moves the viewport back to the newest line on *every* line the
+/// program scrolls: `Terminal.scroll` ends with `yDisp = yBase` unless its
+/// internal `userScrolling` flag is set, and nothing in the package ever sets
+/// it. Anything that draws continuously — an agent CLI redrawing its prompt,
+/// `tail -f`, a build log — therefore snaps the view back the instant it is
+/// scrolled, which reads as "scrolling is broken". This model carries the
+/// "the user is reading history" state the terminal doesn't, and answers the
+/// one question the view asks on every scrolled line: which row does the
+/// viewport belong at?
+///
+/// Rows are absolute indices into the terminal's line buffer. The bottom row
+/// grows by one per line until the scrollback is full, then saturates — which
+/// is exactly how a *trimmed* line (the oldest line dropped, everything above
+/// shifted up one) is told apart from a *grown* buffer, and why the pin has to
+/// follow the text down on a trim to keep the same rows on screen.
+public struct TerminalScrollPin: Sendable, Equatable {
+    /// The buffer row the viewport is held at; nil while it follows the output.
+    public private(set) var pinnedRow: Int?
+
+    /// The bottom row reported by the previous scrolled line, to spot the
+    /// saturation that means the buffer trimmed instead of grew.
+    private var lastBottomRow: Int?
+
+    /// The bottom row a full buffer saturates at — the scrollback size.
+    private let capacityRow: Int
+
+    /// - Parameter scrollbackLines: the terminal's scrollback size in lines.
+    public init(scrollbackLines: Int) {
+        capacityRow = max(0, scrollbackLines)
+    }
+
+    public var isPinned: Bool { pinnedRow != nil }
+
+    /// The user moved the viewport themselves (wheel, drag-select autoscroll).
+    /// Landing at the bottom means "follow the output again".
+    public mutating func userScrolled(to row: Int, atBottom: Bool) {
+        pinnedRow = atBottom ? nil : max(0, row)
+    }
+
+    /// Follow the output again — typing, a switch to the alternate screen, a
+    /// reset.
+    public mutating func release() {
+        pinnedRow = nil
+    }
+
+    /// The program scrolled the buffer one line and the terminal moved the
+    /// viewport to `bottomRow` with it. Returns the row to put the viewport
+    /// back to, or nil while it is following the output.
+    public mutating func bufferScrolled(bottomRow: Int) -> Int? {
+        let previous = lastBottomRow
+        lastBottomRow = bottomRow
+        guard let row = pinnedRow else { return nil }
+        // The bottom didn't move on a buffer that has reached its scrollback
+        // limit: the oldest line was dropped and every row above shifted up
+        // one, so the pin follows the text to keep it still on screen. Once
+        // the pin reaches the top, the text it held scrolls away — the same
+        // thing every terminal does when history overruns the buffer.
+        guard previous == bottomRow, bottomRow >= capacityRow else { return row }
+        let shifted = max(0, row - 1)
+        pinnedRow = shifted
+        return shifted
+    }
+}
+
+/// What a wheel event is worth, for the two places a terminal can send it.
+public enum TerminalWheel {
+    /// Lines of viewport movement, mirroring SwiftTerm's own velocity curve so
+    /// the feel is unchanged where the view takes the wheel over from it.
+    public static func lines(delta: Double, rows: Int) -> Int {
+        switch Int(abs(delta)) {
+        case 10...: return max(rows, 20)
+        case 6...9: return 10
+        case 2...5: return 3
+        default: return 1
+        }
+    }
+
+    /// Wheel reports to send to a program that took the mouse over: one per
+    /// line the event carries, since the program applies its own scroll speed
+    /// on top — the accelerated viewport curve would overshoot by pages. A
+    /// trackpad's sub-line deltas still send one, which is what makes its
+    /// stream of small events feel smooth.
+    public static func reports(delta: Double, rows: Int) -> Int {
+        max(1, min(Int(abs(delta)), max(1, rows)))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TerminalScrollPinTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TerminalScrollPinTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite("TerminalScrollPin")
+struct TerminalScrollPinTests {
+    // MARK: - Following the output
+
+    @Test func followsTheOutputUntilTheUserScrollsUp() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        #expect(!pin.isPinned)
+        #expect(pin.bufferScrolled(bottomRow: 10) == nil)
+        #expect(pin.bufferScrolled(bottomRow: 11) == nil)
+    }
+
+    @Test func scrollingBackToTheBottomFollowsTheOutputAgain() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 20, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 100) == 20)
+        pin.userScrolled(to: 100, atBottom: true)
+        #expect(!pin.isPinned)
+        #expect(pin.bufferScrolled(bottomRow: 101) == nil)
+    }
+
+    @Test func releaseFollowsTheOutputAgain() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 20, atBottom: false)
+        pin.release()
+        #expect(!pin.isPinned)
+        #expect(pin.bufferScrolled(bottomRow: 300) == nil)
+    }
+
+    // MARK: - Holding the viewport
+
+    @Test func holdsTheRowWhileTheBufferGrows() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 42, atBottom: false)
+        for bottom in 100...120 {
+            #expect(pin.bufferScrolled(bottomRow: bottom) == 42)
+        }
+        #expect(pin.pinnedRow == 42)
+    }
+
+    @Test func aStalledBottomBelowCapacityIsNotATrim() {
+        // A program scrolling inside a margin region moves no line into the
+        // scrollback: the bottom stalls, but nothing shifted, so the pin
+        // must not chase it.
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 42, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 120) == 42)
+        #expect(pin.bufferScrolled(bottomRow: 120) == 42)
+        #expect(pin.bufferScrolled(bottomRow: 120) == 42)
+        #expect(pin.pinnedRow == 42)
+    }
+
+    // MARK: - Trimming
+
+    @Test func followsTheTextWhenAFullBufferTrims() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 42, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 500) == 42) // grew to capacity
+        #expect(pin.bufferScrolled(bottomRow: 500) == 41) // trimmed
+        #expect(pin.bufferScrolled(bottomRow: 500) == 40)
+        #expect(pin.pinnedRow == 40)
+    }
+
+    @Test func trimmingStopsAtTheTopOfTheBuffer() {
+        var pin = TerminalScrollPin(scrollbackLines: 2)
+        pin.userScrolled(to: 1, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 2) == 1)
+        #expect(pin.bufferScrolled(bottomRow: 2) == 0)
+        #expect(pin.bufferScrolled(bottomRow: 2) == 0)
+        #expect(pin.pinnedRow == 0)
+    }
+
+    @Test func aFirstScrollAtCapacityIsNotTreatedAsATrim() {
+        // Nothing to compare the bottom against yet — assume it grew, or the
+        // viewport would slide a row on the first line of output.
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: 42, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 500) == 42)
+    }
+
+    // MARK: - Pinning input
+
+    @Test func aNegativeRowPinsToTheTop() {
+        var pin = TerminalScrollPin(scrollbackLines: 500)
+        pin.userScrolled(to: -3, atBottom: false)
+        #expect(pin.pinnedRow == 0)
+    }
+
+    @Test func aScrollbackFreeTerminalNeverHoldsAPosition() {
+        // No scrollback: every scroll is a trim, so the pin decays to the top
+        // immediately instead of freezing the view on stale rows.
+        var pin = TerminalScrollPin(scrollbackLines: 0)
+        pin.userScrolled(to: 3, atBottom: false)
+        #expect(pin.bufferScrolled(bottomRow: 0) == 3)
+        #expect(pin.bufferScrolled(bottomRow: 0) == 2)
+        #expect(pin.bufferScrolled(bottomRow: 0) == 1)
+        #expect(pin.bufferScrolled(bottomRow: 0) == 0)
+    }
+
+    // MARK: - Wheel velocity
+
+    @Test func wheelReportsStayOnePerLineForTheProgram() {
+        // A trackpad's sub-line deltas still report once — its many small
+        // events are what make the scroll smooth.
+        #expect(TerminalWheel.reports(delta: 0.2, rows: 40) == 1)
+        #expect(TerminalWheel.reports(delta: -1.0, rows: 40) == 1)
+        #expect(TerminalWheel.reports(delta: 3.0, rows: 40) == 3)
+        // Never more than a screenful from one event.
+        #expect(TerminalWheel.reports(delta: 400.0, rows: 40) == 40)
+    }
+
+    @Test func wheelVelocityMatchesTheTerminalsOwnCurve() {
+        #expect(TerminalWheel.lines(delta: 0.4, rows: 40) == 1)
+        #expect(TerminalWheel.lines(delta: -1.0, rows: 40) == 1)
+        #expect(TerminalWheel.lines(delta: 3.0, rows: 40) == 3)
+        #expect(TerminalWheel.lines(delta: -7.0, rows: 40) == 10)
+        #expect(TerminalWheel.lines(delta: 30.0, rows: 40) == 40)
+        #expect(TerminalWheel.lines(delta: 30.0, rows: 10) == 20)
+    }
+}

--- a/App/Sources/FeatureDetail/NativeTerminalView.swift
+++ b/App/Sources/FeatureDetail/NativeTerminalView.swift
@@ -203,46 +203,56 @@ final class DroidTerminalView: LocalProcessTerminalView {
     /// program writes, which makes scrolling back through the output of
     /// anything that keeps drawing — an agent CLI, `tail -f`, a build — look
     /// like scrolling is broken.
+    ///
+    /// One monitor serves every terminal. Each open tab and split pane stays
+    /// mounted (the keep-alive), so a monitor apiece would hit-test the whole
+    /// view tree once per terminal for every one of the ~100 wheel events a
+    /// second a trackpad produces; the shared one hit-tests once and hands
+    /// the event to whichever terminal is under the pointer.
+    private static let liveTerminals = NSHashTable<DroidTerminalView>.weakObjects()
+    private static var sharedMonitor: Any?
+
     private func installInputMonitor() {
-        guard inputMonitor == nil else { return }
-        inputMonitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .keyDown]) {
-            [weak self] event in
+        Self.liveTerminals.add(self)
+        guard Self.sharedMonitor == nil else { return }
+        Self.sharedMonitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .keyDown]) {
+            event in
             // `NSEvent` isn't Sendable, so the isolated body hands back the
             // decision and the event is passed on out here.
-            let consumed = MainActor.assumeIsolated { self?.handleMonitored(event) ?? false }
+            let consumed = MainActor.assumeIsolated { DroidTerminalView.handleMonitored(event) }
             return consumed ? nil : event
         }
     }
 
-    /// Returns whether the event was consumed here (only ever a wheel event —
+    private func removeInputMonitor() {
+        Self.liveTerminals.remove(self)
+        guard Self.liveTerminals.count == 0, let monitor = Self.sharedMonitor else { return }
+        NSEvent.removeMonitor(monitor)
+        Self.sharedMonitor = nil
+    }
+
+    /// Returns whether the event was consumed (only ever a wheel event —
     /// keystrokes are observed, never swallowed).
-    private func handleMonitored(_ event: NSEvent) -> Bool {
-        guard isEventInThisTerminal(event) else { return false }
+    private static func handleMonitored(_ event: NSEvent) -> Bool {
+        guard let target = terminal(under: event) else { return false }
         guard event.type == .scrollWheel else {
-            followOutputAfterTyping(event)
+            target.followOutputAfterTyping(event)
             return false
         }
-        return handleScrollWheel(event)
+        return target.handleScrollWheel(event)
     }
 
-    private func removeInputMonitor() {
-        if let inputMonitor { NSEvent.removeMonitor(inputMonitor) }
-        inputMonitor = nil
-    }
-
-    /// Every mounted terminal installs a monitor — including the hidden
-    /// keep-alive tabs — so each one must claim only its own events: the
-    /// pointer inside this view for the wheel, the keyboard focus for keys.
-    private func isEventInThisTerminal(_ event: NSEvent) -> Bool {
-        guard let window else { return false }
-        // Reject an event that belongs to *another* window, but not one with
-        // no window at all: a synthesized event (accessibility tooling, a UI
-        // test) carries none, and the hit test below is the real answer to
-        // "is the pointer over this terminal".
-        if let eventWindow = event.window, eventWindow !== window { return false }
-        if event.type == .keyDown { return window.firstResponder === self }
-        guard let hit = window.contentView?.hitTest(event.locationInWindow) else { return false }
-        return hit === self || hit.isDescendant(of: self)
+    /// The terminal this event belongs to: the one under the pointer for the
+    /// wheel, the one holding keyboard focus for keys.
+    private static func terminal(under event: NSEvent) -> DroidTerminalView? {
+        // A synthesized event (accessibility tooling, a UI test) carries no
+        // window, so fall back to the key window rather than dropping it.
+        guard let window = event.window ?? NSApp.keyWindow else { return nil }
+        if event.type == .keyDown {
+            return liveTerminals.allObjects.first { $0.window === window && window.firstResponder === $0 }
+        }
+        guard let hit = window.contentView?.hitTest(event.locationInWindow) else { return nil }
+        return liveTerminals.allObjects.first { hit === $0 || hit.isDescendant(of: $0) }
     }
 
     /// Returns whether the wheel event was consumed here. Three destinations,
@@ -260,11 +270,17 @@ final class DroidTerminalView: LocalProcessTerminalView {
             )
             return true
         }
-        let lines = TerminalWheel.lines(delta: event.deltaY, rows: terminal.rows)
         if terminal.isCurrentBufferAlternate {
-            sendAlternateScroll(up: up, lines: lines, terminal: terminal)
+            // Not the viewport curve: each key moves the *program's* cursor
+            // one line, so the accelerated count would fling it pages at a
+            // time (and in an editor, drag the caret with it).
+            sendAlternateScroll(
+                up: up, lines: TerminalWheel.reports(delta: event.deltaY, rows: terminal.rows),
+                terminal: terminal
+            )
             return true
         }
+        let lines = TerminalWheel.lines(delta: event.deltaY, rows: terminal.rows)
         if up {
             scrollUp(lines: lines)
         } else {

--- a/App/Sources/FeatureDetail/NativeTerminalView.swift
+++ b/App/Sources/FeatureDetail/NativeTerminalView.swift
@@ -21,6 +21,14 @@ enum TerminalMenuAction: Int {
 final class DroidTerminalView: LocalProcessTerminalView {
     private var dragWatchTimer: Timer?
 
+    /// Where the user parked the viewport, so streaming output can't yank it
+    /// back to the newest line (see `TerminalScrollPin`).
+    private lazy var scrollPin = TerminalScrollPin(
+        scrollbackLines: getTerminal().options.scrollback
+    )
+    /// The wheel/keyboard tap that feeds the pin — see `installInputMonitor`.
+    private var inputMonitor: Any?
+
     /// SwiftTerm's default background, captured before the first alpha is
     /// applied so returning to an opaque window restores the stock look.
     private var opaqueBackground: NSColor?
@@ -122,7 +130,12 @@ final class DroidTerminalView: LocalProcessTerminalView {
     // repeating timer retains its target, so it must die here too.
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         super.viewWillMove(toWindow: newWindow)
-        if newWindow == nil { stopDragWatch() }
+        if newWindow == nil {
+            stopDragWatch()
+            removeInputMonitor()
+        } else {
+            installInputMonitor()
+        }
     }
 
     private func startDragWatch() {
@@ -163,6 +176,7 @@ final class DroidTerminalView: LocalProcessTerminalView {
         } else {
             return
         }
+        noteViewportMoved()
         // Replay the drag at the (unmoved) pointer so the selection extends
         // into the rows the scroll just revealed.
         let synthesized = NSEvent.mouseEvent(
@@ -177,6 +191,180 @@ final class DroidTerminalView: LocalProcessTerminalView {
     /// Farther past the edge scrolls faster, like every native text view.
     private func dragScrollStep(overshoot: CGFloat) -> Int {
         max(1, min(6, Int(overshoot / 12)))
+    }
+
+    // MARK: - Scrolling
+
+    /// SwiftTerm seals `scrollWheel` as `public` (not `open`) — like
+    /// `mouseDragged` above — so the wheel is taken over with a local event
+    /// monitor instead, which is also the only way to hear a keystroke land
+    /// (`keyDown` is sealed the same way). Both feed `scrollPin`: the terminal
+    /// otherwise drags the viewport back to the newest line on every line the
+    /// program writes, which makes scrolling back through the output of
+    /// anything that keeps drawing — an agent CLI, `tail -f`, a build — look
+    /// like scrolling is broken.
+    private func installInputMonitor() {
+        guard inputMonitor == nil else { return }
+        inputMonitor = NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel, .keyDown]) {
+            [weak self] event in
+            // `NSEvent` isn't Sendable, so the isolated body hands back the
+            // decision and the event is passed on out here.
+            let consumed = MainActor.assumeIsolated { self?.handleMonitored(event) ?? false }
+            return consumed ? nil : event
+        }
+    }
+
+    /// Returns whether the event was consumed here (only ever a wheel event —
+    /// keystrokes are observed, never swallowed).
+    private func handleMonitored(_ event: NSEvent) -> Bool {
+        guard isEventInThisTerminal(event) else { return false }
+        guard event.type == .scrollWheel else {
+            followOutputAfterTyping(event)
+            return false
+        }
+        return handleScrollWheel(event)
+    }
+
+    private func removeInputMonitor() {
+        if let inputMonitor { NSEvent.removeMonitor(inputMonitor) }
+        inputMonitor = nil
+    }
+
+    /// Every mounted terminal installs a monitor — including the hidden
+    /// keep-alive tabs — so each one must claim only its own events: the
+    /// pointer inside this view for the wheel, the keyboard focus for keys.
+    private func isEventInThisTerminal(_ event: NSEvent) -> Bool {
+        guard let window else { return false }
+        // Reject an event that belongs to *another* window, but not one with
+        // no window at all: a synthesized event (accessibility tooling, a UI
+        // test) carries none, and the hit test below is the real answer to
+        // "is the pointer over this terminal".
+        if let eventWindow = event.window, eventWindow !== window { return false }
+        if event.type == .keyDown { return window.firstResponder === self }
+        guard let hit = window.contentView?.hitTest(event.locationInWindow) else { return false }
+        return hit === self || hit.isDescendant(of: self)
+    }
+
+    /// Returns whether the wheel event was consumed here. Three destinations,
+    /// in the order every desktop terminal picks them: the program that took
+    /// the mouse over, else the program on the alternate screen, else this
+    /// terminal's own scrollback.
+    private func handleScrollWheel(_ event: NSEvent) -> Bool {
+        guard event.deltaY != 0 else { return false }
+        let terminal = getTerminal()
+        let up = event.deltaY > 0
+        if allowMouseReporting, terminal.mouseMode != .off {
+            sendWheelReport(
+                up: up, ticks: TerminalWheel.reports(delta: event.deltaY, rows: terminal.rows),
+                event: event, terminal: terminal
+            )
+            return true
+        }
+        let lines = TerminalWheel.lines(delta: event.deltaY, rows: terminal.rows)
+        if terminal.isCurrentBufferAlternate {
+            sendAlternateScroll(up: up, lines: lines, terminal: terminal)
+            return true
+        }
+        if up {
+            scrollUp(lines: lines)
+        } else {
+            scrollDown(lines: lines)
+        }
+        noteViewportMoved()
+        return true
+    }
+
+    /// A program that asked for the mouse (an agent CLI, `htop`, `vim` with
+    /// `mouse=a`) scrolls its own content and expects the wheel as a mouse
+    /// *button* report — and it usually sits on the alternate screen, where
+    /// there is no scrollback to move instead. SwiftTerm's wheel handling
+    /// never reports to the program, so the wheel is simply dead in every one
+    /// of them until this forwards it.
+    private func sendWheelReport(
+        up: Bool, ticks: Int, event: NSEvent, terminal: SwiftTerm.Terminal
+    ) {
+        let flags = event.modifierFlags
+        let buttons = terminal.encodeButton(
+            button: up ? 4 : 5, release: false,
+            shift: flags.contains(.shift), meta: flags.contains(.option),
+            control: flags.contains(.control)
+        )
+        let cell = cellUnderPointer(event)
+        for _ in 0..<ticks {
+            terminal.sendEvent(buttonFlags: buttons, x: cell.col, y: cell.row)
+        }
+    }
+
+    /// The grid cell under the pointer. SwiftTerm keeps its cell metrics
+    /// internal, so they are recovered from the frame and the grid it laid
+    /// out in it — off by at most a cell at the far edge, which no
+    /// wheel-scrolling program cares about.
+    private func cellUnderPointer(_ event: NSEvent) -> (col: Int, row: Int) {
+        let terminal = getTerminal()
+        let cols = max(1, terminal.cols)
+        let rows = max(1, terminal.rows)
+        let point = convert(event.locationInWindow, from: nil)
+        let col = Int(point.x / max(1, bounds.width / CGFloat(cols)))
+        let row = Int((bounds.height - point.y) / max(1, bounds.height / CGFloat(rows)))
+        return (min(max(0, col), cols - 1), min(max(0, row), rows - 1))
+    }
+
+    /// The alternate screen keeps no scrollback, so there is nothing to move
+    /// the viewport through — the wheel drives the program instead, one cursor
+    /// key per line (xterm's alternate scroll, which is how `less`, `vim` and
+    /// `man` scroll under a wheel everywhere else).
+    private func sendAlternateScroll(up: Bool, lines: Int, terminal: SwiftTerm.Terminal) {
+        let key: [UInt8]
+        switch (up, terminal.applicationCursor) {
+        case (true, true): key = EscapeSequences.moveUpApp
+        case (true, false): key = EscapeSequences.moveUpNormal
+        case (false, true): key = EscapeSequences.moveDownApp
+        case (false, false): key = EscapeSequences.moveDownNormal
+        }
+        send(Array(repeating: key, count: lines).flatMap { $0 })
+    }
+
+    /// Typing returns to the live output like every desktop terminal does —
+    /// keystrokes landing off-screen is worse than losing the scroll position.
+    /// Command shortcuts (⌘F, ⌘C) send nothing to the shell, so they don't.
+    private func followOutputAfterTyping(_ event: NSEvent) {
+        guard scrollPin.isPinned, !event.modifierFlags.contains(.command) else { return }
+        scrollPin.release()
+        scroll(toPosition: 1)
+    }
+
+    /// Record where the user just left the viewport. At the bottom the pin is
+    /// dropped, so new output scrolls the view again.
+    private func noteViewportMoved() {
+        scrollPin.userScrolled(
+            to: getTerminal().getTopVisibleRow(), atBottom: !canScroll || scrollPosition >= 1
+        )
+    }
+
+    /// The terminal has moved the viewport to the newest line after scrolling
+    /// one line of output. Put it back if the user is reading history: the
+    /// rows on screen don't change, so nothing needs repainting beyond what
+    /// the feed already marked dirty.
+    /// A program switching to (or away from) the alternate screen — where
+    /// SwiftTerm leaves the right margin uninitialized and corrupts every
+    /// `CSI T` scroll. See `TerminalCompat`.
+    override func bufferActivated(source: SwiftTerm.Terminal) {
+        TerminalCompat.repairAlternateScreenMargins(source)
+        super.bufferActivated(source: source)
+    }
+
+    override func scrolled(source terminal: SwiftTerm.Terminal, yDisp: Int) {
+        if terminal.isCurrentBufferAlternate {
+            scrollPin.release()
+        } else if let row = scrollPin.bufferScrolled(bottomRow: yDisp), row != yDisp {
+            // The live buffer, not `scrollTo(row:)`: during synchronized
+            // output (DECSET 2026, which agent CLIs draw their frames with)
+            // the terminal displays a frozen snapshot and `scrollTo` compares
+            // against *that*, so it would skip the write the frame's end then
+            // reveals.
+            terminal.buffer.yDisp = row
+        }
+        super.scrolled(source: terminal, yDisp: yDisp)
     }
 
     /// Right-click menu: the standard edit/find items (targeting self so

--- a/App/Sources/FeatureDetail/TerminalCompat.swift
+++ b/App/Sources/FeatureDetail/TerminalCompat.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftTerm
+
+/// Repairs for SwiftTerm state the library itself leaves inconsistent.
+enum TerminalCompat {
+    /// SwiftTerm initializes the *normal* screen's right margin to `cols - 1`
+    /// but never the alternate screen's, which keeps the 0 it was born with.
+    /// `Terminal.cmdScrollDown` — `CSI T`, the sequence a full-screen program
+    /// uses to scroll its view down a line — then copies
+    /// `marginRight - marginLeft + 1` columns *unconditionally*: with the
+    /// margin left at 0 that is exactly ONE column, so each scroll smears the
+    /// first column down the screen and leaves the rest of every row stale.
+    /// The program repaints only the rows it believes changed, and the screen
+    /// ends up holding two frames interleaved character by character.
+    ///
+    /// Agent CLIs and pagers scroll exactly this way (`ESC[2;48r ESC[1T
+    /// ESC[r`, then repaint the exposed row), so the alternate screen is
+    /// where it bites. Restoring the margin restores the full-width copy.
+    /// (Upstream's `cmdScrollUp` takes the margin path only when
+    /// `marginMode` is set, which is why `CSI S` is unaffected.)
+    ///
+    /// Only the uninitialized state is touched: a program that set its own
+    /// margins with DECSLRM has a non-zero right margin and is left alone.
+    static func repairAlternateScreenMargins(_ terminal: Terminal) {
+        guard terminal.isCurrentBufferAlternate, terminal.cols > 1 else { return }
+        guard terminal.buffer.marginRight == 0 else { return }
+        terminal.buffer.marginLeft = 0
+        terminal.buffer.marginRight = terminal.cols - 1
+    }
+}

--- a/App/Tests/TerminalCompatTests.swift
+++ b/App/Tests/TerminalCompatTests.swift
@@ -1,0 +1,91 @@
+import SwiftTerm
+import Testing
+
+/// The Terminal feature couldn't scroll an agent CLI or a pager, and once the
+/// wheel did reach them their output came back as two frames interleaved
+/// character by character. The cause is upstream: SwiftTerm leaves the
+/// alternate screen's right margin at 0, and `CSI T` (scroll down) copies
+/// `marginRight - marginLeft + 1` columns — one column — per row. These tests
+/// hold the repair in place, so a SwiftTerm bump that changes the behavior
+/// shows up here rather than as smeared text on screen.
+@Suite struct TerminalCompatTests {
+    private final class Sink: TerminalDelegate {
+        func send(source: Terminal, data: ArraySlice<UInt8>) {}
+    }
+
+    private func makeTerminal(cols: Int = 6, rows: Int = 5) -> Terminal {
+        Terminal(delegate: Sink(), options: TerminalOptions(cols: cols, rows: rows, scrollback: 0))
+    }
+
+    /// The screen as plain rows, with SwiftTerm's null padding read as blanks.
+    private func screen(_ terminal: Terminal) -> [String] {
+        (0..<terminal.rows).map { row in
+            var line = ""
+            for col in 0..<terminal.cols {
+                let character = terminal.buffer.getChar(at: Position(col: col, row: row)).getCharacter()
+                line.append(character == "\0" ? " " : character)
+            }
+            while line.hasSuffix(" ") { line.removeLast() }
+            return line
+        }
+    }
+
+    // MARK: - The margin itself
+
+    @Test func alternateScreenMarginIsRepairedToTheFullWidth() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1049h")
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        #expect(terminal.buffer.marginRight == terminal.cols - 1)
+        #expect(terminal.buffer.marginLeft == 0)
+    }
+
+    @Test func normalScreenIsLeftAlone() {
+        let terminal = makeTerminal()
+        let before = terminal.buffer.marginRight
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        #expect(terminal.buffer.marginRight == before)
+    }
+
+    @Test func aProgramsOwnMarginsAreLeftAlone() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1049h")
+        terminal.buffer.marginRight = 3
+        terminal.buffer.marginLeft = 1
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        #expect(terminal.buffer.marginRight == 3)
+        #expect(terminal.buffer.marginLeft == 1)
+    }
+
+    // MARK: - What it buys: a scroll that moves whole rows
+
+    /// `ESC[2;4r ESC[1T ESC[r` — set a scroll region, scroll it down one line,
+    /// release it: the shape an agent CLI or pager uses per wheel notch. Rows
+    /// 2…4 move down one, row 2 blanks, rows 1 and 5 stay put.
+    @Test func scrollDownMovesWholeRowsOnTheAlternateScreen() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1049h")
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        terminal.feed(text: "AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE")
+        terminal.feed(text: "\u{1b}[2;4r\u{1b}[1T\u{1b}[r")
+        #expect(screen(terminal) == ["AAA", "", "BBB", "CCC", "EEE"])
+    }
+
+    @Test func fullScreenScrollDownMovesWholeRowsOnTheAlternateScreen() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "\u{1b}[?1049h")
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        terminal.feed(text: "AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE")
+        terminal.feed(text: "\u{1b}[1T")
+        #expect(screen(terminal) == ["", "AAA", "BBB", "CCC", "DDD"])
+    }
+
+    /// The normal screen never had the defect — the repair must not change it.
+    @Test func scrollDownIsUnchangedOnTheNormalScreen() {
+        let terminal = makeTerminal()
+        TerminalCompat.repairAlternateScreenMargins(terminal)
+        terminal.feed(text: "AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE")
+        terminal.feed(text: "\u{1b}[2;4r\u{1b}[1T\u{1b}[r")
+        #expect(screen(terminal) == ["AAA", "", "BBB", "CCC", "EEE"])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -181,10 +181,15 @@ targets:
       - App/Sources/FeatureDetail/Views/TourPaging.swift
       - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
       - App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
+      # The alternate-screen margin repair, tested against real SwiftTerm so a
+      # dependency bump can't silently change the behavior it works around.
+      - App/Sources/FeatureDetail/TerminalCompat.swift
       - App/Sources/Updates/ReleaseNotesStyler.swift
     dependencies:
       # Theme.swift's fill styles call into WindowEffects (ADBKit).
       - package: ADBKit
+      - package: SwiftTerm
+        product: SwiftTerm
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.rohindh.droidective.tests


### PR DESCRIPTION
Scrolling in the Terminal feature didn't work with full-screen programs, and scrolling back through streaming output snapped to the newest line. Three separate causes.

## The wheel never reached mouse-tracking programs

An agent CLI, `less --mouse`, `htop` and `vim` with `mouse=a` take the mouse over and run on the alternate screen, where there is no scrollback to move through. SwiftTerm's wheel handling only moves its own viewport and never reports to the program, so the wheel did nothing in any of them.

`DroidTerminalView` now routes the wheel three ways, in the order desktop terminals pick them:

1. the program that took the mouse over, as mouse-button reports (`CSI <64/65`),
2. else cursor keys on the alternate screen (xterm alternate scroll — this is what makes `less` and `man` scroll),
3. else this terminal's own scrollback.

SwiftTerm seals `scrollWheel` and `keyDown` as `public` rather than `open`, so they can't be overridden; the events are taken with a local `NSEvent` monitor, which claims only events whose pointer hit-tests into that terminal (hidden keep-alive tabs each install one).

## Scrolling those programs corrupted the screen

SwiftTerm initializes the normal screen's right margin to `cols - 1` but leaves the alternate screen's at 0, and `Terminal.cmdScrollDown` copies `marginRight - marginLeft + 1` columns unconditionally. `CSI T` therefore copied **one column** per row and left the rest of each row stale:

| `ESC[1T` on `AAA BBB CCC DDD EEE` | result |
|---|---|
| normal screen | `␣ AAA BBB CCC DDD` |
| alternate screen | `␣AA ABB BCC CDD DEE` |

Programs scroll their view with `ESC[2;48r ESC[1T ESC[r` and then repaint only the newly exposed row, so the screen ended up holding two frames interleaved character by character. `TerminalCompat.repairAlternateScreenMargins` restores the margin when the alternate screen is activated, and only when it is still 0 — a program that set its own margins with DECSLRM is left alone.

This is an upstream bug (`cmdScrollUp` takes its margin path only when `marginMode` is set; `cmdScrollDown` doesn't). `AppTests` now links SwiftTerm and asserts the scroll behaviour against the real library, so a dependency bump surfaces there rather than as smeared text on screen. When it's fixed upstream, `TerminalCompat` and its tests can be deleted.

## Streaming output snapped the viewport to the bottom

`Terminal.scroll` resets `yDisp` to the newest line unless its internal `userScrolling` flag is set, and nothing in SwiftTerm ever sets it — so scrolling back through anything that keeps writing (`tail -f`, a build log, an agent CLI redrawing) jumped straight back down. `TerminalScrollPin` (ADBKit, pure) carries that state and answers, per scrolled line, which row the viewport belongs at; it follows scrollback trims so the text stays still rather than drifting. Typing returns to the live output, as every desktop terminal does.

## Tests

- `TerminalScrollPinTests` — 12 tests: holding across a growing buffer, following trims at capacity, clamping at the top, releasing at the bottom, and the wheel-to-lines/reports mappings.
- `TerminalCompatTests` — 6 tests against real SwiftTerm: the margin repair, both no-op cases, and whole-row scrolling on the alternate screen.
- 1503 ADBKit tests and AppTests green; build warning-free.

Verified live: `less --mouse` and an agent CLI both scroll; a 60-event scroll flood that previously produced the interleaved text now renders clean; the viewport holds position through continuous output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
