### PR TITLE
Open anything from a palette, and pin what you use

### DIFF
--- a/desktop/src/components/CommandPalette.tsx
+++ b/desktop/src/components/CommandPalette.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from "react"
+import { Pin, Search } from "lucide-react"
+import { cn } from "@/lib/cn"
+import { iconForFeature } from "@/lib/icons"
+import { moveHighlight, paletteResults } from "@/lib/palette"
+import { IS_MAC, shortcutLabel } from "@/lib/platform"
+import type { FeatureSummary } from "@/lib/wire"
+
+/**
+ * The palette: everything openable, one keystroke away.
+ *
+ * Opened with Ctrl/⌘+K or Ctrl/⌘+T, and by the tab strip's `+`. Arrow keys
+ * move, Enter opens in the pane that asked, Ctrl/⌘+P pins or unpins whatever
+ * is highlighted — the same pinned list the sidebar's top section shows.
+ */
+export function CommandPalette({
+  features,
+  favorites,
+  onOpen,
+  onTogglePinned,
+  onDismiss,
+}: {
+  features: FeatureSummary[]
+  favorites: string[]
+  onOpen: (id: string) => void
+  onTogglePinned: (id: string) => void
+  onDismiss: () => void
+}) {
+  const [query, setQuery] = useState("")
+  const [highlight, setHighlight] = useState(0)
+
+  const results = useMemo(
+    () => paletteResults(features, query, favorites),
+    [features, query, favorites],
+  )
+  // Typing narrows the list; the highlight follows it rather than pointing at
+  // a row that is no longer there.
+  const index = Math.min(highlight, Math.max(results.length - 1, 0))
+  const current = results[index]
+
+  useEffect(() => {
+    setHighlight(0)
+  }, [query])
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const modifier = IS_MAC ? event.metaKey : event.ctrlKey
+    if (event.key === "Escape") {
+      event.preventDefault()
+      onDismiss()
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setHighlight(moveHighlight(results.length, index, 1))
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setHighlight(moveHighlight(results.length, index, -1))
+    } else if (modifier && event.key === "p") {
+      event.preventDefault()
+      if (current) onTogglePinned(current.id)
+    } else if (event.key === "Enter" && current) {
+      event.preventDefault()
+      onOpen(current.id)
+      onDismiss()
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40" onPointerDown={onDismiss} />
+      <div className="fixed inset-x-0 top-[12vh] z-50 mx-auto w-[560px] max-w-[90vw] overflow-hidden rounded-xl border border-border-subtle bg-bg-raised shadow-2xl">
+        <div className="flex items-center gap-2.5 border-b border-border-subtle px-3.5 py-3">
+          <Search size={15} className="shrink-0 text-text-tertiary" />
+          <input
+            value={query}
+            // The palette exists to be typed into; landing anywhere else
+            // costs a keystroke every time it opens.
+            // oxlint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            aria-label="Search features"
+            placeholder="Open a feature…"
+            onChange={(event) => {
+              setQuery(event.target.value)
+            }}
+            onKeyDown={onKeyDown}
+            className="min-w-0 flex-1 bg-transparent text-[15px] text-text-primary outline-none placeholder:text-text-tertiary"
+          />
+          <span className="shrink-0 text-[11px] text-text-tertiary">
+            {shortcutLabel("p", IS_MAC)} to pin
+          </span>
+        </div>
+
+        <div className="max-h-[52vh] overflow-y-auto py-1.5">
+          {results.length === 0 ? (
+            <p className="px-4 py-8 text-center text-text-tertiary">Nothing matches “{query}”.</p>
+          ) : (
+            results.map((feature, row) => (
+              <Row
+                key={feature.id}
+                feature={feature}
+                pinned={favorites.includes(feature.id)}
+                highlighted={row === index}
+                onHover={() => {
+                  setHighlight(row)
+                }}
+                onSelect={() => {
+                  onOpen(feature.id)
+                  onDismiss()
+                }}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function Row({
+  feature,
+  pinned,
+  highlighted,
+  onHover,
+  onSelect,
+}: {
+  feature: FeatureSummary
+  pinned: boolean
+  highlighted: boolean
+  onHover: () => void
+  onSelect: () => void
+}) {
+  const Icon = iconForFeature(feature.id, feature.category)
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      onPointerMove={onHover}
+      className={cn(
+        "flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left",
+        highlighted ? "bg-accent/15" : "",
+      )}
+    >
+      <Icon size={16} className="shrink-0 text-accent" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13.5px] text-text-primary">{feature.title}</span>
+        {feature.subtitle ? (
+          <span className="block truncate text-[11.5px] text-text-secondary">
+            {feature.subtitle}
+          </span>
+        ) : null}
+      </span>
+      {pinned ? <Pin size={12} className="shrink-0 text-accent" /> : null}
+    </button>
+  )
+}

--- a/desktop/src/components/FeaturePane.tsx
+++ b/desktop/src/components/FeaturePane.tsx
@@ -16,6 +16,7 @@ export interface FeaturePaneProps {
   onOpen: (id: string) => void
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
 }
 
 /**
@@ -33,6 +34,7 @@ export function FeaturePane(props: FeaturePaneProps) {
         features={props.features}
         sidebarOrder={props.sidebarOrder}
         categoryOrder={props.categoryOrder}
+        favorites={props.favorites}
         onOpen={props.onOpen}
       />
     )

--- a/desktop/src/components/HomeView.tsx
+++ b/desktop/src/components/HomeView.tsx
@@ -13,11 +13,13 @@ export function HomeView({
   features,
   sidebarOrder,
   categoryOrder,
+  favorites,
   onOpen,
 }: {
   features: FeatureSummary[]
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
   onOpen: (id: string) => void
 }) {
   const sections = sidebarSections(features, {
@@ -27,6 +29,7 @@ export function HomeView({
     // Collapsing is a sidebar-space affordance, not a preference against the
     // feature, so Home shows a collapsed group's contents anyway.
     collapsedCategories: [],
+    favorites,
   })
   const total = sections.reduce((count, section) => count + section.features.length, 0)
 

--- a/desktop/src/components/PaneArea.tsx
+++ b/desktop/src/components/PaneArea.tsx
@@ -20,8 +20,10 @@ export interface PaneAreaProps {
   onSplit: (id: string) => void
   onFocusPane: (pane: number) => void
   onContextMenu: (id: string, x: number, y: number) => void
+  onNewTab: (pane: number) => void
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
   splitFraction: number
   onSplitFraction: (fraction: number) => void
 }
@@ -100,6 +102,7 @@ export function PaneArea(props: PaneAreaProps) {
             onClose={props.onClose}
             onDrop={props.onDrop}
             onContextMenu={props.onContextMenu}
+            onNewTab={props.onNewTab}
             dragging={dragging}
             onDragState={setDragging}
           />
@@ -187,6 +190,7 @@ function PaneBody({
             onOpen={props.onOpen}
             sidebarOrder={props.sidebarOrder}
             categoryOrder={props.categoryOrder}
+            favorites={props.favorites}
           />
         </div>
       ))}

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -16,6 +16,8 @@ export interface SidebarProps {
   sidebarOrder: string[]
   categoryOrder: string[]
   collapsedCategories: string[]
+  favorites: string[]
+  onTogglePinned: (id: string) => void
   onSidebarOrder: (order: string[]) => void
   onCategoryOrder: (order: string[]) => void
   onToggleCollapsed: (category: string) => void
@@ -44,8 +46,16 @@ export function Sidebar(props: SidebarProps) {
         sidebarOrder: props.sidebarOrder,
         categoryOrder: props.categoryOrder,
         collapsedCategories: props.collapsedCategories,
+        favorites: props.favorites,
       }),
-    [props.features, props.sidebarOrder, props.categoryOrder, props.collapsedCategories, query],
+    [
+      props.features,
+      props.sidebarOrder,
+      props.categoryOrder,
+      props.collapsedCategories,
+      props.favorites,
+      query,
+    ],
   )
 
   const endDrag = () => {
@@ -99,6 +109,8 @@ export function Sidebar(props: SidebarProps) {
               key={section.category}
               section={section}
               activeID={props.activeID}
+              favorites={props.favorites}
+              onTogglePinned={props.onTogglePinned}
               dragging={dragging}
               slot={slot}
               draggable={!searching}

--- a/desktop/src/components/SidebarSection.tsx
+++ b/desktop/src/components/SidebarSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from "lucide-react"
+import { ChevronRight, Pin, PinOff } from "lucide-react"
 import { pastMidpointY, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
 import { iconForFeature } from "@/lib/icons"
@@ -22,6 +22,8 @@ export interface DropSlot {
 export interface SectionProps {
   section: Section
   activeID: string | null
+  favorites: readonly string[]
+  onTogglePinned: (id: string) => void
   dragging: Dragging | null
   slot: DropSlot | null
   /** Off while searching: relevance order is not an order worth persisting. */
@@ -90,6 +92,10 @@ export function SidebarSection(props: SectionProps) {
               key={feature.id}
               feature={feature}
               active={feature.id === props.activeID}
+              pinned={props.favorites.includes(feature.id)}
+              onTogglePinned={() => {
+                props.onTogglePinned(feature.id)
+              }}
               slot={takesFeature && slot?.id === feature.id ? slot.after : null}
               faded={dragging?.kind === "feature" && dragging.id === feature.id}
               draggable={props.draggable}
@@ -124,6 +130,8 @@ export function SidebarSection(props: SectionProps) {
 function Row({
   feature,
   active,
+  pinned,
+  onTogglePinned,
   slot,
   faded,
   draggable,
@@ -134,6 +142,8 @@ function Row({
 }: {
   feature: FeatureSummary
   active: boolean
+  pinned: boolean
+  onTogglePinned: () => void
   /** Null for no guideline, else which side of the row it sits on. */
   slot: boolean | null
   faded: boolean
@@ -145,32 +155,52 @@ function Row({
 }) {
   const Icon = iconForFeature(feature.id, feature.category)
   return (
-    <button
-      type="button"
+    <div
       draggable={draggable}
-      onClick={onOpen}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
-      title={feature.subtitle ?? feature.title}
       className={cn(
-        "relative flex w-full items-start gap-2.5 px-3 py-1.5 text-left transition-colors",
+        "group relative flex w-full items-start gap-2.5 px-3 py-1.5 transition-colors",
         active ? "bg-accent/12" : "hover:bg-white/[0.04]",
         faded ? "opacity-30" : "",
       )}
     >
-      <Icon
-        size={16}
-        className={cn("mt-[3px] shrink-0", active ? "text-accent" : "text-accent/80")}
-      />
-      <span className="min-w-0">
-        <span className="block truncate text-[13px] text-text-primary">{feature.title}</span>
-        {feature.subtitle ? (
-          <span className="block truncate text-[11px] text-text-secondary">{feature.subtitle}</span>
-        ) : null}
-      </span>
+      <button
+        type="button"
+        onClick={onOpen}
+        title={feature.subtitle ?? feature.title}
+        className="flex min-w-0 flex-1 items-start gap-2.5 text-left"
+      >
+        <Icon
+          size={16}
+          className={cn("mt-[3px] shrink-0", active ? "text-accent" : "text-accent/80")}
+        />
+        <span className="min-w-0">
+          <span className="block truncate text-[13px] text-text-primary">{feature.title}</span>
+          {feature.subtitle ? (
+            <span className="block truncate text-[11px] text-text-secondary">
+              {feature.subtitle}
+            </span>
+          ) : null}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onTogglePinned}
+        title={pinned ? "Unpin" : "Pin to the top"}
+        aria-label={pinned ? `Unpin ${feature.title}` : `Pin ${feature.title}`}
+        className={cn(
+          "mt-[2px] shrink-0 rounded p-0.5 text-text-tertiary hover:text-text-primary",
+          // Reserved space either way, so a row does not shift under the
+          // pointer as it arrives.
+          pinned ? "text-accent" : "opacity-0 group-hover:opacity-100",
+        )}
+      >
+        {pinned ? <Pin size={12} /> : <PinOff size={12} />}
+      </button>
       {slot === null ? null : <Guideline after={slot} />}
-    </button>
+    </div>
   )
 }
 

--- a/desktop/src/components/TabStrip.tsx
+++ b/desktop/src/components/TabStrip.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { House, X } from "lucide-react"
+import { House, Plus, X } from "lucide-react"
 import { pastMidpointX, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
 import { iconForFeature } from "@/lib/icons"
@@ -22,6 +22,8 @@ export interface TabStripProps {
   /** A drop landing in this pane, before `target` (null = the end). */
   onDrop: (id: string, pane: number, target: string | null) => void
   onContextMenu: (id: string, x: number, y: number) => void
+  /** Open the palette with this pane focused, so the choice lands here. */
+  onNewTab: (pane: number) => void
   /** The tab being dragged anywhere in the window, so a strip can accept it. */
   dragging: string | null
   onDragState: (id: string | null) => void
@@ -65,26 +67,12 @@ export function TabStrip(props: TabStripProps) {
       }}
     >
       {props.pane === 0 ? (
-        <>
-          <button
-            type="button"
-            onClick={() => {
-              props.onSelect(HOME_TAB)
-            }}
-            title="Home"
-            aria-label="Home"
-            aria-current={props.tabs.activeTab === HOME_TAB}
-            className={cn(
-              "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
-              props.tabs.activeTab === HOME_TAB
-                ? "bg-accent/15 text-accent"
-                : "text-text-secondary hover:bg-white/[0.05] hover:text-text-primary",
-            )}
-          >
-            <House size={14} />
-          </button>
-          <span className="mx-1.5 h-5 w-px shrink-0 bg-border-subtle" />
-        </>
+        <HomeButton
+          active={props.tabs.activeTab === HOME_TAB}
+          onSelect={() => {
+            props.onSelect(HOME_TAB)
+          }}
+        />
       ) : null}
 
       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
@@ -127,8 +115,44 @@ export function TabStrip(props: TabStripProps) {
             }}
           />
         ))}
+        <button
+          type="button"
+          onClick={() => {
+            props.onNewTab(props.pane)
+          }}
+          title={`New tab (${shortcutLabel("t", IS_MAC)})`}
+          aria-label="New tab"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-white/[0.05] hover:text-text-primary"
+        >
+          <Plus size={14} />
+        </button>
       </div>
     </div>
+  )
+}
+
+/** Home rides a permanent button, so it cannot be closed away or lost in the
+ *  tab overflow — the same place it sits on the Mac. */
+function HomeButton({ active, onSelect }: { active: boolean; onSelect: () => void }) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onSelect}
+        title="Home"
+        aria-label="Home"
+        aria-current={active}
+        className={cn(
+          "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
+          active
+            ? "bg-accent/15 text-accent"
+            : "text-text-secondary hover:bg-white/[0.05] hover:text-text-primary",
+        )}
+      >
+        <House size={14} />
+      </button>
+      <span className="mx-1.5 h-5 w-px shrink-0 bg-border-subtle" />
+    </>
   )
 }
 

--- a/desktop/src/components/WorkspaceShell.tsx
+++ b/desktop/src/components/WorkspaceShell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { CommandPalette } from "@/components/CommandPalette"
 import { PaneArea } from "@/components/PaneArea"
 import { Sidebar } from "@/components/Sidebar"
 import { TabContextMenu } from "@/components/TabContextMenu"
@@ -23,6 +24,7 @@ export function WorkspaceShell({
 }) {
   const workspace = useWorkspace(features)
   const [menu, setMenu] = useState<TabMenuTarget | null>(null)
+  const [paletteOpen, setPaletteOpen] = useState(false)
   // Lifted out of the Apps pane: a `needsBundle` action needs the same choice,
   // so it cannot live inside one tab. A package id means nothing on a different
   // device, so the choice is dropped when the selection changes.
@@ -37,12 +39,25 @@ export function WorkspaceShell({
     [features],
   )
 
+  // Focus the pane first, so whatever is chosen opens in the one that asked.
+  const { focusPane } = workspace
+  const onNewTab = useCallback(
+    (pane: number) => {
+      focusPane(pane)
+      setPaletteOpen(true)
+    },
+    [focusPane],
+  )
+
   const focused = activeTab(workspace.workspace)
   useTabShortcuts({
     activeTab: focused,
     onClose: workspace.close,
     onActivateIndex: workspace.activateIndex,
     onSplit: workspace.split,
+    onPalette: () => {
+      setPaletteOpen(true)
+    },
   })
 
   return (
@@ -54,6 +69,8 @@ export function WorkspaceShell({
         sidebarOrder={workspace.layout.sidebarOrder}
         categoryOrder={workspace.layout.categoryOrder}
         collapsedCategories={workspace.layout.collapsedCategories}
+        favorites={workspace.layout.favorites}
+        onTogglePinned={workspace.togglePin}
         onSidebarOrder={workspace.setSidebarOrder}
         onCategoryOrder={workspace.setCategoryOrder}
         onToggleCollapsed={workspace.toggleCategory}
@@ -74,21 +91,60 @@ export function WorkspaceShell({
         onContextMenu={(id, x, y) => {
           setMenu({ id, x, y })
         }}
+        onNewTab={onNewTab}
         sidebarOrder={workspace.layout.sidebarOrder}
         categoryOrder={workspace.layout.categoryOrder}
+        favorites={workspace.layout.favorites}
         splitFraction={workspace.layout.splitFraction}
         onSplitFraction={workspace.setSplitFraction}
       />
 
-      {menu === null ? null : (
-        <TabContextMenu
-          target={menu}
-          workspace={workspace}
-          onDismiss={() => {
-            setMenu(null)
-          }}
-        />
-      )}
+      <Overlays
+        palette={paletteOpen}
+        menu={menu}
+        features={features}
+        workspace={workspace}
+        onDismissPalette={() => {
+          setPaletteOpen(false)
+        }}
+        onDismissMenu={() => {
+          setMenu(null)
+        }}
+      />
     </div>
+  )
+}
+
+/** The two things that float over the panes. */
+function Overlays({
+  palette,
+  menu,
+  features,
+  workspace,
+  onDismissPalette,
+  onDismissMenu,
+}: {
+  palette: boolean
+  menu: TabMenuTarget | null
+  features: FeatureSummary[]
+  workspace: ReturnType<typeof useWorkspace>
+  onDismissPalette: () => void
+  onDismissMenu: () => void
+}) {
+  return (
+    <>
+      {palette ? (
+        <CommandPalette
+          features={features}
+          favorites={workspace.layout.favorites}
+          onOpen={workspace.open}
+          onTogglePinned={workspace.togglePin}
+          onDismiss={onDismissPalette}
+        />
+      ) : null}
+      {menu === null ? null : (
+        <TabContextMenu target={menu} workspace={workspace} onDismiss={onDismissMenu} />
+      )}
+    </>
   )
 }

--- a/desktop/src/hooks/useTabShortcuts.ts
+++ b/desktop/src/hooks/useTabShortcuts.ts
@@ -12,15 +12,22 @@ export function useTabShortcuts({
   onClose,
   onActivateIndex,
   onSplit,
+  onPalette,
 }: {
   activeTab: string | null
   onClose: (id: string) => void
   onActivateIndex: (index: number) => void
   onSplit: (id: string) => void
+  onPalette: () => void
 }): void {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!hasModifier(event) || event.altKey) return
+      if (event.key === "k" || event.key === "t") {
+        event.preventDefault()
+        onPalette()
+        return
+      }
       if (event.key === "w") {
         event.preventDefault()
         if (activeTab !== null) onClose(activeTab)
@@ -45,5 +52,5 @@ export function useTabShortcuts({
     return () => {
       globalThis.removeEventListener("keydown", onKeyDown)
     }
-  }, [activeTab, onClose, onActivateIndex, onSplit])
+  }, [activeTab, onClose, onActivateIndex, onSplit, onPalette])
 }

--- a/desktop/src/hooks/useWorkspace.ts
+++ b/desktop/src/hooks/useWorkspace.ts
@@ -7,6 +7,7 @@ import {
   type LayoutState,
 } from "@/lib/layout"
 import { clampedFraction } from "@/lib/panes"
+import { togglePinned } from "@/lib/palette"
 import { toggleCollapsed } from "@/lib/sidebar"
 import type { FeatureSummary } from "@/lib/wire"
 import {
@@ -37,6 +38,7 @@ export interface WorkspaceController {
   setSidebarOrder: (order: string[]) => void
   setCategoryOrder: (order: string[]) => void
   toggleCategory: (category: string) => void
+  togglePin: (id: string) => void
 }
 
 /**
@@ -119,6 +121,9 @@ export function useWorkspace(features: FeatureSummary[]): WorkspaceController {
     }, []),
     setCategoryOrder: useCallback((categoryOrder: string[]) => {
       setLayout((current) => ({ ...current, categoryOrder }))
+    }, []),
+    togglePin: useCallback((id: string) => {
+      setLayout((current) => ({ ...current, favorites: togglePinned(current.favorites, id) }))
     }, []),
     toggleCategory: useCallback((category: string) => {
       setLayout((current) => ({

--- a/desktop/src/lib/layout.test.ts
+++ b/desktop/src/lib/layout.test.ts
@@ -24,6 +24,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat", "apps"],
       categoryOrder: ["logs"],
       collapsedCategories: ["input"],
+      favorites: ["logcat"],
       panes: [
         { tabs: [HOME_TAB, "logcat"], activeTab: "logcat" },
         { tabs: ["apps"], activeTab: "apps" },
@@ -49,6 +50,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat", 7, null],
       categoryOrder: "logs",
       collapsedCategories: [{ nope: true }],
+      favorites: null,
       panes: [{ tabs: [HOME_TAB, 3], activeTab: 9 }, "not a pane", { tabs: [] }],
       focusedPane: "second",
       splitFraction: "half",
@@ -57,6 +59,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat"],
       categoryOrder: [],
       collapsedCategories: [],
+      favorites: [],
       panes: [{ tabs: [HOME_TAB], activeTab: null }],
       focusedPane: 0,
       splitFraction: 0.5,

--- a/desktop/src/lib/layout.ts
+++ b/desktop/src/lib/layout.ts
@@ -24,6 +24,8 @@ export interface LayoutState {
   sidebarOrder: string[]
   categoryOrder: string[]
   collapsedCategories: string[]
+  /** Pinned feature ids, in the order they were pinned. */
+  favorites: string[]
   /** One entry per open pane, left to right. */
   panes: SavedPane[]
   focusedPane: number
@@ -38,6 +40,7 @@ export function emptyLayout(): LayoutState {
     sidebarOrder: [],
     categoryOrder: [],
     collapsedCategories: [],
+    favorites: [],
     panes: [{ tabs: [HOME_TAB], activeTab: HOME_TAB }],
     focusedPane: 0,
     splitFraction: 0.5,
@@ -68,6 +71,7 @@ export function loadLayout(storage: Pick<Storage, "getItem">): LayoutState {
     sidebarOrder: stringArray(saved.sidebarOrder),
     categoryOrder: stringArray(saved.categoryOrder),
     collapsedCategories: stringArray(saved.collapsedCategories),
+    favorites: stringArray(saved.favorites),
     panes: panes.length === 0 ? emptyLayout().panes : panes,
     focusedPane: typeof saved.focusedPane === "number" ? saved.focusedPane : 0,
     splitFraction: typeof saved.splitFraction === "number" ? saved.splitFraction : 0.5,

--- a/desktop/src/lib/palette.test.ts
+++ b/desktop/src/lib/palette.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import raw from "@/lib/__fixtures__/features.json"
-import { rankFeatures, relevance } from "@/lib/palette"
+import { moveHighlight, paletteResults, rankFeatures, relevance, togglePinned } from "@/lib/palette"
 import type { FeatureSummary } from "@/lib/wire"
 
 // Real daemon output, captured from `POST /v1/features/list` rather than
@@ -74,5 +74,51 @@ describe("rankFeatures", () => {
     // Deliberately not filtered here: the sidebar wants views as well as
     // actions, and a palette over commands would choose differently again.
     expect(rankFeatures(features, "").map((feature) => feature.id)).toContain("logcat")
+  })
+})
+
+describe("paletteResults", () => {
+  it("opens on what you pinned, in the order you pinned it", () => {
+    const results = paletteResults(features, "", ["logcat", "screenshot"])
+    expect(results.slice(0, 2).map((feature) => feature.id)).toEqual(["logcat", "screenshot"])
+  })
+
+  it("lists a pinned feature once, not twice", () => {
+    const ids = paletteResults(features, "", ["logcat"]).map((feature) => feature.id)
+    expect(ids.filter((id) => id === "logcat")).toHaveLength(1)
+    expect(ids).toHaveLength(features.length)
+  })
+
+  it("lets relevance decide once there is a query", () => {
+    // A weakly-matching pin sitting above an exact match would make the
+    // ranking a lie, so pins are not promoted here.
+    const results = paletteResults(features, "battery", ["logcat"])
+    expect(results[0]?.id).toBe("fake-battery")
+    expect(results.map((feature) => feature.id)).not.toContain("logcat")
+  })
+
+  it("ignores a pinned id that is no longer served", () => {
+    const ids = paletteResults(features, "", ["gone-feature"]).map((feature) => feature.id)
+    expect(ids).toHaveLength(features.length)
+  })
+})
+
+describe("moveHighlight", () => {
+  it("wraps at both ends", () => {
+    expect(moveHighlight(3, 2, 1)).toBe(0)
+    expect(moveHighlight(3, 0, -1)).toBe(2)
+    expect(moveHighlight(3, 0, 1)).toBe(1)
+  })
+
+  it("stays put with nothing to highlight", () => {
+    expect(moveHighlight(0, 0, 1)).toBe(0)
+  })
+})
+
+describe("togglePinned", () => {
+  it("appends then removes, keeping the pinning order", () => {
+    expect(togglePinned([], "logcat")).toEqual(["logcat"])
+    expect(togglePinned(["apps"], "logcat")).toEqual(["apps", "logcat"])
+    expect(togglePinned(["apps", "logcat"], "apps")).toEqual(["logcat"])
   })
 })

--- a/desktop/src/lib/palette.ts
+++ b/desktop/src/lib/palette.ts
@@ -58,6 +58,39 @@ export function rankFeatures(
     const score = relevance(feature, query)
     if (score > 0) scored.push({ feature, score, order })
   })
-  scored.sort((a, b) => (a.score === b.score ? a.order - b.order : b.score - a.score))
-  return scored.map((entry) => entry.feature)
+  return scored
+    .toSorted((a, b) => (a.score === b.score ? a.order - b.order : b.score - a.score))
+    .map((entry) => entry.feature)
+}
+
+/**
+ * What the palette lists.
+ *
+ * With no query, pinned features lead, in the order they were pinned — the
+ * palette opens on what you actually use. With one, relevance decides and
+ * nothing is promoted: a weakly-matching pin sitting above an exact match
+ * would make the ranking a lie.
+ */
+export function paletteResults(
+  features: readonly FeatureSummary[],
+  query: string,
+  favorites: readonly string[],
+): FeatureSummary[] {
+  if (query.trim() !== "") return rankFeatures(features, query)
+  const pinned = favorites.flatMap((id) => features.filter((feature) => feature.id === id))
+  const rest = features.filter((feature) => !favorites.includes(feature.id))
+  return [...pinned, ...rest]
+}
+
+/** Move a highlighted row by `delta`, wrapping at both ends. */
+export function moveHighlight(count: number, current: number, delta: number): number {
+  if (count <= 0) return 0
+  return (current + delta + count) % count
+}
+
+/** Add or remove `id` from the pinned list. */
+export function togglePinned(favorites: readonly string[], id: string): string[] {
+  return favorites.includes(id)
+    ? favorites.filter((entry) => entry !== id)
+    : [...favorites, id]
 }

--- a/desktop/src/lib/sidebar.test.ts
+++ b/desktop/src/lib/sidebar.test.ts
@@ -19,6 +19,7 @@ const plain = {
   sidebarOrder: [],
   categoryOrder: [],
   collapsedCategories: [],
+  favorites: [],
 }
 
 describe("categories", () => {
@@ -122,6 +123,27 @@ describe("sidebarSections", () => {
       collapsedCategories: [...CATEGORY_ORDER],
     })
     expect(visibleFeatures(sections).map((feature) => feature.id)).toContain("fake-battery")
+  })
+
+  it("puts a Pinned section first and lifts its members out of their groups", () => {
+    const sections = sidebarSections(features, { ...plain, favorites: ["logcat", "screenshot"] })
+    expect(sections[0]?.label).toBe("Pinned")
+    expect(sections[0]?.features.map((feature) => feature.id)).toEqual(["logcat", "screenshot"])
+    // Listed once, not in both places.
+    const elsewhere = sections
+      .slice(1)
+      .flatMap((section) => section.features.map((feature) => feature.id))
+    expect(elsewhere).not.toContain("logcat")
+    expect(elsewhere).not.toContain("screenshot")
+  })
+
+  it("has no Pinned section when nothing is pinned", () => {
+    expect(sidebarSections(features, plain).map((section) => section.label)).not.toContain("Pinned")
+  })
+
+  it("does not pin-order a search", () => {
+    const sections = sidebarSections(features, { ...plain, query: "battery", favorites: ["logcat"] })
+    expect(sections[0]?.features[0]?.id).toBe("fake-battery")
   })
 
   it("returns nothing for a query that matches nothing", () => {

--- a/desktop/src/lib/sidebar.ts
+++ b/desktop/src/lib/sidebar.ts
@@ -69,7 +69,12 @@ export interface SidebarLayout {
   sidebarOrder: readonly string[]
   categoryOrder: readonly string[]
   collapsedCategories: readonly string[]
+  /** Pinned feature ids, in the order they were pinned. */
+  favorites: readonly string[]
 }
+
+/** The pseudo-category the Pinned section uses. Never a real wire value. */
+export const PINNED_SECTION = "pinned"
 
 /**
  * The sections the sidebar renders.
@@ -87,10 +92,23 @@ export function sidebarSections(
   if (layout.query.trim() !== "") return searchSections(ordered, layout.query)
 
   const collapsed = new Set(layout.collapsedCategories)
-  const categories = rankBy(orderedCategoryIDs(ordered), layout.categoryOrder, (id) => id)
   const sections: SidebarSection[] = []
-  for (const category of categories) {
-    const matching = ordered.filter((feature) => feature.category === category)
+
+  // Pinned leads, and its members are lifted out of their categories rather
+  // than listed twice — the same call the Mac's `enabledFeatures(in:)` makes.
+  const pinned = layout.favorites.flatMap((id) => ordered.filter((feature) => feature.id === id))
+  if (pinned.length > 0) {
+    sections.push({
+      category: PINNED_SECTION,
+      label: "Pinned",
+      features: pinned,
+      collapsed: collapsed.has(PINNED_SECTION),
+    })
+  }
+
+  const rest = ordered.filter((feature) => !layout.favorites.includes(feature.id))
+  for (const category of rankBy(orderedCategoryIDs(rest), layout.categoryOrder, (id) => id)) {
+    const matching = rest.filter((feature) => feature.category === category)
     if (matching.length === 0) continue
     sections.push({
       category,

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -52,9 +52,9 @@ split panes and no palette produces something that looks like Droidective in a
 screenshot and does not feel like it in use — and every screen ported before
 the shell exists will need reworking to live inside it.
 
-The sidebar and the tab strip have landed; split panes, the palette and hotkeys
-have not. Screens ported now open in a tab, so they will not need reworking for
-that — but a screen is still not finished until it behaves in a split pane.
+The sidebar, the tab strip, split panes and the palette have landed, so a screen
+ported now opens in a tab, splits, and is reachable from the palette without
+being reworked for any of it. Hotkeys and the chrome are still outstanding.
 
 1. **Shell parity** (below) — tabs, split panes, sidebar, palette, hotkeys.
 2. **The screens people open every day** — logcat, file explorer, device info,
@@ -66,9 +66,8 @@ that — but a screen is still not finished until it behaves in a split pane.
 
 ## Cross-cutting shell
 
-None of this is in `desktop/` yet. It is most of what "does not match the
-macOS version" actually means — the current app is three tabs and a list.
-Sourced from `CLAUDE.md` and the App sources.
+Sourced from `CLAUDE.md` and the App sources. The navigation half has landed;
+the chrome and the device bar have not.
 
 ### Navigation and layout
 
@@ -91,7 +90,7 @@ Sourced from `CLAUDE.md` and the App sources.
       reorder, ⌘W / Ctrl+W to close, ⌘1–⌘9 to jump. Open tabs stay mounted and
       hidden rather than unmounted, so a background tab keeps its log stream and
       its loaded lists. Ported from ADBKit's `TabState`, close-focus rules
-      included. Still missing: the `+` button, which needs the palette below.
+      included.
 - [x] **Split panes** — two panes, clamped 30–70% with the same absolute
       per-pane floor (`PaneSplit`, ported to `lib/panes.ts`), a draggable
       divider that persists, and the pane rules ported from ADBKit's
@@ -106,13 +105,19 @@ Sourced from `CLAUDE.md` and the App sources.
 
 ### Finding things
 
-- [ ] **Command palette** (⌘T / ⌘K) over features *and* commands, using the
-      ranking already ported to `desktop/src/lib/palette.ts`.
+- [x] **Command palette** — Ctrl/⌘ + K or T, and the tab strip's `+`, which
+      focuses its pane first so the choice lands there. Arrows move, Enter
+      opens, Ctrl/⌘ + P pins. With no query it opens on the pinned list; with
+      one, relevance decides and pins are not promoted. Commands are not in it
+      yet — this app has no custom commands to offer.
 - [ ] **Per-feature hotkeys**, recordable, with a live-preview recorder.
 - [ ] **Global hotkey → Quick Actions panel** — the non-activating mini app:
       grid of every runnable action, pinned first, custom commands, pick-device
       interstitial, ⌘⏎ run-on-all.
-- [ ] **Pinned / favourites**, shared between the palette and Quick Actions.
+- [x] **Pinned / favourites** — a Pinned section leading the sidebar and the
+      palette's empty-query list, pinned from either. Members are lifted out of
+      their categories rather than listed twice, as `enabledFeatures(in:)` does
+      on the Mac. Quick Actions does not exist here yet to share them with.
 - [ ] **Manage features catalog** — turn features off; everything is on by
       default.
 


### PR DESCRIPTION
Stacked on #255.

**Ctrl/⌘ + K** or **T** opens a palette over every feature the engine
implements — and so does the `+` the tab strip was missing, which focuses its
own pane first so the choice lands there rather than wherever focus happened to
be. Arrows move, Enter opens, Escape closes.

**Ctrl/⌘ + P** pins whatever is highlighted, and a sidebar row has a pin of its
own. Pinned features lead the sidebar in their own section and lead the palette
when nothing has been typed — the two surfaces share one list, as they do on the
Mac. A pinned feature is *lifted out* of its category rather than listed in both
places, which is the call `enabledFeatures(in:)` makes there.

With a query, relevance decides and pins are not promoted: a weakly-matching pin
sitting above an exact match would make the ranking a lie. That is a decision, so
it is in `lib/palette.ts` with a test rather than in the component.

## Verified

`make desktop-test` green (typecheck, oxlint, 169 vitest, cargo
fmt/clippy/test). Against `emulator-5554`: ⌘K opened it, typing `batt` narrowed
to Fake Battery with the row highlighted, ⌘P pinned it and a PINNED section
appeared at the top of the sidebar. The panel's measured position (left edge
477 in an 1100pt window, expected 476) confirms it centres on the window rather
than the pane it is rendered inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)