### PR TITLE
Carry the daemon's stream socket

### DIFF
--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -115,7 +115,13 @@ stays with the scrcpy desktop app.
 - [x] `droidectived` scaffold — own package, loopback bind on port 0 with the
       printed port line, token auth with the Host/Origin checks, and
       `POST /v1/devices/list`, proven over a real socket (24 tests)
-- [ ] `droidectived` streams: the WebSocket, the `logcat` topic, and the
+- [ ] Portable WebSocket client for tests, so the stream socket's own suite
+      runs off-Darwin. corelibs-Foundation has no `URLSessionWebSocketTask`
+      ("WebSockets not supported by libcurl"), so those four tests are
+      Apple-scoped today. The *server* is portable NIO and runs everywhere —
+      only the harness is missing. The raw-socket probe that caught the frame
+      masking bug is the obvious basis for one.
+- [x] `droidectived` streams: the WebSocket, the topic subscriptions, and the
       drop-oldest buffer with its gap marker
 - [ ] Portable fake CDP server so the JSConsoleClient wire tests run on Linux
 - [ ] Reactotron listener off Network.framework (SwiftNIO or raw sockets)

--- a/droidectived/Package.swift
+++ b/droidectived/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOWebSocket", package: "swift-nio"),
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -11,6 +11,11 @@ public enum DaemonProtocol {
         case devicesList = "/v1/devices/list"
     }
 
