### PR TITLE
Run the ADBKit suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      # Compile-only, but only 3 tests short of running. Moving MCP to its own
-      # package (#231) let `swift test` discover and run all 1375 tests here;
-      # successive passes took the failures from 14 to 3. The remainder is
-      # tracked in docs/cross-platform.md. Flip this to `swift test` in the
-      # change that clears them, so the job never lands red.
-      - name: Build ADBKit and its tests (Windows)
+      - name: Run ADBKit tests (Windows)
         run: |
           cd ADBKit
-          swift build --target ADBKit -Xswiftc -warnings-as-errors
-          swift build --target ADBKitTests -Xswiftc -warnings-as-errors
+          swift test -Xswiftc -warnings-as-errors
       # The shipped artifact, not just the library: the beta channel publishes
       # a Windows daemon, so a tag depends on this compiling.
       - name: Build droidectived (Windows, release)

--- a/ADBKit/Sources/ADBKit/Exec/SystemProcessRunner.swift
+++ b/ADBKit/Sources/ADBKit/Exec/SystemProcessRunner.swift
@@ -86,8 +86,24 @@ public struct SystemProcessRunner: ProcessRunning {
                 let resumed = LockedBox(false)
                 process.terminationHandler = { finished in
                     guard !resumed.swap(true) else { return }
+                    #if os(Windows)
+                    // Windows has no signals, so `.uncaughtSignal` is not a
+                    // state a child can reach — and corelibs reports a
+                    // non-`.exit` reason for an ordinary non-zero exit just as
+                    // it does for a TerminateProcess kill, so the reason
+                    // cannot tell those apart. (`exit /b 3` came back with no
+                    // exit code at all, while its stderr arrived intact.)
+                    //
+                    // We already know which kills are ours: the watchdog and
+                    // the cancellation handler each raise a flag before
+                    // terminating. Trust those, and take the status at face
+                    // value otherwise.
+                    let killed = timedOut.get() || cancelled.get()
+                    continuation.resume(returning: killed ? nil : finished.terminationStatus)
+                    #else
                     let exited = finished.terminationReason == .exit
                     continuation.resume(returning: exited ? finished.terminationStatus : nil)
+                    #endif
                 }
                 do {
                     try process.run()

--- a/ADBKit/Tests/ADBKitTests/ApkInspectionServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApkInspectionServiceTests.swift
@@ -117,13 +117,12 @@ import Testing
         try fm.createDirectory(at: buildTools.appendingPathComponent("lib"), withIntermediateDirectories: true)
         // `executableName` appends `.exe` on Windows, which is what the real
         // SDK ships and what the locator looks for; a no-op on POSIX.
-        let exec: [FileAttributeKey: Any] = [.posixPermissions: 0o755]
         let aapt2 = buildTools.appendingPathComponent(ToolLocator.executableName("aapt2"))
-        _ = fm.createFile(atPath: aapt2.path, contents: Data("#!/bin/sh\n".utf8), attributes: exec)
+        try createExecutableStub(at: aapt2)
         let jar = buildTools.appendingPathComponent("lib/apksigner.jar")
         _ = fm.createFile(atPath: jar.path, contents: Data())
         let java = base.appendingPathComponent(ToolLocator.executableName("java"))
-        _ = fm.createFile(atPath: java.path, contents: Data("#!/bin/sh\n".utf8), attributes: exec)
+        try createExecutableStub(at: java)
         return (buildTools.path, aapt2.path, jar.path, java.path)
     }
 }

--- a/ADBKit/Tests/ADBKitTests/ApkSigningServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ApkSigningServiceTests.swift
@@ -103,11 +103,11 @@ import Testing
         try fm.createDirectory(at: buildTools.appendingPathComponent("lib"), withIntermediateDirectories: true)
         // `executableName` appends `.exe` on Windows, which is what the real
         // SDK ships and what the locator looks for; a no-op on POSIX.
-        let exec: [FileAttributeKey: Any] = [.posixPermissions: 0o755]
-        _ = fm.createFile(atPath: buildTools.appendingPathComponent(ToolLocator.executableName("zipalign")).path, contents: Data("#!/bin/sh\n".utf8), attributes: exec)
+        try createExecutableStub(
+            at: buildTools.appendingPathComponent(ToolLocator.executableName("zipalign")))
         _ = fm.createFile(atPath: buildTools.appendingPathComponent("lib/apksigner.jar").path, contents: Data())
         let java = base.appendingPathComponent(ToolLocator.executableName("java"))
-        _ = fm.createFile(atPath: java.path, contents: Data("#!/bin/sh\n".utf8), attributes: exec)
+        try createExecutableStub(at: java)
         return (buildTools.path, java.path)
     }
 }

