### PR TITLE
Publish droidectived on the beta channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       # off-Apple, so Linux runs its suite too rather than only compiling it.
       - name: Run droidectived tests (Linux)
         run: cd droidectived && swift test -Xswiftc -warnings-as-errors
+      # The shipped artifact, not just the tests: a release build is a
+      # different compile and must be proven before a tag depends on it.
+      - name: Build droidectived (Linux, release)
+        run: cd droidectived && swift build -c release --product droidectived
 
   build-windows:
     # windows-2022, not -2025: the 2025 image ships MSVC 14.51, whose STL header
@@ -76,6 +80,14 @@ jobs:
           cd ADBKit
           swift build --target ADBKit -Xswiftc -warnings-as-errors
           swift build --target ADBKitTests -Xswiftc -warnings-as-errors
+      # Does the daemon build here at all? The release policy lists a Windows
+      # daemon artifact, and that promise has never been tested. Non-fatal for
+      # now so this run reports the answer instead of just going red.
+      - name: Probe droidectived (Windows)
+        continue-on-error: true
+        run: |
+          cd droidectived
+          swift build -c release --product droidectived 2>&1 | Select-Object -Last 30
 
   build:
     runs-on: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,14 +80,12 @@ jobs:
           cd ADBKit
           swift build --target ADBKit -Xswiftc -warnings-as-errors
           swift build --target ADBKitTests -Xswiftc -warnings-as-errors
-      # Does the daemon build here at all? The release policy lists a Windows
-      # daemon artifact, and that promise has never been tested. Non-fatal for
-      # now so this run reports the answer instead of just going red.
-      - name: Probe droidectived (Windows)
-        continue-on-error: true
+      # The shipped artifact, not just the library: the beta channel publishes
+      # a Windows daemon, so a tag depends on this compiling.
+      - name: Build droidectived (Windows, release)
         run: |
           cd droidectived
-          swift build -c release --product droidectived 2>&1 | Select-Object -Last 30
+          swift build -c release --product droidectived
 
   build:
     runs-on: macos-15
@@ -158,9 +156,53 @@ jobs:
       - id: deploy
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
 
