### PR TITLE
Fix API Testing UI friction: HTML formatting, resizable panes, adaptive tabs, copy actions

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiCollectionTree.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiCollectionTree.swift
@@ -192,6 +192,36 @@ public enum ApiCollectionTree: Sendable {
     /// Items whose name, URL, or method matches `query`, flattened with the
     /// folder path that leads to each one. An empty query matches nothing —
     /// the caller shows the normal tree instead.
+    /// One row of the sidebar tree: an item and how deep it sits.
+    public struct Row: Identifiable, Sendable, Equatable {
+        public let item: ApiItem
+        public let depth: Int
+
+        public var id: String { item.id }
+
+        public init(item: ApiItem, depth: Int) {
+            self.item = item
+            self.depth = depth
+        }
+    }
+
+    /// Flattens the tree to the rows currently on screen — a collapsed folder
+    /// contributes itself and nothing under it.
+    ///
+    /// The sidebar draws these as sibling `List` rows rather than nesting a
+    /// folder's children inside their parent's row. Nesting meant a folder and
+    /// its contents shared one row's insets while top-level requests each got
+    /// their own, so the gaps between rows were visibly uneven.
+    public static func rows(_ items: [ApiItem], expanded: Set<String>, depth: Int = 0) -> [Row] {
+        var out: [Row] = []
+        for item in items {
+            out.append(Row(item: item, depth: depth))
+            guard case .folder(let folder) = item, expanded.contains(folder.id) else { continue }
+            out.append(contentsOf: rows(folder.items, expanded: expanded, depth: depth + 1))
+        }
+        return out
+    }
+
     public static func search(_ query: String, in items: [ApiItem]) -> [(path: [String], request: SavedRequest)] {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !needle.isEmpty else { return [] }

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiPaneLayout.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiPaneLayout.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Geometry for the API client's two draggable seams — the sidebar edge and the
+/// request/response split. Kept out of the view for the same reason `PaneSplit`
+/// is: the drag gesture and the layout must agree about the bounds, and they
+/// only reliably do that when one tested function decides them.
+///
+/// The sidebar is stored as a width (it should not grow with the window) and the
+/// split as a fraction (it should), which is why they clamp differently.
+public enum ApiPaneLayout {
+
+    /// The sidebar holds a search field, a segmented picker and a tree with
+    /// indented rows; below ~200pt those stop being usable.
+    public static let sidebarRange: ClosedRange<Double> = 200...460
+
+    /// Neither the editor nor the response pane drops below a quarter of the
+    /// split area — past that the request tabs start truncating.
+    public static let fractionRange: ClosedRange<Double> = 0.25...0.75
+
+    /// An absolute floor on top of the fraction, so a tight window shrinks both
+    /// panes evenly instead of squeezing one to nothing.
+    public static let minPane: Double = 240
+
+    /// The sidebar never takes more than a third of the pane, so the request and
+    /// response columns keep the room they need on a narrow window.
+    public static func sidebarWidth(stored: Double, total: Double) -> Double {
+        let clamped = min(sidebarRange.upperBound, max(sidebarRange.lowerBound, stored))
+        guard total > 0 else { return clamped }
+        return min(clamped, max(sidebarRange.lowerBound, total / 3))
+    }
+
+    public static func clampedFraction(_ fraction: Double) -> Double {
+        min(fractionRange.upperBound, max(fractionRange.lowerBound, fraction))
+    }
+
+    /// The leading pane's length for a stored fraction, with the absolute floor
+    /// applied on both sides.
+    public static func leadingLength(total: Double, fraction: Double) -> Double {
+        guard total > 0 else { return 0 }
+        let floor = paneFloor(total: total)
+        let wanted = total * clampedFraction(fraction)
+        return min(max(wanted, floor), total - floor)
+    }
+
+    /// The drag range in points for a given total, matching `leadingLength`
+    /// exactly so the seam stops where the layout stops rather than freezing
+    /// after a dead zone.
+    public static func pointRange(total: Double) -> ClosedRange<Double> {
+        guard total > 0 else { return 0...0 }
+        let floor = paneFloor(total: total)
+        let low = max(total * fractionRange.lowerBound, floor)
+        let high = min(total * fractionRange.upperBound, total - floor)
+        return low...max(low, high)
+    }
+
+    /// Points back to a stored fraction.
+    public static func fraction(forLeading length: Double, total: Double) -> Double {
+        guard total > 0 else { return 0.5 }
+        return clampedFraction(length / total)
+    }
+
+    private static func paneFloor(total: Double) -> Double {
+        min(minPane, total / 2)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiPaneLayout.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiPaneLayout.swift
@@ -53,10 +53,12 @@ public enum ApiPaneLayout {
         return low...max(low, high)
     }
 
-    /// Points back to a stored fraction.
-    public static func fraction(forLeading length: Double, total: Double) -> Double {
-        guard total > 0 else { return 0.5 }
-        return clampedFraction(length / total)
+    /// The fraction a drag lands on: where it started, plus how far it moved as
+    /// a share of the current total. Both halves come from the same `total`, so
+    /// the seam can't be converted through one width and back through another.
+    public static func fraction(from start: Double, movedBy delta: Double, total: Double) -> Double {
+        guard total > 0 else { return clampedFraction(start) }
+        return clampedFraction(start + delta / total)
     }
 
     private static func paneFloor(total: Double) -> Double {

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiQueryString.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiQueryString.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Moves a URL's `?a=1&b=2` into the Params table and back out again.
+///
+/// The two are not kept in lockstep — the builder merges the table on top of
+/// whatever the URL already carries, so a silent two-way sync would be a good
+/// way to lose a parameter. This is the explicit extraction the Params tab
+/// offers instead, and it is pure so the round trip is testable.
+public enum ApiQueryString: Sendable {
+
+    /// The parameters in a URL's query string, in the order they appear.
+    /// A bare `?flag` (no `=`) becomes a parameter with an empty value, which
+    /// is how servers read it.
+    public static func parameters(in url: String) -> [ApiKeyValue] {
+        let query = HttpRequestBuilder.split(url).query
+        guard !query.isEmpty else { return [] }
+        var found: [ApiKeyValue] = []
+        for pair in query.components(separatedBy: "&") where !pair.isEmpty {
+            guard let separator = pair.firstIndex(of: "=") else {
+                found.append(ApiKeyValue(key: decode(pair), value: ""))
+                continue
+            }
+            let name = decode(String(pair[pair.startIndex..<separator]))
+            let value = decode(String(pair[pair.index(after: separator)...]))
+            guard !name.isEmpty else { continue }
+            found.append(ApiKeyValue(key: name, value: value))
+        }
+        return found
+    }
+
+    /// The same URL with its query removed, fragment kept. Pairs with
+    /// `parameters(in:)`: extract into the table, strip from the bar, and the
+    /// request the builder produces is unchanged.
+    public static func removingQuery(from url: String) -> String {
+        let parts = HttpRequestBuilder.split(url)
+        guard !parts.query.isEmpty else { return url }
+        return parts.fragment.isEmpty ? parts.base : parts.base + "#" + parts.fragment
+    }
+
+    public static func hasQuery(_ url: String) -> Bool {
+        !HttpRequestBuilder.split(url).query.isEmpty
+    }
+
+    private static func decode(_ text: String) -> String {
+        let plus = text.replacingOccurrences(of: "+", with: " ")
+        return plus.removingPercentEncoding ?? plus
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiResponseModel.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiResponseModel.swift
@@ -696,8 +696,8 @@ public enum XMLFormatter: Sendable {
         var out: [String] = []
         for row in rows {
             let stripped = String(row.dropFirst(min(common, row.prefix(while: { $0 == " " }).count)))
-            let trailingTrimmed = stripped.replacingOccurrences(
-                of: "[ ]+$", with: "", options: .regularExpression
+            let trailingTrimmed = String(
+                stripped.reversed().drop(while: { $0 == " " }).reversed()
             )
             if trailingTrimmed.isEmpty {
                 // Keep blank lines the author wrote, but never trailing padding.

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/ApiResponseModel.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/ApiResponseModel.swift
@@ -372,10 +372,21 @@ public struct ApiResponse: Sendable {
     public var prettyBody: String? {
         guard let text = bodyString, !text.isEmpty else { return nil }
         switch format {
-        case .json: return JSONFormatter.prettyPrint(text)
+        case .json: return JSONFormatter.prettyPrint(text) ?? JSONFormatter.prettyPrintLines(text)
         case .xml, .html: return XMLFormatter.prettyPrint(text)
-        case .text, .image, .binary: return nil
+        case .text: return ApiResponse.prettyPlainText(text)
+        case .image, .binary: return nil
         }
+    }
+
+    /// `text/plain` covers a lot of ground: servers mislabel JSON, stream
+    /// JSON Lines, and answer form posts in kind. Recognising those is what
+    /// puts the Pretty toggle in front of a body that can use it — anything
+    /// genuinely unstructured returns nil and shows as-is.
+    static func prettyPlainText(_ text: String) -> String? {
+        if let json = JSONFormatter.prettyPrint(text) { return json }
+        if let lines = JSONFormatter.prettyPrintLines(text) { return lines }
+        return FormFormatter.prettyPrint(text)
     }
 
     /// Kept for the response pane's "Pretty" toggle on JSON specifically.
@@ -496,6 +507,26 @@ public enum JSONFormatter: Sendable {
         return out
     }
 
+    /// Pretty-prints JSON Lines / NDJSON — one document per line, as log and
+    /// streaming endpoints emit. Returns nil unless *every* non-empty line
+    /// parses, so a stray line of prose doesn't get a half-formatted body.
+    public static func prettyPrintLines(_ text: String, indent: String = "  ") -> String? {
+        let rows = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard rows.count > 1 else { return nil }
+        var out: [String] = []
+        for row in rows {
+            // Objects and arrays only — a column of bare numbers is a text
+            // file, and "prettifying" it would just be a toggle that does
+            // nothing.
+            guard row.hasPrefix("{") || row.hasPrefix("[") else { return nil }
+            guard let pretty = prettyPrint(row, indent: indent) else { return nil }
+            out.append(pretty)
+        }
+        return out.joined(separator: "\n")
+    }
+
     public static func isValidJSON(_ text: String) -> Bool {
         let data = Data(text.utf8)
         guard !data.isEmpty else { return false }
@@ -507,18 +538,56 @@ extension Character {
     var isJSONWhitespace: Bool { self == " " || self == "\n" || self == "\r" || self == "\t" }
 }
 
+// MARK: - Form-encoded formatting
+
+public enum FormFormatter: Sendable {
+
+    /// Breaks `a=1&b=hello%20world` into one decoded `name = value` per line.
+    /// Returns nil for anything that isn't a single line of `&`-joined pairs,
+    /// so ordinary prose never gets sliced up on a stray `=`.
+    public static func prettyPrint(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(where: \.isNewline) else { return nil }
+        let pairs = trimmed.components(separatedBy: "&")
+        guard pairs.count > 1 || trimmed.contains("=") else { return nil }
+
+        var rows: [String] = []
+        for pair in pairs {
+            guard let separator = pair.firstIndex(of: "=") else { return nil }
+            let name = String(pair[pair.startIndex..<separator])
+            let value = String(pair[pair.index(after: separator)...])
+            guard !name.isEmpty, !name.contains(" ") else { return nil }
+            rows.append("\(decode(name)) = \(decode(value))")
+        }
+        return rows.isEmpty ? nil : rows.joined(separator: "\n")
+    }
+
+    private static func decode(_ text: String) -> String {
+        let plus = text.replacingOccurrences(of: "+", with: " ")
+        return plus.removingPercentEncoding ?? plus
+    }
+}
+
 // MARK: - XML / HTML formatting
 
 public enum XMLFormatter: Sendable {
 
     /// Indents markup one element per line. Text-only elements stay on a single
     /// line, and declarations, comments and CDATA are passed through intact.
+    ///
+    /// Real pages are not well-formed XML, so two rules keep the indentation
+    /// honest on them. A raw-text element (`<script>`, `<style>`) has its body
+    /// taken verbatim to the matching close tag — minified JS is full of `<`,
+    /// and parsing it as markup both mangles the source and runs the depth
+    /// away. And a close tag unwinds to the element it actually closes rather
+    /// than assuming the innermost one, so the unclosed `<p>`/`<li>` that HTML
+    /// permits can't leave the rest of the document drifting right.
     public static func prettyPrint(_ text: String, indent: String = "  ") -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.hasPrefix("<") else { return nil }
 
         var lines: [String] = []
-        var depth = 0
+        var open: [String] = []
         var index = trimmed.startIndex
 
         func append(_ content: String, at level: Int) {
@@ -529,37 +598,116 @@ public enum XMLFormatter: Sendable {
         while index < trimmed.endIndex {
             if trimmed[index] == "<" {
                 guard let close = closingBracket(of: trimmed, from: index) else {
-                    append(String(trimmed[index...]).trimmingCharacters(in: .whitespaces), at: depth)
+                    append(String(trimmed[index...]).trimmingCharacters(in: .whitespaces), at: open.count)
                     break
                 }
                 let tag = String(trimmed[index...close])
-                let kind = classify(tag)
-                switch kind {
+                let name = elementName(tag)?.lowercased()
+                switch classify(tag) {
                 case .closing:
-                    depth -= 1
-                    append(tag, at: depth)
+                    // Unwind to the element this tag closes. A stray close with
+                    // nothing matching it stays where it is rather than pulling
+                    // the whole document a level left.
+                    if let name, let match = open.lastIndex(of: name) {
+                        open.removeSubrange(match...)
+                        append(tag, at: open.count)
+                    } else {
+                        append(tag, at: open.count)
+                    }
                 case .opening:
+                    if let name, rawTextElements.contains(name) {
+                        index = appendRawTextElement(
+                            trimmed, tagStart: index, tagEnd: close, name: name,
+                            depth: open.count, indent: indent, into: &lines
+                        )
+                        continue
+                    }
                     // An element whose entire content is text collapses onto one line.
                     let afterTag = trimmed.index(after: close)
                     if let inlineEnd = inlineTextElementEnd(trimmed, contentStart: afterTag, tag: tag) {
-                        append(String(trimmed[index..<inlineEnd]), at: depth)
+                        append(String(trimmed[index..<inlineEnd]), at: open.count)
                         index = inlineEnd
                         continue
                     }
-                    append(tag, at: depth)
-                    depth += 1
+                    // HTML lets a sibling stand in for the close tag this
+                    // element never got (`<li>a<li>b`, `<tr>` after an open
+                    // `<td>` — which unwinds the cell and then the row).
+                    if let name, let closedBy = implicitlyClosedBy[name] {
+                        while let last = open.last, closedBy.contains(last) { open.removeLast() }
+                    }
+                    append(tag, at: open.count)
+                    if let name { open.append(name) }
                 case .selfContained:
-                    append(tag, at: depth)
+                    append(tag, at: open.count)
                 }
                 index = trimmed.index(after: close)
             } else {
                 let textEnd = trimmed[index...].firstIndex(of: "<") ?? trimmed.endIndex
                 let content = String(trimmed[index..<textEnd]).trimmingCharacters(in: .whitespacesAndNewlines)
-                append(content, at: depth)
+                append(content, at: open.count)
                 index = textEnd
             }
         }
         return lines.isEmpty ? nil : lines.joined(separator: "\n")
+    }
+
+    /// Emits `<script>…</script>` with its body untouched apart from indentation,
+    /// and answers where parsing resumes. An unterminated element takes the rest
+    /// of the document, which is what a truncated response looks like.
+    private static func appendRawTextElement(
+        _ text: String, tagStart: String.Index, tagEnd: String.Index, name: String,
+        depth: Int, indent: String, into lines: inout [String]
+    ) -> String.Index {
+        let pad = String(repeating: indent, count: max(0, depth))
+        let contentStart = text.index(after: tagEnd)
+        let terminator = text.range(
+            of: "</\(name)", options: [.caseInsensitive], range: contentStart..<text.endIndex
+        )
+        let contentEnd = terminator?.lowerBound ?? text.endIndex
+        let body = String(text[contentStart..<contentEnd])
+
+        // A one-line body reads better beside its tags, exactly as
+        // `inlineTextElementEnd` treats an ordinary text-only element.
+        guard body.contains(where: \.isNewline) else {
+            let closeTag = terminator.flatMap { closingBracket(of: text, from: $0.lowerBound) }
+            let end = closeTag.map(text.index(after:)) ?? text.endIndex
+            lines.append(pad + String(text[tagStart..<end]))
+            return end
+        }
+
+        lines.append(pad + String(text[tagStart...tagEnd]))
+        lines.append(contentsOf: dedented(body, to: pad + indent))
+        guard let terminator, let closeTag = closingBracket(of: text, from: terminator.lowerBound)
+        else { return text.endIndex }
+        lines.append(pad + String(text[terminator.lowerBound...closeTag]))
+        return text.index(after: closeTag)
+    }
+
+    /// Re-indents a raw-text body under `pad`, preserving the relative shape the
+    /// author wrote by stripping the block's own common indentation first.
+    private static func dedented(_ body: String, to pad: String) -> [String] {
+        let rows = body.components(separatedBy: .newlines)
+            .map { $0.replacingOccurrences(of: "\t", with: "    ") }
+        let common =
+            rows
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .map { $0.prefix(while: { $0 == " " }).count }
+            .min() ?? 0
+        var out: [String] = []
+        for row in rows {
+            let stripped = String(row.dropFirst(min(common, row.prefix(while: { $0 == " " }).count)))
+            let trailingTrimmed = stripped.replacingOccurrences(
+                of: "[ ]+$", with: "", options: .regularExpression
+            )
+            if trailingTrimmed.isEmpty {
+                // Keep blank lines the author wrote, but never trailing padding.
+                if !out.isEmpty { out.append("") }
+            } else {
+                out.append(pad + trailingTrimmed)
+            }
+        }
+        while out.last?.isEmpty == true { out.removeLast() }
+        return out
     }
 
     private enum TagKind {
@@ -641,5 +789,25 @@ public enum XMLFormatter: Sendable {
     static let voidElements: Set<String> = [
         "area", "base", "br", "col", "embed", "hr", "img", "input",
         "link", "meta", "param", "source", "track", "wbr",
+    ]
+
+    /// Elements whose content is character data rather than markup. Anything
+    /// between the tags belongs to the script/stylesheet, `<` included.
+    static let rawTextElements: Set<String> = ["script", "style", "textarea"]
+
+    /// The open elements an HTML start tag is allowed to close on its own. Only
+    /// the cases that actually appear without close tags in the wild — enough
+    /// to keep a list or a table from stair-stepping off the right edge.
+    static let implicitlyClosedBy: [String: Set<String>] = [
+        "li": ["li"],
+        "dt": ["dt", "dd"],
+        "dd": ["dt", "dd"],
+        "p": ["p"],
+        "tr": ["td", "th", "tr"],
+        "td": ["td", "th"],
+        "th": ["td", "th"],
+        "option": ["option"],
+        "thead": ["td", "th", "tr"],
+        "tbody": ["td", "th", "tr"],
     ]
 }

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/SyntaxHighlighting.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/SyntaxHighlighting.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+/// A coloured run of a response body. Offsets are UTF-16 so the App layer can
+/// hand them straight to an `NSTextStorage` without recomputing anything, and
+/// the tokenizer stays here where it can be tested without a view.
+public struct SyntaxToken: Sendable, Equatable {
+
+    public enum Kind: String, Sendable, CaseIterable {
+        /// A JSON object key, before its colon.
+        case key
+        case string
+        case number
+        /// `true`, `false`, `null`.
+        case literal
+        case punctuation
+        /// The element name inside a tag, `<` and `>` included.
+        case tag
+        case attribute
+        /// A quoted attribute value.
+        case value
+        case comment
+        /// `<!doctype …>`, `<?xml …?>`.
+        case declaration
+    }
+
+    public let kind: Kind
+    public let location: Int
+    public let length: Int
+
+    public init(kind: Kind, location: Int, length: Int) {
+        self.kind = kind
+        self.location = location
+        self.length = length
+    }
+}
+
+/// Colours a response body by structure. Both tokenizers are forgiving: a
+/// truncated or malformed body still yields tokens for the part that parsed,
+/// because a 16 MB cap or a dropped connection is a normal thing to be looking
+/// at in an API client.
+public enum SyntaxHighlighter: Sendable {
+
+    /// Above this the highlight is skipped and the body renders plain. Walking
+    /// a multi-megabyte body is cheap, but the attribute runs it produces are
+    /// not, and a viewer that stalls is worse than one that isn't coloured.
+    public static let maxHighlightableLength = 512 * 1024
+
+    public static func tokens(for text: String, format: ResponseFormat) -> [SyntaxToken] {
+        guard text.utf16.count <= maxHighlightableLength else { return [] }
+        switch format {
+        case .json: return jsonTokens(text)
+        case .xml, .html: return markupTokens(text)
+        case .text, .image, .binary: return []
+        }
+    }
+
+    // MARK: - JSON
+
+    /// Also handles JSON Lines, since concatenated documents tokenize the same
+    /// way one does.
+    public static func jsonTokens(_ text: String) -> [SyntaxToken] {
+        var tokens: [SyntaxToken] = []
+        var offset = 0
+        var pendingString: (location: Int, length: Int)?
+        let characters = Array(text)
+        var index = 0
+
+        func flushPendingString(asKey: Bool) {
+            guard let pending = pendingString else { return }
+            tokens.append(
+                SyntaxToken(
+                    kind: asKey ? .key : .string, location: pending.location, length: pending.length
+                )
+            )
+            pendingString = nil
+        }
+
+        while index < characters.count {
+            let character = characters[index]
+            switch character {
+            case "\"":
+                flushPendingString(asKey: false)
+                let start = offset
+                var length = character.utf16.count
+                var escaped = false
+                index += 1
+                offset += character.utf16.count
+                while index < characters.count {
+                    let inner = characters[index]
+                    length += inner.utf16.count
+                    offset += inner.utf16.count
+                    index += 1
+                    if escaped {
+                        escaped = false
+                    } else if inner == "\\" {
+                        escaped = true
+                    } else if inner == "\"" {
+                        break
+                    }
+                }
+                // Whether this string was a key is only knowable at the colon.
+                pendingString = (start, length)
+                continue
+            case ":":
+                flushPendingString(asKey: true)
+                tokens.append(SyntaxToken(kind: .punctuation, location: offset, length: 1))
+            case "{", "}", "[", "]", ",":
+                flushPendingString(asKey: false)
+                tokens.append(SyntaxToken(kind: .punctuation, location: offset, length: 1))
+            case "t", "f", "n":
+                flushPendingString(asKey: false)
+                if let word = literalWord(characters, at: index) {
+                    tokens.append(SyntaxToken(kind: .literal, location: offset, length: word))
+                    index += word
+                    offset += word
+                    continue
+                }
+            default:
+                if character == "-" || character.isNumber {
+                    flushPendingString(asKey: false)
+                    let length = numberLength(characters, at: index)
+                    if length > 0 {
+                        tokens.append(SyntaxToken(kind: .number, location: offset, length: length))
+                        index += length
+                        offset += length
+                        continue
+                    }
+                }
+            }
+            offset += character.utf16.count
+            index += 1
+        }
+        flushPendingString(asKey: false)
+        return tokens
+    }
+
+    private static func literalWord(_ characters: [Character], at index: Int) -> Int? {
+        for word in ["true", "false", "null"] where matches(characters, at: index, word: word) {
+            return word.count
+        }
+        return nil
+    }
+
+    private static func matches(_ characters: [Character], at index: Int, word: String) -> Bool {
+        let letters = Array(word)
+        guard index + letters.count <= characters.count else { return false }
+        for offset in 0..<letters.count where characters[index + offset] != letters[offset] {
+            return false
+        }
+        return true
+    }
+
+    /// Length in characters of the JSON number starting here — all ASCII, so it
+    /// is also the UTF-16 length.
+    private static func numberLength(_ characters: [Character], at index: Int) -> Int {
+        var cursor = index
+        if characters[cursor] == "-" { cursor += 1 }
+        var digits = 0
+        while cursor < characters.count, characters[cursor].isNumber {
+            cursor += 1
+            digits += 1
+        }
+        guard digits > 0 else { return 0 }
+        if cursor < characters.count, characters[cursor] == "." {
+            cursor += 1
+            while cursor < characters.count, characters[cursor].isNumber { cursor += 1 }
+        }
+        if cursor < characters.count, characters[cursor] == "e" || characters[cursor] == "E" {
+            var probe = cursor + 1
+            if probe < characters.count, characters[probe] == "+" || characters[probe] == "-" {
+                probe += 1
+            }
+            var exponentDigits = 0
+            while probe < characters.count, characters[probe].isNumber {
+                probe += 1
+                exponentDigits += 1
+            }
+            if exponentDigits > 0 { cursor = probe }
+        }
+        return cursor - index
+    }
+
+    // MARK: - XML / HTML
+
+    public static func markupTokens(_ text: String) -> [SyntaxToken] {
+        var tokens: [SyntaxToken] = []
+        var offset = 0
+        let characters = Array(text)
+        var index = 0
+
+        while index < characters.count {
+            guard characters[index] == "<" else {
+                offset += characters[index].utf16.count
+                index += 1
+                continue
+            }
+            if matches(characters, at: index, word: "<!--") {
+                let span = spanLength(characters, from: index, until: "-->")
+                tokens.append(SyntaxToken(kind: .comment, location: offset, length: span.utf16))
+                index += span.characters
+                offset += span.utf16
+                continue
+            }
+            if matches(characters, at: index, word: "<![CDATA[") {
+                let span = spanLength(characters, from: index, until: "]]>")
+                tokens.append(SyntaxToken(kind: .string, location: offset, length: span.utf16))
+                index += span.characters
+                offset += span.utf16
+                continue
+            }
+            let isDeclaration =
+                matches(characters, at: index, word: "<!") || matches(characters, at: index, word: "<?")
+            let span = tagSpan(characters, from: index)
+            if isDeclaration {
+                tokens.append(SyntaxToken(kind: .declaration, location: offset, length: span.utf16))
+            } else {
+                tokens.append(
+                    contentsOf: tagTokens(characters, from: index, span: span, offset: offset)
+                )
+            }
+            index += span.characters
+            offset += span.utf16
+        }
+        return tokens
+    }
+
+    /// Splits one `<tag attr="value">` into its name, attribute names and
+    /// quoted values. Everything not otherwise classified stays uncoloured so
+    /// stray punctuation can't be mistaken for structure.
+    private static func tagTokens(
+        _ characters: [Character], from start: Int, span: (characters: Int, utf16: Int), offset: Int
+    ) -> [SyntaxToken] {
+        var tokens: [SyntaxToken] = []
+        let end = start + span.characters
+        var index = start
+        var cursor = offset
+
+        // `<`, `</` and the element name.
+        var nameLength = 0
+        var namePrefix = characters[index].utf16.count
+        index += 1
+        if index < end, characters[index] == "/" {
+            namePrefix += 1
+            index += 1
+        }
+        while index < end, !characters[index].isWhitespace, characters[index] != ">",
+            characters[index] != "/" {
+            nameLength += characters[index].utf16.count
+            index += 1
+        }
+        tokens.append(SyntaxToken(kind: .tag, location: cursor, length: namePrefix + nameLength))
+        cursor += namePrefix + nameLength
+
+        while index < end {
+            let character = characters[index]
+            if character.isWhitespace || character == "=" || character == "/" || character == ">" {
+                cursor += character.utf16.count
+                index += 1
+                continue
+            }
+            if character == "\"" || character == "'" {
+                var length = character.utf16.count
+                index += 1
+                while index < end, characters[index] != character {
+                    length += characters[index].utf16.count
+                    index += 1
+                }
+                if index < end {
+                    length += characters[index].utf16.count
+                    index += 1
+                }
+                tokens.append(SyntaxToken(kind: .value, location: cursor, length: length))
+                cursor += length
+                continue
+            }
+            var length = 0
+            while index < end, !characters[index].isWhitespace, characters[index] != "=",
+                characters[index] != ">", characters[index] != "/" {
+                length += characters[index].utf16.count
+                index += 1
+            }
+            if length > 0 {
+                tokens.append(SyntaxToken(kind: .attribute, location: cursor, length: length))
+                cursor += length
+            }
+        }
+        return tokens
+    }
+
+    /// The tag from `<` through its `>`, honouring quoted attribute values so a
+    /// `>` inside one doesn't end it early. An unterminated tag runs to the end.
+    private static func tagSpan(
+        _ characters: [Character], from start: Int
+    ) -> (characters: Int, utf16: Int) {
+        var index = start
+        var utf16 = 0
+        var quote: Character?
+        while index < characters.count {
+            let character = characters[index]
+            utf16 += character.utf16.count
+            index += 1
+            if let open = quote {
+                if character == open { quote = nil }
+            } else if character == "\"" || character == "'" {
+                quote = character
+            } else if character == ">" {
+                break
+            }
+        }
+        return (index - start, utf16)
+    }
+
+    private static func spanLength(
+        _ characters: [Character], from start: Int, until terminator: String
+    ) -> (characters: Int, utf16: Int) {
+        var index = start
+        var utf16 = 0
+        while index < characters.count {
+            if matches(characters, at: index, word: terminator) {
+                for offset in 0..<terminator.count {
+                    utf16 += characters[index + offset].utf16.count
+                }
+                index += terminator.count
+                return (index - start, utf16)
+            }
+            utf16 += characters[index].utf16.count
+            index += 1
+        }
+        return (index - start, utf16)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/ApiClient/TabOverflow.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApiClient/TabOverflow.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Decides how many tabs fit on one row and which spill into an overflow menu.
+///
+/// The request editor used `ViewThatFits` over a segmented and a menu picker,
+/// which is all-or-nothing: seven tabs never fit a half-width pane, so the whole
+/// row collapsed to a single centred dropdown even with room for most of them.
+/// This keeps as many real tabs as the width allows and hands only the remainder
+/// to a menu — and never renders a tab that would be clipped.
+public enum TabOverflow {
+
+    public struct Layout: Equatable, Sendable {
+        /// Indices to draw as tabs, in display order.
+        public let visible: [Int]
+        /// Indices for the overflow menu, in display order.
+        public let overflow: [Int]
+
+        public init(visible: [Int], overflow: [Int]) {
+            self.visible = visible
+            self.overflow = overflow
+        }
+    }
+
+    /// Later tabs give way first, so the ones people reach for most keep their
+    /// place. The selection is always drawn — a tab you are looking at must not
+    /// vanish into a menu — so when it would have overflowed it takes the last
+    /// visible slot and that tab moves into the menu instead.
+    ///
+    /// - Parameters:
+    ///   - widths: each tab's rendered width, in display order.
+    ///   - available: width the row has to spend.
+    ///   - spacing: gap between adjacent tabs.
+    ///   - overflowWidth: width of the overflow button, counted only when one is needed.
+    ///   - selected: index of the selected tab, or nil when nothing is selected.
+    public static func layout(
+        widths: [Double],
+        available: Double,
+        spacing: Double,
+        overflowWidth: Double,
+        selected: Int?
+    ) -> Layout {
+        let all = Array(widths.indices)
+        guard !all.isEmpty else { return Layout(visible: [], overflow: []) }
+        if total(of: all, widths: widths, spacing: spacing) <= available {
+            return Layout(visible: all, overflow: [])
+        }
+
+        // Room for the overflow button has to come out of the same budget.
+        let budget = available - overflowWidth - spacing
+        var fitting = 0
+        while fitting < all.count {
+            let candidate = Array(0...fitting)
+            if total(of: candidate, widths: widths, spacing: spacing) <= budget {
+                fitting += 1
+            } else {
+                break
+            }
+        }
+
+        var visible = Array(0..<fitting)
+        var overflow = Array(fitting..<all.count)
+
+        if let selected, overflow.contains(selected) {
+            if let displaced = visible.popLast() {
+                overflow.removeAll { $0 == selected }
+                overflow.append(displaced)
+                overflow.sort()
+                visible.append(selected)
+            } else if widths[selected] <= budget {
+                // Nothing fit at all, but the selection alone does — show it
+                // rather than an anonymous menu button. Measured against the
+                // same budget: a tab that only fits by pushing the overflow
+                // button off the row is a tab that doesn't fit.
+                overflow.removeAll { $0 == selected }
+                visible = [selected]
+            }
+        }
+        return Layout(visible: visible, overflow: overflow)
+    }
+
+    private static func total(of indices: [Int], widths: [Double], spacing: Double) -> Double {
+        guard !indices.isEmpty else { return 0 }
+        let content = indices.reduce(0.0) { $0 + widths[$1] }
+        return content + spacing * Double(indices.count - 1)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ApiClientServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApiClientServiceTests.swift
@@ -864,3 +864,69 @@ private final class Progress: @unchecked Sendable {
         }
     }
 }
+
+// MARK: - Sidebar rows
+
+@Suite struct ApiCollectionRowsTests {
+
+    private func tree() -> [ApiItem] {
+        [
+            .request(SavedRequest(id: "r1", name: "One")),
+            .folder(
+                ApiFolder(
+                    id: "f1",
+                    name: "Folder",
+                    items: [
+                        .request(SavedRequest(id: "r2", name: "Two")),
+                        .folder(
+                            ApiFolder(
+                                id: "f2", name: "Inner",
+                                items: [.request(SavedRequest(id: "r3", name: "Three"))]
+                            )
+                        ),
+                    ]
+                )
+            ),
+            .request(SavedRequest(id: "r4", name: "Four")),
+        ]
+    }
+
+    @Test func aCollapsedTreeShowsOnlyTheTopLevel() {
+        let rows = ApiCollectionTree.rows(tree(), expanded: [])
+        #expect(rows.map(\.id) == ["r1", "f1", "r4"])
+        #expect(rows.allSatisfy { $0.depth == 0 })
+    }
+
+    @Test func anExpandedFolderContributesItsChildrenOneLevelDeeper() {
+        let rows = ApiCollectionTree.rows(tree(), expanded: ["f1"])
+        #expect(rows.map(\.id) == ["r1", "f1", "r2", "f2", "r4"])
+        #expect(rows.map(\.depth) == [0, 0, 1, 1, 0])
+    }
+
+    @Test func nestingGoesAsDeepAsItIsExpanded() {
+        let rows = ApiCollectionTree.rows(tree(), expanded: ["f1", "f2"])
+        #expect(rows.map(\.id) == ["r1", "f1", "r2", "f2", "r3", "r4"])
+        #expect(rows.map(\.depth) == [0, 0, 1, 1, 2, 0])
+    }
+
+    @Test func expandingAnInnerFolderWhoseParentIsClosedChangesNothing() {
+        let rows = ApiCollectionTree.rows(tree(), expanded: ["f2"])
+        #expect(rows.map(\.id) == ["r1", "f1", "r4"])
+    }
+
+    @Test func anEmptyTreeHasNoRows() {
+        #expect(ApiCollectionTree.rows([], expanded: ["f1"]).isEmpty)
+    }
+
+    @Test func anExpandedEmptyFolderStillShowsItself() {
+        let rows = ApiCollectionTree.rows(
+            [.folder(ApiFolder(id: "f1", name: "Empty", items: []))], expanded: ["f1"]
+        )
+        #expect(rows.map(\.id) == ["f1"])
+    }
+
+    @Test func everyRowIsUniquelyIdentified() {
+        let rows = ApiCollectionTree.rows(tree(), expanded: ["f1", "f2"])
+        #expect(Set(rows.map(\.id)).count == rows.count)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ApiPaneLayoutTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApiPaneLayoutTests.swift
@@ -49,7 +49,7 @@ import Testing
 
     @Test func aZeroWidthPaneDoesNotProduceNaN() {
         #expect(ApiPaneLayout.leadingLength(total: 0, fraction: 0.5) == 0)
-        #expect(ApiPaneLayout.fraction(forLeading: 100, total: 0) == 0.5)
+        #expect(ApiPaneLayout.fraction(from: 0.5, movedBy: 100, total: 0) == 0.5)
         #expect(ApiPaneLayout.pointRange(total: 0) == 0...0)
     }
 
@@ -67,14 +67,28 @@ import Testing
         }
     }
 
-    @Test func pointsRoundTripBackToAFraction() {
-        let total = 1000.0
-        let points = ApiPaneLayout.leadingLength(total: total, fraction: 0.4)
-        #expect(ApiPaneLayout.fraction(forLeading: points, total: total) == 0.4)
+    @Test func aDragMovesTheFractionByItsShareOfTheTotal() {
+        #expect(ApiPaneLayout.fraction(from: 0.5, movedBy: 100, total: 1000) == 0.6)
+        #expect(ApiPaneLayout.fraction(from: 0.5, movedBy: -100, total: 1000) == 0.4)
+    }
+
+    @Test func aDragThatDidNotMoveLeavesTheFractionAlone() {
+        #expect(ApiPaneLayout.fraction(from: 0.42, movedBy: 0, total: 1000) == 0.42)
     }
 
     @Test func aDragBeyondTheEdgeStillStoresAValidFraction() {
-        let fraction = ApiPaneLayout.fraction(forLeading: 5000, total: 1000)
-        #expect(ApiPaneLayout.fractionRange.contains(fraction))
+        let far = ApiPaneLayout.fraction(from: 0.5, movedBy: 5000, total: 1000)
+        #expect(ApiPaneLayout.fractionRange.contains(far))
+        let back = ApiPaneLayout.fraction(from: 0.5, movedBy: -5000, total: 1000)
+        #expect(ApiPaneLayout.fractionRange.contains(back))
+    }
+
+    /// The bug this replaced: converting points to a fraction through one total
+    /// and back through another moved the seam on a gesture nobody made.
+    @Test func aDragIsMeasuredEntirelyAgainstOneTotal() {
+        let start = 0.5
+        for total in [400.0, 900.0, 1251.0, 3000.0] {
+            #expect(ApiPaneLayout.fraction(from: start, movedBy: 0, total: total) == start)
+        }
     }
 }

--- a/ADBKit/Tests/ADBKitTests/ApiPaneLayoutTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApiPaneLayoutTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+@Suite struct ApiPaneLayoutTests {
+
+    @Test func aStoredSidebarWidthIsHonouredWhenThereIsRoom() {
+        #expect(ApiPaneLayout.sidebarWidth(stored: 300, total: 1200) == 300)
+    }
+
+    @Test func theSidebarIsClampedToItsRange() {
+        #expect(ApiPaneLayout.sidebarWidth(stored: 50, total: 1200) == 200)
+        #expect(ApiPaneLayout.sidebarWidth(stored: 9000, total: 3000) == 460)
+    }
+
+    @Test func theSidebarNeverTakesMoreThanAThirdOfThePane() {
+        #expect(ApiPaneLayout.sidebarWidth(stored: 460, total: 900) == 300)
+    }
+
+    @Test func aVeryNarrowPaneStillLeavesTheSidebarUsable() {
+        // A third of 300pt is below the floor; the floor wins so the sidebar
+        // stays operable rather than collapsing to a sliver.
+        #expect(ApiPaneLayout.sidebarWidth(stored: 260, total: 300) == 200)
+    }
+
+    @Test func theSplitFractionIsClamped() {
+        #expect(ApiPaneLayout.clampedFraction(0.5) == 0.5)
+        #expect(ApiPaneLayout.clampedFraction(0.01) == 0.25)
+        #expect(ApiPaneLayout.clampedFraction(0.99) == 0.75)
+    }
+
+    @Test func theLeadingPaneFollowsTheFraction() {
+        #expect(ApiPaneLayout.leadingLength(total: 1000, fraction: 0.5) == 500)
+        #expect(ApiPaneLayout.leadingLength(total: 1000, fraction: 0.3) == 300)
+    }
+
+    @Test func theAbsoluteFloorOverridesTheFractionOnATightPane() {
+        // 25% of 800 is 200, below the 240pt floor.
+        #expect(ApiPaneLayout.leadingLength(total: 800, fraction: 0.25) == 240)
+        #expect(ApiPaneLayout.leadingLength(total: 800, fraction: 0.75) == 560)
+    }
+
+    @Test func bothPanesShrinkEvenlyWhenTheFloorCannotHold() {
+        // Under 480pt the floor collapses to half so neither pane is pushed off.
+        #expect(ApiPaneLayout.leadingLength(total: 400, fraction: 0.25) == 200)
+        #expect(ApiPaneLayout.leadingLength(total: 400, fraction: 0.75) == 200)
+    }
+
+    @Test func aZeroWidthPaneDoesNotProduceNaN() {
+        #expect(ApiPaneLayout.leadingLength(total: 0, fraction: 0.5) == 0)
+        #expect(ApiPaneLayout.fraction(forLeading: 100, total: 0) == 0.5)
+        #expect(ApiPaneLayout.pointRange(total: 0) == 0...0)
+    }
+
+    @Test func theDragRangeMatchesWhereTheLayoutActuallyStops() {
+        let total = 800.0
+        let range = ApiPaneLayout.pointRange(total: total)
+        #expect(ApiPaneLayout.leadingLength(total: total, fraction: 0) == range.lowerBound)
+        #expect(ApiPaneLayout.leadingLength(total: total, fraction: 1) == range.upperBound)
+    }
+
+    @Test func theDragRangeNeverInverts() {
+        for total in stride(from: 0.0, through: 2000.0, by: 137.0) {
+            let range = ApiPaneLayout.pointRange(total: total)
+            #expect(range.lowerBound <= range.upperBound)
+        }
+    }
+
+    @Test func pointsRoundTripBackToAFraction() {
+        let total = 1000.0
+        let points = ApiPaneLayout.leadingLength(total: total, fraction: 0.4)
+        #expect(ApiPaneLayout.fraction(forLeading: points, total: total) == 0.4)
+    }
+
+    @Test func aDragBeyondTheEdgeStillStoresAValidFraction() {
+        let fraction = ApiPaneLayout.fraction(forLeading: 5000, total: 1000)
+        #expect(ApiPaneLayout.fractionRange.contains(fraction))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ApiQueryStringTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApiQueryStringTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+@Suite struct ApiQueryStringTests {
+
+    @Test func parametersComeOutInOrder() {
+        let found = ApiQueryString.parameters(in: "https://x.dev/s?b=2&a=1")
+        #expect(found.map(\.key) == ["b", "a"])
+        #expect(found.map(\.value) == ["2", "1"])
+    }
+
+    @Test func valuesArePercentDecoded() {
+        let found = ApiQueryString.parameters(in: "https://x.dev?q=hello%20world&n=a%2Bb")
+        #expect(found.map(\.value) == ["hello world", "a+b"])
+    }
+
+    @Test func plusSignsDecodeAsSpaces() {
+        #expect(ApiQueryString.parameters(in: "https://x.dev?q=two+words").first?.value == "two words")
+    }
+
+    @Test func aValuelessFlagKeepsItsName() {
+        let found = ApiQueryString.parameters(in: "https://x.dev?debug")
+        #expect(found.map(\.key) == ["debug"])
+        #expect(found.map(\.value) == [""])
+    }
+
+    @Test func anEmptyValueSurvives() {
+        let found = ApiQueryString.parameters(in: "https://x.dev?a=&b=2")
+        #expect(found.map(\.value) == ["", "2"])
+    }
+
+    @Test func aValueContainingAnEqualsIsNotSplitTwice() {
+        #expect(
+            ApiQueryString.parameters(in: "https://x.dev?token=a=b=c").first?.value == "a=b=c"
+        )
+    }
+
+    @Test func theFragmentIsNotPartOfTheQuery() {
+        let found = ApiQueryString.parameters(in: "https://x.dev?a=1#section")
+        #expect(found.map(\.value) == ["1"])
+    }
+
+    @Test func aURLWithNoQueryYieldsNothing() {
+        #expect(ApiQueryString.parameters(in: "https://x.dev/path").isEmpty)
+        #expect(ApiQueryString.parameters(in: "").isEmpty)
+        #expect(ApiQueryString.hasQuery("https://x.dev/path") == false)
+        #expect(ApiQueryString.hasQuery("https://x.dev/path?a=1"))
+    }
+
+    @Test func emptyPairsAreSkipped() {
+        let found = ApiQueryString.parameters(in: "https://x.dev?a=1&&b=2")
+        #expect(found.map(\.key) == ["a", "b"])
+    }
+
+    @Test func strippingTheQueryKeepsTheFragment() {
+        #expect(
+            ApiQueryString.removingQuery(from: "https://x.dev/p?a=1#top") == "https://x.dev/p#top"
+        )
+        #expect(ApiQueryString.removingQuery(from: "https://x.dev/p?a=1") == "https://x.dev/p")
+    }
+
+    @Test func aURLWithoutAQueryIsReturnedUntouched() {
+        #expect(ApiQueryString.removingQuery(from: "https://x.dev/p") == "https://x.dev/p")
+    }
+
+    @Test func extractingThenBuildingProducesTheSameRequest() throws {
+        // The point of the round trip: what goes on the wire must not change.
+        let before = SavedRequest(url: "https://x.dev/s?q=hello%20world&n=2")
+        var after = SavedRequest(url: ApiQueryString.removingQuery(from: before.url))
+        after.queryParams = ApiQueryString.parameters(in: before.url)
+
+        let built = try HttpRequestBuilder.prepare(before)
+        let rebuilt = try HttpRequestBuilder.prepare(after)
+        #expect(built.url == rebuilt.url)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ApiResponseTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApiResponseTests.swift
@@ -416,6 +416,202 @@ private func jsonResponse(_ text: String, status: Int = 200) -> ApiResponse {
     }
 }
 
+// MARK: - Raw-text elements and malformed HTML
+
+@Suite struct XMLFormatterRawTextTests {
+
+    @Test func scriptBodiesAreNotParsedAsMarkup() throws {
+        // `c<a.length` is a comparison, not a tag. Parsing it as one used to
+        // both mangle the source and run the indent depth away.
+        let pretty = try #require(
+            XMLFormatter.prettyPrint(
+                "<head><script>\nfor (var c = 0; c < a.length; c++) {\n  f(c);\n}\n</script></head>"
+            )
+        )
+        #expect(pretty == """
+            <head>
+              <script>
+                for (var c = 0; c < a.length; c++) {
+                  f(c);
+                }
+              </script>
+            </head>
+            """)
+    }
+
+    @Test func aScriptDoesNotDisturbTheDepthOfWhatFollows() throws {
+        let pretty = try #require(
+            XMLFormatter.prettyPrint("<body><script>if (a<b) {}</script><p>after</p></body>")
+        )
+        #expect(pretty == """
+            <body>
+              <script>if (a<b) {}</script>
+              <p>after</p>
+            </body>
+            """)
+    }
+
+    @Test func styleBodiesKeepTheirOwnIndentation() throws {
+        let pretty = try #require(
+            XMLFormatter.prettyPrint("<style>\n.a {\n    color: red;\n}\n</style>")
+        )
+        #expect(pretty == """
+            <style>
+              .a {
+                  color: red;
+              }
+            </style>
+            """)
+    }
+
+    @Test func everyLineOfAMultiLineScriptIsIndented() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<div><script>\na();\nb();\n</script></div>"))
+        let scriptLines = pretty.components(separatedBy: .newlines).filter {
+            $0.contains("a();") || $0.contains("b();")
+        }
+        #expect(scriptLines.count == 2)
+        #expect(scriptLines.allSatisfy { $0.hasPrefix("    ") })
+    }
+
+    @Test func anUnclosedScriptTakesTheRestOfTheDocument() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<div><script>\nvar a = 1;\n"))
+        #expect(pretty.contains("var a = 1;"))
+        #expect(!pretty.contains("</script>"))
+    }
+
+    @Test func aCloseTagUnwindsToTheElementItActuallyCloses() throws {
+        // `<p>` never closes in real HTML; without unwinding, everything after
+        // `</div>` would keep drifting right.
+        let pretty = try #require(
+            XMLFormatter.prettyPrint("<div><p>one<p>two</div><footer>end</footer>")
+        )
+        #expect(pretty.hasSuffix("<footer>end</footer>"))
+    }
+
+    @Test func siblingListItemsStayAtOneLevel() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<ul><li>a<li>b<li>c</ul>"))
+        #expect(pretty == """
+            <ul>
+              <li>
+                a
+              <li>
+                b
+              <li>
+                c
+            </ul>
+            """)
+    }
+
+    @Test func tableRowsUnwindTheirCells() throws {
+        let pretty = try #require(
+            XMLFormatter.prettyPrint("<table><tr><td>a<td>b<tr><td>c</table>")
+        )
+        #expect(pretty == """
+            <table>
+              <tr>
+                <td>
+                  a
+                <td>
+                  b
+              <tr>
+                <td>
+                  c
+            </table>
+            """)
+    }
+
+    @Test func aStrayCloseTagDoesNotPullTheDocumentLeft() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<div></span><p>x</p></div>"))
+        #expect(pretty == """
+            <div>
+              </span>
+              <p>x</p>
+            </div>
+            """)
+    }
+
+    @Test func aOneLineScriptStaysBesideItsTags() throws {
+        #expect(XMLFormatter.prettyPrint("<script>var a=1;</script>") == "<script>var a=1;</script>")
+    }
+
+    @Test func anEmptyScriptElementSurvives() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<div><script></script></div>"))
+        #expect(pretty == "<div>\n  <script></script>\n</div>")
+    }
+
+    @Test func theClosingScriptTagIsMatchedCaseInsensitively() throws {
+        let pretty = try #require(XMLFormatter.prettyPrint("<div><SCRIPT>\na();\n</SCRIPT></div>"))
+        #expect(pretty.contains("</SCRIPT>"))
+        #expect(pretty.contains("  a();"))
+    }
+}
+
+// MARK: - Plain-text and NDJSON bodies
+
+@Suite struct PlainTextFormatterTests {
+
+    @Test func mislabelledJSONStillGetsAPrettyForm() throws {
+        let body = response(
+            headers: [(key: "Content-Type", value: "text/plain")],
+            body: Data(#"{"a":1}"#.utf8)
+        )
+        // Sniffing already calls this JSON; the point is the toggle appears.
+        #expect(body.prettyBody == "{\n  \"a\": 1\n}")
+    }
+
+    @Test func jsonLinesArePrettyPrintedDocumentByDocument() throws {
+        let pretty = try #require(JSONFormatter.prettyPrintLines("{\"a\":1}\n{\"b\":2}"))
+        #expect(pretty == "{\n  \"a\": 1\n}\n{\n  \"b\": 2\n}")
+    }
+
+    @Test func ndjsonServedAsJSONFallsBackToTheLineFormatter() throws {
+        let body = response(
+            headers: [(key: "Content-Type", value: "application/x-ndjson")],
+            body: Data("{\"a\":1}\n{\"b\":2}".utf8)
+        )
+        #expect(body.prettyBody == "{\n  \"a\": 1\n}\n{\n  \"b\": 2\n}")
+    }
+
+    @Test func oneBadLineRejectsTheWholeNDJSONBody() {
+        #expect(JSONFormatter.prettyPrintLines("{\"a\":1}\nnot json") == nil)
+    }
+
+    @Test func aColumnOfNumbersIsNotNDJSON() {
+        #expect(JSONFormatter.prettyPrintLines("1\n2\n3") == nil)
+    }
+
+    @Test func aSingleJSONLineIsLeftToThePlainFormatter() {
+        #expect(JSONFormatter.prettyPrintLines("{\"a\":1}") == nil)
+    }
+
+    @Test func formEncodedBodiesBecomeOnePairPerLine() throws {
+        #expect(FormFormatter.prettyPrint("a=1&b=hello%20world") == "a = 1\nb = hello world")
+    }
+
+    @Test func formEncodedPlusSignsDecodeAsSpaces() throws {
+        #expect(FormFormatter.prettyPrint("q=two+words") == "q = two words")
+    }
+
+    @Test func formEncodedEmptyValuesSurvive() throws {
+        #expect(FormFormatter.prettyPrint("a=&b=2") == "a = \nb = 2")
+    }
+
+    @Test func proseIsNotMistakenForAFormBody() {
+        #expect(FormFormatter.prettyPrint("the answer = 42") == nil)
+        #expect(FormFormatter.prettyPrint("no separator here") == nil)
+        #expect(FormFormatter.prettyPrint("line one\nline two") == nil)
+        #expect(FormFormatter.prettyPrint("") == nil)
+    }
+
+    @Test func ordinaryProseHasNoPrettyForm() {
+        let body = response(
+            headers: [(key: "Content-Type", value: "text/plain")],
+            body: Data("just some words".utf8)
+        )
+        #expect(body.prettyBody == nil)
+    }
+}
+
 // MARK: - JSON path probe
 
 @Suite struct JSONProbeTests {

--- a/ADBKit/Tests/ADBKitTests/SyntaxHighlightingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SyntaxHighlightingTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+/// Reads a token back as the substring it points at, which is the property that
+/// actually matters: a length that drifts by one paints the wrong characters.
+private func text(_ token: SyntaxToken, in source: String) -> String {
+    let utf16 = Array(source.utf16)
+    let slice = utf16[token.location..<(token.location + token.length)]
+    return String(decoding: slice, as: UTF16.self)
+}
+
+private func tokens(_ source: String, _ format: ResponseFormat) -> [SyntaxToken] {
+    SyntaxHighlighter.tokens(for: source, format: format)
+}
+
+@Suite struct JSONSyntaxTests {
+
+    @Test func keysAndStringValuesAreToldApart() throws {
+        let source = #"{"name":"ada"}"#
+        let found = tokens(source, .json)
+        let keys = found.filter { $0.kind == .key }
+        let strings = found.filter { $0.kind == .string }
+        #expect(keys.map { text($0, in: source) } == [#""name""#])
+        #expect(strings.map { text($0, in: source) } == [#""ada""#])
+    }
+
+    @Test func numbersCoverSignExponentAndFraction() throws {
+        let source = #"{"a":-1.5e+10,"b":42}"#
+        let numbers = tokens(source, .json).filter { $0.kind == .number }
+        #expect(numbers.map { text($0, in: source) } == ["-1.5e+10", "42"])
+    }
+
+    @Test func literalsAreTokenized() throws {
+        let source = #"[true,false,null]"#
+        let literals = tokens(source, .json).filter { $0.kind == .literal }
+        #expect(literals.map { text($0, in: source) } == ["true", "false", "null"])
+    }
+
+    @Test func aColonInsideAStringDoesNotMakeTheNextStringAKey() throws {
+        let source = #"{"url":"http://x/y","n":1}"#
+        let keys = tokens(source, .json).filter { $0.kind == .key }
+        #expect(keys.map { text($0, in: source) } == [#""url""#, #""n""#])
+    }
+
+    @Test func escapedQuotesDoNotEndAString() throws {
+        let source = #"{"a":"say \"hi\"","b":2}"#
+        let strings = tokens(source, .json).filter { $0.kind == .string }
+        #expect(strings.map { text($0, in: source) } == [#""say \"hi\"""#])
+    }
+
+    @Test func literalPrefixesInsideWordsAreNotLiterals() throws {
+        // `nullable` is not `null`; it lives inside a string and must stay one.
+        let source = #"{"k":"nullable"}"#
+        #expect(tokens(source, .json).contains { $0.kind == .literal } == false)
+    }
+
+    @Test func offsetsSurviveMultiByteCharacters() throws {
+        let source = #"{"emoji":"🙂","after":1}"#
+        let found = tokens(source, .json)
+        let keys = found.filter { $0.kind == .key }
+        #expect(keys.map { text($0, in: source) } == [#""emoji""#, #""after""#])
+        let numbers = found.filter { $0.kind == .number }
+        #expect(numbers.map { text($0, in: source) } == ["1"])
+    }
+
+    @Test func aTruncatedBodyStillTokenizesWhatArrived() throws {
+        let source = #"{"a":1,"b":"unterminated"#
+        let found = tokens(source, .json)
+        #expect(!found.isEmpty)
+        #expect(found.allSatisfy { $0.location + $0.length <= source.utf16.count })
+    }
+
+    @Test func jsonLinesTokenizeAsOneStream() throws {
+        let source = "{\"a\":1}\n{\"b\":2}"
+        let keys = tokens(source, .json).filter { $0.kind == .key }
+        #expect(keys.map { text($0, in: source) } == [#""a""#, #""b""#])
+    }
+}
+
+@Suite struct MarkupSyntaxTests {
+
+    @Test func tagNamesAttributesAndValuesAreSeparated() throws {
+        let source = #"<a href="/x" id='y'>text</a>"#
+        let found = tokens(source, .html)
+        #expect(found.filter { $0.kind == .tag }.map { text($0, in: source) } == ["<a", "</a"])
+        #expect(
+            found.filter { $0.kind == .attribute }.map { text($0, in: source) } == ["href", "id"]
+        )
+        #expect(
+            found.filter { $0.kind == .value }.map { text($0, in: source) } == [#""/x""#, "'y'"]
+        )
+    }
+
+    @Test func aGreaterThanInsideAnAttributeDoesNotEndTheTag() throws {
+        let source = #"<a title="x > y"><b/>"#
+        let tags = tokens(source, .html).filter { $0.kind == .tag }
+        #expect(tags.map { text($0, in: source) } == ["<a", "<b"])
+    }
+
+    @Test func commentsAreOneToken() throws {
+        let source = "<div><!-- a > b --></div>"
+        let comments = tokens(source, .html).filter { $0.kind == .comment }
+        #expect(comments.map { text($0, in: source) } == ["<!-- a > b -->"])
+    }
+
+    @Test func doctypeAndProcessingInstructionsAreDeclarations() throws {
+        let source = "<!doctype html><?xml version=\"1.0\"?><a/>"
+        let declarations = tokens(source, .xml).filter { $0.kind == .declaration }
+        #expect(
+            declarations.map { text($0, in: source) } == ["<!doctype html>", "<?xml version=\"1.0\"?>"]
+        )
+    }
+
+    @Test func cdataIsTreatedAsAString() throws {
+        let source = "<a><![CDATA[x > y]]></a>"
+        let strings = tokens(source, .xml).filter { $0.kind == .string }
+        #expect(strings.map { text($0, in: source) } == ["<![CDATA[x > y]]>"])
+    }
+
+    @Test func textBetweenTagsIsNotTokenized() throws {
+        let source = "<p>hello world</p>"
+        let covered = tokens(source, .html).reduce(0) { $0 + $1.length }
+        #expect(covered == "<p".utf16.count + "</p".utf16.count)
+    }
+
+    @Test func anUnterminatedTagDoesNotRunPastTheEnd() throws {
+        let source = "<div class=\"x"
+        let found = tokens(source, .html)
+        #expect(found.allSatisfy { $0.location + $0.length <= source.utf16.count })
+    }
+
+    @Test func namespacedElementsKeepTheirPrefix() throws {
+        let source = #"<ns:root xmlns:ns="urn:x"/>"#
+        let tags = tokens(source, .xml).filter { $0.kind == .tag }
+        #expect(tags.map { text($0, in: source) } == ["<ns:root"])
+    }
+}
+
+@Suite struct SyntaxHighlighterScopeTests {
+
+    @Test func plainTextAndBinaryAreNotTokenized() {
+        #expect(tokens("hello", .text).isEmpty)
+        #expect(tokens("hello", .binary).isEmpty)
+        #expect(tokens("hello", .image).isEmpty)
+    }
+
+    @Test func aBodyOverTheCapIsLeftPlain() {
+        let huge = String(repeating: "{\"a\":1}", count: SyntaxHighlighter.maxHighlightableLength)
+        #expect(huge.utf16.count > SyntaxHighlighter.maxHighlightableLength)
+        #expect(tokens(huge, .json).isEmpty)
+    }
+
+    @Test func aBodyAtTheCapIsStillTokenized() {
+        let source = #"{"a":1}"#
+        #expect(source.utf16.count <= SyntaxHighlighter.maxHighlightableLength)
+        #expect(!tokens(source, .json).isEmpty)
+    }
+
+    @Test func tokensNeverOverlapOrRunBackwards() {
+        let source = #"{"a":[1,true,"x"],"b":{"c":null}}"#
+        let found = tokens(source, .json)
+        for (previous, next) in zip(found, found.dropFirst()) {
+            #expect(previous.location + previous.length <= next.location)
+        }
+    }
+
+    @Test func markupTokensNeverOverlapOrRunBackwards() {
+        let source = #"<html><body class="a b"><!-- c --><img src="x"/></body></html>"#
+        let found = tokens(source, .html)
+        for (previous, next) in zip(found, found.dropFirst()) {
+            #expect(previous.location + previous.length <= next.location)
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TabOverflowTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TabOverflowTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+@Suite struct TabOverflowTests {
+
+    /// Seven tabs of 100pt, 4pt apart: 7 tabs need 724, 6 need 620, and so on.
+    private let widths = Array(repeating: 100.0, count: 7)
+
+    private func layout(available: Double, selected: Int? = 0) -> TabOverflow.Layout {
+        TabOverflow.layout(
+            widths: widths, available: available, spacing: 4, overflowWidth: 30, selected: selected
+        )
+    }
+
+    @Test func everythingFitsWhenThereIsRoom() {
+        let result = layout(available: 1000)
+        #expect(result.visible == [0, 1, 2, 3, 4, 5, 6])
+        #expect(result.overflow.isEmpty)
+    }
+
+    @Test func anExactFitDoesNotSpill() {
+        // 7 * 100 + 6 * 4 = 724.
+        let result = layout(available: 724)
+        #expect(result.overflow.isEmpty)
+    }
+
+    @Test func oneShortOfAnExactFitSpillsTheLastTab() {
+        let result = layout(available: 723)
+        #expect(result.visible == [0, 1, 2, 3, 4, 5])
+        #expect(result.overflow == [6])
+    }
+
+    @Test func laterTabsGiveWayFirst() {
+        let result = layout(available: 400)
+        #expect(result.visible == [0, 1, 2])
+        #expect(result.overflow == [3, 4, 5, 6])
+    }
+
+    @Test func theOverflowButtonIsPaidForOutOfTheSameBudget() {
+        // 3 tabs + gaps = 308; plus the 30pt button and its gap = 342.
+        #expect(layout(available: 342).visible == [0, 1, 2])
+        #expect(layout(available: 341).visible == [0, 1])
+    }
+
+    /// The whole point of the change: whatever is drawn must actually fit, so
+    /// nothing is ever shown clipped in half.
+    @Test func aDrawnRowAlwaysFits() {
+        for available in stride(from: 0.0, through: 800.0, by: 7.0) {
+            for selected in 0..<widths.count {
+                let result = layout(available: available, selected: selected)
+                guard !result.visible.isEmpty else { continue }
+                let tabs = result.visible.reduce(0.0) { $0 + widths[$1] }
+                    + 4 * Double(result.visible.count - 1)
+                let demand = tabs + (result.overflow.isEmpty ? 0 : 4 + 30)
+                #expect(demand <= available)
+            }
+        }
+    }
+
+    @Test func aRowThatCanTakeATabButNotTheButtonShowsOnlyTheButton() {
+        // 100pt tab + 4 + 30 = 134; at 120 the tab alone would fit but the
+        // pair does not, and half an overflow button is not an option.
+        let result = layout(available: 120, selected: 4)
+        #expect(result.visible.isEmpty)
+        #expect(result.overflow == Array(0..<7))
+    }
+
+    @Test func everyTabAppearsExactlyOnce() {
+        for available in stride(from: 0.0, through: 800.0, by: 11.0) {
+            for selected in 0..<widths.count {
+                let result = layout(available: available, selected: selected)
+                let all = (result.visible + result.overflow).sorted()
+                #expect(all == Array(0..<widths.count))
+            }
+        }
+    }
+
+    @Test func theSelectedTabStaysVisible() {
+        // Selecting Code (6) on a narrow row pulls it out of the menu.
+        let result = layout(available: 400, selected: 6)
+        #expect(result.visible.contains(6))
+        #expect(!result.overflow.contains(6))
+    }
+
+    @Test func thePulledSelectionTakesTheLastSlotAndDisplacesThatTab() {
+        let result = layout(available: 400, selected: 6)
+        #expect(result.visible == [0, 1, 6])
+        #expect(result.overflow == [2, 3, 4, 5])
+    }
+
+    @Test func theOverflowMenuStaysInDisplayOrder() {
+        let result = layout(available: 400, selected: 5)
+        #expect(result.overflow == result.overflow.sorted())
+    }
+
+    @Test func aSelectionThatAlreadyFitsIsNotMoved() {
+        let result = layout(available: 400, selected: 1)
+        #expect(result.visible == [0, 1, 2])
+        #expect(result.overflow == [3, 4, 5, 6])
+    }
+
+    @Test func aRowTooNarrowForAnyTabStillShowsTheSelection() {
+        // 100pt tab + 4 + 30 = 134 exactly.
+        let result = layout(available: 134, selected: 4)
+        #expect(result.visible == [4])
+        #expect(result.overflow == [0, 1, 2, 3, 5, 6])
+    }
+
+    @Test func aRowNarrowerThanOneTabHidesEverything() {
+        let result = layout(available: 40, selected: 3)
+        #expect(result.visible.isEmpty)
+        #expect(result.overflow == Array(0..<7))
+    }
+
+    @Test func noSelectionIsHandled() {
+        let result = TabOverflow.layout(
+            widths: widths, available: 400, spacing: 4, overflowWidth: 30, selected: nil
+        )
+        #expect(result.visible == [0, 1, 2])
+        #expect(result.overflow == [3, 4, 5, 6])
+    }
+
+    @Test func anEmptyTabListProducesNothing() {
+        let result = TabOverflow.layout(
+            widths: [], available: 400, spacing: 4, overflowWidth: 30, selected: nil
+        )
+        #expect(result.visible.isEmpty)
+        #expect(result.overflow.isEmpty)
+    }
+
+    @Test func unevenWidthsAreRespected() {
+        let uneven = [60.0, 200.0, 50.0, 50.0]
+        let result = TabOverflow.layout(
+            widths: uneven, available: 300, spacing: 4, overflowWidth: 30, selected: 0
+        )
+        // 60 + 4 + 200 = 264, plus the button and its gap = 298 — the third
+        // tab would need another 54.
+        #expect(result.visible == [0, 1])
+        #expect(result.overflow == [2, 3])
+    }
+
+    @Test func aZeroWidthRowDoesNotTrap() {
+        let result = layout(available: 0, selected: 0)
+        #expect(result.visible.isEmpty)
+        #expect(result.overflow.count == 7)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ApiClient/AdaptiveTabBar.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/AdaptiveTabBar.swift
@@ -1,0 +1,106 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// A segmented-looking tab row that degrades one tab at a time.
+///
+/// `ViewThatFits` over a segmented and a menu picker was all-or-nothing: seven
+/// request tabs never fit a half-width pane, so the row collapsed to a single
+/// centred dropdown even with room for five of them. This keeps every tab that
+/// fits and hands only the remainder to a "More" menu — and because the widths
+/// are measured rather than guessed, no tab is ever drawn clipped.
+struct AdaptiveTabBar<Tab: Hashable & Identifiable>: View {
+    let tabs: [Tab]
+    let label: (Tab) -> String
+    @Binding var selection: Tab
+    /// `.leading` for a row of its own, `.trailing` when the bar shares a row
+    /// with something else and should sit against the edge.
+    var alignment: HorizontalAlignment = .leading
+
+    private static var spacing: CGFloat { 2 }
+    private static var overflowWidth: CGFloat { 34 }
+
+    var body: some View {
+        // A fixed height keeps the row from resizing as tabs move in and out of
+        // the menu, which would nudge the content below it on every keystroke.
+        GeometryReader { geometry in
+            let widths = tabs.map { Self.width(of: label($0)) }
+            let layout = TabOverflow.layout(
+                widths: widths.map(Double.init),
+                available: Double(geometry.size.width),
+                spacing: Double(Self.spacing),
+                overflowWidth: Double(Self.overflowWidth),
+                selected: tabs.firstIndex(of: selection)
+            )
+            HStack(spacing: Self.spacing) {
+                if alignment == .trailing { Spacer(minLength: 0) }
+                ForEach(layout.visible, id: \.self) { index in
+                    chip(tabs[index], width: widths[index])
+                }
+                if !layout.overflow.isEmpty {
+                    overflowMenu(layout.overflow)
+                }
+                if alignment == .leading { Spacer(minLength: 0) }
+            }
+            .frame(height: geometry.size.height)
+        }
+        .frame(height: Self.rowHeight)
+    }
+
+    private func chip(_ tab: Tab, width: CGFloat) -> some View {
+        let isSelected = tab == selection
+        return Button {
+            selection = tab
+        } label: {
+            Text(label(tab))
+                .font(.app(.callout))
+                .foregroundStyle(isSelected ? Color.black : Color.textMain)
+                .lineLimit(1)
+                .frame(width: width, height: Self.chipHeight)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(isSelected ? Color.brandAccent : Color.clear)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(label(tab))
+    }
+
+    private func overflowMenu(_ indices: [Int]) -> some View {
+        Menu {
+            ForEach(indices, id: \.self) { index in
+                Button {
+                    selection = tabs[index]
+                } label: {
+                    // A checkmark would be dead weight: the selected tab is
+                    // pulled out of the menu and drawn in the row.
+                    Text(label(tabs[index]))
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .frame(width: Self.overflowWidth, height: Self.chipHeight)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("More tabs")
+    }
+
+    // MARK: - Measurement
+
+    static var chipHeight: CGFloat { 22 }
+    static var rowHeight: CGFloat { 22 }
+
+    /// Rendered width of a chip. Measured with the same font the chip draws in
+    /// (`Font.app(.callout)` resolves to the system font at the user's text
+    /// scale) so the fit decision matches what lands on screen.
+    static func width(of text: String) -> CGFloat {
+        let font = NSFont.systemFont(
+            ofSize: AppFontPrefs.pointSize(for: .callout) * AppFontPrefs.sizeScale
+        )
+        let measured = (text as NSString).size(withAttributes: [.font: font]).width
+        return ceil(measured) + 20
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ApiClient/AdaptiveTabBar.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/AdaptiveTabBar.swift
@@ -17,6 +17,8 @@ struct AdaptiveTabBar<Tab: Hashable & Identifiable>: View {
     /// with something else and should sit against the edge.
     var alignment: HorizontalAlignment = .leading
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private static var spacing: CGFloat { 2 }
     private static var overflowWidth: CGFloat { 34 }
 
@@ -54,7 +56,13 @@ struct AdaptiveTabBar<Tab: Hashable & Identifiable>: View {
         } label: {
             Text(label(tab))
                 .font(.app(.callout))
-                .foregroundStyle(isSelected ? Color.black : Color.textMain)
+                // The accent is user-chosen; a hardcoded black label goes
+                // unreadable the moment someone picks a dark one.
+                .foregroundStyle(
+                    isSelected
+                        ? Color.brandAccent.contrastingForeground(for: colorScheme)
+                        : Color.textMain
+                )
                 .lineLimit(1)
                 .frame(width: width, height: Self.chipHeight)
                 .background(
@@ -90,17 +98,57 @@ struct AdaptiveTabBar<Tab: Hashable & Identifiable>: View {
 
     // MARK: - Measurement
 
-    static var chipHeight: CGFloat { 22 }
-    static var rowHeight: CGFloat { 22 }
+    static var chipHeight: CGFloat { TabLabelMetrics.chipHeight }
+    static var rowHeight: CGFloat { TabLabelMetrics.chipHeight }
 
-    /// Rendered width of a chip. Measured with the same font the chip draws in
-    /// (`Font.app(.callout)` resolves to the system font at the user's text
-    /// scale) so the fit decision matches what lands on screen.
+    static func width(of text: String) -> CGFloat { TabLabelMetrics.width(of: text) }
+}
+
+/// Chip sizing, kept out of the generic view so the memo can be a stored static.
+@MainActor
+enum TabLabelMetrics {
+
+    static let chipHeight: CGFloat = 22
+    /// Horizontal padding inside a chip, on top of the measured text.
+    private static let horizontalPadding: CGFloat = 20
+
+    private struct Key: Hashable {
+        let text: String
+        let family: String?
+        let size: CGFloat
+    }
+
+    private static var cache: [Key: CGFloat] = [:]
+
+    /// Rendered width of a chip.
+    ///
+    /// Measured in the font the chip actually draws in, family included:
+    /// `Font.app(.callout)` honours Settings ▸ Appearance ▸ Font, so measuring
+    /// the system font would under-measure a wider family and clip the last
+    /// chip — the one thing this control exists to prevent.
+    ///
+    /// Memoised because this runs for every tab on every layout pass, and a
+    /// pane-divider drag issues a great many of those.
     static func width(of text: String) -> CGFloat {
-        let font = NSFont.systemFont(
-            ofSize: AppFontPrefs.pointSize(for: .callout) * AppFontPrefs.sizeScale
-        )
-        let measured = (text as NSString).size(withAttributes: [.font: font]).width
-        return ceil(measured) + 20
+        let size = AppFontPrefs.pointSize(for: .callout) * AppFontPrefs.sizeScale
+        let family = AppFontPrefs.family
+        let key = Key(text: text, family: family, size: size)
+        if let cached = cache[key] { return cached }
+
+        let measured = (text as NSString)
+            .size(withAttributes: [.font: font(family: family, size: size)])
+            .width
+        let width = ceil(measured) + horizontalPadding
+        // A pane only ever shows a handful of distinct labels; the cap is just
+        // so a pathological run of label changes can't grow this unbounded.
+        if cache.count > 256 { cache.removeAll() }
+        cache[key] = width
+        return width
+    }
+
+    private static func font(family: String?, size: CGFloat) -> NSFont {
+        guard let family else { return .systemFont(ofSize: size) }
+        let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
+        return NSFont(descriptor: descriptor, size: size) ?? .systemFont(ofSize: size)
     }
 }

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiBodyTextView.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiBodyTextView.swift
@@ -1,0 +1,205 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// The response (and generated-code) viewer: a read-only `NSTextView` with
+/// syntax colouring, an optional soft wrap, and AppKit's own find bar.
+///
+/// It replaces a `Text` inside a two-axis `ScrollView`. That combination could
+/// not size a large body — a bidirectional scroll view proposes `nil` in both
+/// axes, so the `maxWidth`/`maxHeight: .infinity` frame had nothing to resolve
+/// against — and left the body blank until a click forced the selectable text
+/// layer to lay itself out, blank again as soon as focus left. A text view owns
+/// its own scrolling and typesetting, so the body is simply always there.
+struct ApiBodyTextView: NSViewRepresentable {
+    let text: String
+    let format: ResponseFormat
+    /// Soft wrap. Off, the view scrolls horizontally and long lines stay intact.
+    let wraps: Bool
+    /// Bump to open the find bar (the feature's ⌘F lands here).
+    var findToken: Int = 0
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = NSTextView()
+        // Regions never scrolled into carry an estimated height instead of
+        // being typeset — the same reason the log view enables it, and what
+        // keeps a multi-megabyte body affordable to open.
+        textView.layoutManager?.allowsNonContiguousLayout = true
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isVerticallyResizable = true
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.usesFindBar = true
+        textView.isIncrementalSearchingEnabled = true
+
+        // LogScrollView applies the document width only once a resize settles,
+        // so dragging the pane divider doesn't re-wrap the whole body per tick.
+        let scrollView = LogScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+        scrollView.documentView = textView
+
+        context.coordinator.install(textView: textView, scrollView: scrollView)
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.update(text: text, format: format, wraps: wraps)
+        context.coordinator.handleFind(findToken)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        private weak var textView: NSTextView?
+        private weak var scrollView: NSScrollView?
+
+        private var renderedText: String?
+        private var renderedFormat: ResponseFormat?
+        private var renderedWraps: Bool?
+        private var lastFindToken = 0
+
+        func install(textView: NSTextView, scrollView: NSScrollView) {
+            self.textView = textView
+            self.scrollView = scrollView
+        }
+
+        func update(text: String, format: ResponseFormat, wraps: Bool) {
+            guard let textView else { return }
+            if renderedWraps != wraps {
+                renderedWraps = wraps
+                apply(wraps: wraps, to: textView)
+            }
+            guard renderedText != text || renderedFormat != format else { return }
+            renderedText = text
+            renderedFormat = format
+
+            let storage = textView.textStorage
+            storage?.beginEditing()
+            storage?.setAttributedString(Self.attributed(text, format: format))
+            storage?.endEditing()
+            // A new body starts at the top, not wherever the last one was read.
+            textView.scroll(NSPoint(x: 0, y: 0))
+        }
+
+        func handleFind(_ token: Int) {
+            guard token != lastFindToken else { return }
+            lastFindToken = token
+            guard token > 0, let textView else { return }
+            textView.window?.makeFirstResponder(textView)
+            textView.performTextFinderAction(findMenuItem)
+        }
+
+        /// `performTextFinderAction` reads the action off the sender's tag —
+        /// there is no typed API for "open the find bar".
+        private lazy var findMenuItem: NSMenuItem = {
+            let item = NSMenuItem()
+            item.tag = NSTextFinder.Action.showFindInterface.rawValue
+            return item
+        }()
+
+        private func apply(wraps: Bool, to textView: NSTextView) {
+            guard let container = textView.textContainer else { return }
+            if wraps {
+                container.widthTracksTextView = true
+                container.size = NSSize(
+                    width: scrollView?.contentSize.width ?? textView.frame.width,
+                    height: CGFloat.greatestFiniteMagnitude
+                )
+                textView.isHorizontallyResizable = false
+                textView.autoresizingMask = []
+                scrollView?.hasHorizontalScroller = false
+            } else {
+                container.widthTracksTextView = false
+                container.size = NSSize(
+                    width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude
+                )
+                textView.isHorizontallyResizable = true
+                textView.autoresizingMask = []
+                scrollView?.hasHorizontalScroller = true
+            }
+            scrollView?.tile()
+        }
+
+        /// Builds the coloured body. One `addAttribute` per token over a single
+        /// editing transaction — the tokenizer already declines bodies too large
+        /// to be worth colouring, and those render in the base style.
+        static func attributed(_ text: String, format: ResponseFormat) -> NSAttributedString {
+            let base: [NSAttributedString.Key: Any] = [
+                .font: ApiSyntaxTheme.font,
+                .foregroundColor: ApiSyntaxTheme.plain,
+            ]
+            let string = NSMutableAttributedString(string: text, attributes: base)
+            let tokens = SyntaxHighlighter.tokens(for: text, format: format)
+            guard !tokens.isEmpty else { return string }
+
+            let length = string.length
+            string.beginEditing()
+            for token in tokens {
+                guard token.location >= 0, token.length > 0,
+                    token.location + token.length <= length
+                else { continue }
+                string.addAttribute(
+                    .foregroundColor,
+                    value: ApiSyntaxTheme.color(for: token.kind),
+                    range: NSRange(location: token.location, length: token.length)
+                )
+            }
+            string.endEditing()
+            return string
+        }
+    }
+}
+
+/// Token colours for the response viewer. Unlike the JS console — a fixed dark
+/// console by design — this pane sits on the app's own (possibly translucent,
+/// possibly light) surface, so every colour is a dynamic `NSColor` that resolves
+/// per appearance.
+enum ApiSyntaxTheme {
+
+    static var font: NSFont {
+        NSFont.monospacedSystemFont(
+            ofSize: AppFontPrefs.pointSize(for: .body) * AppFontPrefs.sizeScale, weight: .regular
+        )
+    }
+
+    static var plain: NSColor { .labelColor }
+
+    static func color(for kind: SyntaxToken.Kind) -> NSColor {
+        switch kind {
+        case .key: dynamic(light: 0x0B_6E_99, dark: 0x9C_DC_FE)
+        case .string, .value: dynamic(light: 0xA3_11_5C, dark: 0xCE_91_78)
+        case .number: dynamic(light: 0x09_69_59, dark: 0xB5_CE_A8)
+        case .literal: dynamic(light: 0x00_00_FF, dark: 0x56_9C_D6)
+        case .tag: dynamic(light: 0x80_00_00, dark: 0x4E_C9_B0)
+        case .attribute: dynamic(light: 0xE5_00_00, dark: 0x9C_DC_FE)
+        case .comment: dynamic(light: 0x00_80_00, dark: 0x6A_99_55)
+        case .declaration: .secondaryLabelColor
+        case .punctuation: .tertiaryLabelColor
+        }
+    }
+
+    private static func dynamic(light: Int, dark: Int) -> NSColor {
+        NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return NSColor(rgb: isDark ? dark : light)
+        }
+    }
+}
+
+extension NSColor {
+    fileprivate convenience init(rgb: Int) {
+        self.init(
+            srgbRed: CGFloat((rgb >> 16) & 0xFF) / 255,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255,
+            blue: CGFloat(rgb & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientModel.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientModel.swift
@@ -33,9 +33,10 @@ final class ApiClientModel {
     var runningCollectionId: String?
     var runProgress: [RunResult] = []
 
-    // MARK: Import feedback
-
-    var importReport: String?
+    /// Set when a background save fails. Collections and history live in one
+    /// JSON document; losing a write silently means work disappears at the next
+    /// launch with nothing having said so.
+    var persistFailure: String?
 
     private var engine: FeatureEngine?
     private var store: JSONStore<ApiClientData>?
@@ -64,7 +65,15 @@ final class ApiClientModel {
     func persist() {
         guard let store else { return }
         let snapshot = data
-        Task { try? await store.save(snapshot) }
+        Task { [weak self] in
+            do {
+                try await store.save(snapshot)
+                self?.persistFailure = nil
+            } catch {
+                self?.persistFailure =
+                    "Couldn't save your API workspace: \(error.localizedDescription)"
+            }
+        }
     }
 
     // MARK: - Scope
@@ -179,15 +188,32 @@ final class ApiClientModel {
         open(SavedRequest(), in: currentCollectionId)
     }
 
+    /// True when the open request differs from what's stored — either edits to
+    /// a saved request, or an unsaved one someone has started filling in. Drives
+    /// the confirmation on New Request and on opening something else, both of
+    /// which used to discard the editor without a word.
+    var hasUnsavedChanges: Bool {
+        guard let collectionId = currentCollectionId,
+            let collection = data.collections.first(where: { $0.id == collectionId }),
+            case .request(let saved)? = ApiCollectionTree.find(current.id, in: collection.items)
+        else {
+            // Never saved: only worth protecting once there's something in it.
+            return !current.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        // `modifiedAt` moves on every save, so comparing it would call an
+        // untouched request dirty.
+        var stored = saved
+        var open = current
+        stored.modifiedAt = 0
+        open.modifiedAt = 0
+        return stored != open
+    }
+
     func loadCurl(_ text: String) -> [String] {
         guard let result = CurlParser.parseWithWarnings(text) else { return [] }
         open(result.request, in: currentCollectionId)
         warnings = result.warnings
         return result.warnings
-    }
-
-    var curlPreview: String {
-        CodeGenerator.generate(.curl, for: current, scope: scope)
     }
 
     func code(for target: CodeTarget) -> String {
@@ -269,6 +295,12 @@ final class ApiClientModel {
     func setCollectionAuth(_ auth: AuthSpec, for collectionId: String) {
         guard let index = data.collections.firstIndex(where: { $0.id == collectionId }) else { return }
         data.collections[index].auth = auth
+        persist()
+    }
+
+    func setCollectionVariables(_ variables: [ApiKeyValue], for collectionId: String) {
+        guard let index = data.collections.firstIndex(where: { $0.id == collectionId }) else { return }
+        data.collections[index].variables = variables
         persist()
     }
 

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSheets.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSheets.swift
@@ -9,6 +9,7 @@ enum ApiClientSheet: Identifiable {
     case newFolder(collectionId: String, parent: String?)
     case renameFolder(collectionId: String, folderId: String)
     case collectionAuth(id: String)
+    case collectionVariables(id: String)
     case newEnvironment
     case environment(id: String)
     case globals
@@ -24,6 +25,7 @@ enum ApiClientSheet: Identifiable {
             return "newFolder-\(collectionId)-\(parent ?? "root")"
         case .renameFolder(_, let folderId): return "renameFolder-\(folderId)"
         case .collectionAuth(let id): return "collectionAuth-\(id)"
+        case .collectionVariables(let id): return "collectionVariables-\(id)"
         case .newEnvironment: return "newEnvironment"
         case .environment(let id): return "environment-\(id)"
         case .globals: return "globals"
@@ -67,6 +69,16 @@ struct ApiClientSheetView: View {
             }
         case .collectionAuth(let id):
             CollectionAuthSheet(model: model, collectionId: id)
+        case .collectionVariables(let id):
+            // Collection variables already resolve (they're the third scope
+            // layer) and Postman import fills them in — there was just no way
+            // to see or edit them.
+            VariablesSheet(
+                title: "Collection Variables",
+                variables: model.data.collections.first { $0.id == id }?.variables ?? [],
+                name: nil,
+                onSave: { _, variables in model.setCollectionVariables(variables, for: id) }
+            )
         case .newEnvironment:
             NameSheet(title: "New Environment", placeholder: "Name", action: "Create") { name in
                 _ = model.addEnvironment(named: name)

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
@@ -86,7 +86,7 @@ struct ApiClientSidebar: View {
 
     private var expandedFolders: Binding<Set<String>> {
         Binding(
-            get: { Set(expandedFolderList.components(separatedBy: "\n").filter { !$0.isEmpty }) },
+            get: { Set(expandedFolderList.components(separatedBy: .newlines).filter { !$0.isEmpty }) },
             set: { expandedFolderList = $0.sorted().joined(separator: "\n") }
         )
     }

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
@@ -200,25 +200,36 @@ struct ApiClientSidebar: View {
         }
     }
 
+    /// Every item is its own `List` row — folders included — so all rows share
+    /// one set of insets. Nesting children inside their parent's row gave a
+    /// folder's contents different spacing from the requests above them.
     private var collectionTree: some View {
         List {
             ForEach(model.data.collections) { collection in
                 Section {
-                    ApiItemList(
-                        items: collection.items,
-                        collection: collection,
-                        model: model,
-                        sheet: $sheet,
-                        expandedFolders: expandedFolders,
-                        pendingDeletion: $pendingDeletion,
-                        depth: 0
-                    )
+                    ForEach(
+                        ApiCollectionTree.rows(collection.items, expanded: expandedFolders.wrappedValue)
+                    ) { row in
+                        ApiItemRow(
+                            row: row,
+                            collection: collection,
+                            model: model,
+                            sheet: $sheet,
+                            expandedFolders: expandedFolders,
+                            pendingDeletion: $pendingDeletion
+                        )
+                        .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
+                        .listRowSeparator(.hidden)
+                    }
                 } header: {
                     collectionHeader(collection)
                 }
             }
         }
-        .listStyle(.sidebar)
+        // Plain, not `.sidebar`: the sidebar style pads every row, which on a
+        // one-line request row reads as a gap rather than breathing room.
+        .listStyle(.plain)
+        .environment(\.defaultMinListRowHeight, 24)
         .translucentListBackground()
     }
 
@@ -462,42 +473,50 @@ struct ApiClientSidebar: View {
     }
 }
 
-// MARK: - Recursive tree rows
+// MARK: - Tree rows
 
-/// Folders nest arbitrarily deep, so the rows recurse. Split out of the sidebar
-/// to keep each `body` small enough for the type checker.
-private struct ApiItemList: View {
-    let items: [ApiItem]
+/// One row of the collection tree. Requests and folders are drawn to the same
+/// grid — the disclosure column is always reserved, so a request's method badge
+/// lines up with the folder names above it instead of hanging a few points off.
+private struct ApiItemRow: View {
+    let row: ApiCollectionTree.Row
     let collection: ApiCollection
     let model: ApiClientModel
     @Binding var sheet: ApiClientSheet?
     @Binding var expandedFolders: Set<String>
     @Binding var pendingDeletion: ApiDeletion?
-    let depth: Int
+
+    /// Width of the disclosure triangle column, reserved on every row.
+    private static let discloseWidth: CGFloat = 12
+    /// Width of the method badge, so names start on one line.
+    private static let methodWidth: CGFloat = 38
+    private static let indentPerLevel: CGFloat = 12
+    /// macOS's compact source-list row. Anything taller reads as a gap
+    /// between one-line rows rather than breathing room.
+    static let rowHeight: CGFloat = 24
 
     var body: some View {
-        ForEach(items) { item in
-            switch item {
-            case .request(let request):
-                requestRow(request)
-            case .folder(let folder):
-                folderRow(folder)
-            }
+        switch row.item {
+        case .request(let request): requestRow(request)
+        case .folder(let folder): folderRow(folder)
         }
     }
+
+    private var indent: CGFloat { CGFloat(row.depth) * Self.indentPerLevel }
 
     private func requestRow(_ request: SavedRequest) -> some View {
         Button {
             model.open(request, in: collection.id)
         } label: {
             HStack(spacing: 6) {
+                Color.clear.frame(width: Self.discloseWidth, height: 1)
                 Text(request.method.rawValue)
                     .font(.app(.caption2, design: .monospaced))
                     .bold()
                     .foregroundStyle(ApiStatusStyle.color(for: request.method))
-                    .frame(width: 44, alignment: .leading)
+                    .frame(width: Self.methodWidth, alignment: .leading)
                 Text(request.name).font(.app(.caption)).lineLimit(1)
-                Spacer()
+                Spacer(minLength: 4)
                 if !request.assertions.isEmpty {
                     Image(systemName: "checkmark.seal")
                         .font(.app(.caption2))
@@ -505,7 +524,8 @@ private struct ApiItemList: View {
                         .help("\(request.assertions.count) test(s)")
                 }
             }
-            .padding(.leading, CGFloat(depth) * 12)
+            .padding(.leading, indent)
+            .frame(minHeight: Self.rowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -514,54 +534,41 @@ private struct ApiItemList: View {
 
     private func folderRow(_ folder: ApiFolder) -> some View {
         let isOpen = expandedFolders.contains(folder.id)
-        return VStack(alignment: .leading, spacing: 0) {
-            Button {
-                if isOpen {
-                    expandedFolders.remove(folder.id)
-                } else {
-                    expandedFolders.insert(folder.id)
-                }
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: isOpen ? "chevron.down" : "chevron.right")
-                        .font(.app(.caption2))
-                        .foregroundStyle(.textMuted)
-                        .frame(width: 10)
-                    Image(systemName: "folder")
-                        .font(.app(.caption2))
-                        .foregroundStyle(.textMuted)
-                    Text(folder.name).font(.app(.caption)).bold().lineLimit(1)
-                    Spacer()
-                    Text("\(ApiCollectionTree.requestCount(in: folder.items))")
-                        .font(.app(.caption2))
-                        .foregroundStyle(.textMuted)
-                }
-                .padding(.leading, CGFloat(depth) * 12)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .contextMenu {
-                Button("New Folder Inside…") {
-                    sheet = .newFolder(collectionId: collection.id, parent: folder.id)
-                }
-                Button("Rename…") {
-                    sheet = .renameFolder(collectionId: collection.id, folderId: folder.id)
-                }
-                Divider()
-                itemMenu(id: folder.id, deletion: .folder(folder, in: collection.id))
-            }
-
+        return Button {
             if isOpen {
-                ApiItemList(
-                    items: folder.items,
-                    collection: collection,
-                    model: model,
-                    sheet: $sheet,
-                    expandedFolders: $expandedFolders,
-                    pendingDeletion: $pendingDeletion,
-                    depth: depth + 1
-                )
+                expandedFolders.remove(folder.id)
+            } else {
+                expandedFolders.insert(folder.id)
             }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isOpen ? "chevron.down" : "chevron.right")
+                    .font(.app(.caption2))
+                    .foregroundStyle(.textMuted)
+                    .frame(width: Self.discloseWidth)
+                Image(systemName: isOpen ? "folder.fill" : "folder")
+                    .font(.app(.caption2))
+                    .foregroundStyle(.textMuted)
+                Text(folder.name).font(.app(.caption)).bold().lineLimit(1)
+                Spacer(minLength: 4)
+                Text("\(ApiCollectionTree.requestCount(in: folder.items))")
+                    .font(.app(.caption2))
+                    .foregroundStyle(.textMuted)
+            }
+            .padding(.leading, indent)
+            .frame(minHeight: Self.rowHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("New Folder Inside…") {
+                sheet = .newFolder(collectionId: collection.id, parent: folder.id)
+            }
+            Button("Rename…") {
+                sheet = .renameFolder(collectionId: collection.id, folderId: folder.id)
+            }
+            Divider()
+            itemMenu(id: folder.id, deletion: .folder(folder, in: collection.id))
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientSidebar.swift
@@ -1,6 +1,77 @@
 import ADBKit
 import SwiftUI
 
+/// A destructive action waiting on a confirmation. Deleting a collection or a
+/// folder takes everything inside it, and clearing history can't be undone —
+/// all of these used to happen on a single menu click.
+struct ApiDeletion: Identifiable {
+
+    enum Target {
+        case collection(String)
+        case item(id: String, collectionId: String)
+        case environment(String)
+        case history
+    }
+
+    let id = UUID()
+    let target: Target
+    let title: String
+    let message: String
+    let confirmLabel: String
+
+    static func collection(_ collection: ApiCollection) -> ApiDeletion {
+        let count = ApiCollectionTree.requestCount(in: collection.items)
+        return ApiDeletion(
+            target: .collection(collection.id),
+            title: "Delete “\(collection.name)”?",
+            message: count == 1
+                ? "Its 1 request is deleted with it. This can't be undone."
+                : "Its \(count) requests are deleted with it. This can't be undone.",
+            confirmLabel: "Delete Collection"
+        )
+    }
+
+    static func request(_ request: SavedRequest, in collectionId: String) -> ApiDeletion {
+        ApiDeletion(
+            target: .item(id: request.id, collectionId: collectionId),
+            title: "Delete “\(request.name)”?",
+            message: "This can't be undone.",
+            confirmLabel: "Delete Request"
+        )
+    }
+
+    static func folder(_ folder: ApiFolder, in collectionId: String) -> ApiDeletion {
+        let count = ApiCollectionTree.requestCount(in: folder.items)
+        return ApiDeletion(
+            target: .item(id: folder.id, collectionId: collectionId),
+            title: "Delete “\(folder.name)”?",
+            message: count == 0
+                ? "The folder is empty. This can't be undone."
+                : "Its \(count) request\(count == 1 ? "" : "s") are deleted with it. "
+                    + "This can't be undone.",
+            confirmLabel: "Delete Folder"
+        )
+    }
+
+    static func environment(_ environment: ApiEnvironment) -> ApiDeletion {
+        ApiDeletion(
+            target: .environment(environment.id),
+            title: "Delete “\(environment.name)”?",
+            message: "Requests using its variables will have nothing to resolve them to.",
+            confirmLabel: "Delete Environment"
+        )
+    }
+
+    static func history(count: Int) -> ApiDeletion {
+        ApiDeletion(
+            target: .history,
+            title: "Clear history?",
+            message: "\(count) entr\(count == 1 ? "y" : "ies") are removed. This can't be undone.",
+            confirmLabel: "Clear History"
+        )
+    }
+}
+
 struct ApiClientSidebar: View {
     let model: ApiClientModel
     @Binding var section: ApiSidebarSection
@@ -8,7 +79,17 @@ struct ApiClientSidebar: View {
     @Binding var alertMessage: String?
 
     @State private var query = ""
-    @State private var expandedFolders: Set<String> = []
+    /// Persisted so a collection doesn't re-collapse every time the pane is
+    /// reopened — the tree is navigation, and navigation should stay put.
+    @AppStorage("apiExpandedFolders") private var expandedFolderList = ""
+    @State private var pendingDeletion: ApiDeletion?
+
+    private var expandedFolders: Binding<Set<String>> {
+        Binding(
+            get: { Set(expandedFolderList.components(separatedBy: "\n").filter { !$0.isEmpty }) },
+            set: { expandedFolderList = $0.sorted().joined(separator: "\n") }
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,6 +105,29 @@ struct ApiClientSidebar: View {
             }
         }
         .background(.bgSurface)
+        .confirmationDialog(
+            pendingDeletion?.title ?? "",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            presenting: pendingDeletion
+        ) { deletion in
+            Button(deletion.confirmLabel, role: .destructive) { perform(deletion) }
+            Button("Cancel", role: .cancel) {}
+        } message: { deletion in
+            Text(deletion.message)
+        }
+    }
+
+    private func perform(_ deletion: ApiDeletion) {
+        switch deletion.target {
+        case .collection(let id): model.deleteCollection(id)
+        case .item(let id, let collectionId): model.deleteItem(id, from: collectionId)
+        case .environment(let id): model.deleteEnvironment(id)
+        case .history: model.clearHistory()
+        }
+        pendingDeletion = nil
     }
 
     private func sectionPicker(_ style: some PickerStyle) -> some View {
@@ -105,7 +209,8 @@ struct ApiClientSidebar: View {
                         collection: collection,
                         model: model,
                         sheet: $sheet,
-                        expandedFolders: $expandedFolders,
+                        expandedFolders: expandedFolders,
+                        pendingDeletion: $pendingDeletion,
                         depth: 0
                     )
                 } header: {
@@ -137,11 +242,13 @@ struct ApiClientSidebar: View {
                 Button("New Folder…") { sheet = .newFolder(collectionId: collection.id, parent: nil) }
                 Button("Rename…") { sheet = .renameCollection(id: collection.id) }
                 Button("Collection Auth…") { sheet = .collectionAuth(id: collection.id) }
+                Button("Collection Variables…") { sheet = .collectionVariables(id: collection.id) }
+                Button("Export…") { exportCollection(collection) }
                 Divider()
                 Button("Run Collection…") { sheet = .runner(collectionId: collection.id) }
                 Divider()
-                Button("Delete Collection", role: .destructive) {
-                    model.deleteCollection(collection.id)
+                Button("Delete Collection…", role: .destructive) {
+                    pendingDeletion = .collection(collection)
                 }
             } label: {
                 Image(systemName: "ellipsis")
@@ -158,9 +265,11 @@ struct ApiClientSidebar: View {
         VStack(spacing: 0) {
             header("History") {
                 if !model.data.history.isEmpty {
-                    Button("Clear") { model.clearHistory() }
-                        .buttonStyle(.borderless)
-                        .font(.app(.caption))
+                    Button("Clear") {
+                        pendingDeletion = .history(count: model.data.history.count)
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.app(.caption))
                 }
             }
             if model.data.history.isEmpty {
@@ -281,13 +390,24 @@ struct ApiClientSidebar: View {
                 Button("Edit…") { sheet = .environment(id: environment.id) }
                 Button("Export…") { exportEnvironment(environment) }
                 Divider()
-                Button("Delete", role: .destructive) { model.deleteEnvironment(environment.id) }
+                Button("Delete…", role: .destructive) {
+                    pendingDeletion = .environment(environment)
+                }
             } label: {
                 Image(systemName: "ellipsis")
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
+        }
+    }
+
+    private func exportCollection(_ collection: ApiCollection) {
+        guard let url = ApiClientFilePanels.askSave(
+            suggestedName: "\(collection.name).postman_collection.json"
+        ) else { return }
+        if let failure = model.exportCollection(collection.id, to: url, includeSecrets: false) {
+            alertMessage = failure
         }
     }
 
@@ -352,6 +472,7 @@ private struct ApiItemList: View {
     let model: ApiClientModel
     @Binding var sheet: ApiClientSheet?
     @Binding var expandedFolders: Set<String>
+    @Binding var pendingDeletion: ApiDeletion?
     let depth: Int
 
     var body: some View {
@@ -388,7 +509,7 @@ private struct ApiItemList: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .contextMenu { itemMenu(id: request.id, isFolder: false) }
+        .contextMenu { itemMenu(id: request.id, deletion: .request(request, in: collection.id)) }
     }
 
     private func folderRow(_ folder: ApiFolder) -> some View {
@@ -427,7 +548,7 @@ private struct ApiItemList: View {
                     sheet = .renameFolder(collectionId: collection.id, folderId: folder.id)
                 }
                 Divider()
-                itemMenu(id: folder.id, isFolder: true)
+                itemMenu(id: folder.id, deletion: .folder(folder, in: collection.id))
             }
 
             if isOpen {
@@ -437,6 +558,7 @@ private struct ApiItemList: View {
                     model: model,
                     sheet: $sheet,
                     expandedFolders: $expandedFolders,
+                    pendingDeletion: $pendingDeletion,
                     depth: depth + 1
                 )
             }
@@ -444,7 +566,7 @@ private struct ApiItemList: View {
     }
 
     @ViewBuilder
-    private func itemMenu(id: String, isFolder: Bool) -> some View {
+    private func itemMenu(id: String, deletion: ApiDeletion) -> some View {
         Button("Duplicate") { model.duplicateItem(id, in: collection.id) }
         Menu("Move To") {
             Button("Top level") { model.move(id, toFolder: nil, in: collection.id) }
@@ -453,9 +575,7 @@ private struct ApiItemList: View {
             }
         }
         Divider()
-        Button(isFolder ? "Delete Folder" : "Delete", role: .destructive) {
-            model.deleteItem(id, from: collection.id)
-        }
+        Button(deletion.confirmLabel + "…", role: .destructive) { pendingDeletion = deletion }
     }
 
     /// Every folder in the collection except the moving item and its own

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
@@ -46,6 +46,7 @@ struct ApiClientView: View {
 
     @State private var sheet: ApiClientSheet?
     @State private var alertMessage: String?
+    @State private var pendingNewRequest = false
 
     private var isNarrow: Bool { paneWidth < 760 }
     private var isCompact: Bool { paneWidth < 620 }
@@ -89,6 +90,16 @@ struct ApiClientView: View {
             actions: { Button("OK") { alertMessage = nil } },
             message: { Text(alertMessage ?? "") }
         )
+        .confirmationDialog(
+            "Discard unsaved changes?",
+            isPresented: $pendingNewRequest
+        ) {
+            Button("Discard and Start New", role: .destructive) { model.newRequest() }
+            Button("Save First…") { sheet = .saveRequest }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("“\(model.current.name)” has edits that aren't saved to a collection.")
+        }
     }
 
     @ViewBuilder
@@ -120,6 +131,7 @@ struct ApiClientView: View {
         VStack(spacing: 0) {
             requestBar
             Divider()
+            if let failure = model.persistFailure { persistFailureStrip(failure) }
             if !model.warnings.isEmpty { warningStrip }
             splitBody
         }
@@ -268,12 +280,15 @@ struct ApiClientView: View {
                 .buttonStyle(.borderless)
                 .help("Import a cURL command")
 
-            Button { sheet = .saveRequest } label: { Image(systemName: "square.and.arrow.down") }
+            // `tray.and.arrow.down` reads as Save; the plain download glyph is
+            // what the response pane uses for an actual download, and having
+            // both mean different things was the confusing part.
+            Button { sheet = .saveRequest } label: { Image(systemName: "tray.and.arrow.down") }
                 .buttonStyle(.borderless)
                 .keyboardShortcut("s", modifiers: .command)
                 .help("Save this request (⌘S)")
 
-            Button { model.newRequest() } label: { Image(systemName: "plus.square") }
+            Button { newRequest() } label: { Image(systemName: "plus.square") }
                 .buttonStyle(.borderless)
                 .help("New request")
 
@@ -281,14 +296,15 @@ struct ApiClientView: View {
 
             Menu {
                 Button("Import Postman Collection or Environment…") { importFile() }
-                if let id = model.currentCollectionId {
-                    Button("Export Collection…") { exportCollection(id, includeSecrets: false) }
-                    Button("Export Collection with Secrets…") {
-                        exportCollection(id, includeSecrets: true)
-                    }
-                    Divider()
-                    Button("Run Collection…") { sheet = .runner(collectionId: id) }
+                Divider()
+                // Every collection is reachable here, not only the one the open
+                // request happens to belong to — with nothing open these were
+                // simply absent.
+                collectionMenu("Export Collection…") { exportCollection($0, includeSecrets: false) }
+                collectionMenu("Export Collection with Secrets…") {
+                    exportCollection($0, includeSecrets: true)
                 }
+                collectionMenu("Run Collection…") { sheet = .runner(collectionId: $0) }
                 Divider()
                 Button("Export Everything…") { exportWorkspace() }
                 Button("Edit Global Variables…") { sheet = .globals }
@@ -298,6 +314,31 @@ struct ApiClientView: View {
             .menuStyle(.borderlessButton)
             .fixedSize()
             .help("Import, export, and run")
+        }
+    }
+
+    /// One collection: a plain item. Several: a submenu. None: nothing, since
+    /// there is nothing to act on.
+    @ViewBuilder
+    private func collectionMenu(_ title: String, action: @escaping (String) -> Void) -> some View {
+        if model.data.collections.count == 1, let only = model.data.collections.first {
+            Button(title) { action(only.id) }
+        } else if model.data.collections.count > 1 {
+            Menu(title) {
+                ForEach(model.data.collections) { collection in
+                    Button(collection.name) { action(collection.id) }
+                }
+            }
+        }
+    }
+
+    /// New Request threw the editor away without asking; an unsaved request is
+    /// often several minutes of typing.
+    private func newRequest() {
+        if model.hasUnsavedChanges {
+            pendingNewRequest = true
+        } else {
+            model.newRequest()
         }
     }
 
@@ -315,6 +356,27 @@ struct ApiClientView: View {
     }
 
     // MARK: - Strips
+
+    /// A failed save used to be swallowed, so collections and history would
+    /// quietly not be there at the next launch.
+    private func persistFailureStrip(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .foregroundStyle(.red)
+                .font(.app(.caption2))
+            Text(message)
+                .font(.app(.caption))
+                .textSelection(.enabled)
+            Spacer()
+            Button("Retry") { model.persist() }
+                .buttonStyle(.link)
+                .font(.app(.caption))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color.red.opacity(0.12))
+    }
 
     private var warningStrip: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -371,15 +433,17 @@ struct ApiClientView: View {
 
     private func exportCollection(_ id: String, includeSecrets: Bool) {
         guard let collection = model.data.collections.first(where: { $0.id == id }) else { return }
-        guard let url = state.askSaveLocation(suggestedName: "\(collection.name).postman_collection.json")
-        else { return }
+        guard let url = ApiClientFilePanels.askSave(
+            suggestedName: "\(collection.name).postman_collection.json"
+        ) else { return }
         if let failure = model.exportCollection(id, to: url, includeSecrets: includeSecrets) {
             alertMessage = failure
         }
     }
 
     private func exportWorkspace() {
-        guard let url = state.askSaveLocation(suggestedName: "droidective-api.json") else { return }
+        guard let url = ApiClientFilePanels.askSave(suggestedName: "droidective-api.json")
+        else { return }
         if let failure = model.exportWorkspace(to: url, includeSecrets: false) {
             alertMessage = failure
         }

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
@@ -42,7 +42,7 @@ struct ApiClientView: View {
     @AppStorage("apiSidebarWidth") private var sidebarWidth = 260.0
     @State private var liveSidebarWidth: Double?
     @AppStorage("apiSplitFraction") private var splitFraction = 0.5
-    @State private var liveSplitPoints: Double?
+    @State private var liveSplitFraction: Double?
 
     @State private var sheet: ApiClientSheet?
     @State private var alertMessage: String?
@@ -143,12 +143,13 @@ struct ApiClientView: View {
             // Stacked when narrow, so the seam runs the other way and the
             // fraction is of height rather than width.
             let total = isNarrow ? geometry.size.height : geometry.size.width
-            let leading = liveSplitPoints
-                ?? ApiPaneLayout.leadingLength(total: total, fraction: splitFraction)
-            let handle = ResizeHandle(
-                value: splitPoints(over: total),
-                live: $liveSplitPoints,
-                range: ApiPaneLayout.pointRange(total: total),
+            let leading = ApiPaneLayout.leadingLength(
+                total: total, fraction: liveSplitFraction ?? splitFraction
+            )
+            let handle = ApiSplitHandle(
+                fraction: $splitFraction,
+                live: $liveSplitFraction,
+                total: total,
                 axis: isNarrow ? .vertical : .horizontal
             )
 
@@ -166,16 +167,6 @@ struct ApiClientView: View {
                 }
             }
         }
-    }
-
-    /// `ResizeHandle` drags in points; the split is stored as a fraction so a
-    /// window resize keeps it. This is the adapter between the two — reads the
-    /// stored fraction as points, writes points back as a fraction.
-    private func splitPoints(over total: CGFloat) -> Binding<Double> {
-        Binding(
-            get: { ApiPaneLayout.leadingLength(total: total, fraction: splitFraction) },
-            set: { splitFraction = ApiPaneLayout.fraction(forLeading: $0, total: total) }
-        )
     }
 
     private var editor: some View {

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
@@ -30,10 +30,19 @@ struct ApiClientView: View {
     @Environment(AppState.self) private var state
     @State private var model = ApiClientModel()
 
-    @State private var sidebarSection: ApiSidebarSection = .collections
-    @State private var requestTab: ApiRequestTab = .params
-    @State private var showSidebar = true
+    @AppStorage("apiSidebarSection") private var sidebarSection: ApiSidebarSection = .collections
+    @AppStorage("apiRequestTab") private var requestTab: ApiRequestTab = .params
+    @AppStorage("apiSidebarVisible") private var showSidebar = true
     @State private var paneWidth: CGFloat = 900
+
+    /// Both seams persist: the sidebar as a width, the editor/response split as
+    /// a fraction of the area left over, so it survives a window resize. The
+    /// `live` value carries the in-flight drag and the commit happens once, on
+    /// release — the same two-binding shape `RootView` uses for its own seams.
+    @AppStorage("apiSidebarWidth") private var sidebarWidth = 260.0
+    @State private var liveSidebarWidth: Double?
+    @AppStorage("apiSplitFraction") private var splitFraction = 0.5
+    @State private var liveSplitPoints: Double?
 
     @State private var sheet: ApiClientSheet?
     @State private var alertMessage: String?
@@ -51,8 +60,14 @@ struct ApiClientView: View {
                         sheet: $sheet,
                         alertMessage: $alertMessage
                     )
-                    .frame(width: max(220, min(320, geometry.size.width * 0.24)))
-                    Divider()
+                    .frame(width: ApiPaneLayout.sidebarWidth(
+                        stored: liveSidebarWidth ?? sidebarWidth, total: geometry.size.width
+                    ))
+                    ResizeHandle(
+                        value: $sidebarWidth,
+                        live: $liveSidebarWidth,
+                        range: ApiPaneLayout.sidebarRange
+                    )
                 }
                 mainColumn
             }
@@ -112,19 +127,43 @@ struct ApiClientView: View {
 
     @ViewBuilder
     private var splitBody: some View {
-        if isNarrow {
-            VStack(spacing: 0) {
-                editor
-                Divider()
-                responsePane
-            }
-        } else {
-            HStack(spacing: 0) {
-                editor.frame(maxWidth: .infinity)
-                Divider()
-                responsePane.frame(maxWidth: .infinity)
+        GeometryReader { geometry in
+            // Stacked when narrow, so the seam runs the other way and the
+            // fraction is of height rather than width.
+            let total = isNarrow ? geometry.size.height : geometry.size.width
+            let leading = liveSplitPoints
+                ?? ApiPaneLayout.leadingLength(total: total, fraction: splitFraction)
+            let handle = ResizeHandle(
+                value: splitPoints(over: total),
+                live: $liveSplitPoints,
+                range: ApiPaneLayout.pointRange(total: total),
+                axis: isNarrow ? .vertical : .horizontal
+            )
+
+            if isNarrow {
+                VStack(spacing: 0) {
+                    editor.frame(height: leading)
+                    handle
+                    responsePane.frame(maxHeight: .infinity)
+                }
+            } else {
+                HStack(spacing: 0) {
+                    editor.frame(width: leading)
+                    handle
+                    responsePane.frame(maxWidth: .infinity)
+                }
             }
         }
+    }
+
+    /// `ResizeHandle` drags in points; the split is stored as a fraction so a
+    /// window resize keeps it. This is the adapter between the two — reads the
+    /// stored fraction as points, writes points back as a fraction.
+    private func splitPoints(over total: CGFloat) -> Binding<Double> {
+        Binding(
+            get: { ApiPaneLayout.leadingLength(total: total, fraction: splitFraction) },
+            set: { splitFraction = ApiPaneLayout.fraction(forLeading: $0, total: total) }
+        )
     }
 
     private var editor: some View {
@@ -142,15 +181,16 @@ struct ApiClientView: View {
     private var requestBar: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                if isNarrow {
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) { showSidebar.toggle() }
-                    } label: {
-                        Image(systemName: "sidebar.left")
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Toggle sidebar")
+                // Shown at every width: the sidebar is hideable in wide layouts
+                // too, and without this button there was no way back once it
+                // was hidden.
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { showSidebar.toggle() }
+                } label: {
+                    Image(systemName: showSidebar ? "sidebar.left" : "sidebar.leading")
                 }
+                .buttonStyle(.borderless)
+                .help(showSidebar ? "Hide sidebar" : "Show sidebar")
 
                 Picker("", selection: $model.current.method) {
                     ForEach(HttpMethod.allCases) { method in

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
@@ -536,11 +536,8 @@ struct ApiRequestEditor: View {
                 .labelsHidden()
                 .frame(maxWidth: 220)
                 Spacer()
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(model.code(for: codeTarget), forType: .string)
-                } label: {
-                    Label("Copy", systemImage: "doc.on.doc")
+                ApiCopyButton(help: "Copy the generated snippet", title: "Copy") {
+                    model.code(for: codeTarget)
                 }
                 .buttonStyle(.bordered)
             }

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
@@ -71,9 +71,10 @@ struct ApiRequestEditor: View {
 
     private var paramsTab: some View {
         VStack(spacing: 0) {
+            if ApiQueryString.hasQuery(model.current.url) { urlQueryStrip }
             ApiKeyValueEditor(
                 title: "Query Parameters",
-                placeholder: "No parameters. Anything after ? in the URL shows up here.",
+                placeholder: "No parameters. These are appended to the URL when the request is sent.",
                 items: $model.current.queryParams
             )
             if !pathVariableNames.isEmpty {
@@ -81,6 +82,41 @@ struct ApiRequestEditor: View {
                 pathVariables
             }
         }
+    }
+
+    /// The URL bar and this table are both sent — the builder merges them — so
+    /// a query typed into the bar is *not* silently mirrored here. This offers
+    /// the move explicitly rather than leaving people to wonder why pasting a
+    /// URL with `?a=1` left the table empty.
+    private var urlQueryStrip: some View {
+        let found = ApiQueryString.parameters(in: model.current.url)
+        return HStack(spacing: 8) {
+            Image(systemName: "arrow.down.to.line.compact")
+                .foregroundStyle(.textMuted)
+                .font(.app(.caption))
+            Text(
+                found.count == 1
+                    ? "The URL carries 1 parameter."
+                    : "The URL carries \(found.count) parameters."
+            )
+            .font(.app(.caption))
+            .foregroundStyle(.textMuted)
+            Spacer()
+            Button("Move Into Table") { extractQueryFromURL() }
+                .buttonStyle(.link)
+                .font(.app(.caption))
+                .help("Take them out of the URL and list them here, where they can be toggled")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color.brandAccent.opacity(0.08))
+    }
+
+    private func extractQueryFromURL() {
+        let found = ApiQueryString.parameters(in: model.current.url)
+        guard !found.isEmpty else { return }
+        model.current.queryParams.append(contentsOf: found)
+        model.current.url = ApiQueryString.removingQuery(from: model.current.url)
     }
 
     /// `:name` placeholders present in the URL path.
@@ -808,9 +844,12 @@ enum ApiClientFilePanels {
         return panel.runModal() == .OK ? panel.url : nil
     }
 
+    /// The one save panel this feature uses, defaulting to the same folder
+    /// every other save in the app opens in.
     static func askSave(suggestedName: String) -> URL? {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = suggestedName
+        panel.directoryURL = try? ScreenCaptureService.ensureCaptureDir()
         panel.canCreateDirectories = true
         NSApp?.activate(ignoringOtherApps: true)
         return panel.runModal() == .OK ? panel.url : nil

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
@@ -11,25 +11,13 @@ struct ApiRequestEditor: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ViewThatFits(in: .horizontal) {
-                tabPicker(.segmented)
-                tabPicker(.menu)
-            }
+            AdaptiveTabBar(tabs: ApiRequestTab.allCases, label: label(for:), selection: $tab)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
             Divider()
             content
         }
         .background(.bgSurface.opacity(0.5))
-    }
-
-    private func tabPicker(_ style: some PickerStyle) -> some View {
-        Picker("", selection: $tab) {
-            ForEach(ApiRequestTab.allCases) { value in
-                Text(label(for: value)).tag(value)
-            }
-        }
-        .labelsHidden()
-        .pickerStyle(style)
-        .padding(8)
     }
 
     private func label(for tab: ApiRequestTab) -> String {

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiRequestEditor.swift
@@ -523,13 +523,10 @@ struct ApiRequestEditor: View {
             .padding(.horizontal, 12)
             .padding(.top, 8)
 
-            ScrollView([.horizontal, .vertical]) {
-                Text(model.code(for: codeTarget))
-                    .font(.app(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
+            // Same viewer as the response body — a generated snippet is long
+            // enough to hit the blank-until-clicked layout problem too.
+            ApiBodyTextView(text: model.code(for: codeTarget), format: .text, wraps: true)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
@@ -195,9 +195,13 @@ struct ApiResponsePane: View {
                 .buttonStyle(.borderless)
                 .help(wraps ? "Wrap long lines (on)" : "Wrap long lines (off)")
 
+                // Deliberately not bound to ⌘F: this pane can sit in a hidden
+                // keep-alive tab, and a shortcut declared there would take ⌘F
+                // app-wide. AppKit's own ⌘F still opens the find bar once the
+                // body has focus; this button is the path that always works.
                 Button { findToken += 1 } label: { Image(systemName: "magnifyingglass") }
                     .buttonStyle(.borderless)
-                    .help("Find in body (⌘F)")
+                    .help("Find in body")
 
                 copyButton("Copy the body as shown") { bodyText(response) }
 

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
@@ -21,6 +21,9 @@ struct ApiResponsePane: View {
     @State private var showRaw = false
     @AppStorage("apiBodyWraps") private var wraps = true
     @State private var findToken = 0
+    /// Names what a menu-driven copy just put on the clipboard. Inline buttons
+    /// acknowledge themselves; a menu has closed by the time it could.
+    @State private var copyToastMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,6 +42,7 @@ struct ApiResponsePane: View {
             }
         }
         .background(.bgSurface.opacity(0.3))
+        .apiCopyToast($copyToastMessage)
     }
 
     // MARK: - Status
@@ -69,7 +73,9 @@ struct ApiResponsePane: View {
             Menu {
                 Button("Save Body to File…") { saveBody(response) }
                 Divider()
-                Button("Copy Everything") { copy(everythingText(response)) }
+                Button("Copy Everything") {
+                    copy(everythingText(response), acknowledging: "Copied the whole response")
+                }
             } label: {
                 Image(systemName: "square.and.arrow.down")
             }
@@ -103,11 +109,10 @@ struct ApiResponsePane: View {
     }
 
     /// The copy button every section carries, so the thing on screen is always
-    /// one click from the clipboard.
+    /// one click from the clipboard — and says so once it is.
     private func copyButton(_ help: String, _ text: @escaping () -> String) -> some View {
-        Button { copy(text()) } label: { Image(systemName: "doc.on.doc") }
+        ApiCopyButton(help: help, text: text)
             .buttonStyle(.borderless)
-            .help(help)
     }
 
     /// A section's own header strip: a title, its copy button, and whatever else
@@ -270,9 +275,18 @@ struct ApiResponsePane: View {
                             .textSelection(.enabled)
                     }
                     .contextMenu {
-                        Button("Copy Value") { copy(header.value) }
-                        Button("Copy Name") { copy(header.key) }
-                        Button("Copy Line") { copy("\(header.key): \(header.value)") }
+                        Button("Copy Value") {
+                            copy(header.value, acknowledging: "Copied \(header.key)")
+                        }
+                        Button("Copy Name") {
+                            copy(header.key, acknowledging: "Copied the header name")
+                        }
+                        Button("Copy Line") {
+                            copy(
+                                "\(header.key): \(header.value)",
+                                acknowledging: "Copied \(header.key)"
+                            )
+                        }
                     }
                 }
                 .listStyle(.plain)
@@ -317,9 +331,14 @@ struct ApiResponsePane: View {
                             .foregroundStyle(.textMuted)
                     }
                     .contextMenu {
-                        Button("Copy Value") { copy(cookie.value) }
+                        Button("Copy Value") {
+                            copy(cookie.value, acknowledging: "Copied \(cookie.name)")
+                        }
                         Button("Copy as Cookie Header") {
-                            copy("\(cookie.name)=\(cookie.value)")
+                            copy(
+                                "\(cookie.name)=\(cookie.value)",
+                                acknowledging: "Copied \(cookie.name)"
+                            )
                         }
                     }
                 }
@@ -497,10 +516,15 @@ struct ApiResponsePane: View {
         response.headers.map { "\($0.key): \($0.value)" }.joined(separator: "\n")
     }
 
-    private func copy(_ text: String) {
-        guard !text.isEmpty else { return }
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
+    /// Copies and raises the capsule. Nothing on the clipboard means nothing
+    /// to announce, so an empty section stays quiet instead of claiming success.
+    private func copy(_ text: String, acknowledging message: String) {
+        guard copyApiText(text) else { return }
+        copyToastMessage = message
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.6))
+            if copyToastMessage == message { copyToastMessage = nil }
+        }
     }
 
     private func saveBody(_ response: ApiResponse) {

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
@@ -220,10 +220,15 @@ struct ApiResponsePane: View {
             } else {
                 List(Array(response.headers.enumerated()), id: \.offset) { _, header in
                     HStack(alignment: .top, spacing: 8) {
+                        // A fixed column truncated the long names that matter
+                        // (`strict-transport-security`, `content-security-policy`);
+                        // this holds the column but lets a long name have more.
                         Text(header.key)
                             .font(.app(.caption, design: .monospaced))
                             .bold()
-                            .frame(width: 170, alignment: .leading)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(minWidth: 170, alignment: .leading)
                         Text(header.value)
                             .font(.app(.caption, design: .monospaced))
                             .foregroundStyle(.textMuted)

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
@@ -66,13 +66,10 @@ struct ApiResponsePane: View {
                     .help("The body was larger than the per-request limit in Settings.")
             }
 
-            Spacer()
-
             Menu {
-                Button("Copy Body") { copy(bodyText(response)) }
-                Button("Copy Response Headers") { copy(headerText(response)) }
-                Divider()
                 Button("Save Body to File…") { saveBody(response) }
+                Divider()
+                Button("Copy Everything") { copy(everythingText(response)) }
             } label: {
                 Image(systemName: "square.and.arrow.down")
             }
@@ -80,23 +77,53 @@ struct ApiResponsePane: View {
             .menuIndicator(.hidden)
             .fixedSize()
 
-            ViewThatFits(in: .horizontal) {
-                tabPicker(.segmented)
-                tabPicker(.menu)
-            }
+            // Takes the width left over from the status metrics and sits against
+            // the trailing edge, dropping tabs into a menu only once they truly
+            // stop fitting.
+            AdaptiveTabBar(
+                tabs: Tab.allCases, label: \.label, selection: $tab, alignment: .trailing
+            )
         }
         .padding(8)
     }
 
-    private func tabPicker(_ style: some PickerStyle) -> some View {
-        Picker("", selection: $tab) {
-            ForEach(Tab.allCases) { value in
-                Text(value.label).tag(value)
-            }
+    /// One clipboard-friendly dump of the whole exchange, for pasting into an
+    /// issue: status line, headers, then the body as shown.
+    private func everythingText(_ response: ApiResponse) -> String {
+        var parts = [
+            "\(response.statusCode) \(response.statusText) · "
+                + String(format: "%.0f ms", response.elapsedMs) + " · \(response.sizeText)"
+        ]
+        if !response.finalURL.isEmpty { parts.append(response.finalURL) }
+        let headers = headerText(response)
+        if !headers.isEmpty { parts.append(headers) }
+        let body = bodyText(response)
+        if !body.isEmpty { parts.append(body) }
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// The copy button every section carries, so the thing on screen is always
+    /// one click from the clipboard.
+    private func copyButton(_ help: String, _ text: @escaping () -> String) -> some View {
+        Button { copy(text()) } label: { Image(systemName: "doc.on.doc") }
+            .buttonStyle(.borderless)
+            .help(help)
+    }
+
+    /// A section's own header strip: a title, its copy button, and whatever else
+    /// that section needs on the right.
+    private func sectionBar(
+        _ title: String, copyHelp: String, copying text: @escaping () -> String
+    ) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+            copyButton(copyHelp, text)
+            Spacer()
         }
-        .labelsHidden()
-        .pickerStyle(style)
-        .frame(maxWidth: 240)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
     }
 
     private var assertionStrip: some View {
@@ -167,6 +194,8 @@ struct ApiResponsePane: View {
                     .buttonStyle(.borderless)
                     .help("Find in body (⌘F)")
 
+                copyButton("Copy the body as shown") { bodyText(response) }
+
                 Spacer()
                 Text(response.mediaType.isEmpty ? response.format.rawValue : response.mediaType)
                     .font(.app(.caption2, design: .monospaced))
@@ -218,6 +247,12 @@ struct ApiResponsePane: View {
                     .foregroundStyle(.textMuted)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
+                VStack(spacing: 0) {
+                    sectionBar(
+                        "\(response.headers.count) headers",
+                        copyHelp: "Copy all response headers"
+                    ) { headerText(response) }
+                    Divider()
                 List(Array(response.headers.enumerated()), id: \.offset) { _, header in
                     HStack(alignment: .top, spacing: 8) {
                         // A fixed column truncated the long names that matter
@@ -234,9 +269,15 @@ struct ApiResponsePane: View {
                             .foregroundStyle(.textMuted)
                             .textSelection(.enabled)
                     }
+                    .contextMenu {
+                        Button("Copy Value") { copy(header.value) }
+                        Button("Copy Name") { copy(header.key) }
+                        Button("Copy Line") { copy("\(header.key): \(header.value)") }
+                    }
                 }
                 .listStyle(.plain)
                 .translucentListBackground()
+                }
             }
         }
     }
@@ -250,6 +291,12 @@ struct ApiResponsePane: View {
                     .foregroundStyle(.textMuted)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
+                VStack(spacing: 0) {
+                    sectionBar(
+                        cookies.count == 1 ? "1 cookie" : "\(cookies.count) cookies",
+                        copyHelp: "Copy every cookie this response set"
+                    ) { cookieText(cookies) }
+                    Divider()
                 List(cookies) { cookie in
                     VStack(alignment: .leading, spacing: 2) {
                         HStack(spacing: 6) {
@@ -269,11 +316,27 @@ struct ApiResponsePane: View {
                             .font(.app(.caption2))
                             .foregroundStyle(.textMuted)
                     }
+                    .contextMenu {
+                        Button("Copy Value") { copy(cookie.value) }
+                        Button("Copy as Cookie Header") {
+                            copy("\(cookie.name)=\(cookie.value)")
+                        }
+                    }
                 }
                 .listStyle(.plain)
                 .translucentListBackground()
+                }
             }
         }
+    }
+
+    private func cookieText(_ cookies: [ApiCookie]) -> String {
+        cookies.map { cookie in
+            let detail = cookieDetail(cookie)
+            let line = "\(cookie.name)=\(cookie.value)"
+            return detail.isEmpty ? line : "\(line) · \(detail)"
+        }
+        .joined(separator: "\n")
     }
 
     private func cookieDetail(_ cookie: ApiCookie) -> String {
@@ -294,6 +357,41 @@ struct ApiResponsePane: View {
     }
 
     private func timingTab(_ response: ApiResponse) -> some View {
+        VStack(spacing: 0) {
+            sectionBar("Timing", copyHelp: "Copy the timing breakdown") {
+                timingText(response)
+            }
+            Divider()
+            timingForm(response)
+        }
+    }
+
+    private func timingText(_ response: ApiResponse) -> String {
+        var lines: [String] = []
+        if let timing = response.timing {
+            let phases: [(String, Double?)] = [
+                ("DNS lookup", timing.dns), ("Connect", timing.connect),
+                ("TLS handshake", timing.tls), ("First byte", timing.firstByte),
+                ("Total", timing.total),
+            ]
+            for (name, value) in phases {
+                guard let value else { continue }
+                lines.append(String(format: "%@: %.0f ms", name, value))
+            }
+        } else {
+            lines.append(String(format: "Total: %.0f ms", response.elapsedMs))
+        }
+        if !response.finalURL.isEmpty { lines.append("Final URL: \(response.finalURL)") }
+        if let prepared = model.prepared {
+            lines.append("Sent bytes: \(ApiResponse.formatBytes(prepared.body?.count ?? 0))")
+        }
+        for hop in response.redirects {
+            lines.append("\(hop.statusCode) \(hop.from) -> \(hop.to)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func timingForm(_ response: ApiResponse) -> some View {
         Form {
             Section("Timing") {
                 if let timing = response.timing {

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiResponsePane.swift
@@ -19,6 +19,8 @@ struct ApiResponsePane: View {
 
     @State private var tab: Tab = .body
     @State private var showRaw = false
+    @AppStorage("apiBodyWraps") private var wraps = true
+    @State private var findToken = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -133,8 +135,19 @@ struct ApiResponsePane: View {
     @ViewBuilder
     private func bodyTab(_ response: ApiResponse) -> some View {
         VStack(spacing: 0) {
-            if response.prettyBody != nil {
-                HStack {
+            bodyToolbar(response)
+            bodyContent(response)
+        }
+    }
+
+    /// The bar above the body. It stays put for every textual body — not only
+    /// the ones with a pretty form — so wrapping and Find don't come and go
+    /// with the content type.
+    @ViewBuilder
+    private func bodyToolbar(_ response: ApiResponse) -> some View {
+        if response.format.isTextual, !response.body.isEmpty {
+            HStack(spacing: 8) {
+                if response.prettyBody != nil {
                     Picker("", selection: $showRaw) {
                         Text("Pretty").tag(false)
                         Text("Raw").tag(true)
@@ -142,15 +155,25 @@ struct ApiResponsePane: View {
                     .labelsHidden()
                     .pickerStyle(.segmented)
                     .frame(width: 150)
-                    Spacer()
-                    Text(response.mediaType.isEmpty ? response.format.rawValue : response.mediaType)
-                        .font(.app(.caption2, design: .monospaced))
-                        .foregroundStyle(.textMuted)
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
+
+                Button { wraps.toggle() } label: {
+                    Image(systemName: wraps ? "text.alignleft" : "arrow.left.and.right")
+                }
+                .buttonStyle(.borderless)
+                .help(wraps ? "Wrap long lines (on)" : "Wrap long lines (off)")
+
+                Button { findToken += 1 } label: { Image(systemName: "magnifyingglass") }
+                    .buttonStyle(.borderless)
+                    .help("Find in body (⌘F)")
+
+                Spacer()
+                Text(response.mediaType.isEmpty ? response.format.rawValue : response.mediaType)
+                    .font(.app(.caption2, design: .monospaced))
+                    .foregroundStyle(.textMuted)
             }
-            bodyContent(response)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
         }
     }
 
@@ -170,13 +193,10 @@ struct ApiResponsePane: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         } else if let text = displayText(response) {
-            ScrollView([.horizontal, .vertical]) {
-                Text(text)
-                    .font(.app(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .padding(8)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            }
+            ApiBodyTextView(
+                text: text, format: response.format, wraps: wraps, findToken: findToken
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             VStack(spacing: 6) {
                 Image(systemName: "doc.zipper").font(.largeTitle).foregroundStyle(.textMuted)

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiSplitHandle.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiSplitHandle.swift
@@ -1,0 +1,69 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// The draggable seam between the request editor and the response pane.
+///
+/// Fraction-native on purpose. Driving it through `ResizeHandle` meant storing
+/// a fraction but dragging in points, so the conversion needed the pane's width
+/// on the way in and again on the way out — and SwiftUI hands the gesture a
+/// `Binding` captured at whichever render created it. When the two widths
+/// disagreed the split jumped on a gesture nobody meant to make. Here the drag
+/// distance is divided by the *current* total and nothing else is converted.
+struct ApiSplitHandle: View {
+    @Binding var fraction: Double
+    /// The in-flight fraction, so the layout can follow the drag without
+    /// writing to storage on every tick.
+    @Binding var live: Double?
+    let total: CGFloat
+    var axis: Axis = .horizontal
+
+    @State private var startFraction: Double?
+
+    var body: some View {
+        Divider()
+            .overlay {
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(
+                        width: axis == .horizontal ? 8 : nil,
+                        height: axis == .vertical ? 8 : nil
+                    )
+                    .contentShape(Rectangle())
+                    .onHover { inside in
+                        if inside {
+                            (axis == .horizontal ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown)
+                                .set()
+                        } else {
+                            NSCursor.arrow.set()
+                        }
+                    }
+                    .gesture(
+                        DragGesture(coordinateSpace: .named(ResizeHandle.dragSpace))
+                            .onChanged { gesture in
+                                if startFraction == nil {
+                                    // A gesture can end without `onEnded` (focus
+                                    // loss, ⌘-Tab mid-drag); commit what it left
+                                    // behind before starting a fresh one.
+                                    if let stale = live { fraction = stale }
+                                    startFraction = fraction
+                                }
+                                let delta = axis == .horizontal
+                                    ? gesture.translation.width
+                                    : gesture.translation.height
+                                live = ApiPaneLayout.fraction(
+                                    from: startFraction ?? fraction, movedBy: delta, total: total
+                                )
+                            }
+                            .onEnded { _ in
+                                // A press that never moved is not a resize. Without
+                                // this, a click anywhere that AppKit reports as a
+                                // zero-distance drag rewrote the split.
+                                if let live, live != startFraction { fraction = live }
+                                live = nil
+                                startFraction = nil
+                            }
+                    )
+            }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ApiClient/CopyButton.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/CopyButton.swift
@@ -1,0 +1,104 @@
+import AppKit
+import SwiftUI
+
+/// Copies and reports whether there was anything to copy — an empty body
+/// shouldn't claim success. (`copyToPasteboard` is the app-wide unconditional
+/// twin; the acknowledgement here needs to know when nothing happened.)
+@discardableResult
+@MainActor
+func copyApiText(_ text: String) -> Bool {
+    guard !text.isEmpty else { return false }
+    copyToPasteboard(text)
+    return true
+}
+
+/// A copy button that says so: the icon becomes a checkmark for a moment after
+/// a successful copy, because a button that looks identical before and after
+/// leaves you wondering whether the click registered — and re-copying "just in
+/// case" is the tell that it didn't.
+///
+/// Reactotron has its own filled-pill variant suited to that console; this is
+/// the borderless icon a dense toolbar wants.
+///
+/// Nothing moves: the checkmark is drawn in the same slot as the icon, so a row
+/// of controls doesn't reflow on every copy.
+struct ApiCopyButton: View {
+    let help: String
+    /// Optional visible label, for the places that show "Copy" rather than an
+    /// icon alone.
+    var title: String?
+    let text: () -> String
+
+    @State private var copied = false
+    @State private var revert: Task<Void, Never>?
+
+    /// Long enough to notice, short enough not to linger past the next action.
+    private static let holdSeconds: Double = 1.2
+
+    var body: some View {
+        Button {
+            guard copyApiText(text()) else { return }
+            acknowledge()
+        } label: {
+            if let title {
+                Label(copied ? "Copied" : title, systemImage: symbol)
+                    .foregroundStyle(copied ? Color.brandAccent : Color.textMain)
+            } else {
+                Image(systemName: symbol)
+                    .foregroundStyle(copied ? Color.brandAccent : Color.textMain)
+                    // Both glyphs share one frame so the checkmark can't nudge
+                    // its neighbours.
+                    .frame(width: 16, alignment: .center)
+            }
+        }
+        .help(copied ? "Copied" : help)
+        .animation(.easeInOut(duration: 0.15), value: copied)
+        .onDisappear { revert?.cancel() }
+    }
+
+    private var symbol: String { copied ? "checkmark" : "doc.on.doc" }
+
+    private func acknowledge() {
+        copied = true
+        // A second copy restarts the hold rather than reverting mid-way.
+        revert?.cancel()
+        revert = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(Self.holdSeconds))
+            guard !Task.isCancelled else { return }
+            copied = false
+        }
+    }
+}
+
+/// The acknowledgement for copies started from a menu, where the control that
+/// would show a checkmark has already closed. A small capsule naming what was
+/// copied, which fades itself out.
+struct ApiCopyToast: ViewModifier {
+    @Binding var message: String?
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .bottom) {
+            if let message {
+                Label(message, systemImage: "checkmark.circle.fill")
+                    .font(.app(.caption))
+                    .foregroundStyle(.textMain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(.bgSurface, in: Capsule())
+                    .overlay(Capsule().strokeBorder(Color.borderSubtle))
+                    .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
+                    .padding(.bottom, 16)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .allowsHitTesting(false)
+            }
+        }
+        .animation(.easeInOut(duration: 0.18), value: message)
+    }
+}
+
+extension View {
+    /// Shows `message` as a transient "copied" capsule over this view.
+    func apiCopyToast(_ message: Binding<String?>) -> some View {
+        modifier(ApiCopyToast(message: message))
+    }
+}

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -985,7 +985,11 @@ struct ResizeHandle: View {
                                 live = min(max(next, range.lowerBound), range.upperBound)
                             }
                             .onEnded { _ in
-                                if let live { value = live }
+                                // A press that never moved is not a resize.
+                                // AppKit reports some clicks as zero-distance
+                                // drags, and committing those wrote a clamped
+                                // value back over the stored one.
+                                if let live, live != startValue { value = live }
                                 live = nil
                                 startValue = nil
                             }


### PR DESCRIPTION
Fixes reported UI friction in the API Testing pane and closes the gaps an audit
of the feature turned up.

## Response viewer

The HTML pretty-printer parsed `<script>` and `<style>` bodies as markup, so
minified JS — full of `<` — was mangled and ran the indent depth away, and a
close tag always assumed the innermost element, leaving everything after an
unclosed `<p>` or `<li>` drifting right. Raw-text elements now keep their body
verbatim, indented as a block, and a close tag unwinds to the element it
actually closes. Plain-text bodies gain a pretty form where there is one: JSON
Lines, and form-encoded bodies as one decoded pair per line.

The body moves from a `Text` inside a two-axis `ScrollView` — which could not
size a large body, leaving it blank until a click and blank again on focus loss
— to a read-only `NSTextView` with syntax colouring, a wrap toggle and AppKit's
find bar. The generated-code tab had the same construction and gets the same
viewer.

## Layout

Both seams of the three-pane layout are draggable and persist; they were fixed
frames with decorative dividers. The split is stored as a fraction and dragged
in fraction space — an earlier points/fraction round trip could use two
different pane widths and moved the seam on a click. Both seams also ignore a
drag that never moved, since AppKit reports some clicks as zero-distance drags;
that guard covers the app sidebar too.

The request tabs used `ViewThatFits` over a segmented and a menu picker, which
is all-or-nothing: seven tabs never fit a half-width pane, so the row collapsed
to one centred dropdown even with room for five. `TabOverflow` now keeps every
tab that fits and hands only the remainder to a menu, measuring widths in the
font the tabs render in so nothing is drawn clipped — including the case where
a tab fits but the tab plus the overflow button does not. Response tabs use the
same control.

Sidebar rows nested a folder's children inside their parent's row, so gaps were
uneven, and `.listStyle(.sidebar)` padded a one-line row to ~40pt.
`ApiCollectionTree.rows` flattens the visible tree into sibling rows at the
24pt source-list height, with the disclosure column reserved on every row so
method badges line up.

## Copying

Body, headers, cookies and the timing breakdown each carry a copy button, with
per-row copy in headers and cookies and a Copy Everything that dumps the status
line, headers and body together. Every copy acknowledges itself: inline buttons
flip to a checkmark, and menu-driven copies raise a short capsule naming what
was copied.

## Audit fixes

- Deleting a collection, folder, request or environment, and clearing history,
  all happened on a single menu click. Each now names what it removes.
- New Request discarded the open editor silently; it offers to save first.
- The Params placeholder claimed anything after `?` in the URL appeared there,
  which was never true — the URL and the table are merged at send time, not
  mirrored. The copy says what happens, and a strip offers to move a URL's
  query into the table (`ApiQueryString`, with a test proving the request on
  the wire is unchanged).
- Collection variables resolved but had no editor.
- Export and Run Collection were unreachable unless a request from that
  collection was open.
- A failed background save was swallowed.
- Folder expansion, sidebar section and request tab reset on every visit.
- Long response header names were truncated by a fixed column.
- Removes the unused `curlPreview` and `importReport`, and the feature's
  duplicate save panel.

## Tests

~120 new tests: the HTML/plain-text formatters, the syntax tokenizer (offsets
read back as the substring they point at), `TabOverflow` (including a property
test that every drawn row fits at every width), `ApiPaneLayout`, the tree
flattening, and `ApiQueryString`.

`make verify` green — 1600 ADBKit, 99 ReactotronMCP, 40 droidectived, 99
AppTests.

## Verified live

Driven against a local fixture server: HTML prettifies with the script body
intact, JSON renders coloured, both seams drag to the expected values and
survive a relaunch, the overflow menu appears only when tabs genuinely stop
fitting, sidebar rows measure 24pt, and both copy acknowledgements appear.
