### PR TITLE
Add the daemon's stream buffer and subscription protocol

### DIFF
--- a/droidectived/Sources/DaemonCore/StreamBuffer.swift
+++ b/droidectived/Sources/DaemonCore/StreamBuffer.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The bounded queue behind one stream subscription.
+///
+/// A slow UI must never grow an unbounded queue in the daemon — the same trap
+/// that forced the macOS log readers back onto Foundation's pull-driven reader.
+/// So each subscription holds at most `capacity` items; past that the **oldest
+/// go first** and the client is told how many, rather than the daemon eating
+/// memory or the producer stalling.
+///
+/// This deliberately differs from the Mac app, which stalls: `bytes.lines` is
+/// pull-driven, so a slow consumer backpressures the pipe. The divergence is
+/// the decision — a responsive UI with an honest gap beats one that silently
+/// falls behind real time. It also matches what the device already does, since
+/// Android's logcat ring buffer drops under load regardless; "lossless" was
+/// never actually on offer.
+///
+/// Dropping oldest rather than newest is the other half of that: a log tail is
+/// read from the bottom, so the newest lines are the ones worth keeping.
+struct StreamBuffer<Item: Sendable>: Sendable {
+    /// Items waiting to go out, oldest first.
+    private(set) var pending: [Item] = []
+    /// Items discarded since the last `drain`, and never silently.
+    private(set) var dropped = 0
+
+    let capacity: Int
+
+    /// - Parameter capacity: maximum items held before dropping starts. Must be
+    ///   at least 1; a zero-capacity buffer would drop everything and report a
+    ///   gap forever, which is a configuration bug rather than a runtime state.
+    init(capacity: Int) {
+        precondition(capacity >= 1, "a stream buffer must hold at least one item")
+        self.capacity = capacity
+    }
+
+    /// Appends `items`, discarding the oldest to stay within capacity.
+    ///
+    /// Takes a batch rather than one item because that is how the producers
+    /// deliver: `LogcatStreamer` already coalesces on its flush interval, and
+    /// re-splitting a batch to push it one line at a time would be pure waste.
+    mutating func append(contentsOf items: some Collection<Item>) {
+        pending.append(contentsOf: items)
+        let excess = pending.count - capacity
+        guard excess > 0 else { return }
+        pending.removeFirst(excess)
+        dropped += excess
+    }
+
+    /// Everything waiting, plus how many were lost getting here — then resets.
+    ///
+    /// The count rides with the batch rather than being reported separately so
+    /// the client can place the gap correctly: these N items arrived *after*
+    /// that many were dropped.
+    mutating func drain() -> (items: [Item], dropped: Int) {
+        defer {
+            pending.removeAll(keepingCapacity: true)
+            dropped = 0
+        }
+        return (pending, dropped)
+    }
+
+    var isEmpty: Bool { pending.isEmpty && dropped == 0 }
+}