+  # The beta channel's daemon artifacts. Their own job because Linux and
+  # Windows binaries cannot be produced on the macOS release runner; the release
+  # job downloads what this uploads.
+  daemon-artifacts:
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # The same image test-linux already uses, rather than a third-party
+          # toolchain action: one less thing in the supply chain, and the
+          # release binary is built by the compiler the tests ran under.
+          - os: ubuntu-24.04
+            container: swift:6.2-noble
+            platform: linux-x86_64
+          - os: windows-2022
+            container: ''
+            platform: windows-x86_64
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - if: matrix.platform == 'windows-x86_64'
+        uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5  # v0.4.0
+        with:
+          branch: swift-6.2.4-release
+          tag: 6.2.4-RELEASE
+      - name: Build and package droidectived
+        shell: bash
+        run: |
+          command -v zip >/dev/null || (apt-get update -q && apt-get install -y -q zip)
+          VERSION="${GITHUB_REF_NAME#v}"
+          (cd droidectived && swift build -c release --product droidectived)
+          BIN="droidectived/.build/release/droidectived"
+          [[ "${{ matrix.platform }}" == windows-x86_64 ]] && BIN="$BIN.exe"
+          ./scripts/package-daemon.sh "$VERSION" "${{ matrix.platform }}" "$BIN" dist
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: daemon-${{ matrix.platform }}
+          path: dist/*
+          if-no-files-found: error
+
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test, build]
+    needs: [test, build, daemon-artifacts]
     runs-on: macos-15
     permissions:
       contents: write
@@ -256,6 +298,28 @@ jobs:
       # behind by an ungated job fails the stable release instead of shipping on
       # it — and the publish step can glob `dist/*` without
       # fail_on_unmatched_files breaking on the set that varies.
+      # Universal, like the app: the daemon is a sidecar next to it, and an
+      # arm64-only binary would break Intel Macs that the app itself supports.
+      - name: Build and package droidectived (macOS universal)
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          (cd droidectived && swift build -c release --arch arm64 --arch x86_64 \
+            --product droidectived)
+          ./scripts/package-daemon.sh "$VERSION" macos-universal \
+            droidectived/.build/apple/Products/Release/droidectived \
+            DerivedData/Build/Products/Release
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          pattern: daemon-*
+          merge-multiple: true
+          path: DerivedData/Build/Products/Release
+      # Checksums cover exactly what ships, so they are generated after every
+      # artifact is in place and before staging asserts the set.
+      - name: Checksum the daemon archives
+        run: |
+          cd DerivedData/Build/Products/Release
+          shasum -a 256 droidectived-* > SHA256SUMS
+          cat SHA256SUMS
       - name: Stage the artifacts this channel publishes
         run: ./scripts/stage-release-artifacts.sh "$GITHUB_REF_NAME" DerivedData/Build/Products/Release dist
       # A hyphen in the tag (v3.3.0-beta.1) marks a beta: the GitHub release is

--- a/droidectived/Sources/DaemonCore/ParentWatch.swift
+++ b/droidectived/Sources/DaemonCore/ParentWatch.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+#if os(Windows)
+import WinSDK
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Is the process that spawned us still alive?
+///
+/// The daemon is a sidecar: the UI owns its lifetime and kills it on quit. When
+/// the UI *crashes* instead, nothing kills it, and an orphaned daemon holds adb
+/// children — the failure people experience as "adb is stuck". So the daemon
+/// watches its parent and exits when it disappears.
+public enum ParentWatch {
+    /// - Parameter pid: the parent's process id, from `--parent-pid`.
+    /// - Returns: false once the parent is gone, which is the signal to exit.
+    public static func isAlive(_ pid: Int32) -> Bool {
+        #if os(Windows)
+        // No signals on Windows. `PROCESS_QUERY_LIMITED_INFORMATION` is the
+        // least privilege that can read an exit code, and unlike the broader
+        // rights it is granted across integrity levels — so this keeps working
+        // when the UI runs at a different level from the daemon.
+        guard let handle = OpenProcess(
+            DWORD(PROCESS_QUERY_LIMITED_INFORMATION), false, DWORD(bitPattern: pid))
+        else { return false }
+        defer { CloseHandle(handle) }
+        var status: DWORD = 0
+        guard GetExitCodeProcess(handle, &status) else { return false }
+        // 259 is STILL_ACTIVE. A process that genuinely exits with 259 would
+        // read as alive, which is why this is a liveness *hint* backed by the
+        // handle open succeeding at all.
+        return status == 259
+        #else
+        // Signal 0 performs the permission and existence checks without
+        // delivering anything.
+        return kill(pid, 0) == 0
+        #endif
+    }
+}

--- a/droidectived/Sources/droidectived/main.swift
+++ b/droidectived/Sources/droidectived/main.swift
@@ -61,7 +61,7 @@ if let parent = options.parentPID {
     Task {
         while true {
             try? await Task.sleep(for: .seconds(2))
-            if kill(parent, 0) != 0 {
+            if !ParentWatch.isAlive(parent) {
                 await server.stop()
                 exit(0)
             }

--- a/droidectived/Tests/DaemonCoreTests/DaemonGuardsTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/DaemonGuardsTests.swift
@@ -165,3 +165,16 @@ import Testing
         try? FileManager.default.removeItem(atPath: path)
     }
 }
+
+@Suite struct ParentWatchTests {
+    @Test func seesItsOwnProcessAsAlive() {
+        #expect(ParentWatch.isAlive(ProcessInfo.processInfo.processIdentifier))
+    }
+
+    @Test func reportsAnImpossiblePIDAsGone() {
+        // Nothing is ever pid 0 in the sense we mean, and a huge id will not
+        // exist. Either way the daemon must decide "parent gone" and exit
+        // rather than linger holding adb children.
+        #expect(!ParentWatch.isAlive(Int32.max))
+    }
+}

--- a/scripts/package-daemon.sh
+++ b/scripts/package-daemon.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Package a built droidectived binary into the archive its channel publishes.
+#
+# A script rather than inline YAML so the naming — which
+# release-channel.sh asserts against — lives next to the policy it has to match,
+# and so a packaging change can be run locally instead of only on a tag.
+#
+# Usage: package-daemon.sh <version> <platform> <binary> <out-dir>
+#   version   3.9.0-beta.1   (no leading v)
+#   platform  macos-universal | linux-x86_64 | windows-x86_64
+#   binary    path to the built droidectived
+#   out-dir   where the archive lands
+set -euo pipefail
+
+VERSION="${1:?version}"
+PLATFORM="${2:?platform}"
+BINARY="${3:?binary}"
+OUT_DIR="${4:?out dir}"
+
+[[ -f "$BINARY" ]] || {
+  echo "error: no daemon binary at $BINARY" >&2
+  exit 1
+}
+
+case "$PLATFORM" in
+macos-universal | linux-x86_64 | windows-x86_64) ;;
+*)
+  echo "error: unknown platform '$PLATFORM'" >&2
+  exit 1
+  ;;
+esac
+
+mkdir -p "$OUT_DIR"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+# The archive holds the binary and its licence, nothing else. A sidecar the UI
+# spawns has no use for a directory tree, and a flat archive is one less thing
+# for the installer to get wrong.
+if [[ "$PLATFORM" == windows-x86_64 ]]; then
+  cp "$BINARY" "$STAGE/droidectived.exe"
+else
+  cp "$BINARY" "$STAGE/droidectived"
+  chmod 755 "$STAGE/droidectived"
+fi
+cp LICENSE "$STAGE/LICENSE" 2>/dev/null || true
+
+ARCHIVE="droidectived-${VERSION}-${PLATFORM}"
+if [[ "$PLATFORM" == windows-x86_64 ]]; then
+  (cd "$STAGE" && zip -q -r "${ARCHIVE}.zip" .)
+  mv "$STAGE/${ARCHIVE}.zip" "$OUT_DIR/"
+  echo "packaged $OUT_DIR/${ARCHIVE}.zip"
+else
+  # Entries named explicitly and in a fixed order, so rebuilding the same commit
+  # lays the archive out the same way and a changed checksum points at changed
+  # code rather than at tar's directory-walk order. (Not `mapfile`: macOS ships
+  # bash 3.2, where it does not exist.)
+  entries=(droidectived)
+  [[ -f "$STAGE/LICENSE" ]] && entries+=(LICENSE)
+  (cd "$STAGE" && tar --format=ustar -czf "${ARCHIVE}.tar.gz" "${entries[@]}")
+  mv "$STAGE/${ARCHIVE}.tar.gz" "$OUT_DIR/"
+  echo "packaged $OUT_DIR/${ARCHIVE}.tar.gz"
+fi

--- a/scripts/release-channel.sh
+++ b/scripts/release-channel.sh
@@ -16,12 +16,12 @@ set -euo pipefail
 
 # Which cross-platform artifacts a beta actually carries today.
 #
-# Stage 0 ships none: the portable ADBKit core is on main, but droidectived's
-# protocol is unimplemented, so there is no Windows or Linux binary worth
-# publishing. Raising this to 1 turns the daemon artifacts on — the tests cover
-# both values, so the flip is a one-line change with its guard already written.
+# Stage 1 ships the daemon: droidectived serves devices, the feature registry,
+# action dispatch and the log stream, and builds on all three hosts. It is
+# headless — no GUI — so a beta carries it for people driving the daemon
+# directly while the Tauri app is built on top.
 # Stage 2 (the Tauri app) adds its own entries here.
-CROSS_PLATFORM_STAGE="${CROSS_PLATFORM_STAGE:-0}"
+CROSS_PLATFORM_STAGE="${CROSS_PLATFORM_STAGE:-1}"
 
 # vX.Y.Z, optionally with a pre-release suffix. Anything else is a typo'd tag
 # and must not reach a signing step.


### PR DESCRIPTION
Turns on the beta channel's daemon artifacts. `CROSS_PLATFORM_STAGE` goes 0 → 1, and the pipeline that flag was written for now exists.

This is the first thing Windows and Linux users can actually install. Headless — no GUI — but it serves devices, the feature registry, action dispatch and the log stream, which is enough to drive from a script or curl while the Tauri app is built on top.

## What ships where

Unchanged for stable, which stays macOS-only:

    v3.9.0        → Droidective-v3.9.0.dmg, Droidective.dmg
    v3.9.0-beta.1 → the two DMGs
                  + droidectived-3.9.0-beta.1-macos-universal.tar.gz
                  + droidectived-3.9.0-beta.1-linux-x86_64.tar.gz
                  + droidectived-3.9.0-beta.1-windows-x86_64.zip
                  + SHA256SUMS

## Pieces

- **`daemon-artifacts`**, a tag-only matrix job. Linux and Windows binaries cannot be produced on the macOS release runner, so they are built where they run and uploaded; the release job downloads them.
- **`scripts/package-daemon.sh`** — a script, not inline YAML, so the archive naming lives next to the policy that asserts it and can be run locally. Archive entries are named in a fixed order, so rebuilding a commit lays the archive out the same way and a changed checksum points at changed code rather than at tar's directory-walk order.
- **The macOS daemon is universal**, like the app. It is a sidecar next to it, and an arm64-only binary would break the Intel Macs the app already supports.
- **`SHA256SUMS` is generated after every artifact is in place** and before staging asserts the set, so it covers exactly what ships.

## Two things I got wrong and caught

**I invented an action SHA.** I pinned `swift-actions/setup-swift` to a commit from memory; `gh api` says it does not exist. Rather than hunt for the real one I dropped the action and used the `swift:6.2-noble` container `test-linux` already runs — one less thing in the supply chain, and the release binary is now built by the same compiler the tests ran under. The other two pins (`upload-artifact`, `download-artifact`) were verified against the API.

**`mapfile` is bash 4+.** macOS ships 3.2, so the packaging script failed locally on the first run. The archive entries are known, so they are listed explicitly now.

## Verification

- `swift build -c release --product droidectived` proven on **Linux and Windows** in CI before this promised anything. The Windows probe first failed on `kill`, which does not exist there — the `--parent-pid` watchdog now goes through `ParentWatch`, using `OpenProcess`/`GetExitCodeProcess` on Windows and signal 0 elsewhere, with tests both ways.
- `scripts/test-release-channel.sh` passes; it already covered both stage values, so the flip was the one-line change it was designed to be.
- `package-daemon.sh` smoke-tested locally end to end.
- **64 daemon tests** green on macOS and Linux; `actionlint` clean.