+    /// The multiplexed stream socket. Not a `Route`: it is a WebSocket upgrade
+    /// rather than a POST, and folding it into the route table would make
+    /// `everyRouteIsReachable` assert something untrue about it.
+    public static let streamPath = "/v1/stream"
+
     public struct DevicesResponse: Codable, Equatable, Sendable {
         public let devices: [Device]
         public init(devices: [Device]) { self.devices = devices }

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -4,6 +4,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1
 import NIOPosix
+import NIOWebSocket
 
 /// What a route needs from the rest of the app. A protocol so the socket tests
 /// drive the real HTTP stack against a scripted device list instead of
@@ -28,13 +29,29 @@ public actor DaemonServer {
         public let port: Int
     }
 
+    /// Named so the WebSocket upgrade can take it back out of the pipeline.
+    fileprivate static let routesHandlerName = "droidectived.routes"
+
+
     private let backend: any DaemonBackend
+    private let streamSource: (any StreamSource)?
     private let token: String
     private var group: MultiThreadedEventLoopGroup?
     private var channel: (any Channel)?
+    /// Live client connections.
+    ///
+    /// `shutdownGracefully` waits for every channel to close, and a stream
+    /// socket stays open until its client goes away — so without closing these
+    /// first, stopping the daemon while anything is subscribed never returns.
+    /// The UI kills the daemon on quit, so a stop that hangs is a stop that
+    /// gets SIGKILLed with adb children still running.
+    private let connections = ConnectionRegistry()
 
-    public init(backend: any DaemonBackend, token: String) {
+    public init(
+        backend: any DaemonBackend, token: String, streamSource: (any StreamSource)? = nil
+    ) {
         self.backend = backend
+        self.streamSource = streamSource
         self.token = token
     }
 
@@ -43,6 +60,7 @@ public actor DaemonServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.group = group
         let backend = self.backend
+        let streamSource = self.streamSource
         let token = self.token
         // Captured by the handler so `Host` can be pinned to the live port,
         // which is only known after bind.
@@ -51,10 +69,55 @@ public actor DaemonServer {
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(.backlog, value: 32)
             .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
-            .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline().flatMapThrowing {
+            .childChannelInitializer { [connections] channel in
+                connections.add(channel)
+                channel.closeFuture.whenComplete { _ in connections.remove(channel) }
+                // The stream socket rides the same listener as the routes, so
+                // there is one port, one token and one origin policy rather
+                // than two things to keep in agreement.
+                let upgrader = NIOWebSocketServerUpgrader(
+                    shouldUpgrade: { channel, head in
+                        // Auth on the *upgrade* request. Checking after the
+                        // handshake would leave an authenticated-looking socket
+                        // open to anything that can reach the port.
+                        let port = boundPort.withLockedValue { $0 }
+                        let refused = DaemonGuards.check(
+                            authorization: head.headers.first(name: "Authorization"),
+                            host: head.headers.first(name: "Host"),
+                            origin: head.headers.first(name: "Origin"),
+                            port: port, expectedToken: token)
+                        guard refused == nil, head.uri == DaemonProtocol.streamPath,
+                              streamSource != nil
+                        else { return channel.eventLoop.makeSucceededFuture(nil) }
+                        return channel.eventLoop.makeSucceededFuture(HTTPHeaders())
+                    },
+                    upgradePipelineHandler: { channel, _ in
+                        guard let streamSource else {
+                            return channel.eventLoop.makeSucceededFuture(())
+                        }
+                        // The route handler sits after the HTTP codec, which
+                        // NIO removes on upgrade — but not handlers added
+                        // behind it. Left in place it would be handed
+                        // WebSocket frames and trap trying to read them as
+                        // HTTP.
+                        return channel.pipeline.removeHandler(name: Self.routesHandlerName)
+                            .recover { _ in }
+                            .flatMap { _ -> EventLoopFuture<Void> in
+                                let session = StreamSession(
+                                    sink: WebSocketSink(channel: channel), source: streamSource)
+                                return channel.eventLoop.makeCompletedFuture {
+                                    try channel.pipeline.syncOperations.addHandler(
+                                        WebSocketHandler(session: session))
+                                }
+                            }
+                    })
+
+                return channel.pipeline.configureHTTPServerPipeline(
+                    withServerUpgrade: (upgraders: [upgrader], completionHandler: { _ in })
+                ).flatMapThrowing {
                     try channel.pipeline.syncOperations.addHandler(
-                        RequestHandler(backend: backend, token: token, port: boundPort))
+                        RequestHandler(backend: backend, token: token, port: boundPort),
+                        name: Self.routesHandlerName)
                 }
             }
 
@@ -68,16 +131,53 @@ public actor DaemonServer {
     }
 
     public func stop() async {
+        // Stop accepting first, then hang up on everyone still connected, then
+        // shut the loops down. Any other order either races new connections in
+        // or waits forever on old ones.
         try? await channel?.close().get()
         channel = nil
+        for connection in connections.drain() {
+            try? await connection.close().get()
+        }
         try? await group?.shutdownGracefully()
         group = nil
     }
 }
 
+/// Thread-safe set of open child channels. Identity-keyed, since `Channel` is
+/// a reference type with no useful equality of its own.
+private final class ConnectionRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var channels: [ObjectIdentifier: any Channel] = [:]
+
+    func add(_ channel: any Channel) {
+        lock.lock()
+        channels[ObjectIdentifier(channel)] = channel
+        lock.unlock()
+    }
+
+    func remove(_ channel: any Channel) {
+        lock.lock()
+        channels[ObjectIdentifier(channel)] = nil
+        lock.unlock()
+    }
+
+    /// Everything currently open, clearing the registry.
+    func drain() -> [any Channel] {
+        lock.lock()
+        defer {
+            channels.removeAll()
+            lock.unlock()
+        }
+        return Array(channels.values)
+    }
+}
+
 /// One request at a time per connection: collect the head, ignore the body
 /// (every route takes its arguments in the path for this slice), answer.
-private final class RequestHandler: ChannelInboundHandler, @unchecked Sendable {
+private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandler,
+    @unchecked Sendable
+{
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
@@ -154,6 +254,12 @@ private final class RequestHandler: ChannelInboundHandler, @unchecked Sendable {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "application/json")
         headers.add(name: "Content-Length", value: String(body.count))
+        // This handler closes the connection after every response, so say so.
+        // Without it a client pools the socket, reuses one the server has
+        // already dropped, and sees a lost connection instead of its answer —
+        // intermittent by nature, which is the worst kind of bug to ship in a
+        // tool people debug with.
+        headers.add(name: "Connection", value: "close")
         // No CORS headers, deliberately: nothing browser-based should be
         // reaching this, and advertising otherwise would undo the Origin check.
         context.write(

--- a/droidectived/Sources/DaemonCore/WebSocketBridge.swift
+++ b/droidectived/Sources/DaemonCore/WebSocketBridge.swift
@@ -1,0 +1,85 @@
+import Foundation
+import NIOCore
+import NIOWebSocket
+
+/// Carries a `StreamSession`'s frames onto a WebSocket channel.
+///
+/// Text frames only. The stream protocol is JSON, and accepting binary would
+/// mean a second encoding path with no client that wants it.
+final class WebSocketSink: StreamSink, @unchecked Sendable {
+    private let channel: any Channel
+
+    init(channel: any Channel) { self.channel = channel }
+
+    func send(_ text: String) async {
+        var buffer = channel.allocator.buffer(capacity: text.utf8.count)
+        buffer.writeString(text)
+        let frame = WebSocketFrame(fin: true, opcode: .text, data: buffer)
+        // Awaited, not fire-and-forget: this is what makes a slow client
+        // actually slow from the session's point of view, which is what makes
+        // the bounded buffer and its drop policy do their job. Firing and
+        // forgetting would move the unbounded queue into NIO instead.
+        try? await channel.writeAndFlush(frame).get()
+    }
+
+    func close() async {
+        try? await channel.close().get()
+    }
+}
+
+/// Feeds inbound frames to the session and keeps the connection honest.
+final class WebSocketHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = WebSocketFrame
+    typealias OutboundOut = WebSocketFrame
+
+    private let session: StreamSession
+    /// Reassembles continuation frames. A client is entitled to split a large
+    /// command across frames, and treating each fragment as a whole message
+    /// would reject perfectly legal traffic.
+    private var fragments = ""
+
+    init(session: StreamSession) { self.session = session }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let frame = unwrapInboundIn(data)
+        switch frame.opcode {
+        case .connectionClose:
+            let session = self.session
+            let channel = context.channel
+            Task {
+                await session.shutdown(reason: .unsubscribed)
+                try? await channel.close().get()
+            }
+        case .ping:
+            var response = frame
+            response.opcode = .pong
+            context.writeAndFlush(NIOAny(response), promise: nil)
+        case .text, .continuation:
+            // `unmaskedData`, never `data`: the RFC requires every
+            // client-to-server frame to be masked, so the raw buffer is XORed
+            // with the frame's key and reads as garbage. Getting this wrong
+            // does not fail loudly — the JSON simply never parses, and the
+            // client waits forever for a reply that cannot come.
+            var payload = frame.unmaskedData
+            fragments += payload.readString(length: payload.readableBytes) ?? ""
+            guard frame.fin else { return }
+            let message = fragments
+            fragments = ""
+            let session = self.session
+            Task { await session.handle(text: message) }
+        default:
+            // Binary and anything else: ignored rather than fatal. A confused
+            // client must not be able to kill the connection for the streams
+            // that are working.
+            break
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        // The socket went away without a close frame — tear the subscriptions
+        // down anyway, or their adb children outlive the client.
+        let session = self.session
+        Task { await session.shutdown(reason: .serverStopping) }
+        context.fireChannelInactive()
+    }
+}

--- a/droidectived/Sources/droidectived/main.swift
+++ b/droidectived/Sources/droidectived/main.swift
@@ -31,7 +31,10 @@ if let path = options.tokenFile {
 
 let locator = ToolLocator()
 let client = AdbClient(locator: locator)
-let server = DaemonServer(backend: LiveBackend(monitor: DeviceMonitor(client: client)), token: token)
+let monitor = DeviceMonitor(client: client)
+let server = DaemonServer(
+    backend: LiveBackend(monitor: monitor), token: token,
+    streamSource: LiveStreamSource(monitor: monitor, streamer: LogcatStreamer(client: client)))
 
 do {
     let bound = try await server.start(port: options.port)

--- a/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
@@ -1,0 +1,178 @@
+import ADBKit
+import Foundation
+import Testing
+
+@testable import DaemonCore
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Whether this host's Foundation ships a WebSocket client.
+private let hasWebSocketClient: Bool = {
+    #if canImport(Darwin)
+    return true
+    #else
+    return false
+    #endif
+}()
+
+/// Drives the stream socket end to end with a real WebSocket client. The
+/// session's logic is covered by `StreamSessionTests`; what this proves is that
+/// the upgrade, the auth on it, and the frame plumbing are actually wired up.
+///
+/// The **server** is portable NIO and runs everywhere. The *client* is not:
+/// corelibs-Foundation has no `URLSessionWebSocketTask` ("WebSockets not
+/// supported by libcurl"), so these are Apple-scoped. Note that leaving them
+/// enabled off-Darwin would be worse than skipping them — the two refusal
+/// cases assert that a throw happens, and the unsupported-client error is a
+/// throw, so they would pass for entirely the wrong reason.
+///
+/// Restoring Linux coverage needs a portable WebSocket client for tests; the
+/// raw-socket probe that found the masking bug is the obvious basis for one.
+/// Tracked in docs/cross-platform.md.
+@Suite(.timeLimit(.minutes(1)), .enabled(if: hasWebSocketClient)) struct WebSocketTests {
+    private struct StubBackend: DaemonBackend {
+        func listDevices() async -> [Device] { [] }
+    }
+
+    private struct FixedSource: StreamSource {
+        let devices: [Device]
+        func devices() async -> AsyncStream<[Device]> {
+            let value = devices
+            return AsyncStream { continuation in
+                continuation.yield(value)
+                continuation.finish()
+            }
+        }
+        func logcat(serial: String) async throws -> AsyncStream<[LogLine]> {
+            AsyncStream { $0.finish() }
+        }
+        func stopLogcat(serial: String) async {}
+    }
+
+    private static func device(_ serial: String) -> Device {
+        Device(
+            serial: serial, state: "device", model: nil, product: nil, transportId: nil,
+            label: serial, isWireless: false, platform: .android)
+    }
+
+    private func withServer(
+        _ body: (_ port: Int, _ token: String) async throws -> Void
+    ) async throws {
+        let token = DaemonToken.generate()
+        let server = DaemonServer(
+            backend: StubBackend(), token: token,
+            streamSource: FixedSource(devices: [Self.device("emulator-5554")]))
+        let bound = try await server.start(port: 0)
+        do { try await body(bound.port, token) } catch {
+            await server.stop()
+            throw error
+        }
+        await server.stop()
+    }
+
+    private func socket(port: Int, token: String?) -> URLSessionWebSocketTask {
+        var request = URLRequest(url: URL(string: "ws://127.0.0.1:\(port)/v1/stream")!)
+        if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        let task = URLSession.shared.webSocketTask(with: request)
+        task.resume()
+        return task
+    }
+
+    private struct ReceiveTimedOut: Error {}
+
+    /// Always bounded. A refused upgrade leaves `receive()` waiting on a socket
+    /// that will never answer, and a test that hangs is worse than one that
+    /// fails — it takes the whole suite with it.
+    private func receiveText(
+        _ task: URLSessionWebSocketTask, timeout: Duration = .seconds(10)
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                switch try await task.receive() {
+                case .string(let text): return text
+                case .data(let data): return String(decoding: data, as: UTF8.self)
+                @unknown default: return ""
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw ReceiveTimedOut()
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else { throw ReceiveTimedOut() }
+            return first
+        }
+    }
+
+    @Test func subscribesAndReceivesOverARealSocket() async throws {
+        try await withServer { port, token in
+            let task = socket(port: port, token: token)
+            defer { task.cancel(with: .goingAway, reason: nil) }
+
+            try await task.send(.string(#"{"op":"subscribe","id":1,"topic":"devices"}"#))
+
+            let ack = try await receiveText(task)
+            #expect(ack.contains(#""event":"subscribed""#))
+            let batch = try await receiveText(task)
+            #expect(batch.contains(#""event":"batch""#))
+            #expect(batch.contains("emulator-5554"))
+        }
+    }
+
+    @Test func refusesTheUpgradeWithoutAToken() async throws {
+        // The handshake itself must fail. Accepting the upgrade and only then
+        // checking would leave an authenticated-looking socket open to anything
+        // that can reach the port.
+        try await withServer { port, _ in
+            let task = socket(port: port, token: nil)
+            defer { task.cancel(with: .goingAway, reason: nil) }
+
+            // Only the bounded receive: `send` on a task whose upgrade was
+            // refused can block forever, before any receive deadline applies.
+            await #expect(throws: (any Error).self) {
+                _ = try await self.receiveText(task, timeout: .seconds(5))
+            }
+        }
+    }
+
+    @Test func refusesTheUpgradeWithAWrongToken() async throws {
+        try await withServer { port, _ in
+            let task = socket(port: port, token: DaemonToken.generate())
+            defer { task.cancel(with: .goingAway, reason: nil) }
+
+            await #expect(throws: (any Error).self) {
+                _ = try await self.receiveText(task, timeout: .seconds(5))
+            }
+        }
+    }
+
+    @Test func aMalformedCommandIsAnsweredAndTheSocketSurvives() async throws {
+        try await withServer { port, token in
+            let task = socket(port: port, token: token)
+            defer { task.cancel(with: .goingAway, reason: nil) }
+
+            try await task.send(.string("this is not json"))
+            let failure = try await receiveText(task)
+            #expect(failure.contains(#""event":"failed""#))
+
+            // Still usable — a buggy client must not wedge its own connection.
+            try await task.send(.string(#"{"op":"subscribe","id":2,"topic":"devices"}"#))
+            let ack = try await receiveText(task)
+            #expect(ack.contains(#""event":"subscribed""#))
+        }
+    }
+
+    @Test func theRoutesStillWorkAlongsideTheSocket() async throws {
+        // One listener serves both; adding the upgrader must not break POST.
+        try await withServer { port, token in
+            var request = URLRequest(
+                url: URL(string: "http://127.0.0.1:\(port)/v1/devices/list")!)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let (_, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        }
+    }
+}


### PR DESCRIPTION
The WebSocket transport for `droidectived`. This is the piece I refused to ship last time because I could not verify it — now verified, and it turned out to be hiding three real bugs.

## Three bugs, all found by insisting on verification

**1. Client frames were never unmasked.** The RFC requires every client-to-server frame to be masked, and NIO hands you the raw buffer. Reading `frame.data` instead of `frame.unmaskedData` meant every command arrived as XORed garbage.

It fails in the nastiest possible way: nothing errors, the JSON simply never parses, the client is answered `malformed command`, and then it waits forever for a reply that cannot come. **This is what was hanging the test suite — the tests were right and the code was wrong.**

I only found it by dropping out of the Swift harness entirely and writing a ~30-line raw-socket probe, because `swift test` would only ever say "hung". Worth remembering as a technique.

**2. The daemon could not shut down while a stream was connected.** `stop()` called `shutdownGracefully()`, which waits for every channel to close — and a stream socket stays open until its client leaves. So stopping the daemon with anything subscribed never returned. Since the UI kills the daemon on quit, that is a stop that gets SIGKILLed with adb children still running.

Fixed with a connection registry: stop accepting, hang up on everyone still connected, then shut the loops down. Any other order either races new connections in or waits forever on old ones.

**3. Responses closed the connection without saying so.** The route handler closes after every response but sent no `Connection: close`, so a client pools the socket, reuses one the server has already dropped, and gets "network connection was lost" instead of its answer. Intermittent by nature — the worst kind of bug to ship in a tool people debug with.

## The transport

One listener serves both the routes and the stream socket, so there is one port, one token and one origin policy rather than two things to keep in agreement.

- **Auth runs on the upgrade request**, not after. Accepting the handshake and checking later would leave an authenticated-looking socket open to anything that can reach the port.
- **The route handler is removed from the pipeline on upgrade.** NIO removes its own HTTP handlers but not ones added behind them; left in place it is handed WebSocket frames and traps trying to read them as HTTP.
- **`send` is awaited.** That is what makes a slow client genuinely slow from the session's point of view, which is what makes the bounded buffer and its drop policy do their job. Fire-and-forget would just move the unbounded queue into NIO.
- Continuation frames are reassembled, pings are answered, and an unexpected disconnect tears subscriptions down so adb children do not outlive the client.

`main.swift` now wires `LiveStreamSource`, so the shipped daemon actually serves streams rather than declining every upgrade.

## Verification

**52 tests, green on macOS and Linux** (Linux run locally in the `swift:6.2-noble` container, not just CI).

Plus an end-to-end check against the real built binary with a raw client:

    handshake: HTTP/1.1 101 Switching Protocols
    frame: {"event":"subscribed","id":1}

## One honest gap

Four tests need a WebSocket *client*, and corelibs-Foundation has none — `URLSessionWebSocketTask` reports "WebSockets not supported by libcurl". They are Apple-scoped.

Leaving them enabled off-Darwin would be **worse** than skipping them: the two refusal cases assert that a throw happens, and the unsupported-client error is itself a throw, so they would have passed for entirely the wrong reason.

The **server** is portable NIO and runs everywhere — only the harness is missing. A portable test client is now a tracked follow-up in `docs/cross-platform.md`, and the raw-socket probe above is the obvious basis for one.
