### PR TITLE
Make an action's result mean what it says

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,158 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +304,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +363,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -342,6 +513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +529,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -448,6 +637,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -684,12 +879,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -710,6 +911,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
+ "tauri-plugin-opener",
  "tauri-plugin-shell",
  "thiserror 2.0.19",
  "tokio",
@@ -788,6 +991,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,10 +1045,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -846,6 +1108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +1128,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -934,6 +1208,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1081,6 +1368,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1267,10 +1564,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1289,6 +1606,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1541,6 +1864,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +2110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +2190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2249,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-conv"
@@ -1954,6 +2316,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2153,6 +2516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2594,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2276,6 +2666,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2719,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2402,6 +2817,18 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2572,6 +2999,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3284,6 +3724,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,6 +3882,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3451,6 +3941,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3731,7 +4235,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3763,6 +4279,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.19",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -3798,6 +4325,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4030,6 +4568,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4738,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -4597,6 +5211,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,6 +5300,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4688,6 +5337,87 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4749,3 +5479,58 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
+]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,13 @@ tauri = { version = "2.11.5", features = [] }
 # resolves the per-platform binary location that a hand-rolled path would get
 # wrong on at least one of the three targets.
 tauri-plugin-shell = "2.3.5"
+# The two host capabilities an action result promises: "Copy Device IP" has to
+# reach the clipboard, and "saved to …" has to be openable. Both are reached
+# through our own commands rather than the plugins' JS APIs, so the webview's
+# capability file stays at `core:default` and gains nothing it could be
+# tricked into using.
+tauri-plugin-clipboard-manager = "2.3.2"
+tauri-plugin-opener = "2.5.4"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 # Loopback plain HTTP only — no TLS features, so no rustls/openssl in the tree.

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -8,7 +8,9 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
-use tauri::State;
+use tauri::{AppHandle, State};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_opener::OpenerExt;
 
 use crate::daemon::stream::StreamMessage;
 use crate::daemon::wire::{
@@ -115,6 +117,36 @@ pub async fn control_app(
             action,
         })
         .await
+}
+
+/// Puts an action's `copyText` on the system clipboard.
+///
+/// Here rather than `navigator.clipboard` in the webview: that needs a secure
+/// context and a user gesture the browser agrees was one, and on `WebKitGTK` it
+/// can fail silently — which is the exact defect this replaces. A command
+/// either works or returns an error the UI can show.
+#[tauri::command]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "tauri's command macro hands AppHandle in by value"
+)]
+pub fn copy_text(app: AppHandle, text: String) -> Result<(), DaemonError> {
+    app.clipboard()
+        .write_text(text)
+        .map_err(|error| DaemonError::Host(format!("could not copy to the clipboard: {error}")))
+}
+
+/// Shows a file in the system file manager — the affordance behind an action
+/// that reports where it saved something.
+#[tauri::command]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "tauri's command macro hands AppHandle in by value"
+)]
+pub fn reveal_path(app: AppHandle, path: String) -> Result<(), DaemonError> {
+    app.opener()
+        .reveal_item_in_dir(&path)
+        .map_err(|error| DaemonError::Host(format!("could not open {path}: {error}")))
 }
 
 /// Subscribes to the device list. Returns the id to pass to `stop_watching`.