--- a/droidectived/Sources/DaemonCore/StreamProtocol.swift
+++ b/droidectived/Sources/DaemonCore/StreamProtocol.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// The multiplexed stream protocol: one WebSocket carrying every subscription,
+/// rather than a socket per stream. A UI showing logcat plus device changes
+/// plus performance would otherwise hold three sockets with three lifecycles.
+public enum StreamProtocol {
+    /// Topics a client may subscribe to. A table, so a completeness test can
+    /// iterate it — the same reason the HTTP routes are one.
+    public enum Topic: String, Codable, CaseIterable, Sendable {
+        case devices
+        case logcat
+    }
+
+    // MARK: client → server
+
+    public struct Command: Codable, Equatable, Sendable {
+        public enum Operation: String, Codable, Sendable {
+            case subscribe
+            case unsubscribe
+        }
+        public let op: Operation
+        /// Client-chosen correlation id. Every event carries it back, which is
+        /// what makes one socket able to serve many streams.
+        public let id: Int
+        /// Required for `subscribe`, ignored for `unsubscribe` — the id alone
+        /// identifies what to tear down.
+        public let topic: Topic?
+        public let params: Params?
+
+        public struct Params: Codable, Equatable, Sendable {
+            public let serial: String?
+            public let filter: String?
+            public init(serial: String? = nil, filter: String? = nil) {
+                self.serial = serial
+                self.filter = filter
+            }
+        }
+
+        public init(op: Operation, id: Int, topic: Topic? = nil, params: Params? = nil) {
+            self.op = op
+            self.id = id
+            self.topic = topic
+            self.params = params
+        }
+    }
+
+    // MARK: server → client
+
+    /// Event kinds. `dropped` is a first-class event rather than a field on
+    /// `batch`, so a gap is still reported when it happens between batches.
+    public enum EventKind: String, Codable, Sendable {
+        case subscribed
+        case batch
+        case dropped
+        case ended
+        case failed
+    }
+
+    /// Why a subscription stopped, so the UI can distinguish "the device went
+    /// away" from "you asked me to stop" without parsing prose.
+    public enum EndReason: String, Codable, Sendable {
+        case unsubscribed
+        case deviceDisconnected = "device_disconnected"
+        case serverStopping = "server_stopping"
+    }
+
+    /// A server→client frame. Generic over the payload so each topic keeps its
+    /// own ADBKit model rather than everything degrading to `[String: Any]`.
+    public struct Event<Payload: Codable & Sendable>: Codable, Sendable {
+        public let id: Int
+        public let event: EventKind
+        public let items: [Payload]?
+        public let count: Int?
+        public let reason: EndReason?
+        public let message: String?
+
+        private init(
+            id: Int, event: EventKind, items: [Payload]? = nil, count: Int? = nil,
+            reason: EndReason? = nil, message: String? = nil
+        ) {
+            self.id = id
+            self.event = event
+            self.items = items
+            self.count = count
+            self.reason = reason
+            self.message = message
+        }
+
+        public static func subscribed(id: Int) -> Self { .init(id: id, event: .subscribed) }
+        public static func batch(id: Int, items: [Payload]) -> Self {
+            .init(id: id, event: .batch, items: items)
+        }
+        /// Emitted when the bounded buffer discarded items — never silently.
+        public static func dropped(id: Int, count: Int) -> Self {
+            .init(id: id, event: .dropped, count: count)
+        }
+        public static func ended(id: Int, reason: EndReason) -> Self {
+            .init(id: id, event: .ended, reason: reason)
+        }
+        public static func failed(id: Int, message: String) -> Self {
+            .init(id: id, event: .failed, message: message)
+        }
+    }
+
+    /// Why a `subscribe` was refused, before any stream exists.
+    public enum SubscribeError: String, Sendable {
+        case duplicateID = "duplicate_id"
+        case missingTopic = "missing_topic"
+        case missingSerial = "missing_serial"
+
+        public var message: String {
+            switch self {
+            case .duplicateID: return "That subscription id is already in use."
+            case .missingTopic: return "subscribe needs a topic."
+            case .missingSerial: return "That topic needs a device serial."
+            }
+        }
+    }
+
+    /// Validates a command against the live subscriptions. Pure, so the rules
+    /// are tested without a socket.
+    public static func validate(
+        _ command: Command, activeIDs: Set<Int>
+    ) -> SubscribeError? {
+        switch command.op {
+        case .unsubscribe:
+            // Tearing down an unknown id is deliberately not an error: a client
+            // racing its own teardown against an `ended` event would otherwise
+            // see a spurious failure for doing the right thing.
+            return nil
+        case .subscribe:
+            guard let topic = command.topic else { return .missingTopic }
+            guard !activeIDs.contains(command.id) else { return .duplicateID }
+            if topic.needsSerial, command.params?.serial?.isEmpty ?? true {
+                return .missingSerial
+            }
+            return nil
+        }
+    }
+}
+
+extension StreamProtocol.Topic {
+    /// Whether the topic is scoped to one device. `devices` is host-wide — it
+    /// *is* the list of devices — so it takes no serial.
+    public var needsSerial: Bool {
+        switch self {
+        case .devices: return false
+        case .logcat: return true
+        }
+    }
+}

