### PR TITLE
Give every feature its own icon

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -32,6 +32,7 @@ its own.
 | `src/lib/tabs.ts` | the open tabs and what gets focus on close — ADBKit's `TabState` |
 | `src/lib/ordering.ts` | drag-reorder math — ADBKit's `SidebarOrdering` |
 | `src/lib/layout.ts` | what the window remembers between launches |
+| `src/lib/icons.ts` | one lucide glyph per registry id — the wire carries none |
 | `src/lib/logbuffer.ts` | the log feed's ring buffer and its gap markers |
 | `src/lib/fields.ts` | form values → run parameters |
 | `src-tauri/src/daemon/` | spawning, the HTTP client, and the stream socket |
@@ -119,5 +120,9 @@ the tabs arrive.
 - **No component library.** `clsx` + `tailwind-merge` and a handful of
   hand-written controls in `src/components/Controls.tsx`. Worth revisiting when
   the surface grows past a few forms.
+- **Icons are lucide, one per registry id**, listed in `src/lib/icons.ts`. The
+  daemon deliberately does not send `FeatureDef.icon` — SF Symbol names mean
+  nothing off Apple — so the pairing is made here, and a test fails if a
+  feature arrives without one rather than letting it inherit a category glyph.
 - Exact dependency versions, no `^`. A desktop app that builds differently next
   month is a support problem.

--- a/desktop/src/components/ActionForm.tsx
+++ b/desktop/src/components/ActionForm.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { Banner, Button, Select, Slider, Switch, TextInput } from "@/components/Controls"
 import { asDaemonError, runAction } from "@/lib/daemon"
-import { iconForCategory } from "@/lib/icons"
+import { iconForFeature } from "@/lib/icons"
 import { coerce, initialValues, missingRequired, runFields, type FormValues } from "@/lib/fields"
 import type { DaemonError, Device, FeatureField, FeatureSummary, RunResponse } from "@/lib/wire"
 
