### PR TITLE
Give logcat the controls the Mac has

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -171,11 +171,13 @@ pub fn export_text(app: AppHandle, name: String, contents: String) -> Result<Str
         .download_dir()
         .map_err(|error| DaemonError::Host(format!("no Downloads folder: {error}")))?
         .join("Droidective");
-    std::fs::create_dir_all(&folder)
-        .map_err(|error| DaemonError::Host(format!("could not create {}: {error}", folder.display())))?;
+    std::fs::create_dir_all(&folder).map_err(|error| {
+        DaemonError::Host(format!("could not create {}: {error}", folder.display()))
+    })?;
     let path = folder.join(name);
-    std::fs::write(&path, contents)
-        .map_err(|error| DaemonError::Host(format!("could not write {}: {error}", path.display())))?;
+    std::fs::write(&path, contents).map_err(|error| {
+        DaemonError::Host(format!("could not write {}: {error}", path.display()))
+    })?;
     Ok(path.to_string_lossy().into_owned())
 }
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_opener::OpenerExt;
 
@@ -147,6 +147,36 @@ pub fn reveal_path(app: AppHandle, path: String) -> Result<(), DaemonError> {
     app.opener()
         .reveal_item_in_dir(&path)
         .map_err(|error| DaemonError::Host(format!("could not open {path}: {error}")))
+}
+
+/// Writes text into `~/Downloads/Droidective/<name>` and returns the path.
+///
+/// The Mac exports there too, so someone moving between the two finds their
+/// files in the same place. A fixed folder rather than a save dialog: it is one
+/// fewer plugin, one fewer capability, and the path comes back for the Show in
+/// folder button to use.
+#[tauri::command]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "tauri's command macro hands AppHandle in by value"
+)]
+pub fn export_text(app: AppHandle, name: String, contents: String) -> Result<String, DaemonError> {
+    // A name is built from a feature id and a timestamp, never from device
+    // output — but it ends up in a path, so it is checked rather than trusted.
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(DaemonError::Host(format!("refusing to write {name}")));
+    }
+    let folder = app
+        .path()
+        .download_dir()
+        .map_err(|error| DaemonError::Host(format!("no Downloads folder: {error}")))?
+        .join("Droidective");
+    std::fs::create_dir_all(&folder)
+        .map_err(|error| DaemonError::Host(format!("could not create {}: {error}", folder.display())))?;
+    let path = folder.join(name);
+    std::fs::write(&path, contents)
+        .map_err(|error| DaemonError::Host(format!("could not write {}: {error}", path.display())))?;
+    Ok(path.to_string_lossy().into_owned())
 }
 
 /// Subscribes to the device list. Returns the id to pass to `stop_watching`.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() -> tauri::Result<()> {
             commands::stop_watching,
             commands::copy_text,
             commands::reveal_path,