--- a/droidectived/Tests/DaemonCoreTests/StreamBufferTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/StreamBufferTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+
+@testable import DaemonCore
+
+/// The drop policy is a decision, not an implementation detail, so it is
+/// pinned here rather than left to whatever the queue happens to do under load.
+@Suite struct StreamBufferTests {
+    @Test func holdsEverythingUnderCapacity() {
+        var buffer = StreamBuffer<Int>(capacity: 5)
+        buffer.append(contentsOf: [1, 2, 3])
+
+        let drained = buffer.drain()
+        #expect(drained.items == [1, 2, 3])
+        #expect(drained.dropped == 0, "nothing was over capacity, so nothing was lost")
+    }
+
+    @Test func dropsOldestNotNewest() {
+        // A log tail is read from the bottom: the newest lines are the ones
+        // worth keeping, so overflow must discard from the front.
+        var buffer = StreamBuffer<Int>(capacity: 3)
+        buffer.append(contentsOf: [1, 2, 3, 4, 5])
+
+        let drained = buffer.drain()
+        #expect(drained.items == [3, 4, 5])
+        #expect(drained.dropped == 2)
+    }
+
+    @Test func neverExceedsCapacityAcrossManyAppends() {
+        var buffer = StreamBuffer<Int>(capacity: 4)
+        for batch in 0..<50 {
+            buffer.append(contentsOf: [batch * 2, batch * 2 + 1])
+            #expect(buffer.pending.count <= 4, "the buffer is what bounds daemon memory")
+        }
+        let drained = buffer.drain()
+        #expect(drained.items == [96, 97, 98, 99], "the newest survive")
+        #expect(drained.dropped == 96)
+    }
+
+    @Test func reportsTheGapWithTheBatchItPrecedes() {
+        // The count rides with the batch so the UI can place the gap: these
+        // items arrived *after* that many were lost.
+        var buffer = StreamBuffer<Int>(capacity: 2)
+        buffer.append(contentsOf: [1, 2, 3])
+
+        let first = buffer.drain()
+        #expect(first.items == [2, 3])
+        #expect(first.dropped == 1)
+
+        buffer.append(contentsOf: [4])
+        let second = buffer.drain()
+        #expect(second.items == [4])
+        #expect(second.dropped == 0, "the gap is reported once, not carried forward")
+    }
+
+    @Test func drainingLeavesItEmpty() {
+        var buffer = StreamBuffer<Int>(capacity: 3)
+        buffer.append(contentsOf: [1, 2, 3, 4])
+        _ = buffer.drain()
+
+        #expect(buffer.isEmpty)
+        let again = buffer.drain()
+        #expect(again.items.isEmpty)
+        #expect(again.dropped == 0)
+    }
+
+    @Test func aSingleOversizedBatchIsTruncatedNotRejected() {
+        // A burst larger than the whole buffer must still deliver its tail —
+        // dropping the batch entirely would lose the most recent lines, which
+        // is the opposite of the policy.
+        var buffer = StreamBuffer<Int>(capacity: 3)
+        buffer.append(contentsOf: Array(1...100))
+
+        let drained = buffer.drain()
+        #expect(drained.items == [98, 99, 100])
+        #expect(drained.dropped == 97)
+    }
+
+    @Test func emptyAppendChangesNothing() {
+        var buffer = StreamBuffer<Int>(capacity: 3)
+        buffer.append(contentsOf: [1])
+        buffer.append(contentsOf: [])
+
+        let drained = buffer.drain()
+        #expect(drained.items == [1])
+        #expect(drained.dropped == 0)
+    }
+
+    @Test func capacityOfOneKeepsOnlyTheLatest() {
+        var buffer = StreamBuffer<Int>(capacity: 1)
+        buffer.append(contentsOf: [1, 2, 3])
+
+        let drained = buffer.drain()
+        #expect(drained.items == [3])
+        #expect(drained.dropped == 2)
+    }
+}
+
+@Suite struct StreamProtocolTests {
+    private func subscribe(
+        id: Int, topic: StreamProtocol.Topic?, serial: String? = nil
+    ) -> StreamProtocol.Command {
+        StreamProtocol.Command(
+            op: .subscribe, id: id, topic: topic,
+            params: serial.map { StreamProtocol.Command.Params(serial: $0) })
+    }
+
+    @Test func acceptsAWellFormedSubscription() {
+        #expect(
+            StreamProtocol.validate(
+                subscribe(id: 1, topic: .logcat, serial: "emulator-5554"), activeIDs: [])
+                == nil)
+        #expect(StreamProtocol.validate(subscribe(id: 1, topic: .devices), activeIDs: []) == nil)
+    }
+
+    @Test func rejectsAReusedID() {
+        // Correlation ids are how one socket serves many streams; reusing a
+        // live one would silently cross two streams' events.
+        #expect(
+            StreamProtocol.validate(subscribe(id: 7, topic: .devices), activeIDs: [7])
+                == .duplicateID)
+    }
+
+    @Test func rejectsASubscribeWithNoTopic() {
+        #expect(StreamProtocol.validate(subscribe(id: 1, topic: nil), activeIDs: []) == .missingTopic)
+    }
+
+    @Test func rejectsADeviceScopedTopicWithNoSerial() {
+        #expect(
+            StreamProtocol.validate(subscribe(id: 1, topic: .logcat), activeIDs: [])
+                == .missingSerial)
+        #expect(
+            StreamProtocol.validate(subscribe(id: 1, topic: .logcat, serial: ""), activeIDs: [])
+                == .missingSerial)
+    }
+
+    @Test func hostWideTopicsNeedNoSerial() {
+        #expect(!StreamProtocol.Topic.devices.needsSerial, "the device list is the host's, not a device's")
+        #expect(StreamProtocol.Topic.logcat.needsSerial)
+    }
+
+    @Test func unsubscribingAnUnknownIDIsNotAnError() {
+        // A client racing its own teardown against an `ended` event is doing
+        // the right thing and must not see a spurious failure.
+        let command = StreamProtocol.Command(op: .unsubscribe, id: 99)
+        #expect(StreamProtocol.validate(command, activeIDs: []) == nil)
+    }
+
+    @Test func commandsRoundTripThroughJSON() throws {
+        let json = Data(
+            #"{"op":"subscribe","id":3,"topic":"logcat","params":{"serial":"R58M","filter":"E"}}"#
+                .utf8)
+        let decoded = try JSONDecoder().decode(StreamProtocol.Command.self, from: json)
+        #expect(decoded.op == .subscribe)
+        #expect(decoded.id == 3)
+        #expect(decoded.topic == .logcat)
+        #expect(decoded.params?.serial == "R58M")
+        #expect(decoded.params?.filter == "E")
+    }
+
+    @Test func eventsEncodeTheShapeTheUIParses() throws {
+        func encoded(_ event: StreamProtocol.Event<Int>) throws -> String {
+            String(decoding: try DaemonProtocol.encode(event), as: UTF8.self)
+        }
+        #expect(try encoded(.batch(id: 1, items: [7])) == #"{"event":"batch","id":1,"items":[7]}"#)
+        #expect(try encoded(.dropped(id: 1, count: 12)) == #"{"count":12,"event":"dropped","id":1}"#)
+        #expect(
+            try encoded(.ended(id: 1, reason: .deviceDisconnected))
+                == #"{"event":"ended","id":1,"reason":"device_disconnected"}"#)
+    }
+}


