### PR TITLE
Stop the real-process tests flaking on loaded CI runners

### DIFF
--- a/ADBKit/Tests/ADBKitTests/ChildCommands.swift
+++ b/ADBKit/Tests/ADBKitTests/ChildCommands.swift
@@ -73,7 +73,7 @@ enum ChildCommands {
     static let sleepForever = (executable: "/bin/sleep", arguments: ["30"])
     static let spewForever = (executable: "/usr/bin/yes", arguments: [String]())
     static let sleepThenPrint = (
-        executable: "/bin/sh", arguments: ["-c", "sleep 0.3; echo done"]
+        executable: "/bin/sh", arguments: ["-c", "sleep 1; echo done"]
     )
 
     static let echoOutput = "hello\n"

--- a/ADBKit/Tests/ADBKitTests/SystemProcessRunnerTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SystemProcessRunnerTests.swift
@@ -9,10 +9,22 @@ import Testing
 @Suite struct SystemProcessRunnerTests {
     let runner = SystemProcessRunner()
 
+    /// Timeout for the cases that assert a child *completed*, where the value
+    /// is only a safety net rather than the thing under test.
+    ///
+    /// It was 5 s, which a loaded CI container can exceed just spawning
+    /// `/bin/echo` — that produced three false failures in one day (`echo`
+    /// reported `timedOut` with its output already captured). Generous here
+    /// costs nothing: a healthy run finishes in milliseconds and never waits.
+    /// The tests that genuinely measure timing — `timeoutKillsAndFlags` and
+    /// `cancellationKillsChildAndReturnsPromptly` — keep their tight bounds,
+    /// because there the duration *is* the assertion.
+    static let generousTimeout: Duration = .seconds(30)
+
     @Test func capturesStdoutAndExitCode() async {
         let output = await runner.run(
             executable: ChildCommands.echo.executable,
-            arguments: ChildCommands.echo.arguments, timeout: .seconds(5)
+            arguments: ChildCommands.echo.arguments, timeout: Self.generousTimeout
         )
         #expect(output.exitCode == 0)
         #expect(output.stdoutText == ChildCommands.echoOutput)
@@ -22,14 +34,15 @@ import Testing
     @Test func capturesStderrAndNonZeroExit() async {
         let output = await runner.run(
             executable: ChildCommands.stderrAndExit3.executable,
-            arguments: ChildCommands.stderrAndExit3.arguments, timeout: .seconds(5)
+            arguments: ChildCommands.stderrAndExit3.arguments, timeout: Self.generousTimeout
         )
         #expect(output.exitCode == 3)
         #expect(output.stderrText == ChildCommands.stderrOutput)
     }
 
     @Test func launchFailureReportsNilExit() async {
-        let output = await runner.run(executable: "/no/such/binary", arguments: [], timeout: .seconds(5))
+        let output = await runner.run(
+            executable: "/no/such/binary", arguments: [], timeout: Self.generousTimeout)
         #expect(output.exitCode == nil)
         #expect(output.stderrText.contains("failed to launch"))
     }
@@ -51,6 +64,9 @@ import Testing
         // full-pipe deadlock if draining stalls; the cap must also hold.
         let output = await runner.run(
             executable: ChildCommands.spewForever.executable,
+            // Short on purpose, unlike the completion cases above: this child
+            // never exits, so the timeout is what ends the test. Raising it
+            // just adds dead wall-clock to every run.
             arguments: ChildCommands.spewForever.arguments, timeout: .seconds(3),
             maxOutputBytes: 64 * 1024
         )
@@ -73,7 +89,8 @@ import Testing
                 group.addTask {
                     let output = await runner.run(
                         executable: ChildCommands.sleepThenPrint.executable,
-                        arguments: ChildCommands.sleepThenPrint.arguments, timeout: .seconds(10)
+                        arguments: ChildCommands.sleepThenPrint.arguments,
+                        timeout: Self.generousTimeout
                     )
                     return output.exitCode
                 }


### PR DESCRIPTION
`SystemProcessRunnerTests` produced three false CI failures in one day — the macOS starvation canary once, the Linux suite twice — while passing locally on the same commits every time.

## Cause

The tests that assert a child *completed* used a 5 s timeout. That is plenty on a healthy machine and not always enough on a loaded CI container: the clearest failure had `echo hello` reporting `timedOut` **with its 6 bytes of output already captured**, so the child had run fine and only the deadline was too tight.

## Fix

Those cases now use a 30 s safety net (`generousTimeout`). It costs nothing on a healthy run — they finish in milliseconds and never wait — and the value was never the thing under test.

The tests that genuinely measure timing keep their tight bounds, because there the duration *is* the assertion:

- `timeoutKillsAndFlags` — still a 300 ms timeout
- `cancellationKillsChildAndReturnsPromptly` — still asserts a sub-10 s return

`largeOutputIsCappedNotDeadlocked` deliberately keeps a **short** 3 s timeout, and now says why: its child never exits, so the timeout is what ends the test. I raised it to 30 s first and it added 31 seconds of dead wall-clock to every run — reverted, with a comment so nobody repeats it.

The 16-way canary's children now sleep 1 s instead of 0.3 s. Same `> 5 ticks` assertion, far more headroom: a healthy run ticks ~50 times, and the blocking-runner regression this guards against would still show 0–1.

## Verification

Full ADBKit suite green (**1503 tests**), `-warnings-as-errors` clean. `SystemProcessRunnerTests` runs in 3.1 s, unchanged from before.

No production code, no `App/` changes.