### PR TITLE
Browse and control installed apps from the desktop app

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppsExplorerService.swift
@@ -5,6 +5,15 @@ public struct AppListing: Sendable, Equatable, Identifiable {
     public let versionName: String?
     public let isSystem: Bool
 
+    /// The memberwise initialiser is internal to this package, so callers
+    /// outside it — `droidectived`'s tests build listings with no device —
+    /// need one that is not.
+    public init(packageId: String, versionName: String?, isSystem: Bool) {
+        self.packageId = packageId
+        self.versionName = versionName
+        self.isSystem = isSystem
+    }
+
     public var id: String { packageId }
     /// Display name derived from the package id ("weather" → "Weather").
     public var displayName: String { Self.displayName(for: packageId) }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -53,11 +53,23 @@ resolves. It is gitignored — build it, do not commit it.
 ## What works so far
 
 Device picker, the action palette (search, forms, toggles, destructive
-confirmation), and live logcat with visible gap markers.
+confirmation), the installed-app browser with its verbs, and live logcat with
+visible gap markers.
 
-Not yet: the full-screen view features (file explorer, apps, crash catcher,
-performance…), which are `kind: "view"` in the registry and need whole panels
-rather than a form. They are filtered out of the palette rather than shown as
+The app chosen in **Apps** is the app the palette acts on: a `needsBundle`
+feature (Monkey) is disabled until one is picked, and every other action gets
+it as optional context — the rule `AppState.run` applies on the Mac. The
+choice is owned by `App.tsx`, not the Apps pane, so switching tabs keeps it
+and switching *device* drops it.
+
+Rough edge: the app list is re-fetched whenever the Apps tab is opened, since
+the pane remounts. It is a `dumpsys package packages` parse, so that is a
+second or two each time — worth lifting into shared state if it starts to
+grate.
+
+Not yet: the remaining full-screen view features (file explorer, crash
+catcher, performance…), which are `kind: "view"` in the registry and need
+whole panels rather than a form. They are filtered out of the palette rather than shown as
 dead rows. Hub members *are* listed standalone — this app has no hub screens,
 and they are most of the runnable surface.
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -11,7 +11,10 @@ use tauri::ipc::Channel;
 use tauri::State;
 
 use crate::daemon::stream::StreamMessage;
-use crate::daemon::wire::{Device, FeatureSummary, RunRequest, RunResponse, SubscribeParams};
+use crate::daemon::wire::{
+    AppControlRequest, AppsResponse, Device, FeatureSummary, RunRequest, RunResponse,
+    SubscribeParams,
+};
 use crate::daemon::{DaemonStatus, Supervisor};
 use crate::error::DaemonError;
 
@@ -84,6 +87,32 @@ pub async fn run_action(
             serial: args.serial,
             platform: args.platform,
             fields: args.fields,
+        })
+        .await
+}
+
+#[tauri::command]
+pub async fn list_apps(
+    supervisor: State<'_, Supervisor>,
+    serial: String,
+) -> Result<AppsResponse, DaemonError> {
+    supervisor.client().await?.list_apps(serial).await
+}
+
+#[tauri::command]
+pub async fn control_app(
+    supervisor: State<'_, Supervisor>,
+    serial: String,
+    package_id: String,
+    action: String,
+) -> Result<RunResponse, DaemonError> {
+    supervisor
+        .client()
+        .await?
+        .control_app(&AppControlRequest {
+            serial,
+            package_id,
+            action,
         })
         .await
 }

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -4,8 +4,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::daemon::wire::{
-    Device, DevicesResponse, ErrorEnvelope, FeatureSummary, FeaturesResponse, RunRequest,
-    RunResponse,
+    AppControlRequest, AppsListRequest, AppsResponse, Device, DevicesResponse, ErrorEnvelope,
+    FeatureSummary, FeaturesResponse, RunRequest, RunResponse,
 };
 use crate::error::DaemonError;
 