### PR DESCRIPTION
The next slice of `droidectived`: the two pure pieces the WebSocket transport will sit on. No transport yet — this is the part where the decisions live, so it is worth landing and reviewing on its own.

## The drop policy, made concrete

`StreamBuffer` implements what you decided in #233: a bounded per-subscription queue that discards **oldest first** and reports the count, rather than growing without limit or stalling the producer.

Dropping oldest rather than newest is the other half of that choice — a log tail is read from the bottom, so the newest lines are the ones worth keeping. `aSingleOversizedBatchIsTruncatedNotRejected` pins the case that would otherwise be tempting to special-case: a burst bigger than the whole buffer still delivers its tail, because dropping it entirely would lose exactly the lines the user wants.

The gap count rides **with the batch it precedes**, so the UI can place it correctly: these N items arrived after that many were lost. It resets on drain, so a gap is reported once rather than carried forward.

This deliberately differs from the Mac app, which stalls — `bytes.lines` is pull-driven, so a slow consumer backpressures the pipe. The divergence is the decision, and it matches what the device already does: Android's logcat ring buffer drops under load regardless, so "lossless" was never on offer.

## The subscription protocol

One socket multiplexed by client-chosen correlation id, rather than a socket per stream — a UI showing logcat, devices and performance would otherwise juggle three lifecycles.

Worth review:

- **`dropped` is its own event**, not a field on `batch`, so a gap is still reported when it happens between batches.
- **`ended` carries a typed reason** (`unsubscribed` / `device_disconnected` / `server_stopping`) so the UI distinguishes "the device went away" from "you asked me to stop" without parsing prose.
- **Unsubscribing an unknown id is deliberately not an error.** A client racing its own teardown against an `ended` event is doing the right thing and must not be punished for it.
- **`Topic.needsSerial`** separates host-wide topics from device-scoped ones, so `devices` correctly takes no serial while `logcat` requires one.

## Testing

16 new tests, 40 in the package. The buffer's invariant is asserted *inside* the loop across 50 appends — bounded memory is the whole point, so it is checked continuously rather than only at the end. The event encodings are pinned as exact JSON strings, since that is the contract a non-Swift UI parses and a field rename should be a visible diff in the PR.

Verified on macOS **and** in a Linux container (40 tests both). No production code outside the new package; no `App/` changes.

## Next

The WebSocket transport that carries these, then wiring the `logcat` topic to `LogcatStreamer`.