--- a/desktop/src-tauri/src/error.rs
+++ b/desktop/src-tauri/src/error.rs
@@ -24,6 +24,11 @@ pub enum DaemonError {
     Transport(String),
     #[error("droidectived sent a reply this build cannot read: {0}")]
     Decode(String),
+    /// A host capability refused — the clipboard, or revealing a file. Nothing
+    /// to do with the daemon, but the UI already has one error path and a
+    /// second shape would only be one more thing to branch on.
+    #[error("{0}")]
+    Host(String),
 }
 
 impl DaemonError {
@@ -35,6 +40,7 @@ impl DaemonError {
             Self::Refused { code, .. } => code,
             Self::Transport(_) => "transport_failed",
             Self::Decode(_) => "decode_failed",
+            Self::Host(_) => "host_action_failed",
         }
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -24,6 +24,11 @@ const STATUS_EVENT: &str = "daemon://status";
 pub fn run() -> tauri::Result<()> {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        // Registered for their Rust APIs only. The capability file grants the
+        // webview neither, so the clipboard and the file manager are reachable
+        // through our own commands and nowhere else.
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_opener::init())
         .manage(Supervisor::default())
         .invoke_handler(tauri::generate_handler![
             commands::daemon_status,
@@ -35,6 +40,8 @@ pub fn run() -> tauri::Result<()> {
             commands::watch_devices,
             commands::watch_logcat,
             commands::stop_watching,
+            commands::copy_text,
+            commands::reveal_path,
         ])
         .setup(|app| {
             // Off the setup path: spawning the sidecar and waiting for its

--- a/desktop/src/components/ActionForm.tsx
+++ b/desktop/src/components/ActionForm.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from "react"
 import { Banner, Button, Select, Slider, Switch, TextInput } from "@/components/Controls"
+import { ResultActions } from "@/components/ResultActions"
+import { useArmedConfirm } from "@/hooks/useArmedConfirm"
 import { asDaemonError, runAction } from "@/lib/daemon"
 import { iconForFeature } from "@/lib/icons"
 import { coerce, initialValues, missingRequired, runFields, type FormValues } from "@/lib/fields"
@@ -23,20 +25,24 @@ export function ActionForm({
   const [running, setRunning] = useState(false)
   const [result, setResult] = useState<RunResponse | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
-  const [confirming, setConfirming] = useState(false)
+  const confirm = useArmedConfirm()
 
   const missing = useMemo(() => missingRequired(feature, values), [feature, values])
   const ready = device?.state === "device"
   // The registry says this one acts on an app, and nothing has been chosen.
   const needsApp = feature.needsBundle && packageId === null
+  // Scoped to this feature on this device, so switching either expires the
+  // arming instead of carrying it across.
+  const target = device?.serial ?? ""
+  const confirming = feature.isDestructive && confirm.isArmed(feature.id, target)
 
   const run = async () => {
     if (feature.isDestructive && !confirming) {
-      setConfirming(true)
+      confirm.arm(feature.id, target)
       return
     }
     if (!device) return
-    setConfirming(false)
+    confirm.disarm()
     setRunning(true)
     setResult(null)
     setError(null)
@@ -89,9 +95,7 @@ export function ActionForm({
         needsApp={needsApp}
         confirming={confirming}
         onRun={() => void run()}
-        onCancel={() => {
-          setConfirming(false)
-        }}
+        onCancel={confirm.disarm}
       />
 
       <Outcome error={error} result={result} />
@@ -192,6 +196,7 @@ function Outcome({ error, result }: { error: DaemonError | null; result: RunResp
               Needs the ADBKeyboard IME installed on the device.
             </div>
           ) : null}
+          <ResultActions result={result} />
         </Banner>
       ) : null}
     </>

--- a/desktop/src/components/AppsPane.tsx
+++ b/desktop/src/components/AppsPane.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Boxes, RefreshCw, Search } from "lucide-react"
 import { Banner, Button, Switch } from "@/components/Controls"
+import { ResultActions } from "@/components/ResultActions"
+import { useArmedConfirm } from "@/hooks/useArmedConfirm"
 import { actionLabel, searchApps, sortApps } from "@/lib/apps"
 import { asDaemonError, controlApp, listApps } from "@/lib/daemon"
 import { cn } from "@/lib/cn"
@@ -202,18 +204,20 @@ function AppDetail({
   serial: string
 }) {
   const [running, setRunning] = useState<string | null>(null)
-  const [confirming, setConfirming] = useState<string | null>(null)
   const [result, setResult] = useState<RunResponse | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
+  const confirm = useArmedConfirm()
 
   const run = async (action: AppActionDescriptor) => {
     // A second press for the destructive ones, matching the Quick Actions
-    // panel's second-⏎ rule. The daemon says which those are.
-    if (action.isDestructive && confirming !== action.id) {
-      setConfirming(action.id)
+    // panel's second-⏎ rule. The daemon says which those are. The arming is
+    // scoped to this verb on this package and expires on its own, so a stray
+    // click later — or on a different app — cannot clear anyone's data.
+    if (action.isDestructive && !confirm.isArmed(action.id, app.packageId)) {
+      confirm.arm(action.id, app.packageId)
       return
     }
-    setConfirming(null)
+    confirm.disarm()
     setRunning(action.id)
     setResult(null)
     setError(null)
@@ -242,7 +246,7 @@ function AppDetail({
         </div>
       </header>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {actions.map((action) => (
           <Button
             key={action.id}
@@ -252,11 +256,14 @@ function AppDetail({
           >
             {running === action.id
               ? "Running…"
-              : confirming === action.id
+              : confirm.isArmed(action.id, app.packageId)
                 ? `Really ${actionLabel(action).toLowerCase()}?`
                 : actionLabel(action)}
           </Button>
         ))}
+        {actions.some((action) => confirm.isArmed(action.id, app.packageId)) ? (
+          <Button onClick={confirm.disarm}>Cancel</Button>
+        ) : null}
       </div>
 
       {error ? (
@@ -265,7 +272,12 @@ function AppDetail({
           {error.detail ? <div className="mt-1 opacity-70">{error.detail}</div> : null}
         </Banner>
       ) : null}
-      {result ? <Banner tone={result.ok ? "ok" : "error"}>{result.message}</Banner> : null}
+      {result ? (
+        <Banner tone={result.ok ? "ok" : "error"}>
+          {result.message}
+          <ResultActions result={result} />
+        </Banner>
+      ) : null}
     </div>
   )
 }

--- a/desktop/src/components/ResultActions.tsx
+++ b/desktop/src/components/ResultActions.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react"
+import { Check, Clipboard, FolderOpen } from "lucide-react"
+import { asDaemonError, copyText, revealPath } from "@/lib/daemon"
+import type { RunResponse } from "@/lib/wire"
+
+/**
+ * What an action gave back, and what you can do with it.
+ *
+ * A result carrying `copyText` lands on the clipboard **immediately** — that is
+ * the whole point of Copy Device IP, Copy Foreground Bundle ID and Copy Current
+ * Activity, and it is what `AppState.show` does on the Mac. It used to render
+ * the value and stop there, so the action's name was a promise the UI did not
+ * keep.
+ *
+ * The button is for later: this pane keeps its result on screen, unlike the
+ * Mac's toast, so "still on the clipboard?" stops being obvious after you have
+ * copied something else.
+ */
+export function ResultActions({ result }: { result: RunResponse }) {
+  const [copied, setCopied] = useState(false)
+  const [flash, setFlash] = useState(false)
+  const [failure, setFailure] = useState<string | null>(null)
+
+  const text = result.copyText
+  useEffect(() => {
+    if (text === null) return
+    setFailure(null)
+    setCopied(false)
+    copyText(text)
+      .then(() => {
+        setCopied(true)
+      })
+      // Loudly: a copy that quietly does nothing is the defect this replaces.
+      .catch((thrown: unknown) => {
+        setFailure(asDaemonError(thrown).message)
+      })
+  }, [text])
+
+  if (text === null && result.revealPath === null) return null
+
+  const recopy = async () => {
+    if (text === null) return
+    setFailure(null)
+    try {
+      await copyText(text)
+      setCopied(true)
+      setFlash(true)
+      globalThis.setTimeout(() => {
+        setFlash(false)
+      }, 1200)
+    } catch (thrown) {
+      setFailure(asDaemonError(thrown).message)
+    }
+  }
+
+  const reveal = async (path: string) => {
+    setFailure(null)
+    try {
+      await revealPath(path)
+    } catch (thrown) {
+      setFailure(asDaemonError(thrown).message)
+    }
+  }
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      {text === null ? null : (
+        <SmallButton icon={copied ? Check : Clipboard} onClick={() => void recopy()}>
+          {flash ? "Copied" : copied ? "Copy again" : "Copy"}
+        </SmallButton>
+      )}
+      {result.revealPath === null ? null : (
+        <SmallButton icon={FolderOpen} onClick={() => void reveal(result.revealPath ?? "")}>
+          Show in folder
+        </SmallButton>
+      )}
+      {copied && failure === null ? (
+        <span className="text-text-tertiary">· copied to the clipboard</span>
+      ) : null}
+      {failure === null ? null : <span className="text-danger">{failure}</span>}
+    </div>
+  )
+}
+
+function SmallButton({
+  icon: Icon,
+  onClick,
+  children,
+}: {
+  icon: typeof Clipboard
+  onClick: () => void
+  children: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-1.5 rounded-md bg-white/[0.06] px-2 py-1 text-[12px] text-text-primary transition-colors hover:bg-white/[0.12]"
+    >
+      <Icon size={12} />
+      {children}
+    </button>
+  )
+}

--- a/desktop/src/hooks/useArmedConfirm.ts
+++ b/desktop/src/hooks/useArmedConfirm.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react"
+import { arm, CONFIRM_WINDOW_MS, isArmed, type Armed } from "@/lib/confirm"
+
+export interface ArmedConfirm {
+  /** Whether pressing this button now would actually run it. */
+  isArmed: (actionId: string, target: string) => boolean
+  /** Arm a button. Replaces any previous arming — only one at a time. */
+  arm: (actionId: string, target: string) => void
+  disarm: () => void
+}
+
+/**
+ * Holds the one armed destructive action, and makes sure it goes away.
+ *
+ * Three things disarm it, and all three matter: pressing Cancel, the window
+ * losing focus, and the window itself passing. The timer is not the guard —
+ * `isArmed` is, and it re-checks the clock — but without it the button would
+ * sit there reading "Really clear data?" long after the arming expired.
+ */
+export function useArmedConfirm(): ArmedConfirm {
+  const [armed, setArmed] = useState<Armed | null>(null)
+
+  useEffect(() => {
+    if (armed === null) return
+    const timer = globalThis.setTimeout(() => {
+      setArmed(null)
+    }, CONFIRM_WINDOW_MS)
+    // Looking away is as good as saying no.
+    const onBlur = () => {
+      setArmed(null)
+    }
+    globalThis.addEventListener("blur", onBlur)
+    return () => {
+      globalThis.clearTimeout(timer)
+      globalThis.removeEventListener("blur", onBlur)
+    }
+  }, [armed])
+
+  return {
+    isArmed: useCallback(
+      (actionId: string, target: string) => isArmed(armed, actionId, target, Date.now()),
+      [armed],
+    ),
+    arm: useCallback((actionId: string, target: string) => {
+      setArmed(arm(actionId, target, Date.now()))
+    }, []),
+    disarm: useCallback(() => {
+      setArmed(null)
+    }, []),
+  }
+}

--- a/desktop/src/lib/confirm.test.ts
+++ b/desktop/src/lib/confirm.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { arm, CONFIRM_WINDOW_MS, isArmed } from "@/lib/confirm"
+
+describe("isArmed", () => {
+  const armed = arm("clear-data", "com.example.app", 1000)
+
+  it("authorises the same button on the same target, straight away", () => {
+    expect(isArmed(armed, "clear-data", "com.example.app", 1000)).toBe(true)
+  })
+
+  it("authorises nothing when nothing is armed", () => {
+    expect(isArmed(null, "clear-data", "com.example.app", 1000)).toBe(false)
+  })
+
+  it("does not carry over to a different button", () => {
+    // Arming Clear Data must not authorise Uninstall stood next to it.
+    expect(isArmed(armed, "uninstall", "com.example.app", 1000)).toBe(false)
+  })
+
+  it("does not carry over to a different app", () => {
+    // The scenario worth preventing: arm on one app, pick another, press
+    // again, and wipe the wrong one.
+    expect(isArmed(armed, "clear-data", "com.other.app", 1000)).toBe(false)
+  })
+
+  it("expires", () => {
+    expect(isArmed(armed, "clear-data", "com.example.app", 1000 + CONFIRM_WINDOW_MS - 1)).toBe(true)
+    expect(isArmed(armed, "clear-data", "com.example.app", 1000 + CONFIRM_WINDOW_MS)).toBe(false)
+    expect(isArmed(armed, "clear-data", "com.example.app", 1000 + 600_000)).toBe(false)
+  })
+})

--- a/desktop/src/lib/confirm.ts
+++ b/desktop/src/lib/confirm.ts
@@ -1,0 +1,41 @@
+/**
+ * Arming a destructive action.
+ *
+ * The Mac's rule is that a confirmation is *modal and momentary* — a second
+ * press, right now, on the thing you just pressed. A boolean flag is neither:
+ * it stays armed while you go and do something else, and a stray click minutes
+ * later clears an app's data.
+ *
+ * So an arming records what it was for and when, and everything else — a
+ * different button, a different app, or simply time passing — expires it.
+ */
+export interface Armed {
+  /** The button that was pressed: an action id, or a feature id. */
+  actionId: string
+  /** What it would act on — a package id, a device serial, or "". */
+  target: string
+  armedAt: number
+}
+
+/**
+ * How long an arming lasts. Long enough to move the pointer and press again,
+ * short enough that a forgotten one cannot be triggered by accident.
+ */
+export const CONFIRM_WINDOW_MS = 5000
+
+/** Whether `armed` still authorises running `actionId` against `target`. */
+export function isArmed(
+  armed: Armed | null,
+  actionId: string,
+  target: string,
+  now: number,
+): boolean {
+  if (armed === null) return false
+  if (armed.actionId !== actionId || armed.target !== target) return false
+  return now - armed.armedAt < CONFIRM_WINDOW_MS
+}
+
+/** The arming a press creates. */
+export function arm(actionId: string, target: string, now: number): Armed {
+  return { actionId, target, armedAt: now }
+}

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -63,6 +63,19 @@ export function controlApp(args: {
   return invoke<RunResponse>("control_app", args)
 }
 
+/**
+ * Host capabilities, not daemon calls — but they arrive the same way and fail
+ * the same way, so they live beside the rest rather than in a second module
+ * with its own error shape.
+ */
+export function copyText(text: string): Promise<void> {
+  return invoke("copy_text", { text })
+}
+
+export function revealPath(path: string): Promise<void> {
+  return invoke("reveal_path", { path })
+}
+
 /** A live subscription. Always `stop()` it when the view goes away. */
 export interface Subscription {
   id: number

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -149,15 +149,20 @@ Sourced from `CLAUDE.md` and the App sources.
 
 Found by driving the app against a live emulator, not by reading it.
 
-- [ ] **`copyText` never reaches the clipboard.** "Copy Device IP" runs, prints
-      `10.0.2.16`, and copies nothing — the action's name is a promise the UI
-      does not keep. Every action returning `copyText` has this.
-- [ ] **`revealPath` has no affordance.** Screenshot and friends report where
-      the file went with no way to open the folder.
-- [ ] **The destructive confirmation is sticky.** Clicking Clear Data arms
-      "Really clear data?" with no Cancel, no timeout and no disarm on blur, so
-      a stray click minutes later wipes app data. The Mac's second-⏎ rule is
-      modal and momentary; this is not.
+- [x] ~~**`copyText` never reaches the clipboard.**~~ A result carrying
+      `copyText` now lands on the clipboard the moment it arrives, as
+      `AppState.show` does on the Mac, and says so. Through a Rust command
+      (`tauri-plugin-clipboard-manager`), not `navigator.clipboard`, which
+      needs a gesture the browser agrees was one and can fail silently on
+      WebKitGTK — the same failure in a new place.
+- [x] ~~**`revealPath` has no affordance.**~~ A "Show in folder" button, via
+      `tauri-plugin-opener`. Both plugins are registered for their Rust APIs
+      only, so the webview's capability file stays at `core:default`.
+- [x] ~~**The destructive confirmation is sticky.**~~ An arming now records
+      *which* button on *which* target, and expires after five seconds
+      (`lib/confirm.ts`). A Cancel button appears while armed, the window
+      losing focus disarms, and an arming on one app never authorises the same
+      verb on another.
 - [ ] **Logcat cannot be restarted.** Stop disables the button and the only way
       back is a tab switch or a device change.
 - [ ] **Logcat has no level or app filter** — the Mac has both, plus a


### PR DESCRIPTION
Stacked on #253. Clears three of the six defects in the tracker — all in what
happens *after* an action runs.

## `copyText` reached nothing

"Copy Device IP" printed `10.0.2.16` and copied nothing. A result carrying
`copyText` now lands on the clipboard the moment it arrives — what
`AppState.show` does on the Mac — and says so, with a button to copy it again
once the pane has been sitting there a while (this pane keeps its result, unlike
the Mac's toast).

## `revealPath` had no affordance

Screenshot reported where the file went with no way to get to it. There is a
**Show in folder** button now.

Both go through Rust commands rather than `navigator.clipboard` and a link: the
webview needs a user gesture the browser agrees was one, and on WebKitGTK it can
fail silently — the same defect in a new place. `tauri-plugin-clipboard-manager`
and `tauri-plugin-opener` are registered for their **Rust APIs only**, so the
capability file stays at `core:default` and the webview gains nothing it could
be tricked into using.

## The destructive confirmation was sticky

Clicking Clear Data armed "Really clear data?" with no Cancel, no timeout and no
disarm on blur, so a stray click minutes later wiped app data.

An arming now records *which* button on *which* target and expires after five
seconds (`lib/confirm.ts`, unit-tested). Cancel appears while armed, the window
losing focus disarms, and arming on one app never authorises the same verb on
another. The Mac's second-press rule is modal and momentary; now so is this one.

## Verified

`make desktop-test` green (typecheck, oxlint, 127 vitest, cargo
fmt/clippy/test). Against `emulator-5554`:

- primed the clipboard with a sentinel, ran Copy Device IP, and read back
  `10.0.2.16` — matching `adb shell ip route`;
- ran Screenshot, clicked Show in folder, and Finder opened the containing
  folder;
- armed Clear Data (button became "Really clear data?", Cancel appeared) and
  watched it revert to "Clear Data" on its own six seconds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)