+            commands::export_text,
         ])
         .setup(|app| {
             // Off the setup path: spawning the sidecar and waiting for its

--- a/desktop/src/components/LogcatPane.tsx
+++ b/desktop/src/components/LogcatPane.tsx
@@ -1,9 +1,21 @@
-import { useEffect, useRef, useState } from "react"
-import { Pause, Search } from "lucide-react"
+import { useMemo, useRef, useState } from "react"
+import { Eraser, Pause, Play } from "lucide-react"
 import { Banner, Button } from "@/components/Controls"
+import { LogcatToolbar } from "@/components/LogcatToolbar"
 import { useLogcatStream } from "@/hooks/useLogcatStream"
 import { cn } from "@/lib/cn"
-import { LOG_CAPACITY, matchesFilter, type LogBuffer, type LogRow } from "@/lib/logbuffer"
+import { asDaemonError, exportText } from "@/lib/daemon"
+import {
+  emptyFilter,
+  LOG_CAPACITY,
+  logText,
+  matchesFind,
+  matchesLogFilter,
+  tagsByFrequency,
+  type LogBuffer,
+  type LogFilter,
+  type LogRow,
+} from "@/lib/logbuffer"
 import type { Device } from "@/lib/wire"
 
 /** How many rows go into the DOM. The buffer holds more; this is what renders. */
@@ -24,19 +36,32 @@ const LEVEL_STYLES: Record<string, string> = {
 }
 
 export function LogcatPane({ device }: { device: Device | null }) {
-  const { buffer, streaming, error, ended, stop } = useLogcatStream(device?.serial ?? null)
-  const [filter, setFilter] = useState("")
+  const stream = useLogcatStream(device?.serial ?? null)
+  const [filter, setFilter] = useState<LogFilter>(emptyFilter)
+  const [find, setFind] = useState("")
   const [following, setFollowing] = useState(true)
+  const [saved, setSaved] = useState<string | null>(null)
+  const [failure, setFailure] = useState<string | null>(null)
   const scroller = useRef<HTMLDivElement | null>(null)
 
-  const visible = buffer.rows.filter((row) => matchesFilter(row, filter))
+  const { buffer } = stream
+  const visible = useMemo(
+    () => buffer.rows.filter((row) => matchesLogFilter(row, filter)),
+    [buffer.rows, filter],
+  )
   const rendered = visible.slice(Math.max(0, visible.length - RENDER_WINDOW))
+  const tags = useMemo(() => tagsByFrequency(buffer.rows).slice(0, 40), [buffer.rows])
+  const hits = useMemo(
+    () => (find.trim() === "" ? 0 : visible.filter((row) => matchesFind(row, find)).length),
+    [visible, find],
+  )
 
-  useEffect(() => {
-    if (!following) return
-    const element = scroller.current
-    if (element) element.scrollTop = element.scrollHeight
-  }, [rendered.length, following])
+  // Pinning to the bottom is a layout effect in spirit, but it only has to
+  // happen after the rows are in the DOM, which this is.
+  const pin = (element: HTMLDivElement | null) => {
+    scroller.current = element
+    if (element && following) element.scrollTop = element.scrollHeight
+  }
 
   if (!device) {
     return <p className="p-6 text-text-tertiary">Connect a device to read its log.</p>
@@ -44,57 +69,44 @@ export function LogcatPane({ device }: { device: Device | null }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-bg-root">
-      <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-bg-chrome px-3 py-2">
-        <div className="flex w-72 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
-          <Search size={13} className="shrink-0 text-text-tertiary" />
-          <input
-            value={filter}
-            aria-label="Filter lines"
-            placeholder="Search lines…"
-            onChange={(event) => {
-              setFilter(event.target.value)
-            }}
-            className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
-          />
-        </div>
-        <div className="flex-1" />
-        {following ? null : (
-          <Button
-            onClick={() => {
-              setFollowing(true)
-            }}
-          >
-            Jump to newest
-          </Button>
-        )}
-        <Button onClick={() => void stop()} disabled={!streaming} title="Stop streaming">
-          <span className="flex items-center gap-1.5">
-            <Pause size={13} />
-            Stop
-          </span>
-        </Button>
-      </div>
+      <LogcatToolbar
+        filter={filter}
+        onFilter={setFilter}
+        find={find}
+        onFind={setFind}
+        hits={hits}
+        tags={tags}
+        onExport={() => {
+          void saveLog(visible).then(setSaved, (thrown: unknown) => {
+            setFailure(asDaemonError(thrown).message)
+          })
+        }}
+      />
 
       <StatusRow
-        streaming={streaming}
+        streaming={stream.streaming}
         buffer={buffer}
         shown={visible.length}
         rendered={rendered.length}
+        following={following}
+        onFollow={() => {
+          setFollowing(true)
+          if (scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight
+        }}
+        onClear={stream.clear}
+        onStop={() => void stream.stop()}
+        onRestart={stream.restart}
       />
 
-      {error ? (
-        <div className="px-3 pt-3">
-          <Banner tone="error">{error.message}</Banner>
-        </div>
-      ) : null}
-      {ended !== null && !error ? (
-        <div className="px-3 pt-3">
-          <Banner tone="warn">The log stream ended ({ended}).</Banner>
-        </div>
-      ) : null}
+      <Notices
+        error={stream.error?.message ?? null}
+        ended={stream.ended}
+        failure={failure}
+        saved={saved}
+      />
 
       <div
-        ref={scroller}
+        ref={pin}
         onScroll={(event) => {
           // Following is a decision about intent, so it is read from a real
           // scroll position rather than inferred from a programmatic pin.
@@ -105,11 +117,28 @@ export function LogcatPane({ device }: { device: Device | null }) {
         data-selectable
       >
         {rendered.map((row) => (
-          <Row key={row.key} row={row} />
+          <Row
+            key={row.key}
+            row={row}
+            hit={matchesFind(row, find)}
+            onTag={(tag) => {
+              setFilter((current) =>
+                current.tags.includes(tag)
+                  ? current
+                  : { ...current, tags: [...current.tags, tag] },
+              )
+            }}
+          />
         ))}
       </div>
     </div>
   )
+}
+
+/** Writes what is on screen, named for when it was taken. */
+function saveLog(rows: readonly LogRow[]): Promise<string> {
+  const stamp = new Date().toISOString().replaceAll(/[:.]/gu, "-").slice(0, 19)
+  return exportText(`logcat_${stamp}.txt`, logText(rows))
 }
 
 /** The Mac app's thin state strip: what the feed is doing, and how much of it. */
@@ -118,11 +147,21 @@ function StatusRow({
   buffer,
   shown,
   rendered,
+  following,
+  onFollow,
+  onClear,
+  onStop,
+  onRestart,
 }: {
   streaming: boolean
   buffer: LogBuffer
   shown: number
   rendered: number
+  following: boolean
+  onFollow: () => void
+  onClear: () => void
+  onStop: () => void
+  onRestart: () => void
 }) {
   // Every cap says so out loud. A feed that quietly shows a subset is a feed
   // that lies about being complete.
@@ -145,11 +184,46 @@ function StatusRow({
       <span className="text-[11.5px] text-text-tertiary">
         {[`${shown.toLocaleString()} lines`, ...notes].join(" · ")}
       </span>
+      {following ? null : (
+        <Button onClick={onFollow} title="Scroll back to the newest line">
+          Jump to newest
+        </Button>
+      )}
+      <Button onClick={onClear} title="Clear what is on screen">
+        <span className="flex items-center gap-1.5">
+          <Eraser size={13} />
+          Clear
+        </span>
+      </Button>
+      {/* Stop used to be a one-way door: the only way back was a tab switch. */}
+      {streaming ? (
+        <Button onClick={onStop} title="Stop streaming">
+          <span className="flex items-center gap-1.5">
+            <Pause size={13} />
+            Stop
+          </span>
+        </Button>
+      ) : (
+        <Button onClick={onRestart} tone="primary" title="Start streaming again">
+          <span className="flex items-center gap-1.5">
+            <Play size={13} />
+            Start
+          </span>
+        </Button>
+      )}
     </div>
   )
 }
 
-function Row({ row }: { row: LogRow }) {
+function Row({
+  row,
+  hit,
+  onTag,
+}: {
+  row: LogRow
+  hit: boolean
+  onTag: (tag: string) => void
+}) {
   if (row.kind === "gap") {
     return (
       <div className="my-1 flex items-center gap-2 text-warn">
@@ -166,14 +240,54 @@ function Row({ row }: { row: LogRow }) {
       className={cn(
         "whitespace-pre-wrap break-words",
         LEVEL_STYLES[line.level] ?? "text-text-secondary",
+        // Find highlights rather than hides — that is the point of the split.
+        hit ? "rounded-sm bg-warn/20" : "",
       )}
     >
       <span className="text-text-tertiary">{line.time} </span>
       <span className="text-text-tertiary">{line.pid.padStart(5, " ")} </span>
-      <span>
-        {line.level}/{line.tag}:{" "}
-      </span>
+      <span>{line.level}/</span>
+      <button
+        type="button"
+        onClick={() => {
+          onTag(line.tag)
+        }}
+        title={`Show only ${line.tag}`}
+        className="underline decoration-dotted underline-offset-2 hover:text-accent"
+      >
+        {line.tag}
+      </button>
+      <span>: </span>
       {line.message}
+    </div>
+  )
+}
+
+/** Whatever the feed has to say for itself, above the rows. */
+function Notices({
+  error,
+  ended,
+  failure,
+  saved,
+}: {
+  error: string | null
+  ended: string | null
+  failure: string | null
+  saved: string | null
+}) {
+  const notices: { tone: "error" | "warn" | "ok"; text: string }[] = []
+  if (error !== null) notices.push({ tone: "error", text: error })
+  else if (ended !== null) notices.push({ tone: "warn", text: `The log stream ended (${ended}).` })
+  if (failure !== null) notices.push({ tone: "error", text: failure })
+  if (saved !== null) notices.push({ tone: "ok", text: `Saved to ${saved}` })
+  if (notices.length === 0) return null
+  return (
+    <div className="flex shrink-0 flex-col gap-2 px-3 pt-3">
+      {notices.map((notice) => (
+        <Banner key={notice.text} tone={notice.tone}>
+          {notice.text}
+        </Banner>
+      ))}
     </div>
   )
 }

--- a/desktop/src/components/LogcatToolbar.tsx
+++ b/desktop/src/components/LogcatToolbar.tsx
@@ -1,0 +1,187 @@
+import { Download, Filter, Search, X } from "lucide-react"
+import { Select } from "@/components/Controls"
+import { cn } from "@/lib/cn"
+import { LEVELS, type Level, type LogFilter } from "@/lib/logbuffer"
+
+const LEVEL_NAMES: Record<Level, string> = {
+  V: "Verbose",
+  D: "Debug",
+  I: "Info",
+  W: "Warn",
+  E: "Error",
+  F: "Fatal",
+}
+
+/**
+ * Filter, Find, level, tags, export.
+ *
+ * Filter and Find are deliberately two fields, as they are on the Mac: "show me
+ * only this" and "where is this?" are different questions, and one box that did
+ * both would answer neither well.
+ */
+export function LogcatToolbar({
+  filter,
+  onFilter,
+  find,
+  onFind,
+  hits,
+  tags,
+  onExport,
+}: {
+  filter: LogFilter
+  onFilter: (filter: LogFilter) => void
+  find: string
+  onFind: (find: string) => void
+  hits: number
+  tags: string[]
+  onExport: () => void
+}) {
+  return (
+    <div className="shrink-0 border-b border-border-subtle bg-bg-chrome">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Field
+          icon={Filter}
+          value={filter.text}
+          label="Filter lines"
+          placeholder="Filter — hides the rest…"
+          onChange={(text) => {
+            onFilter({ ...filter, text })
+          }}
+        />
+        <Field
+          icon={Search}
+          value={find}
+          label="Find in the log"
+          placeholder="Find — highlights only…"
+          onChange={onFind}
+        />
+        {find.trim() === "" ? null : (
+          <span className="shrink-0 text-[11.5px] text-text-tertiary">
+            {hits.toLocaleString()} {hits === 1 ? "hit" : "hits"}
+          </span>
+        )}
+
+        <div className="w-[124px] shrink-0">
+          <Select
+            value={filter.minLevel}
+            options={LEVELS.map((level) => ({ value: level, label: LEVEL_NAMES[level] }))}
+            onChange={(value) => {
+              onFilter({ ...filter, minLevel: value as Level })
+            }}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onExport}
+          title="Export what is shown to ~/Downloads/Droidective"
+          aria-label="Export the log"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md bg-bg-raised text-text-secondary hover:bg-border-subtle hover:text-text-primary"
+        >
+          <Download size={13} />
+        </button>
+      </div>
+
+      <TagBar
+        chosen={filter.tags}
+        tags={tags}
+        onToggle={(tag) => {
+          onFilter({
+            ...filter,
+            tags: filter.tags.includes(tag)
+              ? filter.tags.filter((entry) => entry !== tag)
+              : [...filter.tags, tag],
+          })
+        }}
+        onClear={() => {
+          onFilter({ ...filter, tags: [] })
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * The tag chips.
+ *
+ * Chosen tags always show; the rest are the most frequent in the buffer, which
+ * is the only ranking that puts the tag you are looking for near the front of a
+ * log with hundreds of them.
+ */
+function TagBar({
+  chosen,
+  tags,
+  onToggle,
+  onClear,
+}: {
+  chosen: readonly string[]
+  tags: string[]
+  onToggle: (tag: string) => void
+  onClear: () => void
+}) {
+  const offered = [...chosen, ...tags.filter((tag) => !chosen.includes(tag))].slice(0, 16)
+  if (offered.length === 0) return null
+  return (
+    <div className="flex items-center gap-1.5 overflow-x-auto px-3 pb-2">
+      {chosen.length === 0 ? null : (
+        <button
+          type="button"
+          onClick={onClear}
+          className="flex shrink-0 items-center gap-1 rounded-full bg-bg-raised px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+        >
+          <X size={9} strokeWidth={3} />
+          All tags
+        </button>
+      )}
+      {offered.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => {
+            onToggle(tag)
+          }}
+          className={cn(
+            "shrink-0 rounded-full px-2 py-0.5 text-[11px] transition-colors",
+            chosen.includes(tag)
+              ? "bg-accent/20 text-accent"
+              : "bg-bg-raised text-text-tertiary hover:text-text-primary",
+          )}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function Field({
+  icon: Icon,
+  value,
+  label,
+  placeholder,
+  onChange,
+}: {
+  icon: typeof Search
+  value: string
+  label: string
+  placeholder: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
+      <Icon size={13} className="shrink-0 text-text-tertiary" />
+      <input
+        value={value}
+        aria-label={label}
+        placeholder={placeholder}
+        onChange={(event) => {
+          onChange(event.target.value)
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onChange("")
+        }}
+        className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
+      />
+    </div>
+  )
+}

--- a/desktop/src/hooks/useLogcatStream.ts
+++ b/desktop/src/hooks/useLogcatStream.ts
@@ -10,6 +10,10 @@ export interface LogcatStream {
   /** Why the daemon stopped sending, if it did. */
   ended: string | null
   stop: () => Promise<void>
+  /** Subscribe again after a stop. Keeps whatever is already buffered. */
+  restart: () => void
+  /** Throw away what has been buffered, without touching the subscription. */
+  clear: () => void
 }
 
 /**
@@ -24,6 +28,9 @@ export function useLogcatStream(serial: string | null): LogcatStream {
   const [streaming, setStreaming] = useState(false)
   const [error, setError] = useState<DaemonError | null>(null)
   const [ended, setEnded] = useState<string | null>(null)
+  // Bumping this re-runs the effect, which is the whole restart: Stop used to
+  // be a one-way door, with a tab switch the only way back.
+  const [generation, setGeneration] = useState(0)
   const subscription = useRef<Subscription | null>(null)
 
   const stop = useCallback(async () => {
@@ -33,12 +40,24 @@ export function useLogcatStream(serial: string | null): LogcatStream {
     await live?.stop()
   }, [])
 
+  const restart = useCallback(() => {
+    setGeneration((current) => current + 1)
+  }, [])
+
+  const clear = useCallback(() => {
+    setBuffer(emptyBuffer())
+  }, [])
+
+  // A different device is a different log; a restart is the same one.
+  useEffect(() => {
+    setBuffer(emptyBuffer())
+  }, [serial])
+
   useEffect(() => {
     if (serial === null) return
     // StrictMode runs this twice in development; without the flag the second
     // run's subscription replaces the first, which is then never stopped.
     let cancelled = false
-    setBuffer(emptyBuffer())
     setEnded(null)
     setError(null)
 
@@ -83,7 +102,7 @@ export function useLogcatStream(serial: string | null): LogcatStream {
       cancelled = true
       void stop()
     }
-  }, [serial, stop])
+  }, [serial, generation, stop])
 
-  return { buffer, streaming, error, ended, stop }
+  return { buffer, streaming, error, ended, stop, restart, clear }
 }

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -76,6 +76,11 @@ export function revealPath(path: string): Promise<void> {
   return invoke("reveal_path", { path })
 }
 
+/** Writes into ~/Downloads/Droidective and returns where it landed. */
+export function exportText(name: string, contents: string): Promise<string> {
+  return invoke<string>("export_text", { name, contents })
+}
+
 /** A live subscription. Always `stop()` it when the view goes away. */
 export interface Subscription {
   id: number

--- a/desktop/src/lib/logbuffer.test.ts
+++ b/desktop/src/lib/logbuffer.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest"
-import { emptyBuffer, matchesFilter, withGap, withLines } from "@/lib/logbuffer"
+import {
+  emptyBuffer,
+  emptyFilter,
+  logText,
+  matchesFind,
+  matchesLogFilter,
+  tagsByFrequency,
+  withGap,
+  withLines,
+} from "@/lib/logbuffer"
 import type { LogRow } from "@/lib/logbuffer"
 import type { LogLine } from "@/lib/wire"
 
@@ -87,24 +96,107 @@ describe("withGap", () => {
   })
 })
 
-describe("matchesFilter", () => {
-  const row: LogRow = { kind: "line", key: 0, line: line("Boot completed", { tag: "ActivityManager" }) }
+const text = (value: string) => ({ ...emptyFilter(), text: value })
 
+describe("matchesLogFilter", () => {
+  const row: LogRow = {
+    kind: "line",
+    key: 0,
+    line: line("Boot completed", { tag: "ActivityManager" }),
+  }
   it("matches the tag and the message, case-insensitively", () => {
-    expect(matchesFilter(row, "activitymanager")).toBe(true)
-    expect(matchesFilter(row, "BOOT")).toBe(true)
-    expect(matchesFilter(row, "nope")).toBe(false)
+    expect(matchesLogFilter(row, text("activitymanager"))).toBe(true)
+    expect(matchesLogFilter(row, text("BOOT"))).toBe(true)
+    expect(matchesLogFilter(row, text("nope"))).toBe(false)
   })
 
   it("matches everything for an empty filter", () => {
-    expect(matchesFilter(row, "")).toBe(true)
-    expect(matchesFilter(row, "  ")).toBe(true)
+    expect(matchesLogFilter(row, emptyFilter())).toBe(true)
+    expect(matchesLogFilter(row, text("  "))).toBe(true)
   })
 
   it("never filters out a gap", () => {
     // Hiding the marker would turn a visible interruption back into a silent
     // one, which is exactly what it exists to prevent.
     const gap: LogRow = { kind: "gap", key: 1, count: 9 }
-    expect(matchesFilter(gap, "activitymanager")).toBe(true)
+    expect(matchesLogFilter(gap, text("activitymanager"))).toBe(true)
+    expect(matchesLogFilter(gap, { ...emptyFilter(), minLevel: "E", tags: ["Other"] })).toBe(true)
+  })
+
+  it("hides everything quieter than the chosen level", () => {
+    const warn: LogRow = { kind: "line", key: 2, line: line("careful", { level: "W" }) }
+    const debug: LogRow = { kind: "line", key: 3, line: line("chatter", { level: "D" }) }
+    const atWarn = { ...emptyFilter(), minLevel: "W" as const }
+    expect(matchesLogFilter(warn, atWarn)).toBe(true)
+    expect(matchesLogFilter(debug, atWarn)).toBe(false)
+    // Verbose is the floor, so it hides nothing.
+    expect(matchesLogFilter(debug, emptyFilter())).toBe(true)
+  })
+
+  it("shows only the chosen tags, and all of them when none is chosen", () => {
+    const other: LogRow = { kind: "line", key: 4, line: line("hello", { tag: "Zygote" }) }
+    const chosen = { ...emptyFilter(), tags: ["ActivityManager"] }
+    expect(matchesLogFilter(row, chosen)).toBe(true)
+    expect(matchesLogFilter(other, chosen)).toBe(false)
+    expect(matchesLogFilter(other, emptyFilter())).toBe(true)
+  })
+
+  it("applies every part of the filter at once", () => {
+    const loud: LogRow = { kind: "line", key: 5, line: line("boom", { tag: "Zygote", level: "E" }) }
+    expect(
+      matchesLogFilter(loud, { text: "boom", minLevel: "W", tags: ["Zygote"] }),
+    ).toBe(true)
+    expect(
+      matchesLogFilter(loud, { text: "boom", minLevel: "W", tags: ["ActivityManager"] }),
+    ).toBe(false)
+  })
+})
+
+describe("matchesFind", () => {
+  const row: LogRow = {
+    kind: "line",
+    key: 0,
+    line: line("Boot completed", { tag: "ActivityManager" }),
+  }
+
+  it("hits on the tag and the message", () => {
+    expect(matchesFind(row, "boot")).toBe(true)
+    expect(matchesFind(row, "activity")).toBe(true)
+    expect(matchesFind(row, "nope")).toBe(false)
+  })
+
+  it("hits nothing for an empty query, and never a gap", () => {
+    // Find highlights; an empty query highlighting every row would be noise.
+    expect(matchesFind(row, "")).toBe(false)
+    expect(matchesFind({ kind: "gap", key: 1, count: 3 }, "boot")).toBe(false)
+  })
+})
+
+describe("logText", () => {
+  it("writes the shape adb prints, with gaps called out", () => {
+    const rows: LogRow[] = [
+      { kind: "line", key: 0, line: line("up", { tag: "Boot", level: "I" }) },
+      { kind: "gap", key: 1, count: 12 },
+    ]
+    const lines = logText(rows).split("\n")
+    expect(lines[0]).toContain("I/Boot: up")
+    expect(lines[1]).toBe("--- 12 lines dropped ---")
+  })
+
+  it("is empty for nothing", () => {
+    expect(logText([])).toBe("")
+  })
+})
+
+describe("tagsByFrequency", () => {
+  it("puts the loudest tag first, and breaks ties by name", () => {
+    const rows: LogRow[] = [
+      { kind: "line", key: 0, line: line("a", { tag: "Zygote" }) },
+      { kind: "line", key: 1, line: line("b", { tag: "Boot" }) },
+      { kind: "line", key: 2, line: line("c", { tag: "Boot" }) },
+      { kind: "line", key: 3, line: line("d", { tag: "Alarm" }) },
+      { kind: "gap", key: 4, count: 2 },
+    ]
+    expect(tagsByFrequency(rows)).toEqual(["Boot", "Alarm", "Zygote"])
   })
 })

--- a/desktop/src/lib/logbuffer.ts
+++ b/desktop/src/lib/logbuffer.ts
@@ -70,13 +70,73 @@ function trim(buffer: LogBuffer, capacity: number): LogBuffer {
   return { ...buffer, rows: buffer.rows.slice(buffer.rows.length - capacity) }
 }
 
-/** Case-insensitive substring match over the parts a reader can see. */
-export function matchesFilter(row: LogRow, filter: string): boolean {
-  const needle = filter.toLowerCase().trim()
-  if (needle === "") return true
-  // A gap always shows: hiding it would turn a visible interruption back into
-  // a silent one, which is the whole thing the marker exists to prevent.
+/** Android's priorities, quietest first. The order *is* the comparison. */
+export const LEVELS = ["V", "D", "I", "W", "E", "F"] as const
+export type Level = (typeof LEVELS)[number]
+
+export interface LogFilter {
+  /** Hides every line that does not contain it. */
+  text: string
+  /** Hides everything quieter than this. */
+  minLevel: Level
+  /** Tag chips; a line matching any of them shows. Empty means all tags. */
+  tags: readonly string[]
+}
+
+export function emptyFilter(): LogFilter {
+  return { text: "", minLevel: "V", tags: [] }
+}
+
+/**
+ * Whether a row survives the filter.
+ *
+ * A gap always shows, whatever is filtered: hiding it would turn a visible
+ * interruption back into a silent one, which is the whole thing the marker
+ * exists to prevent.
+ */
+export function matchesLogFilter(row: LogRow, filter: LogFilter): boolean {
   if (row.kind === "gap") return true
   const { tag, message, level, pid } = row.line
+  if (LEVELS.indexOf(level as Level) < LEVELS.indexOf(filter.minLevel)) return false
+  if (filter.tags.length > 0 && !filter.tags.includes(tag)) return false
+  const needle = filter.text.toLowerCase().trim()
+  if (needle === "") return true
   return `${tag} ${message} ${level} ${pid}`.toLowerCase().includes(needle)
+}
+
+/**
+ * Whether a row is a Find hit.
+ *
+ * Find highlights without hiding, which is the split the Mac's log view keeps:
+ * "where is this?" and "show me only this" are different questions, and one
+ * control cannot answer both.
+ */
+export function matchesFind(row: LogRow, find: string): boolean {
+  const needle = find.toLowerCase().trim()
+  if (needle === "" || row.kind === "gap") return false
+  const { tag, message } = row.line
+  return `${tag} ${message}`.toLowerCase().includes(needle)
+}
+
+/** The visible rows as text, for export or the clipboard. */
+export function logText(rows: readonly LogRow[]): string {
+  return rows
+    .map((row) =>
+      row.kind === "gap"
+        ? `--- ${row.count.toLocaleString()} lines dropped ---`
+        : `${row.line.time} ${row.line.pid} ${row.line.level}/${row.line.tag}: ${row.line.message}`,
+    )
+    .join("\n")
+}
+
+/** Every tag present, most frequent first — what the tag chips offer. */
+export function tagsByFrequency(rows: readonly LogRow[]): string[] {
+  const counts = new Map<string, number>()
+  for (const row of rows) {
+    if (row.kind !== "line") continue
+    counts.set(row.line.tag, (counts.get(row.line.tag) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .toSorted((a, b) => (b[1] === a[1] ? a[0].localeCompare(b[0]) : b[1] - a[1]))
+    .map(([tag]) => tag)
 }

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -174,10 +174,12 @@ Found by driving the app against a live emulator, not by reading it.
       (`lib/confirm.ts`). A Cancel button appears while armed, the window
       losing focus disarms, and an arming on one app never authorises the same
       verb on another.
-- [ ] **Logcat cannot be restarted.** Stop disables the button and the only way
-      back is a tab switch or a device change.
-- [ ] **Logcat has no level or app filter** — the Mac has both, plus a
-      find-vs-filter split, export, clear, and tag-filter chips.
+- [x] ~~**Logcat cannot be restarted.**~~ Stop becomes Start, and the
+      subscription comes back with the buffer intact.
+- [~] **Logcat has no level or app filter.** The level picker, the
+      find-vs-filter split, export, clear and tag chips have landed. The *app*
+      filter has not: it needs a pid → package map the daemon does not serve
+      yet, and matching on the tag would be a filter that quietly misses lines.
 - [x] ~~**The app list re-fetches on every tab switch**, because the pane
       remounts and the data is not lifted.~~ Fixed by the tab shell: an open
       tab stays mounted while it is in the background, so the pane no longer
@@ -547,22 +549,22 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 #### `logcat` — Logcat  ·  🟡 partial
 > Live log stream with search and filters
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane exists; the app filter is what it is still missing.
 - **macOS view** `LogcatView` — `App/Sources/FeatureDetail/Views/LogcatView.swift`
 - **Must replicate**
-  - [ ] picker: Level
-  - [ ] field: Filter lines…
+  - [x] picker: Level
+  - [x] field: Filter lines…
   - [ ] label: All apps
   - [ ] label: Add from installed apps
   - [ ] label: Use app on device screen
   - [ ] label: Add manually / manage…
-  - [ ] tooltip: Show only the lines containing this text
-  - [ ] tooltip: Find & highlight in the log without hiding lines (⌘F)
-  - [ ] tooltip: Export buffer to ~/Downloads/Droidective
-  - [ ] tooltip: Clear
+  - [x] tooltip: Show only the lines containing this text
+  - [x] tooltip: Find & highlight in the log without hiding lines
+  - [x] tooltip: Export buffer to ~/Downloads/Droidective
+  - [x] tooltip: Clear
   - [ ] tooltip: Stream one app's logs — pick a saved bundle or add a new one
-  - [ ] tooltip: Remove tag filter
-  - [ ] export: save/export to a file
+  - [x] tooltip: Remove tag filter
+  - [x] export: save/export to a file
 
 #### `performance` — Performance Monitor  ·  ⬜ todo
 > Live CPU, RAM & FPS with recording and export


### PR DESCRIPTION
Stacked on #256. Clears one of the two remaining tracker defects and most of
the other.

## Stop was a one-way door

It disabled the button, and the only way back was a tab switch or a device
change. It is a **Start** button now, and the subscription comes back with the
buffer intact — a restart is the same log, so only a device change clears it.

## Filter and Find are two fields

Which is the split the Mac's log view keeps: *show me only this* hides, *where
is this?* highlights, and one box that did both would answer neither well.
Beside them:

- a **level picker** that hides everything quieter than the one chosen;
- **tag chips**, ranked by how much each tag is actually saying, plus a
  clickable tag in every row that filters to it;
- **Clear**;
- **export** of what is on screen to `~/Downloads/Droidective` — the same folder
  the Mac uses, so someone moving between the two finds their files in the same
  place.

Export goes through a new `export_text` command rather than a save dialog: one
fewer plugin, one fewer capability, and the path comes back for the Show in
folder button that already exists. The filename is checked for separators before
it becomes a path even though it is built here, not by the device.

`matchesFilter` becomes `matchesLogFilter` over a `LogFilter` — level, text and
tags applied together, with a gap marker surviving all three, because a hidden
gap turns a visible interruption back into a silent one.

## Still missing

The **per-app filter**. It needs a pid → package map the daemon does not serve
yet, and matching on the tag instead would be a filter that quietly misses
lines. Left ticked as partial in the tracker rather than claimed.

## Verified

`make desktop-test` green (typecheck, oxlint, 177 vitest, cargo
fmt/clippy/test). Against `emulator-5554`: opened the pane streaming ~800 lines,
then read the state back from the accessibility tree across a Stop (button
became Start, status "Stopped") and a Start (back to "Streaming") — the defect
this fixes, checked rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)