### PR TITLE
Expose the feature registry and action dispatch over HTTP

### DIFF
--- a/droidectived/Sources/DaemonCore/ActionRoutes.swift
+++ b/droidectived/Sources/DaemonCore/ActionRoutes.swift
@@ -1,0 +1,145 @@
+import ADBKit
+import Foundation
+
+/// Wire shapes for the feature surface.
+///
+/// Actions route straight through `FeatureEngine.run`, so the daemon carries
+/// **no feature knowledge of its own**: a new registry action is reachable over
+/// HTTP the day it lands, with no daemon change. That is the same property
+/// `implementedIDs` already gives the Mac app, and it is why this is a thin
+/// pass-through rather than a hand-maintained endpoint per action.
+public enum ActionProtocol {
+    /// A form field's value. JSON has no tagged unions, so this decodes from a
+    /// bare string, number or bool — what a UI would naturally send — rather
+    /// than demanding `{"type":"string","value":…}`.
+    public struct Value: Codable, Equatable, Sendable {
+        public let feature: FeatureValue
+
+        public init(_ feature: FeatureValue) { self.feature = feature }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            // Bool before number: `JSONDecoder` will happily read `true` as 1.
+            if let bool = try? container.decode(Bool.self) {
+                feature = .bool(bool)
+            } else if let number = try? container.decode(Double.self) {
+                feature = .number(number)
+            } else {
+                feature = .string(try container.decode(String.self))
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch feature {
+            case .string(let value): try container.encode(value)
+            case .number(let value): try container.encode(value)
+            case .bool(let value): try container.encode(value)
+            }
+        }
+    }
+
+    public struct RunRequest: Codable, Equatable, Sendable {
+        public let featureId: String
+        public let serial: String
+        /// Defaults to Android — the overwhelmingly common case, and omitting
+        /// it should not be an error for a client that only drives phones.
+        public let platform: String?
+        public let fields: [String: Value]?
+
+        public init(
+            featureId: String, serial: String, platform: String? = nil,
+            fields: [String: Value]? = nil
+        ) {
+            self.featureId = featureId
+            self.serial = serial
+            self.platform = platform
+            self.fields = fields
+        }
+
+        /// `nil` for an unrecognised platform string, so it is rejected rather
+        /// than silently treated as Android.
+        public var resolvedPlatform: DevicePlatform? {
+            switch platform {
+            case nil, "android": return .android
+            case "iosSimulator", "ios-simulator": return .iosSimulator
+            default: return nil
+            }
+        }
+
+        public var featureValues: [String: FeatureValue] {
+            (fields ?? [:]).mapValues(\.feature)
+        }
+    }
+
+    public struct RunResponse: Codable, Equatable, Sendable {
+        public let ok: Bool
+        public let message: String
+        public let copyText: String?
+        public let revealPath: String?
+        public let needsAdbKeyboard: Bool
+
+        public init(_ result: FeatureResult) {
+            ok = result.ok
+            message = result.message
+            copyText = result.copyText
+            revealPath = result.revealPath
+            needsAdbKeyboard = result.needsAdbKeyboard
+        }
+    }
+
+    /// A feature as a UI needs it: enough to render a row and a form, and
+    /// nothing that is Mac-specific.
+    public struct FeatureSummary: Codable, Equatable, Sendable {
+        public let id: String
+        public let title: String
+        public let subtitle: String?
+        public let category: String
+        public let kind: String
+        public let implemented: Bool
+        public let needsDevice: Bool
+        public let needsBundle: Bool
+        public let fields: [Field]
+
+        public struct Field: Codable, Equatable, Sendable {
+            public let name: String
+            public let label: String
+            public let control: String
+            public let options: [String]
+            public let placeholder: String?
+            public let optional: Bool
+        }
+    }
+
+    public struct FeaturesResponse: Codable, Equatable, Sendable {
+        public let features: [FeatureSummary]
+    }
+
+    /// The registry, flattened for the wire.
+    ///
+    /// `icon` is deliberately dropped: it is an SF Symbol name, which means
+    /// nothing off Apple, and shipping it would invite a web UI to depend on
+    /// something it cannot render.
+    public static func features() -> FeaturesResponse {
+        let implemented = FeatureEngine.implementedIDs
+        return FeaturesResponse(
+            features: FeatureRegistry.all.map { def in
+                FeatureSummary(
+                    id: def.id,
+                    title: def.title,
+                    subtitle: def.subtitle,
+                    category: String(describing: def.category),
+                    kind: String(describing: def.kind),
+                    implemented: implemented.contains(def.id),
+                    needsDevice: def.needsDevice,
+                    needsBundle: def.needsBundle,
+                    fields: def.fields.map { field in
+                        FeatureSummary.Field(
+                            name: field.name, label: field.label,
+                            control: String(describing: field.control),
+                            options: field.options.map(\.value),
+                            placeholder: field.placeholder, optional: field.optional)
+                    })
+            })
+    }
+}

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -9,6 +9,8 @@ public enum DaemonProtocol {
     /// `McpToolRegistry` and `FeatureRegistry` are tables.
     public enum Route: String, CaseIterable, Sendable {
         case devicesList = "/v1/devices/list"
+        case featuresList = "/v1/features/list"
+        case actionsRun = "/v1/actions/run"
     }
 
     /// The multiplexed stream socket. Not a `Route`: it is a WebSocket upgrade
@@ -64,6 +66,13 @@ public enum DaemonProtocol {
 
     public static let notFound = ErrorBody(
         code: "unknown_route", message: "No such endpoint.")
+    public static let badRequest = ErrorBody(
+        code: "bad_request", message: "The request body could not be read.")
+    public static let unknownFeature = ErrorBody(
+        code: "unknown_feature", message: "No such feature, or it has no runner.")
+    public static let unknownPlatform = ErrorBody(
+        code: "unknown_platform", message: "platform must be android or iosSimulator.")
+
     public static let methodNotAllowed = ErrorBody(
         code: "method_not_allowed", message: "Endpoints are POST.")
 

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -11,13 +11,33 @@ import NIOWebSocket
 /// requiring adb on the test host.
 public protocol DaemonBackend: Sendable {
     func listDevices() async -> [Device]
+    /// Runs a registry feature. The daemon holds no feature knowledge of its
+    /// own — this is a straight pass-through to `FeatureEngine`.
+    func runAction(
+        featureID: String, serial: String, platform: DevicePlatform,
+        params: [String: FeatureValue]
+    ) async -> FeatureResult
 }
 
 /// `DeviceMonitor` in production.
 public struct LiveBackend: DaemonBackend {
     private let monitor: DeviceMonitor
-    public init(monitor: DeviceMonitor) { self.monitor = monitor }
+    private let engine: FeatureEngine
+
+    public init(monitor: DeviceMonitor, engine: FeatureEngine) {
+        self.monitor = monitor
+        self.engine = engine
+    }
+
     public func listDevices() async -> [Device] { await monitor.list(force: true) }
+
+    public func runAction(
+        featureID: String, serial: String, platform: DevicePlatform,
+        params: [String: FeatureValue]
+    ) async -> FeatureResult {
+        await engine.run(
+            featureID: featureID, serial: serial, platform: platform, params: params)
+    }
 }
 
 /// Loopback HTTP for the request/response half of the protocol.
@@ -185,6 +205,7 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
     private let token: String
     private let port: NIOLockedValueBox<Int>
     private var head: HTTPRequestHead?
+    private var body = ByteBufferAllocator().buffer(capacity: 0)
 
     init(backend: any DaemonBackend, token: String, port: NIOLockedValueBox<Int>) {
         self.backend = backend
@@ -196,11 +217,13 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
         switch unwrapInboundIn(data) {
         case .head(let head):
             self.head = head
-        case .body:
-            break
+        case .body(var buffer):
+            body.writeBuffer(&buffer)
         case .end:
             guard let head else { return }
             self.head = nil
+            let body = self.body
+            self.body = ByteBufferAllocator().buffer(capacity: 0)
             let loop = context.eventLoop
             let boxedContext = NIOLoopBound(context, eventLoop: loop)
             let port = self.port.withLockedValue { $0 }
@@ -208,10 +231,10 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
             let token = self.token
             // The route is async; hop the answer back onto the event loop.
             Task { [self] in
-                let (status, body) = await Self.respond(
-                    head: head, port: port, token: token, backend: backend)
+                let (status, responseBody) = await Self.respond(
+                    head: head, body: body, port: port, token: token, backend: backend)
                 loop.execute {
-                    self.write(context: boxedContext.value, status: status, body: body)
+                    self.write(context: boxedContext.value, status: status, body: responseBody)
                 }
             }
         }
@@ -220,7 +243,8 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
     /// Pure-ish routing: guards, then the route. Split out so the socket tests
     /// and any future unit test exercise the same decision path.
     static func respond(
-        head: HTTPRequestHead, port: Int, token: String, backend: any DaemonBackend
+        head: HTTPRequestHead, body: ByteBuffer, port: Int, token: String,
+        backend: any DaemonBackend
     ) async -> (HTTPResponseStatus, Data) {
         func encoded(_ body: some Encodable) -> Data {
             (try? DaemonProtocol.encode(body)) ?? Data("{}".utf8)
@@ -247,6 +271,33 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
         case .devicesList:
             let devices = await backend.listDevices()
             return (.ok, encoded(DaemonProtocol.DevicesResponse(devices: devices)))
+
+        case .featuresList:
+            return (.ok, encoded(ActionProtocol.features()))
+
+        case .actionsRun:
+            let raw = Data(body.readableBytesView)
+            guard let request = try? JSONDecoder().decode(
+                ActionProtocol.RunRequest.self, from: raw)
+            else { return (.badRequest, encoded(DaemonProtocol.badRequest)) }
+            guard let platform = request.resolvedPlatform else {
+                return (.badRequest, encoded(DaemonProtocol.unknownPlatform))
+            }
+            // Unknown ids are a 404 rather than a 500: asking for a feature
+            // that does not exist is the client's mistake, not a daemon fault,
+            // and `run` would otherwise answer with a generic failure that a
+            // UI cannot distinguish from a device problem.
+            guard FeatureEngine.implementedIDs.contains(request.featureId) else {
+                return (.notFound, encoded(DaemonProtocol.unknownFeature))
+            }
+            let result = await backend.runAction(
+                featureID: request.featureId, serial: request.serial,
+                platform: platform, params: request.featureValues)
+            // A failed action is a *successful* request: 200 with ok=false.
+            // Mapping it to 5xx would conflate "the device said no" with "the
+            // daemon broke", which is the distinction `AdbClient` exists to
+            // preserve.
+            return (.ok, encoded(ActionProtocol.RunResponse(result)))
         }
     }
 

--- a/droidectived/Sources/droidectived/main.swift
+++ b/droidectived/Sources/droidectived/main.swift
@@ -32,8 +32,14 @@ if let path = options.tokenFile {
 let locator = ToolLocator()
 let client = AdbClient(locator: locator)
 let monitor = DeviceMonitor(client: client)
+// Same on-disk home as the Mac app, via ADBKit's own path helper — so a
+// developer running both does not end up with two divergent overrides files.
+let engine = FeatureEngine(
+    client: client, locator: locator, monitor: monitor,
+    overridesStore: JSONStore<OverridesMap>(filename: "overrides.json", default: [:]),
+    toolsDirectory: AppPaths.supportDir.appendingPathComponent("tools"))
 let server = DaemonServer(
-    backend: LiveBackend(monitor: monitor), token: token,
+    backend: LiveBackend(monitor: monitor, engine: engine), token: token,
     streamSource: LiveStreamSource(monitor: monitor, streamer: LogcatStreamer(client: client)))
 
 do {

--- a/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
@@ -1,0 +1,210 @@
+import ADBKit
+import Foundation
+import Testing
+
+@testable import DaemonCore
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// The action and feature routes, over a real socket.
+@Suite(.timeLimit(.minutes(1))) struct ActionRouteTests {
+    private actor CallLog {
+        private(set) var calls: [(id: String, serial: String, platform: DevicePlatform,
+                                 params: [String: FeatureValue])] = []
+        func record(
+            _ id: String, _ serial: String, _ platform: DevicePlatform,
+            _ params: [String: FeatureValue]
+        ) {
+            calls.append((id, serial, platform, params))
+        }
+        var count: Int { calls.count }
+        var last: (id: String, serial: String, platform: DevicePlatform,
+                   params: [String: FeatureValue])? { calls.last }
+    }
+
+    private struct RecordingBackend: DaemonBackend {
+        let log: CallLog
+        var result = FeatureResult(ok: true, message: "done")
+
+        func listDevices() async -> [Device] { [] }
+
+        func runAction(
+            featureID: String, serial: String, platform: DevicePlatform,
+            params: [String: FeatureValue]
+        ) async -> FeatureResult {
+            await log.record(featureID, serial, platform, params)
+            return result
+        }
+    }
+
+    private func withServer(
+        result: FeatureResult = FeatureResult(ok: true, message: "done"),
+        _ body: (_ port: Int, _ token: String, _ log: CallLog) async throws -> Void
+    ) async throws {
+        let token = DaemonToken.generate()
+        let log = CallLog()
+        let server = DaemonServer(
+            backend: RecordingBackend(log: log, result: result), token: token)
+        let bound = try await server.start(port: 0)
+        do { try await body(bound.port, token, log) } catch {
+            await server.stop()
+            throw error
+        }
+        await server.stop()
+    }
+
+    private func post(
+        port: Int, path: String, token: String, json: String? = nil
+    ) async throws -> (status: Int, body: String) {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let json { request.httpBody = Data(json.utf8) }
+        let (data, response) = try await URLSession.shared.data(for: request)
+        return (
+            (response as? HTTPURLResponse)?.statusCode ?? -1,
+            String(decoding: data, as: UTF8.self)
+        )
+    }
+
+    // MARK: features
+
+    @Test func listsEveryRegistryFeature() async throws {
+        try await withServer { port, token, _ in
+            let (status, body) = try await post(
+                port: port, path: "/v1/features/list", token: token)
+            #expect(status == 200)
+            let decoded = try JSONDecoder().decode(
+                ActionProtocol.FeaturesResponse.self, from: Data(body.utf8))
+            #expect(decoded.features.count == FeatureRegistry.all.count)
+            // SF Symbol names mean nothing off Apple; shipping them would
+            // invite a web UI to depend on something it cannot render.
+            #expect(!body.contains("\"icon\""))
+        }
+    }
+
+    @Test func marksWhichFeaturesActuallyHaveRunners() async throws {
+        try await withServer { port, token, _ in
+            let (_, body) = try await post(port: port, path: "/v1/features/list", token: token)
+            let decoded = try JSONDecoder().decode(
+                ActionProtocol.FeaturesResponse.self, from: Data(body.utf8))
+            let implemented = Set(decoded.features.filter(\.implemented).map(\.id))
+            #expect(implemented == FeatureEngine.implementedIDs)
+        }
+    }
+
+    // MARK: actions
+
+    @Test func runsAnActionThroughTheEngineUntouched() async throws {
+        // The daemon must add no feature knowledge: whatever the client sends
+        // is what `FeatureEngine` receives.
+        try await withServer { port, token, log in
+            let (status, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"""
+                    {"featureId":"dark-mode","serial":"emulator-5554",
+                     "fields":{"enabled":true,"count":3,"name":"x"}}
+                    """#)
+            #expect(status == 200)
+            #expect(body.contains(#""ok":true"#))
+
+            let call = try #require(await log.last)
+            #expect(call.id == "dark-mode")
+            #expect(call.serial == "emulator-5554")
+            #expect(call.platform == .android, "platform defaults to android")
+            // Bare JSON scalars decode to the right FeatureValue case; bool
+            // must not be read as the number 1.
+            #expect(call.params["enabled"] == .bool(true))
+            #expect(call.params["count"] == .number(3))
+            #expect(call.params["name"] == .string("x"))
+        }
+    }
+
+    @Test func aFailedActionIsStillA200() async throws {
+        // "The device said no" is not "the daemon broke" — collapsing them
+        // into a 5xx would destroy the distinction AdbClient exists to keep.
+        try await withServer(result: FeatureResult(ok: false, message: "device offline")) {
+            port, token, _ in
+            let (status, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"{"featureId":"dark-mode","serial":"x"}"#)
+            #expect(status == 200)
+            #expect(body.contains(#""ok":false"#))
+            #expect(body.contains("device offline"))
+        }
+    }
+
+    @Test func carriesTheResultsExtras() async throws {
+        try await withServer(
+            result: FeatureResult(
+                ok: true, message: "saved", copyText: "10.0.0.1",
+                revealPath: "/tmp/shot.png", needsAdbKeyboard: true)
+        ) { port, token, _ in
+            let (_, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"{"featureId":"dark-mode","serial":"x"}"#)
+            // Decoded, not substring-matched: JSON escapes `/` as `\/`, so a
+            // raw contains() on a path is a false negative waiting to happen.
+            let decoded = try JSONDecoder().decode(
+                ActionProtocol.RunResponse.self, from: Data(body.utf8))
+            #expect(decoded.copyText == "10.0.0.1")
+            #expect(decoded.revealPath == "/tmp/shot.png")
+            #expect(decoded.needsAdbKeyboard)
+        }
+    }
+
+    @Test func rejectsAnUnknownFeatureWithoutCallingTheEngine() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"{"featureId":"no-such-feature","serial":"x"}"#)
+            #expect(status == 404)
+            #expect(body.contains("unknown_feature"))
+            #expect(await log.count == 0, "an unknown id must not reach the engine")
+        }
+    }
+
+    @Test func rejectsAnUnknownPlatform() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"{"featureId":"dark-mode","serial":"x","platform":"windows-phone"}"#)
+            #expect(status == 400)
+            #expect(body.contains("unknown_platform"))
+            #expect(await log.count == 0)
+        }
+    }
+
+    @Test func acceptsTheIOSSimulatorPlatform() async throws {
+        try await withServer { port, token, log in
+            _ = try await post(
+                port: port, path: "/v1/actions/run", token: token,
+                json: #"{"featureId":"screenshot","serial":"UDID","platform":"iosSimulator"}"#)
+            #expect(await log.last?.platform == .iosSimulator)
+        }
+    }
+
+    @Test func rejectsAMalformedBody() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await post(
+                port: port, path: "/v1/actions/run", token: token, json: "{not json")
+            #expect(status == 400)
+            #expect(body.contains("bad_request"))
+            #expect(await log.count == 0)
+        }
+    }
+
+    @Test func actionsStillNeedTheToken() async throws {
+        try await withServer { port, _, log in
+            var request = URLRequest(
+                url: URL(string: "http://127.0.0.1:\(port)/v1/actions/run")!)
+            request.httpMethod = "POST"
+            request.httpBody = Data(#"{"featureId":"dark-mode","serial":"x"}"#.utf8)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            #expect((response as? HTTPURLResponse)?.statusCode == 401)
+            #expect(await log.count == 0)
+        }
+    }
+}

--- a/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
@@ -16,6 +16,13 @@ import FoundationNetworking
     private struct StubBackend: DaemonBackend {
         let devices: [Device]
         func listDevices() async -> [Device] { devices }
+        func runAction(
+            featureID: String, serial: String, platform: DevicePlatform,
+            params: [String: FeatureValue]
+        ) async -> FeatureResult {
+            FeatureResult(ok: true, message: "stub")
+        }
+
     }
 
     private static func device(_ serial: String) -> Device {
@@ -120,7 +127,13 @@ import FoundationNetworking
         try await withServer { port, token in
             for route in DaemonProtocol.Route.allCases {
                 let (status, _) = try await send(port: port, path: route.rawValue, token: token)
-                #expect(status == 200, "\(route.rawValue) is in the table but not routed")
+                // Reachable, not necessarily satisfied: routes that need a body
+                // answer 400 to this empty probe, and that still proves they
+                // are wired. Only 404/405 mean the table and the handler have
+                // drifted apart, which is what this guards.
+                #expect(
+                    status != 404 && status != 405,
+                    "\(route.rawValue) is in the table but not routed (\(status))")
             }
         }
     }

--- a/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
@@ -34,6 +34,13 @@ private let hasWebSocketClient: Bool = {
 @Suite(.timeLimit(.minutes(1)), .enabled(if: hasWebSocketClient)) struct WebSocketTests {
     private struct StubBackend: DaemonBackend {
         func listDevices() async -> [Device] { [] }
+        func runAction(
+            featureID: String, serial: String, platform: DevicePlatform,
+            params: [String: FeatureValue]
+        ) async -> FeatureResult {
+            FeatureResult(ok: true, message: "stub")
+        }
+
     }
 
     private struct FixedSource: StreamSource {


### PR DESCRIPTION
Two routes that between them make the whole feature surface reachable from a non-Swift UI.

- `POST /v1/features/list` — the registry, flattened
- `POST /v1/actions/run` — straight through to `FeatureEngine.run`

## The leverage

The daemon holds **no feature knowledge of its own**. `actions/run` is a pass-through, so a new registry action is reachable over HTTP the day it lands, with no daemon change — the same property `implementedIDs` already gives the Mac app. Verified against the real binary: **60 features listed, 55 reporting a runner.**

## Decisions worth a look

- **A failed action is a 200 with `ok:false`.** "The device said no" is not "the daemon broke". Mapping it to 5xx would destroy exactly the distinction `AdbClient` exists to preserve, and a UI could no longer tell a device problem from a daemon fault.
- **An unknown feature id is 404 and never reaches the engine.** Otherwise `run` answers with a generic failure that looks identical to a device error.
- **An unrecognised platform string is rejected, not defaulted.** Silently treating `"windows-phone"` as Android would run the wrong thing on the wrong device.
- **Field values decode from bare JSON scalars** — `true`, `3`, `"x"` — rather than demanding a tagged `{"type":…}` wrapper, because that is what a UI naturally sends. Bool is tried before number, since `JSONDecoder` will happily read `true` as `1`.
- **`icon` is deliberately not on the wire.** It is an SF Symbol name, meaningless off Apple, and shipping it would invite a web UI to depend on something it cannot render. A test asserts it stays out.

## Testing

11 new tests, **62 in the package**, green on macOS and Linux (Linux run locally in the container).

`everyRouteIsReachable` needed adjusting: it asserted every route returns 200, which stops being true once a route requires a body. It now asserts the route is *routed* — anything but 404/405 — since drift between the table and the handler is what it actually guards.

Also fixed a latent false-negative in my own new test: JSON escapes `/` as `\/`, so a substring check on a path would have silently passed forever. It decodes now.