@@ -45,6 +45,18 @@ impl DaemonClient {
 
     pub async fn run_action(&self, request: &RunRequest) -> Result<RunResponse, DaemonError> {
         self.post("/v1/actions/run", request).await
+    }
+
+    pub async fn list_apps(&self, serial: String) -> Result<AppsResponse, DaemonError> {
+        self.post("/v1/apps/list", &AppsListRequest { serial })
+            .await
+    }
+
+    pub async fn control_app(
+        &self,
+        request: &AppControlRequest,
+    ) -> Result<RunResponse, DaemonError> {
+        self.post("/v1/apps/control", request).await
     }
 
     /// One request path, so every route shares one error contract.

--- a/desktop/src-tauri/src/daemon/wire.rs
+++ b/desktop/src-tauri/src/daemon/wire.rs
@@ -114,6 +114,52 @@ pub struct RunResponse {
     pub needs_adb_keyboard: bool,
 }
 
+/// One installed app, as `/v1/apps/list` sends it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSummary {
+    #[serde(rename = "packageId")]
+    pub package_id: String,
+    /// Derived from the package id by the daemon, so this client does not
+    /// reimplement the rule and then drift from it.
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "versionName")]
+    pub version_name: Option<String>,
+    #[serde(rename = "isSystem")]
+    pub is_system: bool,
+}
+
+/// A verb the daemon accepts, with its own destructive flag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppActionDescriptor {
+    pub id: String,
+    #[serde(rename = "isDestructive")]
+    pub is_destructive: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppsResponse {
+    pub apps: Vec<AppSummary>,
+    /// Sent with the list, so the UI offers exactly the verbs the daemon runs.
+    pub actions: Vec<AppActionDescriptor>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppsListRequest {
+    pub serial: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppControlRequest {
+    pub serial: String,
+    #[serde(rename = "packageId")]
+    pub package_id: String,
+    /// An `AppControlService.AppAction` raw value. A string rather than an
+    /// enum: the daemon owns the verb list and rejects an unknown one, so
+    /// mirroring it here would only add a place to fall behind.
+    pub action: String,
+}
+
 /// `{"error":{"code":…,"message":…,"detail":…}}`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ErrorEnvelope {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ pub fn run() -> tauri::Result<()> {
             commands::list_devices,
             commands::list_features,
             commands::run_action,
+            commands::list_apps,
+            commands::control_app,
             commands::watch_devices,
             commands::watch_logcat,
             commands::stop_watching,

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,17 +1,29 @@
-import { useState } from "react"
-import { ScrollText, Zap, type LucideIcon } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Boxes, ScrollText, Zap, type LucideIcon } from "lucide-react"
 import { ActionsPane } from "@/components/ActionsPane"
+import { AppsPane } from "@/components/AppsPane"
 import { Banner } from "@/components/Controls"
 import { DeviceBar } from "@/components/DeviceBar"
 import { LogcatPane } from "@/components/LogcatPane"
 import { useSession } from "@/hooks/useSession"
 import { cn } from "@/lib/cn"
 
-type Tab = "actions" | "logcat"
+type Tab = "actions" | "apps" | "logcat"
 
 export function App() {
   const session = useSession()
   const [tab, setTab] = useState<Tab>("actions")
+  // Lifted out of the Apps pane: a `needsBundle` action in the palette needs
+  // the same choice, so it cannot live inside one tab.
+  const [packageId, setPackageId] = useState<string | null>(null)
+
+  // A package id means nothing on a different device, so the choice is
+  // dropped when the selection changes — here, where it is owned, rather than
+  // in the pane that happens to set it.
+  const serial = session.selected?.serial ?? null
+  useEffect(() => {
+    setPackageId(null)
+  }, [serial])
 
   if (session.status.state === "starting") {
     return <Splash>Starting droidectived…</Splash>
@@ -47,6 +59,15 @@ export function App() {
           Actions
         </TabButton>
         <TabButton
+          active={tab === "apps"}
+          icon={Boxes}
+          onClick={() => {
+            setTab("apps")
+          }}
+        >
+          Apps
+        </TabButton>
+        <TabButton
           active={tab === "logcat"}
           icon={ScrollText}
           onClick={() => {
@@ -64,7 +85,13 @@ export function App() {
       ) : null}
 
       {tab === "actions" ? (
-        <ActionsPane features={session.features} device={session.selected} />
+        <ActionsPane
+          features={session.features}
+          device={session.selected}
+          packageId={packageId}
+        />
+      ) : tab === "apps" ? (
+        <AppsPane device={session.selected} selected={packageId} onSelect={setPackageId} />
       ) : (
         <LogcatPane device={session.selected} />
       )}

--- a/desktop/src/components/ActionForm.tsx
+++ b/desktop/src/components/ActionForm.tsx
@@ -6,7 +6,16 @@ import { coerce, initialValues, missingRequired, runFields, type FormValues } fr
 import type { DaemonError, Device, FeatureField, FeatureSummary, RunResponse } from "@/lib/wire"
 
 /** The detail pane: a feature's parameters, a Run button, and what came back. */
-export function ActionForm({ feature, device }: { feature: FeatureSummary; device: Device | null }) {
+export function ActionForm({
+  feature,
+  device,
+  packageId,
+}: {
+  feature: FeatureSummary
+  device: Device | null
+  /** The app chosen in the Apps tab, if any. */
+  packageId: string | null
+}) {
   // Re-keyed by feature id from the parent, so state resets when the
   // selection changes rather than leaking one feature's input into the next.
   const [values, setValues] = useState<FormValues>(() => initialValues(feature))
@@ -18,7 +27,8 @@ export function ActionForm({ feature, device }: { feature: FeatureSummary; devic
 
   const missing = useMemo(() => missingRequired(feature, values), [feature, values])
   const ready = device?.state === "device"
-  const Icon = iconForCategory(feature.category)
+  // The registry says this one acts on an app, and nothing has been chosen.
+  const needsApp = feature.needsBundle && packageId === null
 
   const run = async () => {
     if (feature.isDestructive && !confirming) {
@@ -31,7 +41,7 @@ export function ActionForm({ feature, device }: { feature: FeatureSummary; devic
     setResult(null)
     setError(null)
     try {
-      const fields = runFields(feature, values, toggleOn)
+      const fields = runFields(feature, values, toggleOn, packageId)
       setResult(
         await runAction({
           featureId: feature.id,
@@ -49,19 +59,7 @@ export function ActionForm({ feature, device }: { feature: FeatureSummary; devic
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-y-auto p-6">
-      <header className="flex items-start gap-3">
-        <Icon size={22} className="mt-0.5 shrink-0 text-accent" />
-        <div className="min-w-0">
-          <h2 className="text-[17px] font-semibold text-text-primary" data-selectable>
-            {feature.title}
-          </h2>
-          {feature.subtitle ? (
-            <p className="mt-0.5 text-text-secondary" data-selectable>
-              {feature.subtitle}
-            </p>
-          ) : null}
-        </div>
-      </header>
+      <FeatureHeader feature={feature} />
 
       {feature.kind === "toggleAction" || feature.fields.length > 0 ? (
         <div className="flex flex-col gap-4 rounded-lg border border-border-subtle bg-bg-surface p-4">
@@ -84,10 +82,11 @@ export function ActionForm({ feature, device }: { feature: FeatureSummary; devic
       <RunControls
         label={running ? "Running…" : confirming ? "Really run it?" : "Run"}
         tone={feature.isDestructive ? "danger" : "primary"}
-        disabled={running || !ready || missing.length > 0}
+        disabled={running || !ready || needsApp || missing.length > 0}
         device={device}
         ready={ready}
         missing={missing}
+        needsApp={needsApp}
         confirming={confirming}
         onRun={() => void run()}
         onCancel={() => {
@@ -100,6 +99,25 @@ export function ActionForm({ feature, device }: { feature: FeatureSummary; devic
   )
 }
 
+function FeatureHeader({ feature }: { feature: FeatureSummary }) {
+  const Icon = iconForCategory(feature.category)
+  return (
+    <header className="flex items-start gap-3">
+      <Icon size={22} className="mt-0.5 shrink-0 text-accent" />
+      <div className="min-w-0">
+        <h2 className="text-[17px] font-semibold text-text-primary" data-selectable>
+          {feature.title}
+        </h2>
+        {feature.subtitle ? (
+          <p className="mt-0.5 text-text-secondary" data-selectable>
+            {feature.subtitle}
+          </p>
+        ) : null}
+      </div>
+    </header>
+  )
+}
+
 function RunControls({
   label,
   tone,
@@ -107,6 +125,7 @@ function RunControls({
   device,
   ready,
   missing,
+  needsApp,
   confirming,
   onRun,
   onCancel,
@@ -117,6 +136,7 @@ function RunControls({
   device: Device | null
   ready: boolean
   missing: string[]
+  needsApp: boolean
   confirming: boolean
   onRun: () => void
   onCancel: () => void
@@ -132,6 +152,9 @@ function RunControls({
         {label}
       </Button>
       {confirming ? <Button onClick={onCancel}>Cancel</Button> : null}
+      {needsApp ? (
+        <span className="text-text-tertiary">Pick an app in the Apps tab first</span>
+      ) : null}
       {missing.length > 0 ? (
         <span className="text-text-tertiary">Fill in {missing.join(", ")}</span>
       ) : null}

--- a/desktop/src/components/ActionsPane.tsx
+++ b/desktop/src/components/ActionsPane.tsx
@@ -13,9 +13,11 @@ import type { Device, FeatureSummary } from "@/lib/wire"
 export function ActionsPane({
   features,
   device,
+  packageId,
 }: {
   features: FeatureSummary[]
   device: Device | null
+  packageId: string | null
 }) {
   const [query, setQuery] = useState("")
   const [selectedID, setSelectedID] = useState<string | null>(null)
@@ -62,7 +64,12 @@ export function ActionsPane({
         {selected ? (
           // Keyed by id so each feature's form starts from its own defaults
           // instead of inheriting the previous one's state.
-          <ActionForm key={selected.id} feature={selected} device={device} />
+          <ActionForm
+            key={selected.id}
+            feature={selected}
+            device={device}
+            packageId={packageId}
+          />
         ) : (
           <p className="p-6 text-text-tertiary">Pick an action.</p>
         )}

--- a/desktop/src/components/AppsPane.tsx
+++ b/desktop/src/components/AppsPane.tsx
@@ -1,0 +1,271 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Boxes, RefreshCw, Search } from "lucide-react"
+import { Banner, Button, Switch } from "@/components/Controls"
+import { actionLabel, searchApps, sortApps } from "@/lib/apps"
+import { asDaemonError, controlApp, listApps } from "@/lib/daemon"
+import { cn } from "@/lib/cn"
+import type {
+  AppActionDescriptor,
+  AppSummary,
+  DaemonError,
+  Device,
+  RunResponse,
+} from "@/lib/wire"
+
+/**
+ * The installed-app browser, and the verbs that act on one.
+ *
+ * The selected app is lifted to the caller because it is not local to this
+ * screen: a `needsBundle` action in the palette needs the same choice, the
+ * way the Mac app's selected bundle feeds `AppState.run`.
+ */
+export function AppsPane({
+  device,
+  selected,
+  onSelect,
+}: {
+  device: Device | null
+  selected: string | null
+  onSelect: (packageId: string | null) => void
+}) {
+  const [apps, setApps] = useState<AppSummary[]>([])
+  const [actions, setActions] = useState<AppActionDescriptor[]>([])
+  const [query, setQuery] = useState("")
+  const [includeSystem, setIncludeSystem] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<DaemonError | null>(null)
+
+  const serial = device?.serial ?? null
+  const load = useCallback(async () => {
+    if (serial === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await listApps(serial)
+      setApps(response.apps)
+      setActions(response.actions)
+    } catch (thrown) {
+      setError(asDaemonError(thrown))
+    } finally {
+      setLoading(false)
+    }
+  }, [serial])
+
+  // A full `dumpsys package packages` parse, so it is fetched on open rather
+  // than polled. Clearing the selection is deliberately *not* done here: this
+  // pane remounts on every tab switch, and resetting on mount would throw
+  // away a choice the palette is still using. The device change that really
+  // invalidates it is handled where the state lives.
+  useEffect(() => {
+    setApps([])
+    void load()
+  }, [load])
+
+  const visible = useMemo(
+    () => sortApps(searchApps(apps, query, includeSystem)),
+    [apps, query, includeSystem],
+  )
+  const current = apps.find((app) => app.packageId === selected) ?? null
+
+  if (!device) {
+    return <p className="p-6 text-text-tertiary">Connect a device to browse its apps.</p>
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <AppList
+        apps={visible}
+        query={query}
+        onQuery={setQuery}
+        includeSystem={includeSystem}
+        onIncludeSystem={setIncludeSystem}
+        loading={loading}
+        loaded={apps.length > 0}
+        selected={selected}
+        onSelect={onSelect}
+        onRefresh={() => void load()}
+      />
+
+      <div className="min-w-0 flex-1 bg-bg-root">
+        {error ? (
+          <div className="p-6">
+            <Banner tone="error">
+              {error.message}
+              {error.detail ? <div className="mt-1 opacity-70">{error.detail}</div> : null}
+            </Banner>
+          </div>
+        ) : current ? (
+          <AppDetail key={current.packageId} app={current} actions={actions} serial={device.serial} />
+        ) : (
+          <p className="p-6 text-text-tertiary">Pick an app.</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** The searchable app list. Its own component only so `AppsPane` stays legible. */
+function AppList({
+  apps,
+  query,
+  onQuery,
+  includeSystem,
+  onIncludeSystem,
+  loading,
+  loaded,
+  selected,
+  onSelect,
+  onRefresh,
+}: {
+  apps: AppSummary[]
+  query: string
+  onQuery: (value: string) => void
+  includeSystem: boolean
+  onIncludeSystem: (value: boolean) => void
+  loading: boolean
+  loaded: boolean
+  selected: string | null
+  onSelect: (packageId: string) => void
+  onRefresh: () => void
+}) {
+  return (
+      <aside className="flex w-[340px] shrink-0 flex-col border-r border-border-subtle bg-bg-chrome">
+        <div className="flex items-center gap-2 px-3 py-2.5">
+          <div className="flex flex-1 items-center gap-2 rounded-lg bg-bg-raised px-2.5 py-1.5 focus-within:ring-1 focus-within:ring-accent/60">
+            <Search size={13} className="shrink-0 text-text-tertiary" />
+            <input
+              value={query}
+              aria-label="Search apps"
+              placeholder={`Search ${String(apps.length)} apps…`}
+              onChange={(event) => {
+                onQuery(event.target.value)
+              }}
+              className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
+            />
+          </div>
+          <Button onClick={onRefresh} disabled={loading} title="Refresh">
+            <RefreshCw size={13} className={loading ? "animate-spin" : undefined} />
+          </Button>
+        </div>
+        <div className="px-3 pb-2">
+          <Switch checked={includeSystem} onChange={onIncludeSystem} label="System apps" />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto pb-2">
+          {loading && !loaded ? (
+            <p className="px-4 py-8 text-center text-text-tertiary">Reading the package list…</p>
+          ) : apps.length === 0 ? (
+            <p className="px-4 py-8 text-center text-text-tertiary">No apps match.</p>
+          ) : (
+            apps.map((app) => (
+              <button
+                key={app.packageId}
+                type="button"
+                onClick={() => {
+                  onSelect(app.packageId)
+                }}
+                className={cn(
+                  "flex w-full items-start gap-2.5 px-4 py-1.5 text-left transition-colors",
+                  app.packageId === selected ? "bg-accent/12" : "hover:bg-white/[0.04]",
+                )}
+              >
+                <Boxes size={17} className="mt-[3px] shrink-0 text-accent" />
+                <span className="min-w-0">
+                  <span className="block truncate text-[13.5px] text-text-primary">
+                    {app.displayName}
+                    {app.isSystem ? (
+                      <span className="ml-1.5 text-[10.5px] uppercase tracking-wide text-text-tertiary">
+                        system
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="block truncate text-[11.5px] text-text-secondary">
+                    {app.packageId}
+                    {app.versionName === null ? "" : ` · ${app.versionName}`}
+                  </span>
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </aside>
+  )
+}
+
+function AppDetail({
+  app,
+  actions,
+  serial,
+}: {
+  app: AppSummary
+  actions: AppActionDescriptor[]
+  serial: string
+}) {
+  const [running, setRunning] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState<string | null>(null)
+  const [result, setResult] = useState<RunResponse | null>(null)
+  const [error, setError] = useState<DaemonError | null>(null)
+
+  const run = async (action: AppActionDescriptor) => {
+    // A second press for the destructive ones, matching the Quick Actions
+    // panel's second-⏎ rule. The daemon says which those are.
+    if (action.isDestructive && confirming !== action.id) {
+      setConfirming(action.id)
+      return
+    }
+    setConfirming(null)
+    setRunning(action.id)
+    setResult(null)
+    setError(null)
+    try {
+      setResult(await controlApp({ serial, packageId: app.packageId, action: action.id }))
+    } catch (thrown) {
+      setError(asDaemonError(thrown))
+    } finally {
+      setRunning(null)
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-y-auto p-6">
+      <header className="flex items-start gap-3">
+        <Boxes size={22} className="mt-0.5 shrink-0 text-accent" />
+        <div className="min-w-0">
+          <h2 className="text-[17px] font-semibold text-text-primary" data-selectable>
+            {app.displayName}
+          </h2>
+          <p className="mt-0.5 text-text-secondary" data-selectable>
+            {app.packageId}
+            {app.versionName === null ? "" : ` · ${app.versionName}`}
+            {app.isSystem ? " · system app" : ""}
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        {actions.map((action) => (
+          <Button
+            key={action.id}
+            tone={action.isDestructive ? "danger" : "default"}
+            disabled={running !== null}
+            onClick={() => void run(action)}
+          >
+            {running === action.id
+              ? "Running…"
+              : confirming === action.id
+                ? `Really ${actionLabel(action).toLowerCase()}?`
+                : actionLabel(action)}
+          </Button>
+        ))}
+      </div>
+
+      {error ? (
+        <Banner tone="error">
+          {error.message}
+          {error.detail ? <div className="mt-1 opacity-70">{error.detail}</div> : null}
+        </Banner>
+      ) : null}
+      {result ? <Banner tone={result.ok ? "ok" : "error"}>{result.message}</Banner> : null}
+    </div>
+  )
+}

--- a/desktop/src/lib/apps.test.ts
+++ b/desktop/src/lib/apps.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { actionLabel, searchApps, sortApps } from "@/lib/apps"
+import type { AppSummary } from "@/lib/wire"
+
+function app(packageId: string, overrides: Partial<AppSummary> = {}): AppSummary {
+  return {
+    packageId,
+    displayName: packageId.split(".").at(-1) ?? packageId,
+    versionName: "1.0",
+    isSystem: false,
+    ...overrides,
+  }
+}
+
+const apps = [
+  app("com.example.weather", { displayName: "Weather" }),
+  app("com.android.settings", { displayName: "Settings", isSystem: true }),
+  app("com.acme.banking", { displayName: "Banking", versionName: "3.4.1" }),
+]
+
+describe("searchApps", () => {
+  it("hides system apps unless asked", () => {
+    expect(searchApps(apps, "", false).map((each) => each.packageId)).toEqual([
+      "com.example.weather",
+      "com.acme.banking",
+    ])
+    expect(searchApps(apps, "", true)).toHaveLength(3)
+  })
+
+  it("matches the package id, the name, and the version", () => {
+    expect(searchApps(apps, "acme", false).map((each) => each.displayName)).toEqual(["Banking"])
+    expect(searchApps(apps, "weather", false).map((each) => each.displayName)).toEqual(["Weather"])
+    expect(searchApps(apps, "3.4", false).map((each) => each.displayName)).toEqual(["Banking"])
+  })
+
+  it("is case-insensitive and ignores surrounding space", () => {
+    expect(searchApps(apps, "  WEATHER  ", false)).toHaveLength(1)
+  })
+
+  it("still hides system apps that match the query", () => {
+    // Otherwise typing narrows the list and system apps reappear, which reads
+    // as the toggle having no effect.
+    expect(searchApps(apps, "settings", false)).toEqual([])
+    expect(searchApps(apps, "settings", true)).toHaveLength(1)
+  })
+})
+
+describe("sortApps", () => {
+  it("puts user apps before system apps, alphabetically within each", () => {
+    expect(sortApps(apps).map((each) => each.displayName)).toEqual([
+      "Banking",
+      "Weather",
+      "Settings",
+    ])
+  })
+
+  it("does not mutate its input", () => {
+    const original = [...apps]
+    sortApps(apps)
+    expect(apps).toEqual(original)
+  })
+})
+
+describe("actionLabel", () => {
+  it("names the verbs the daemon ships", () => {
+    expect(actionLabel({ id: "clearData", isDestructive: true })).toBe("Clear Data")
+    expect(actionLabel({ id: "stop", isDestructive: false })).toBe("Force Stop")
+  })
+
+  it("still renders a verb this build has never heard of", () => {
+    // The daemon owns the verb list; one added later must appear rather than
+    // silently disappear from the UI.
+    expect(actionLabel({ id: "freezeSolid", isDestructive: false })).toBe("Freeze Solid")
+  })
+})

--- a/desktop/src/lib/apps.ts
+++ b/desktop/src/lib/apps.ts
@@ -1,0 +1,60 @@
+import type { AppActionDescriptor, AppSummary } from "@/lib/wire"
+
+/**
+ * Pure rules for the Apps pane.
+ *
+ * The verbs and their destructive flags come from the daemon; only the English
+ * belongs here. A label this file does not know still renders — the daemon is
+ * the authority on which verbs exist, so an unrecognised one must not vanish
+ * from the UI.
+ */
+
+const LABELS: Record<string, string> = {
+  open: "Open",
+  restart: "Restart",
+  stop: "Force Stop",
+  minimize: "Minimize",
+  clearCache: "Clear Cache",
+  clearData: "Clear Data",
+  uninstall: "Uninstall",
+}
+
+export function actionLabel(action: AppActionDescriptor): string {
+  return LABELS[action.id] ?? titleCase(action.id)
+}
+
+/** "clearCache" → "Clear Cache", for a verb shipped after this build. */
+function titleCase(id: string): string {
+  const spaced = id.replaceAll(/([a-z\d])([A-Z])/gu, "$1 $2")
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/**
+ * Filters the list, mirroring `AppListing.matches`: package id, display name
+ * or version. System apps are hidden unless asked for — there are hundreds of
+ * them and they bury the handful anyone is looking for.
+ */
+export function searchApps(
+  apps: AppSummary[],
+  query: string,
+  includeSystem: boolean,
+): AppSummary[] {
+  const needle = query.toLowerCase().trim()
+  return apps.filter((app) => {
+    if (!includeSystem && app.isSystem) return false
+    if (needle === "") return true
+    return (
+      app.packageId.toLowerCase().includes(needle) ||
+      app.displayName.toLowerCase().includes(needle) ||
+      (app.versionName?.toLowerCase().includes(needle) ?? false)
+    )
+  })
+}
+
+/** User apps first, then system, each alphabetical by display name. */
+export function sortApps(apps: AppSummary[]): AppSummary[] {
+  return apps.toSorted((a, b) => {
+    if (a.isSystem !== b.isSystem) return a.isSystem ? 1 : -1
+    return a.displayName.localeCompare(b.displayName)
+  })
+}

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -1,6 +1,7 @@
 import { Channel, invoke } from "@tauri-apps/api/core"
 import { listen, type UnlistenFn } from "@tauri-apps/api/event"
 import type {
+  AppsResponse,
   DaemonError,
   DaemonStatus,
   Device,
@@ -48,6 +49,18 @@ export function runAction(args: {
   fields?: Record<string, FieldValue>
 }): Promise<RunResponse> {
   return invoke<RunResponse>("run_action", { args })
+}
+
+export function listApps(serial: string): Promise<AppsResponse> {
+  return invoke<AppsResponse>("list_apps", { serial })
+}
+
+export function controlApp(args: {
+  serial: string
+  packageId: string
+  action: string
+}): Promise<RunResponse> {
+  return invoke<RunResponse>("control_app", args)
 }
 
 /** A live subscription. Always `stop()` it when the view goes away. */

--- a/desktop/src/lib/fields.test.ts
+++ b/desktop/src/lib/fields.test.ts
@@ -107,4 +107,30 @@ describe("runFields", () => {
   it("sends no fields map at all for an action with no parameters", () => {
     expect(runFields(byID("screenshot"), {})).toBeUndefined()
   })
+
+  it("passes the selected app to a feature that needs one", () => {
+    // `monkey` is the runnable action with needsBundle; without this it ran
+    // with no package at all.
+    const monkey = byID("monkey")
+    expect(monkey.needsBundle).toBe(true)
+    expect(runFields(monkey, {}, undefined, "com.x")).toMatchObject({ packageId: "com.x" })
+  })
+
+  it("passes the selected app as context to features that do not need one", () => {
+    // The Mac supplies it the same way, for features like bug-report that
+    // include app detail when a bundle happens to be selected.
+    expect(runFields(byID("screenshot"), {}, undefined, "com.x")).toEqual({ packageId: "com.x" })
+  })
+
+  it("omits the app when none is selected", () => {
+    expect(runFields(byID("screenshot"), {}, undefined, null)).toBeUndefined()
+    expect(runFields(byID("screenshot"), {}, undefined, "")).toBeUndefined()
+  })
+
+  it("keeps a toggle's `on` alongside the selected app", () => {
+    expect(runFields(byID("dark-mode"), {}, true, "com.x")).toEqual({
+      on: true,
+      packageId: "com.x",
+    })
+  })
 })

--- a/desktop/src/lib/fields.ts
+++ b/desktop/src/lib/fields.ts
@@ -1,5 +1,5 @@
 import type { FeatureField, FeatureSummary, FieldValue } from "@/lib/wire"
-import { TOGGLE_PARAM } from "@/lib/wire"
+import { PACKAGE_PARAM, TOGGLE_PARAM } from "@/lib/wire"
 
 /**
  * Turning a rendered form into the parameters a runner expects.
@@ -84,15 +84,22 @@ export function runFields(
   feature: FeatureSummary,
   values: FormValues,
   toggleOn?: boolean,
+  packageId?: string | null,
 ): FormValues | undefined {
-  if (feature.kind === "toggleAction") {
-    return { [TOGGLE_PARAM]: toggleOn ?? false }
-  }
   const fields: FormValues = {}
-  for (const field of feature.fields) {
-    const value = values[field.name]
-    if (isBlank(value) || value === undefined) continue
-    fields[field.name] = value
+  if (feature.kind === "toggleAction") {
+    fields[TOGGLE_PARAM] = toggleOn ?? false
+  } else {
+    for (const field of feature.fields) {
+      const value = values[field.name]
+      if (isBlank(value) || value === undefined) continue
+      fields[field.name] = value
+    }
+  }
+  // Required for a `needsBundle` feature and harmless context for the rest —
+  // the same rule `AppState.run` applies on the Mac.
+  if (packageId !== undefined && packageId !== null && packageId !== "") {
+    fields[PACKAGE_PARAM] = packageId
   }
   return Object.keys(fields).length > 0 ? fields : undefined
 }

--- a/desktop/src/lib/wire.ts
+++ b/desktop/src/lib/wire.ts
@@ -61,6 +61,33 @@ export interface FeatureSummary {
   fields: FeatureField[]
 }
 
+export interface AppSummary {
+  packageId: string
+  /** Derived by the daemon from the package id, so clients do not drift. */
+  displayName: string
+  versionName: string | null
+  isSystem: boolean
+}
+
+/** A verb the daemon accepts, with the runner's own destructive flag. */
+export interface AppActionDescriptor {
+  id: string
+  isDestructive: boolean
+}
+
+export interface AppsResponse {
+  apps: AppSummary[]
+  actions: AppActionDescriptor[]
+}
+
+/**
+ * How a selected app reaches a feature runner.
+ *
+ * `needsBundle` features are given it as a required parameter and the rest as
+ * optional context — the same rule `AppState` applies on the Mac.
+ */
+export const PACKAGE_PARAM = "packageId"
+
 export interface RunResponse {
   ok: boolean
   message: string

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -107,9 +107,10 @@ and then quietly forgotten.
 
 `desktop/` — Tauri 2 + React 19 + Vite + Tailwind v4 over `droidectived`; see
 `desktop/README.md`. Working today: the device picker, the action palette
-(search, forms, toggles, destructive confirmation) and live logcat with
-visible gap markers. Still to come: the full-screen view features, apps and
-files, then the terminal via xterm.js against a daemon PTY endpoint.
+(search, forms, toggles, destructive confirmation), the installed-app browser
+with its verbs, and live logcat with visible gap markers. Still to come: the
+remaining full-screen view features and files, then the terminal via xterm.js
+against a daemon PTY endpoint.
 Mirroring stays with the scrcpy desktop app.
 
 Two decisions worth keeping:

--- a/docs/droidectived-protocol.md
+++ b/docs/droidectived-protocol.md
@@ -136,6 +136,15 @@ convention rather than a declared field — a `.toggleAction` has an empty
 `params["on"]`, the Mac's `ToggleActionView` sends it, and
 `aToggleActionIsDrivenByAnOnParameter` is what fails if it is ever renamed.
 
+`/v1/apps/list` and `/v1/apps/control` are the same kind of pass-through, over
+`AppsExplorerService` and `AppControlService`. The list response carries the
+**verb table** alongside the apps (`actions: [{id, isDestructive}]`) rather
+than leaving a client to keep its own copy: the two are always wanted
+together, and a client with a private list of which verbs are dangerous will
+eventually disagree with the runner about it. An unknown verb is a 400 that
+never reaches the device. adb refusing — device gone, unauthorised — is a 502
+carrying adb's own words, not a 500.
+
 ### 4.1 Errors
 
 One shape everywhere, so the UI has one error path:

--- a/droidectived/Sources/DaemonCore/AppRoutes.swift
+++ b/droidectived/Sources/DaemonCore/AppRoutes.swift
@@ -1,0 +1,89 @@
+import ADBKit
+import Foundation
+
+/// Wire shapes for the installed-app surface.
+///
+/// Like the action routes, these are a thin pass-through: `AppsExplorerService`
+/// does the listing and `AppControlService` the verbs, so the daemon adds no
+/// knowledge of its own about what an app is or what may be done to one.
+public enum AppProtocol {
+    public struct ListRequest: Codable, Equatable, Sendable {
+        public let serial: String
+        public init(serial: String) { self.serial = serial }
+    }
+
+    /// One installed app.
+    ///
+    /// A DTO rather than `AppListing` itself: that type is not `Codable`, and
+    /// its `displayName` is a computed property that would not survive
+    /// encoding. Sending the name means a client does not have to reimplement
+    /// the package-id → title rule and then drift from it.
+    public struct AppSummary: Codable, Equatable, Sendable {
+        public let packageId: String
+        public let displayName: String
+        public let versionName: String?
+        public let isSystem: Bool
+
+        public init(_ listing: AppListing) {
+            packageId = listing.packageId
+            displayName = listing.displayName
+            versionName = listing.versionName
+            isSystem = listing.isSystem
+        }
+    }
+
+    /// A verb the daemon accepts, carrying the registry's own destructive
+    /// flag. Sent rather than left to the client, for the same reason
+    /// `isDestructive` rides on a feature: a client that keeps its own copy
+    /// of which verbs are dangerous will eventually disagree with the one
+    /// that actually runs them.
+    public struct ActionDescriptor: Codable, Equatable, Sendable {
+        public let id: String
+        public let isDestructive: Bool
+    }
+
+    public struct ListResponse: Codable, Equatable, Sendable {
+        public let apps: [AppSummary]
+        /// Shipped with the list because the two are always wanted together:
+        /// there is nothing to act on before the apps arrive.
+        public let actions: [ActionDescriptor]
+
+        public init(apps: [AppSummary], actions: [ActionDescriptor] = AppProtocol.actions) {
+            self.apps = apps
+            self.actions = actions
+        }
+    }
+
+    public struct ControlRequest: Codable, Equatable, Sendable {
+        public let serial: String
+        public let packageId: String
+        /// An `AppControlService.AppAction` raw value: "open", "restart",
+        /// "stop", "minimize", "clearCache", "clearData", "uninstall".
+        public let action: String
+
+        public init(serial: String, packageId: String, action: String) {
+            self.serial = serial
+            self.packageId = packageId
+            self.action = action
+        }
+
+        /// `nil` for a verb this daemon does not know, so it is refused rather
+        /// than silently treated as something else.
+        public var resolvedAction: AppControlService.AppAction? {
+            AppControlService.AppAction(rawValue: action)
+        }
+    }
+
+    /// The verbs a client may offer, so a UI renders the set the daemon
+    /// actually accepts instead of a hardcoded list that can drift.
+    public static var actions: [ActionDescriptor] {
+        AppControlService.AppAction.allCases.map {
+            ActionDescriptor(id: $0.rawValue, isDestructive: $0.isDestructive)
+        }
+    }
+
+    public static let unknownAction = DaemonProtocol.ErrorBody(
+        code: "unknown_action",
+        message: "No such app action.",
+        detail: "known actions: \(actions.map(\.id).joined(separator: ", "))")
+}

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -11,6 +11,8 @@ public enum DaemonProtocol {
         case devicesList = "/v1/devices/list"
         case featuresList = "/v1/features/list"
         case actionsRun = "/v1/actions/run"
+        case appsList = "/v1/apps/list"
+        case appsControl = "/v1/apps/control"
     }
 
     /// The multiplexed stream socket. Not a `Route`: it is a WebSocket upgrade

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -17,16 +17,26 @@ public protocol DaemonBackend: Sendable {
         featureID: String, serial: String, platform: DevicePlatform,
         params: [String: FeatureValue]
     ) async -> FeatureResult
+    /// Every installed app on the device, user and system.
+    func listApps(serial: String) async throws -> [AppListing]
+    /// One verb against one package.
+    func controlApp(
+        serial: String, packageId: String, action: AppControlService.AppAction
+    ) async throws -> FeatureResult
 }
 
 /// `DeviceMonitor` in production.
 public struct LiveBackend: DaemonBackend {
     private let monitor: DeviceMonitor
     private let engine: FeatureEngine
+    /// The app services are cheap value types over this, so they are built per
+    /// call rather than held — there is no state to keep.
+    private let client: AdbClient
 
-    public init(monitor: DeviceMonitor, engine: FeatureEngine) {
+    public init(monitor: DeviceMonitor, engine: FeatureEngine, client: AdbClient) {
         self.monitor = monitor
         self.engine = engine
+        self.client = client
     }
 
     public func listDevices() async -> [Device] { await monitor.list(force: true) }
@@ -37,6 +47,17 @@ public struct LiveBackend: DaemonBackend {
     ) async -> FeatureResult {
         await engine.run(
             featureID: featureID, serial: serial, platform: platform, params: params)
+    }
+
+    public func listApps(serial: String) async throws -> [AppListing] {
+        try await AppsExplorerService(client: client).listAll(serial: serial)
+    }
+
+    public func controlApp(
+        serial: String, packageId: String, action: AppControlService.AppAction
+    ) async throws -> FeatureResult {
+        try await AppControlService(client: client)
+            .control(serial: serial, packageId: packageId, action: action)
     }
 }
 
@@ -298,6 +319,42 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
             // daemon broke", which is the distinction `AdbClient` exists to
             // preserve.
             return (.ok, encoded(ActionProtocol.RunResponse(result)))
+
+        case .appsList:
+            let raw = Data(body.readableBytesView)
+            guard let request = try? JSONDecoder().decode(
+                AppProtocol.ListRequest.self, from: raw)
+            else { return (.badRequest, encoded(DaemonProtocol.badRequest)) }
+            do {
+                let apps = try await backend.listApps(serial: request.serial)
+                return (.ok, encoded(AppProtocol.ListResponse(
+                    apps: apps.map(AppProtocol.AppSummary.init))))
+            } catch {
+                // adb refused: the device went away, or is unauthorised. That
+                // is the device's answer rather than a daemon fault, so it
+                // goes out as a 502 carrying adb's own words.
+                return (.badGateway, encoded(DaemonProtocol.ErrorBody(
+                    code: "adb_failed", message: "Could not list apps.",
+                    detail: "\(error)")))
+            }
+
+        case .appsControl:
+            let raw = Data(body.readableBytesView)
+            guard let request = try? JSONDecoder().decode(
+                AppProtocol.ControlRequest.self, from: raw)
+            else { return (.badRequest, encoded(DaemonProtocol.badRequest)) }
+            guard let action = request.resolvedAction else {
+                return (.badRequest, encoded(AppProtocol.unknownAction))
+            }
+            do {
+                let result = try await backend.controlApp(
+                    serial: request.serial, packageId: request.packageId, action: action)
+                return (.ok, encoded(ActionProtocol.RunResponse(result)))
+            } catch {
+                return (.badGateway, encoded(DaemonProtocol.ErrorBody(
+                    code: "adb_failed", message: "The app action failed.",
+                    detail: "\(error)")))
+            }
         }
     }
 

--- a/droidectived/Sources/droidectived/main.swift
+++ b/droidectived/Sources/droidectived/main.swift
@@ -39,7 +39,7 @@ let engine = FeatureEngine(
     overridesStore: JSONStore<OverridesMap>(filename: "overrides.json", default: [:]),
     toolsDirectory: AppPaths.supportDir.appendingPathComponent("tools"))
 let server = DaemonServer(
-    backend: LiveBackend(monitor: monitor, engine: engine), token: token,
+    backend: LiveBackend(monitor: monitor, engine: engine, client: client), token: token,
     streamSource: LiveStreamSource(monitor: monitor, streamer: LogcatStreamer(client: client)))
 
 do {

--- a/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
@@ -22,6 +22,19 @@ import FoundationNetworking
         var count: Int { calls.count }
         var last: (id: String, serial: String, platform: DevicePlatform,
                    params: [String: FeatureValue])? { calls.last }
+
+        private(set) var appCalls: [(serial: String, packageId: String,
+                                     action: AppControlService.AppAction)] = []
+        func recordApp(
+            _ serial: String, _ packageId: String, _ action: AppControlService.AppAction
+        ) {
+            appCalls.append((serial, packageId, action))
+        }
+        var lastApp: (serial: String, packageId: String,
+                      action: AppControlService.AppAction)? { appCalls.last }
+
+        private(set) var listedSerials: [String] = []
+        func recordList(_ serial: String) { listedSerials.append(serial) }
     }
 
     private struct RecordingBackend: DaemonBackend {
@@ -35,6 +48,21 @@ import FoundationNetworking
             params: [String: FeatureValue]
         ) async -> FeatureResult {
             await log.record(featureID, serial, platform, params)
+            return result
+        }
+
+        func listApps(serial: String) async throws -> [AppListing] {
+            await log.recordList(serial)
+            return [
+                AppListing(packageId: "com.example.weather", versionName: "2.1", isSystem: false),
+                AppListing(packageId: "com.android.settings", versionName: nil, isSystem: true),
+            ]
+        }
+
+        func controlApp(
+            serial: String, packageId: String, action: AppControlService.AppAction
+        ) async throws -> FeatureResult {
+            await log.recordApp(serial, packageId, action)
             return result
         }
     }
@@ -167,6 +195,75 @@ import FoundationNetworking
                 #expect(call.id == toggle.id)
                 #expect(call.params["on"] == .bool(true), "the on parameter for \(toggle.id)")
             }
+        }
+    }
+
+    // MARK: apps
+
+    @Test func listsInstalledAppsWithTheirDisplayNames() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await self.post(
+                port: port, path: "/v1/apps/list", token: token,
+                json: #"{"serial":"emulator-5554"}"#)
+            #expect(status == 200)
+            let decoded = try JSONDecoder().decode(
+                AppProtocol.ListResponse.self, from: Data(body.utf8))
+            #expect(await log.listedSerials == ["emulator-5554"])
+            #expect(decoded.apps.count == 2)
+
+            let weather = try #require(decoded.apps.first)
+            #expect(weather.packageId == "com.example.weather")
+            #expect(weather.versionName == "2.1")
+            #expect(!weather.isSystem)
+            // The package-id -> title rule is a computed property on
+            // `AppListing`, so it only survives the wire because the DTO sends
+            // it; otherwise every client reimplements it and they drift.
+            #expect(weather.displayName == "Weather")
+            #expect(decoded.apps.last?.isSystem == true)
+        }
+    }
+
+    @Test func runsAnAppVerbThroughTheService() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await self.post(
+                port: port, path: "/v1/apps/control", token: token,
+                json: #"{"serial":"S1","packageId":"com.x","action":"clearData"}"#)
+            #expect(status == 200)
+            #expect(body.contains(#""ok":true"#))
+
+            let call = try #require(await log.lastApp)
+            #expect(call.serial == "S1")
+            #expect(call.packageId == "com.x")
+            #expect(call.action == .clearData)
+        }
+    }
+
+    /// Every verb the daemon advertises has to be one it will actually accept,
+    /// or a UI built from that list offers buttons that 400.
+    @Test func acceptsEveryAdvertisedAppAction() async throws {
+        try await withServer { port, token, log in
+            #expect(!AppProtocol.actions.isEmpty)
+            for action in AppProtocol.actions {
+                let (status, _) = try await self.post(
+                    port: port, path: "/v1/apps/control", token: token,
+                    json: #"{"serial":"S1","packageId":"com.x","action":"\#(action.id)"}"#)
+                #expect(status == 200, "action \(action.id)")
+                #expect(await log.lastApp?.action.rawValue == action.id)
+                #expect(
+                    await log.lastApp?.action.isDestructive == action.isDestructive,
+                    "the advertised destructive flag must be the runner's own")
+            }
+        }
+    }
+
+    @Test func rejectsAnUnknownAppActionWithoutTouchingTheDevice() async throws {
+        try await withServer { port, token, log in
+            let (status, body) = try await self.post(
+                port: port, path: "/v1/apps/control", token: token,
+                json: #"{"serial":"S1","packageId":"com.x","action":"detonate"}"#)
+            #expect(status == 400)
+            #expect(body.contains("unknown_action"))
+            #expect(await log.lastApp == nil, "an unknown verb must not reach the device")
         }
     }
 

--- a/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
@@ -23,6 +23,13 @@ import FoundationNetworking
             FeatureResult(ok: true, message: "stub")
         }
 
+        func listApps(serial: String) async throws -> [AppListing] { [] }
+
+        func controlApp(
+            serial: String, packageId: String, action: AppControlService.AppAction
+        ) async throws -> FeatureResult {
+            FeatureResult(ok: true, message: "stub")
+        }
     }
 
     private static func device(_ serial: String) -> Device {

--- a/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
@@ -41,6 +41,13 @@ private let hasWebSocketClient: Bool = {
             FeatureResult(ok: true, message: "stub")
         }
 
+        func listApps(serial: String) async throws -> [AppListing] { [] }
+
+        func controlApp(
+            serial: String, packageId: String, action: AppControlService.AppAction
+        ) async throws -> FeatureResult {
+            FeatureResult(ok: true, message: "stub")
+        }
     }
 
     private struct FixedSource: StreamSource {


### PR DESCRIPTION
Adds the Apps screen to the Windows/Linux app, and the two daemon routes
behind it. Also closes a gap in what shipped in #247.

macOS is untouched: no file under `App/` changes, and the one ADBKit edit is a
new public initialiser.

## The daemon routes

`/v1/apps/list` and `/v1/apps/control`, both thin pass-throughs over services
ADBKit already has (`AppsExplorerService`, `AppControlService`). The daemon
gains no knowledge of what an app is or what may be done to one.

The list response carries the **verb table** alongside the apps —
`actions: [{id, isDestructive}]` — rather than leaving the client to keep its
own copy. The two are always wanted together, and a client with a private list
of which verbs are dangerous will eventually disagree with the runner that
actually runs them. Same reasoning that put `isDestructive` on a feature
summary. An unknown verb is a 400 that never reaches the device; adb refusing
is a 502 carrying adb's own words.

`AppSummary` sends `displayName` because it is a *computed* property on
`AppListing` and would not otherwise survive encoding, leaving every client to
reimplement the package-id to title rule and then drift from it.

## The gap this closes

`monkey` is a runnable action with `needsBundle`, and the desktop app had no
way to choose an app, so it ran with no package at all. It is now disabled
until one is picked, and every other action receives the choice as optional
context, which is the rule `AppState.run` applies on the Mac.

The selection is owned by `App.tsx`, not the Apps pane, because the palette
needs the same choice. That placement also gets the lifetime right: switching
tabs keeps it (the pane remounts, and resetting on mount would throw away a
choice the palette is still using), while switching *device* drops it, since a
package id means nothing on another device.

## Tests

Daemon 70 to 74, including one that posts every advertised verb and asserts
the runner's own destructive flag matches what was advertised, so the table
cannot describe a verb the daemon would reject. Desktop 41 to 53, covering the
list filtering and sorting, the label fallback for a verb this build has never
seen, and the new `packageId` plumbing.

`make desktop-test`, `swift test` in both packages, and ADBKit's 1699 all pass.

## Verified by hand

Built and launched: the Apps tab renders and the empty state is correct. **The
app listing itself is not verified against a real device** since I have none
attached, so that path rests on the route tests and the recording backend.