@@ -100,7 +100,7 @@ export function ActionForm({
 }
 
 function FeatureHeader({ feature }: { feature: FeatureSummary }) {
-  const Icon = iconForCategory(feature.category)
+  const Icon = iconForFeature(feature.id, feature.category)
   return (
     <header className="flex items-start gap-3">
       <Icon size={22} className="mt-0.5 shrink-0 text-accent" />

--- a/desktop/src/components/HomeView.tsx
+++ b/desktop/src/components/HomeView.tsx
@@ -1,4 +1,4 @@
-import { iconForCategory } from "@/lib/icons"
+import { iconForFeature } from "@/lib/icons"
 import { categoryLabel, sidebarSections } from "@/lib/sidebar"
 import type { FeatureSummary } from "@/lib/wire"
 
@@ -62,7 +62,7 @@ export function HomeView({
 }
 
 function Tile({ feature, onOpen }: { feature: FeatureSummary; onOpen: () => void }) {
-  const Icon = iconForCategory(feature.category)
+  const Icon = iconForFeature(feature.id, feature.category)
   return (
     <button
       type="button"

--- a/desktop/src/components/SidebarSection.tsx
+++ b/desktop/src/components/SidebarSection.tsx
@@ -1,7 +1,7 @@
 import { ChevronRight } from "lucide-react"
 import { pastMidpointY, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
-import { iconForCategory } from "@/lib/icons"
+import { iconForFeature } from "@/lib/icons"
 import type { SidebarSection as Section } from "@/lib/sidebar"
 import type { FeatureSummary } from "@/lib/wire"
 
@@ -143,7 +143,7 @@ function Row({
   onDragOver: (event: React.DragEvent<HTMLElement>) => void
   onDrop: (event: React.DragEvent<HTMLElement>) => void
 }) {
-  const Icon = iconForCategory(feature.category)
+  const Icon = iconForFeature(feature.id, feature.category)
   return (
     <button
       type="button"

--- a/desktop/src/components/TabStrip.tsx
+++ b/desktop/src/components/TabStrip.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { House, X } from "lucide-react"
 import { pastMidpointX, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
-import { iconForCategory } from "@/lib/icons"
+import { iconForFeature } from "@/lib/icons"
 import { HOME_TAB } from "@/lib/layout"
 import { dropTarget } from "@/lib/ordering"
 import { IS_MAC, shortcutLabel } from "@/lib/platform"
@@ -124,7 +124,7 @@ function Chip({
 }) {
   // A tab whose feature has gone is still closable: showing its id beats
   // rendering a blank chip nobody can get rid of.
-  const Icon = iconForCategory(feature?.category ?? "")
+  const Icon = iconForFeature(id, feature?.category ?? "")
   return (
     <div
       draggable

--- a/desktop/src/index.css
+++ b/desktop/src/index.css
@@ -60,6 +60,18 @@ select,
   -webkit-user-drag: element;
 }
 
+/* The webview's default focus ring is the system blue, which is the one colour
+   in the window that belongs to no theme. Keyboard focus still shows — this
+   only drops the ring a plain click leaves behind, and recolours the rest. */
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
 ::-webkit-scrollbar {
   width: 11px;
   height: 11px;

--- a/desktop/src/lib/icons.test.ts
+++ b/desktop/src/lib/icons.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import raw from "@/lib/__fixtures__/features.json"
+import { featuresWithIcons, iconForFeature } from "@/lib/icons"
+import type { FeatureSummary } from "@/lib/wire"
+
+// Real daemon output, captured from `POST /v1/features/list`.
+const features = (raw as unknown as { features: FeatureSummary[] }).features
+
+describe("iconForFeature", () => {
+  it("has a glyph for every feature the daemon serves", () => {
+    // The guard on a table the wire cannot supply: a feature added to the
+    // registry lands here as a failure rather than as a row quietly wearing
+    // its category's icon.
+    const missing = features
+      .filter((feature) => !featuresWithIcons().includes(feature.id))
+      .map((feature) => feature.id)
+    expect(missing).toEqual([])
+  })
+
+  it("has no entry for a feature that no longer exists", () => {
+    const served = new Set(features.map((feature) => feature.id))
+    expect(featuresWithIcons().filter((id) => !served.has(id))).toEqual([])
+  })
+
+  it("gives neighbours in a category different glyphs", () => {
+    // The whole point: before this, every Connection feature was one Wi-Fi
+    // symbol repeated eight times.
+    const connection = features.filter((feature) => feature.category === "connection")
+    const glyphs = new Set(connection.map((feature) => iconForFeature(feature.id, feature.category)))
+    expect(connection.length).toBeGreaterThan(4)
+    expect(glyphs.size).toBe(connection.length)
+  })
+
+  it("falls back to the category for an id it has never seen", () => {
+    // Two unknown ids in a category agree with each other and differ from
+    // another category's — which is what "fell back to the category" means.
+    expect(iconForFeature("brand-new-a", "logs")).toBe(iconForFeature("brand-new-b", "logs"))
+    expect(iconForFeature("brand-new-a", "logs")).not.toBe(iconForFeature("brand-new-a", "input"))
+  })
+
+  it("falls back again for a category it has never seen", () => {
+    expect(iconForFeature("brand-new-feature", "brandNewCategory")).toBeTypeOf("object")
+  })
+})

--- a/desktop/src/lib/icons.ts
+++ b/desktop/src/lib/icons.ts
@@ -1,22 +1,165 @@
 import {
+  AppWindow,
+  ArrowLeftRight,
   Atom,
+  BatteryLow,
+  BellRing,
   Boxes,
+  Braces,
+  Camera,
+  ChartLine,
+  CodeXml,
+  Crosshair,
+  Dices,
+  FastForward,
+  FileArchive,
+  FileSearch,
+  Film,
+  FolderOpen,
+  Gauge,
+  Globe,
+  HardDrive,
+  Info,
   Keyboard,
+  Languages,
+  Layers,
+  LayoutGrid,
+  Link,
+  LockKeyhole,
+  LockOpen,
+  MemoryStick,
+  Monitor,
+  MonitorPlay,
   MonitorSmartphone,
+  Moon,
+  Network,
+  OctagonX,
+  Package,
+  PackageOpen,
+  PackagePlus,
+  Radio,
+  RadioTower,
+  RefreshCw,
+  Ruler,
   ScrollText,
+  Send,
+  Server,
+  Settings2,
+  Shield,
+  ShieldCheck,
+  Signal,
+  Signature,
   SlidersHorizontal,
-  Wrench,
+  Smartphone,
+  SquareMenu,
+  SquareTerminal,
+  Syringe,
+  Terminal,
+  TriangleAlert,
+  Video,
+  WandSparkles,
+  Waypoints,
   Wifi,
+  Wrench,
   type LucideIcon,
 } from "lucide-react"
 
 /**
- * A glyph per category, standing in for the Mac app's per-feature icons.
+ * A glyph per feature.
  *
  * The daemon deliberately drops `FeatureDef.icon` — those are SF Symbol names,
- * which mean nothing off Apple. Category icons keep the sidebar's visual
- * rhythm without inventing a second icon registry to drift from the first.
- * The pairings mirror `FeatureCategory.icon` in ADBKit.
+ * which mean nothing off Apple — so the pairing is made here instead, one
+ * lucide icon per registry id, chosen to read as the same thing the Mac's
+ * symbol does. Held client-side for the same reason as the category order:
+ * it is a rendering choice, and shipping SF Symbol names to a web UI would
+ * only invite it to depend on something it cannot draw.
+ *
+ * `icons.test.ts` fails if the daemon serves a feature this table has no entry
+ * for, so a new feature shows up as a failing test rather than as a row
+ * wearing its neighbour's icon.
+ */
+const BY_FEATURE: Record<string, LucideIcon> = {
+  // Input & Clipboard
+  "send-text": Keyboard,
+
+  // Connection
+  "get-ip": Globe,
+  connection: Network,
+  "reverse-port": ArrowLeftRight,
+  "wireless-adb": RadioTower,
+  emulators: MonitorPlay,
+  "network-speed": Gauge,
+  wifi: Wifi,
+  "private-dns": LockKeyhole,
+
+  // React Native
+  "react-native": Atom,
+  "open-dev-menu": SquareMenu,
+  "reload-js": RefreshCw,
+  "deep-link": Link,
+  "process-death": OctagonX,
+  "rn-dev-host": Server,
+  reactotron: Radio,
+  "js-console": CodeXml,
+
+  // Screen & Capture
+  scrcpy: Monitor,
+  screenshot: Camera,
+  "screen-record": Video,
+  "video-editor": Film,
+  "demo-mode": WandSparkles,
+
+  // Device State
+  "file-explorer": HardDrive,
+  "device-info": Info,
+  "root-status": Shield,
+  "system-restrictions": LockOpen,
+  "dev-settings": Settings2,
+  simulate: SlidersHorizontal,
+  "fake-battery": BatteryLow,
+  "dark-mode": Moon,
+  "push-notification": BellRing,
+  "layout-overrides": Ruler,
+  "animation-scale": FastForward,
+  locale: Languages,
+  "network-toggles": Signal,
+  "http-proxy": Waypoints,
+
+  // App Management
+  apps: LayoutGrid,
+  "install-app": PackagePlus,
+  "apk-studio": Wrench,
+  "apk-inspector": FileSearch,
+  "apk-sign": Signature,
+  "apk-decompile": Braces,
+  "aab-convert": PackageOpen,
+  "frida-console": Syringe,
+  "app-management": AppWindow,
+  permissions: ShieldCheck,
+  "app-info": Package,
+  "current-activity": Layers,
+  "foreground-package": Crosshair,
+  meminfo: MemoryStick,
+  "sandbox-browser": FolderOpen,
+  monkey: Dices,
+
+  // Logs & Diagnostics
+  logcat: ScrollText,
+  "ios-logs": Smartphone,
+  "crash-catcher": TriangleAlert,
+  "bug-report": FileArchive,
+  performance: ChartLine,
+
+  // Tool UX
+  "api-client": Send,
+  terminal: SquareTerminal,
+  "custom-commands": Terminal,
+}
+
+/**
+ * The fallback when a feature has no glyph of its own — a category still says
+ * roughly what a thing is, which beats a generic square. The pairings mirror
+ * `FeatureCategory.icon` in ADBKit.
  */
 const BY_CATEGORY: Record<string, LucideIcon> = {
   input: Keyboard,
@@ -29,6 +172,12 @@ const BY_CATEGORY: Record<string, LucideIcon> = {
   toolUX: Wrench,
 }
 
-export function iconForCategory(category: string): LucideIcon {
-  return BY_CATEGORY[category] ?? Wrench
+/** The glyph for a feature, falling back to its category and then to a tool. */
+export function iconForFeature(id: string, category: string): LucideIcon {
+  return BY_FEATURE[id] ?? BY_CATEGORY[category] ?? Wrench
+}
+
+/** Every registry id this build has a glyph for. */
+export function featuresWithIcons(): string[] {
+  return Object.keys(BY_FEATURE)
 }

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -121,6 +121,12 @@ Sourced from `CLAUDE.md` and the App sources.
 
 ### Chrome and feel
 
+- [x] **Per-feature icons.** The daemon drops `FeatureDef.icon` on purpose —
+      those are SF Symbol names, which mean nothing off Apple — so
+      `desktop/src/lib/icons.ts` pairs each registry id with a lucide glyph
+      chosen to read as the same thing the Mac's symbol does. A test fails if
+      the daemon serves a feature the table has no entry for, so a new feature
+      cannot quietly inherit its neighbour's icon.
 - [ ] **Settings** — Appearance (accent colour, custom background/text,
       window opacity / blur / grain), General, Hotkeys, Tools, Privacy, MCP.
 - [ ] **Window translucency** — the `.bgRoot`/`.bgSurface` token system, with


### PR DESCRIPTION
Stacked on #252 — base retargets to `main` when that merges.

Every one of the 60 registry features was wearing its *category's* glyph, so
all eight Connection features rendered as the same Wi-Fi symbol and the sidebar
read as rows of nothing in particular.

The daemon drops `FeatureDef.icon` on purpose — those are SF Symbol names,
which mean nothing off Apple — so the pairing is made client-side: one lucide
icon per registry id, each chosen to read as the same thing the Mac's symbol
does. `wireless-adb` is a radio tower, `reverse-port` a left-right arrow,
`monkey` a pair of dice, `apk-decompile` braces, `frida-console` a syringe.

lucide-react was already a dependency and has all 60 glyphs, so nothing new is
added. Every name was checked against the installed package rather than
assumed.

## Guards

`icons.test.ts` fails if the daemon serves a feature the table has no entry
for, and if the table names a feature that no longer exists — so a new feature
cannot quietly inherit its neighbour's icon. The category table stays as the
fallback, so an unknown feature still gets something meaningful.

## Also

The webview's default focus ring was system blue, the one colour in the window
belonging to no theme. It is now the accent, kept on `:focus-visible` so
keyboard focus is still visible and only the ring a plain click leaves behind
goes away.

## Verified

`make desktop-test` green (typecheck, oxlint, 122 vitest, cargo
fmt/clippy/test). Checked by eye against `emulator-5554` across the sidebar,
the tab strip, the Home grid and an action form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)