--- a/ADBKit/Tests/ADBKitTests/MockProcessRunner.swift
+++ b/ADBKit/Tests/ADBKitTests/MockProcessRunner.swift
@@ -58,3 +58,40 @@ func makeTempOverridesStore() -> JSONStore<OverridesMap> {
         .appendingPathComponent("adbkit-overrides-\(UUID().uuidString)")
     return JSONStore(filename: "overrides.json", default: [:], directory: dir)
 }
+
+/// A stub binary at `url` that the host's own `isExecutableFile` will accept.
+///
+/// On Windows that has to be a real PE image. `isExecutableFile` there asks
+/// Windows what kind of binary the file is, so a shell script named `.exe` is
+/// not executable and every SDK tool "resolves" as missing — which surfaces
+/// far away, as a nil package name rather than as a missing tool. Copying a
+/// system binary keeps the real predicate (the one production uses) under
+/// test instead of stubbing out the resolution the test exists to exercise;
+/// `MockProcessRunner` intercepts the spawn, so the stub is never run.
+func createExecutableStub(at url: URL) throws {
+    let fm = FileManager.default
+    #if os(Windows)
+    let source = ProcessInfo.processInfo.environment["ComSpec"]
+        ?? #"C:\Windows\System32\cmd.exe"#
+    try? fm.removeItem(at: url)
+    try fm.copyItem(atPath: source, toPath: url.path)
+    #else
+    _ = fm.createFile(
+        atPath: url.path, contents: Data("#!/bin/sh\n".utf8),
+        attributes: [.posixPermissions: 0o755])
+    #endif
+    // Checked rather than assumed: a stub the host declines to call
+    // executable makes the tool resolve as missing, and the resulting failure
+    // names neither the stub nor the tool.
+    guard fm.isExecutableFile(atPath: url.path) else {
+        throw StubNotExecutable(path: url.path, exists: fm.fileExists(atPath: url.path))
+    }
+}
+
+struct StubNotExecutable: Error, CustomStringConvertible {
+    let path: String
+    let exists: Bool
+    var description: String {
+        "the host does not consider \(path) executable (file exists: \(exists))"
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ pane per feature. Swift 6 + SwiftUI, macOS 14+.
 
 Two layers, strictly separated so a second **Apple** UI (iPad/visionOS) could
 reuse ADBKit almost as-is. The Windows/Linux port is now scheduled and staged
-(strategy + phases in `docs/cross-platform.md`): ADBKit compiles and tests on
-Linux (CI `test-linux`; `make test-linux` locally) and build-verifies on
+(strategy + phases in `docs/cross-platform.md`): ADBKit compiles and runs its
+whole suite on Linux (CI `test-linux`; `make test-linux` locally) and on
 Windows (CI `build-windows`). The Apple-bound subsystems — the Mirror media
 stack, the Network.framework servers (Reactotron, the JS-console test fake),
 `NSDataDetector`, `proc_pid_rusage` — are `#if canImport`-gated out rather than

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -6,9 +6,9 @@ The port strategy, what is already true on `main`, and what comes next.
 
 Three layers; the top one is per-platform, everything under it is shared Swift:
 
-1. **ADBKit** (the existing core) — compiles and tests on macOS and Linux, and
-   build-verifies on Windows. All adb logic, parsers, and services live here.
-2. **`droidectived`** (phase 2, not yet built) — a small local daemon target
+1. **ADBKit** (the existing core) — compiles and tests on macOS, Linux and
+   Windows. All adb logic, parsers, and services live here.
+2. **`droidectived`** (phase 2, landed) — a small local daemon target
    exposing ADBKit over localhost HTTP + WebSocket JSON so a non-Swift UI can
    drive it. It doubles as the remote-host protocol an iOS companion would
    need someday.
@@ -25,9 +25,9 @@ stack is mature. Rewriting the core in another language would throw away the
 ## Phase 1 (landed): a portable core
 
 `cd ADBKit && swift test` passes on Linux — CI runs the same suite in a
-`swift:6.2` container (`test-linux`) — and Windows compiles the library and
-test target (`build-windows`; running the tests there waits on a Windows audit
-of the process-spawning tests, which hardcode POSIX paths).
+`swift:6.2` container (`test-linux`) — and on Windows, where `build-windows`
+now runs it rather than only compiling it. All three hosts run the same
+suite.
 
 Apple-only subsystems are compile-gated with `#if canImport(...)`, not
 stubbed — a platform that can't mirror simply doesn't expose the type:
@@ -89,10 +89,9 @@ any that is not inside a matching `#if canImport(...)` gate. Its allowlist is
 empty, and a companion test fails on a stale entry, so debt cannot be excused
 and then quietly forgotten.
 
-## Phase 2: `droidectived`
+## Phase 2 (landed): `droidectived`
 
-**Full protocol design: `droidectived-protocol.md`** (written, not implemented —
-review it before any code lands). Sketch:
+**Full protocol design and current state: `droidectived-protocol.md`.** Shape:
 
 - An executable target in ADBKit's package; `swift build` produces it on
   Linux/Windows (static-musl is an option on Linux).
@@ -157,20 +156,21 @@ sidecar, then `cargo fmt`/`clippy`/`test` on Linux).
       drop-oldest buffer with its gap marker
 - [ ] Portable fake CDP server so the JSConsoleClient wire tests run on Linux
 - [ ] Reactotron listener off Network.framework (SwiftNIO or raw sockets)
-- [ ] Windows: fix the last 3 tests, then flip `build-windows` to `swift test`.
-      The suite runs there now (1375 discovered); failures went 14 → 3.
-      Remaining, with the leading hypothesis for each:
-      (1) `capturesStderrAndNonZeroExit` — the child still fails to launch.
-      `ChildCommands` writes a temp `.cmd` and passes `url.path`, but Foundation
-      on Windows renders `URL.path` POSIX-style (`/C:/Users/…`), which cmd
-      cannot open. Build the path as a `String` with backslashes from `%TEMP%`
-      instead of going through `URL`.
-      (2)+(3) `ApkInspectionServiceTests` / `ApkSigningServiceTests` still
-      report `toolMissing` even though `buildToolBinary` now appends `.exe` and
-      the fixtures create `.exe` files. Next thing to check is
-      `FileManager.isExecutableFile` on Windows — the fixtures write shell-script
-      text into a file named `.exe`, and it may validate the PE image (or
-      consult PATHEXT) rather than just testing for readability.
+- [x] Windows: the last 3 tests, and `build-windows` flipped to `swift test`.
+      Both causes turned out to be different from the standing hypotheses, and
+      both were found by running the suite there and reading the output rather
+      than reasoning about it:
+      (1) `capturesStderrAndNonZeroExit` was not a launch failure — the child
+      ran and its stderr arrived intact. `SystemProcessRunner` nils the exit
+      code unless `terminationReason == .exit`, and corelibs reports a
+      non-`.exit` reason on Windows for an ordinary non-zero exit as readily as
+      for a TerminateProcess kill. Since Windows has no signals, the reason
+      cannot separate the two; the runner now trusts the flags it already sets
+      before killing a child. Gated, so POSIX is untouched.
+      (2)+(3) The APK suites' seeded tools never resolved, because
+      `isExecutableFile` on Windows asks what kind of binary a file is and a
+      shell script named `aapt2.exe` is not one. The fixtures now copy a real
+      system binary there, which keeps the production predicate under test.
 - [ ] Windows: xz decode for frida assets; `HostNetwork` via GetAdaptersAddresses
 - [ ] Linux: interface ranking in `HostNetwork.pickPrimary` (en*/eth*/wl* over docker0/veth)
 - [ ] API client: portable expectations for `URLSessionTransport` so


### PR DESCRIPTION
Clears the last three Windows test failures and flips `build-windows` from
`swift build` to `swift test`. All three hosts now run the same suite:
**1559 tests green on Windows**, 1639 on macOS, and Linux unchanged.

Both causes turned out to be different from the hypotheses recorded in
`docs/cross-platform.md`. I ran the suite on Windows first and read the
output rather than fixing from the notes — worth it, because the notes
pointed at the wrong layer in both cases.

## 1. The exit code, not the launch

`capturesStderrAndNonZeroExit` was filed as "the child still fails to
launch", with a suspected `URL.path` problem in the temp `.cmd` the fixture
writes. It reported exactly one failure — `exitCode → nil` — while the
assertion on the child's stderr passed. The child ran fine and wrote `oops`;
only the reading of its result was wrong.

`SystemProcessRunner` nils the exit code unless `terminationReason == .exit`,
and corelibs reports a non-`.exit` reason on Windows for an ordinary non-zero
exit exactly as it does for a TerminateProcess kill. `cmd /c echo` (exit 0)
passed all along, which is what made this look like a launch failure.

Windows has no signals, so `.uncaughtSignal` is not a state a child can reach
and the reason cannot separate "exited 3" from "we killed it". The runner
already knows which kills are its own — the watchdog and the cancellation
handler each raise a flag before terminating — so those decide instead.
Gated, so the macOS and Linux path is byte-identical.

## 2. A stub Windows would not call executable

The APK suites seed a fake build-tools directory and assert on the argument
vectors the services build. On Windows the seeded tools never resolved, so
both services took their tool-missing path and failed far from the cause: a
nil package name in one, a `toolMissing` throw in the other.

`isExecutableFile` on Windows asks what kind of binary a file is, and a shell
script named `aapt2.exe` is not one. The stub is now a copy of a real system
binary there, which keeps the production predicate under test rather than
stubbing out the resolution these tests exist to exercise; MockProcessRunner
intercepts the spawn, so the stub is never run.

The shared helper also checks its own work and throws a named error, because
a fixture that quietly fails this precondition reports it three layers away
as something unrelated.

## Notes

No shipping macOS behaviour changes: the one runtime edit is inside
`#if os(Windows)`, and the rest is test fixtures, CI and docs.