### PR TITLE
Browse and search every device property

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -14,8 +14,8 @@ use tauri_plugin_opener::OpenerExt;
 
 use crate::daemon::stream::StreamMessage;
 use crate::daemon::wire::{
-    AppControlRequest, AppsResponse, Device, FeatureSummary, RunRequest, RunResponse,
-    SubscribeParams,
+    AppControlRequest, AppsResponse, Device, DevicePropsResponse, FeatureSummary, RunRequest,
+    RunResponse, SubscribeParams,
 };
 use crate::daemon::{DaemonStatus, Supervisor};
 use crate::error::DaemonError;
@@ -117,6 +117,14 @@ pub async fn control_app(
             action,
         })
         .await
+}
+
+#[tauri::command]
+pub async fn device_props(
+    supervisor: State<'_, Supervisor>,
+    serial: String,
+) -> Result<DevicePropsResponse, DaemonError> {
+    supervisor.client().await?.device_props(serial).await
 }
 
 /// Puts an action's `copyText` on the system clipboard.

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -53,7 +53,8 @@ impl DaemonClient {
     }
 
     pub async fn device_props(&self, serial: String) -> Result<DevicePropsResponse, DaemonError> {
-        self.post("/v1/device/props", &DeviceRequest { serial }).await
+        self.post("/v1/device/props", &DeviceRequest { serial })
+            .await
     }
 
     pub async fn control_app(

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -4,8 +4,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::daemon::wire::{
-    AppControlRequest, AppsListRequest, AppsResponse, Device, DevicesResponse, ErrorEnvelope,
-    FeatureSummary, FeaturesResponse, RunRequest, RunResponse,
+    AppControlRequest, AppsListRequest, AppsResponse, Device, DevicePropsResponse, DeviceRequest,
+    DevicesResponse, ErrorEnvelope, FeatureSummary, FeaturesResponse, RunRequest, RunResponse,
 };
 use crate::error::DaemonError;
 
@@ -50,6 +50,10 @@ impl DaemonClient {
     pub async fn list_apps(&self, serial: String) -> Result<AppsResponse, DaemonError> {
         self.post("/v1/apps/list", &AppsListRequest { serial })
             .await
+    }
+
+    pub async fn device_props(&self, serial: String) -> Result<DevicePropsResponse, DaemonError> {
+        self.post("/v1/device/props", &DeviceRequest { serial }).await
     }
 
     pub async fn control_app(

--- a/desktop/src-tauri/src/daemon/wire.rs
+++ b/desktop/src-tauri/src/daemon/wire.rs
@@ -150,6 +150,18 @@ pub struct AppsListRequest {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DeviceRequest {
+    pub serial: String,
+}
+
+/// Everything `getprop` printed. Passed through as a map rather than reshaped:
+/// which property matters is the reader's question, not this layer's.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DevicePropsResponse {
+    pub properties: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct AppControlRequest {
     pub serial: String,
     #[serde(rename = "packageId")]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() -> tauri::Result<()> {
             commands::run_action,
             commands::list_apps,
             commands::control_app,
+            commands::device_props,
             commands::watch_devices,
             commands::watch_logcat,
             commands::stop_watching,

--- a/desktop/src/components/DeviceInfoPane.tsx
+++ b/desktop/src/components/DeviceInfoPane.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Clipboard, Download, RefreshCw, Search } from "lucide-react"
+import { Banner, Button } from "@/components/Controls"
+import { asDaemonError, copyText, deviceProps, exportText } from "@/lib/daemon"
+import {
+  countRows,
+  propertiesText,
+  propertyGroups,
+  summary,
+  type PropertyGroup,
+} from "@/lib/deviceinfo"
+import type { DaemonError, Device } from "@/lib/wire"
+
+/**
+ * Every property the device answers, searchable — the Mac's Device Info screen.
+ *
+ * One `getprop` on open rather than a poll: a device answers over a thousand
+ * properties and almost none of them change while you are reading them.
+ */
+export function DeviceInfoPane({ device }: { device: Device | null }) {
+  const [properties, setProperties] = useState<Record<string, string>>({})
+  const [query, setQuery] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<DaemonError | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const serial = device?.serial ?? null
+  const load = useCallback(async () => {
+    if (serial === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      setProperties((await deviceProps(serial)).properties)
+    } catch (thrown) {
+      setError(asDaemonError(thrown))
+    } finally {
+      setLoading(false)
+    }
+  }, [serial])
+
+  useEffect(() => {
+    setProperties({})
+    void load()
+  }, [load])
+
+  const groups = useMemo(() => propertyGroups(properties, query), [properties, query])
+  const total = Object.keys(properties).length
+  const shown = countRows(groups)
+
+  const act = (run: () => Promise<string>) => () => {
+    setError(null)
+    run().then(setNotice, (thrown: unknown) => {
+      setError(asDaemonError(thrown))
+    })
+  }
+
+  if (!device) {
+    return <p className="p-6 text-text-tertiary">Connect a device to read its properties.</p>
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <Toolbar
+        query={query}
+        onQuery={setQuery}
+        total={total}
+        loading={loading}
+        onCopy={act(async () => {
+          await copyText(propertiesText(properties))
+          return "Copied every property to the clipboard."
+        })}
+        onExport={act(
+          async () =>
+            `Saved to ${await exportText(`getprop_${device.serial}.txt`, propertiesText(properties))}`,
+        )}
+        onRefresh={() => void load()}
+      />
+
+      {error ? (
+        <div className="px-3 pt-3">
+          <Banner tone="error">
+            {error.message}
+            {error.detail ? <div className="mt-1 opacity-70">{error.detail}</div> : null}
+          </Banner>
+        </div>
+      ) : null}
+      {notice === null ? null : (
+        <div className="px-3 pt-3">
+          <Banner tone="ok">{notice}</Banner>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4" data-selectable>
+        {loading && total === 0 ? (
+          <p className="py-8 text-center text-text-tertiary">Reading the device…</p>
+        ) : total === 0 ? (
+          <p className="py-8 text-center text-text-tertiary">No properties came back.</p>
+        ) : (
+          <>
+            <Summary properties={properties} />
+            {shown === 0 ? (
+              <p className="py-8 text-center text-text-tertiary">Nothing matches “{query}”.</p>
+            ) : (
+              groups.map((group) => <Group key={group.prefix} group={group} />)
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Toolbar({
+  query,
+  onQuery,
+  total,
+  loading,
+  onCopy,
+  onExport,
+  onRefresh,
+}: {
+  query: string
+  onQuery: (value: string) => void
+  total: number
+  loading: boolean
+  onCopy: () => void
+  onExport: () => void
+  onRefresh: () => void
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle bg-bg-chrome px-3 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
+        <Search size={13} className="shrink-0 text-text-tertiary" />
+        <input
+          value={query}
+          aria-label="Filter properties"
+          placeholder={total === 0 ? "Filter properties…" : `Filter ${total} properties…`}
+          onChange={(event) => {
+            onQuery(event.target.value)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") onQuery("")
+          }}
+          className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
+        />
+      </div>
+      <Button onClick={onCopy} title="Copy every property">
+        <Clipboard size={13} />
+      </Button>
+      <Button onClick={onExport} title="Export to ~/Downloads/Droidective">
+        <Download size={13} />
+      </Button>
+      <Button onClick={onRefresh} disabled={loading} title="Read the device again">
+        <RefreshCw size={13} className={loading ? "animate-spin" : undefined} />
+      </Button>
+    </div>
+  )
+}
+
+/** The handful worth reading first, before the thousand that follow. */
+function Summary({ properties }: { properties: Record<string, string> }) {
+  const rows = summary(properties)
+  if (rows.length === 0) return null
+  return (
+    <div className="mb-5 grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-2">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="rounded-lg border border-border-subtle bg-bg-surface px-3 py-2"
+        >
+          <div className="text-[10.5px] uppercase tracking-[0.06em] text-text-tertiary">
+            {row.label}
+          </div>
+          <div className="truncate text-[13px] text-text-primary" title={row.value}>
+            {row.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Group({ group }: { group: PropertyGroup }) {
+  return (
+    <section className="mb-4">
+      <h3 className="mb-1 text-[10.5px] font-medium uppercase tracking-[0.06em] text-text-tertiary">
+        {group.prefix}
+      </h3>
+      <div className="overflow-hidden rounded-lg border border-border-subtle">
+        {group.rows.map((row, index) => (
+          <div
+            key={row.key}
+            className={
+              index % 2 === 0
+                ? "flex gap-4 px-3 py-1 font-mono text-[11.5px]"
+                : "flex gap-4 bg-white/[0.02] px-3 py-1 font-mono text-[11.5px]"
+            }
+          >
+            <span className="w-[46%] shrink-0 truncate text-text-secondary" title={row.key}>
+              {row.key}
+            </span>
+            <span className="min-w-0 flex-1 break-all text-text-primary">{row.value}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/desktop/src/components/FeaturePane.tsx
+++ b/desktop/src/components/FeaturePane.tsx
@@ -1,6 +1,7 @@
 import { Construction } from "lucide-react"
 import { ActionForm } from "@/components/ActionForm"
 import { AppsPane } from "@/components/AppsPane"
+import { DeviceInfoPane } from "@/components/DeviceInfoPane"
 import { HomeView } from "@/components/HomeView"
 import { LogcatPane } from "@/components/LogcatPane"
 import { HOME_TAB } from "@/lib/layout"
@@ -52,6 +53,8 @@ export function FeaturePane(props: FeaturePaneProps) {
       )
     case "logcat":
       return <LogcatPane device={props.device} />
+    case "device-info":
+      return <DeviceInfoPane device={props.device} />
     default:
       return isRunnable(props.feature) ? (
         <ActionForm

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -55,6 +55,11 @@ export function listApps(serial: string): Promise<AppsResponse> {
   return invoke<AppsResponse>("list_apps", { serial })
 }
 
+/** Everything `getprop` printed, as the daemon passed it through. */
+export function deviceProps(serial: string): Promise<{ properties: Record<string, string> }> {
+  return invoke<{ properties: Record<string, string> }>("device_props", { serial })
+}
+
 export function controlApp(args: {
   serial: string
   packageId: string

--- a/desktop/src/lib/deviceinfo.test.ts
+++ b/desktop/src/lib/deviceinfo.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+import {
+  countRows,
+  matchesProperty,
+  propertiesText,
+  propertyGroups,
+  summary,
+} from "@/lib/deviceinfo"
+
+// A slice of a real emulator dump, keys and shapes unchanged.
+const properties: Record<string, string> = {
+  "ro.product.model": "sdk_gphone64_arm64",
+  "ro.product.manufacturer": "Google",
+  "ro.product.cpu.abi": "arm64-v8a",
+  "ro.build.version.release": "14",
+  "ro.build.version.sdk": "34",
+  "ro.build.id": "UE1A.230829.036",
+  "ro.build.type": "userdebug",
+  "ro.serialno": "EMULATOR34X3X11X0",
+  "persist.sys.timezone": "Europe/London",
+  "debug.force_rtl": "0",
+  "init.svc.adbd": "running",
+}
+
+describe("summary", () => {
+  it("leads with what someone actually wants to know", () => {
+    expect(summary(properties).slice(0, 3)).toEqual([
+      { label: "Model", value: "sdk_gphone64_arm64" },
+      { label: "Manufacturer", value: "Google" },
+      { label: "Android", value: "14" },
+    ])
+  })
+
+  it("skips a key the device did not answer rather than showing 'unknown'", () => {
+    // A phone and an emulator do not answer the same set.
+    const sparse = summary({ "ro.product.model": "Pixel" })
+    expect(sparse).toEqual([{ label: "Model", value: "Pixel" }])
+  })
+
+  it("skips a key answered with nothing", () => {
+    expect(summary({ "ro.product.model": "" })).toEqual([])
+  })
+})
+
+describe("propertyGroups", () => {
+  it("groups by two dotted segments, not one", () => {
+    // `ro` alone would be most of the dump in a single heap.
+    const prefixes = propertyGroups(properties, "").map((group) => group.prefix)
+    expect(prefixes).toContain("ro.build")
+    expect(prefixes).toContain("ro.product")
+    expect(prefixes).not.toContain("ro")
+  })
+
+  it("sorts the groups and the rows inside them", () => {
+    const groups = propertyGroups(properties, "")
+    const prefixes = groups.map((group) => group.prefix)
+    expect(prefixes).toEqual(prefixes.toSorted())
+    const build = groups.find((group) => group.prefix === "ro.build")
+    expect(build?.rows.map((row) => row.key)).toEqual([
+      "ro.build.id",
+      "ro.build.type",
+      "ro.build.version.release",
+      "ro.build.version.sdk",
+    ])
+  })
+
+  it("keeps a key with no dot in it", () => {
+    const groups = propertyGroups({ bare: "yes" }, "")
+    expect(groups).toEqual([{ prefix: "bare", rows: [{ key: "bare", value: "yes" }] }])
+  })
+
+  it("filters on the value as well as the key", () => {
+    // Searching for what a property *says* is as common as searching its name.
+    const groups = propertyGroups(properties, "Europe/London")
+    expect(countRows(groups)).toBe(1)
+    expect(groups[0]?.rows[0]?.key).toBe("persist.sys.timezone")
+  })
+
+  it("drops a group that has nothing left in it", () => {
+    const groups = propertyGroups(properties, "timezone")
+    expect(groups.map((group) => group.prefix)).toEqual(["persist.sys"])
+  })
+
+  it("returns nothing for a query that matches nothing", () => {
+    expect(propertyGroups(properties, "zzzzz")).toEqual([])
+    expect(countRows([])).toBe(0)
+  })
+
+  it("copes with a device that answered nothing", () => {
+    expect(propertyGroups({}, "")).toEqual([])
+  })
+})
+
+describe("matchesProperty", () => {
+  it("is case-insensitive over both halves", () => {
+    const row = { key: "ro.build.type", value: "userdebug" }
+    expect(matchesProperty(row, "BUILD")).toBe(true)
+    expect(matchesProperty(row, "USERDEBUG")).toBe(true)
+    expect(matchesProperty(row, "   ")).toBe(true)
+    expect(matchesProperty(row, "nope")).toBe(false)
+  })
+})
+
+describe("propertiesText", () => {
+  it("writes sorted key=value lines", () => {
+    const lines = propertiesText({ b: "2", a: "1" }).split("\n")
+    expect(lines).toEqual(["a=1", "b=2"])
+  })
+
+  it("is empty for nothing", () => {
+    expect(propertiesText({})).toBe("")
+  })
+})

--- a/desktop/src/lib/deviceinfo.ts
+++ b/desktop/src/lib/deviceinfo.ts
@@ -1,0 +1,96 @@
+/**
+ * Making sense of a `getprop` dump.
+ *
+ * A device answers with well over a thousand properties in no useful order.
+ * The daemon passes them through untouched — which property matters is the
+ * reader's question — so the arranging happens here, where it can be tested
+ * against a real dump rather than eyeballed in a list.
+ */
+
+export interface PropertyRow {
+  key: string
+  value: string
+}
+
+export interface PropertyGroup {
+  /** The `ro.build` in `ro.build.version.sdk` — how getprop already groups. */
+  prefix: string
+  rows: PropertyRow[]
+}
+
+/**
+ * The handful worth reading first, in the order the Mac's Device Info header
+ * shows them. Anything missing is simply skipped: an emulator and a phone do
+ * not answer the same set, and a row reading "unknown" is worse than no row.
+ */
+const SUMMARY_KEYS: readonly { readonly key: string; readonly label: string }[] = [
+  { key: "ro.product.model", label: "Model" },
+  { key: "ro.product.manufacturer", label: "Manufacturer" },
+  { key: "ro.build.version.release", label: "Android" },
+  { key: "ro.build.version.sdk", label: "API level" },
+  { key: "ro.build.id", label: "Build" },
+  { key: "ro.product.cpu.abi", label: "ABI" },
+  { key: "ro.serialno", label: "Serial" },
+  { key: "ro.build.type", label: "Build type" },
+]
+
+export interface SummaryRow {
+  label: string
+  value: string
+}
+
+export function summary(properties: Readonly<Record<string, string>>): SummaryRow[] {
+  return SUMMARY_KEYS.flatMap(({ key, label }) => {
+    const value = properties[key]
+    return value === undefined || value === "" ? [] : [{ label, value }]
+  })
+}
+
+/** Case-insensitive match over the key and the value, both of which get read. */
+export function matchesProperty(row: PropertyRow, query: string): boolean {
+  const needle = query.toLowerCase().trim()
+  if (needle === "") return true
+  return `${row.key} ${row.value}`.toLowerCase().includes(needle)
+}
+
+/**
+ * Every property a query matches, grouped by its first two dotted segments and
+ * sorted within each group.
+ *
+ * Two segments rather than one: `ro` alone would be most of the dump in a
+ * single heap, and `ro.build` against `ro.product` is the split someone reading
+ * it already has in mind.
+ */
+export function propertyGroups(
+  properties: Readonly<Record<string, string>>,
+  query: string,
+): PropertyGroup[] {
+  const groups = new Map<string, PropertyRow[]>()
+  for (const [key, value] of Object.entries(properties)) {
+    const row = { key, value }
+    if (!matchesProperty(row, query)) continue
+    const prefix = key.split(".").slice(0, 2).join(".")
+    const existing = groups.get(prefix)
+    if (existing) existing.push(row)
+    else groups.set(prefix, [row])
+  }
+  return [...groups.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([prefix, rows]) => ({
+      prefix,
+      rows: rows.toSorted((left, right) => left.key.localeCompare(right.key)),
+    }))
+}
+
+/** How many rows survived the query — what the count in the search field says. */
+export function countRows(groups: readonly PropertyGroup[]): number {
+  return groups.reduce((total, group) => total + group.rows.length, 0)
+}
+
+/** The whole dump as `key=value` lines, for export or the clipboard. */
+export function propertiesText(properties: Readonly<Record<string, string>>): string {
+  return Object.keys(properties)
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((key) => `${key}=${properties[key] ?? ""}`)
+    .join("\n")
+}

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -209,9 +209,10 @@ The daemon serves devices, features, apps and logcat today and nothing else, so
 that is the real cost of each screen, and it is why they are ordered by how
 often someone opens them rather than by how hard they look.
 
-1. **Device info** — the smallest of the four-layer screens, so it is where the
-   pattern gets established: a route over `DeviceProps`/`DeviceOverview` and a
-   searchable property browser.
+1. ~~**Device info.**~~ Landed — and it is the worked example of the four
+   layers: `DaemonProtocol.Route.deviceProps` + a `DaemonBackend` method, a
+   Rust `device_props` command, `lib/deviceinfo.ts` for the arranging, and a
+   pane. Copy that shape for the rest.
 2. **File explorer** — browse, copy/move/delete, pull, root toggle, new folder,
    context menu. The first screen that *writes* to the device, so its route
    needs the same `shellQuote` care ADBKit applies.
@@ -489,13 +490,15 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 - **Must replicate**
   - [ ] tooltip: Refresh from the device
 
-#### `device-info` — Device Info  ·  ⬜ todo
+#### `device-info` — Device Info  ·  🟡 partial
 > Browse and search every device property
 - **Kind** `view`
-- **Note** Not started on Windows/Linux.
+- **Note** Built. `/v1/device/props` passes `getprop` through untouched; the
+  pane adds a summary header, two-segment grouping, search over key and value,
+  copy and export.
 - **macOS view** `DeviceInfoView` — `App/Sources/FeatureDetail/Views/DeviceInfoView.swift`
 - **Must replicate**
-  - [ ] field: Filter properties…
+  - [x] field: Filter properties…
 
 #### `fake-battery` — Fake Battery  ·  🟡 partial
 > Set a fake battery level and unplugged state

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -13,6 +13,7 @@ public enum DaemonProtocol {
         case actionsRun = "/v1/actions/run"
         case appsList = "/v1/apps/list"
         case appsControl = "/v1/apps/control"
+        case deviceProps = "/v1/device/props"
     }
 
     /// The multiplexed stream socket. Not a `Route`: it is a WebSocket upgrade
@@ -23,6 +24,22 @@ public enum DaemonProtocol {
     public struct DevicesResponse: Codable, Equatable, Sendable {
         public let devices: [Device]
         public init(devices: [Device]) { self.devices = devices }
+    }
+
+    public struct DeviceRequest: Codable, Equatable, Sendable {
+        public let serial: String
+        public init(serial: String) { self.serial = serial }
+    }
+
+    /// Everything `getprop` printed, unparsed.
+    ///
+    /// The dictionary is passed through rather than reshaped into named
+    /// fields: which properties matter is the reader's question, and a daemon
+    /// that picked a subset would be deciding it for them — the Mac's Device
+    /// Info screen is a search box over the same raw set.
+    public struct DevicePropsResponse: Codable, Equatable, Sendable {
+        public let properties: [String: String]
+        public init(properties: [String: String]) { self.properties = properties }
     }
 
     /// One error shape everywhere, so the UI has exactly one error path.

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -23,6 +23,8 @@ public protocol DaemonBackend: Sendable {
     func controlApp(
         serial: String, packageId: String, action: AppControlService.AppAction
     ) async throws -> FeatureResult
+    /// Every `getprop` key and value on the device.
+    func deviceProperties(serial: String) async throws -> [String: String]
 }
 
 /// `DeviceMonitor` in production.
@@ -58,6 +60,10 @@ public struct LiveBackend: DaemonBackend {
     ) async throws -> FeatureResult {
         try await AppControlService(client: client)
             .control(serial: serial, packageId: packageId, action: action)
+    }
+
+    public func deviceProperties(serial: String) async throws -> [String: String] {
+        try await DeviceProps.all(client: client, serial: serial)
     }
 }
 
@@ -295,6 +301,22 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
 
         case .featuresList:
             return (.ok, encoded(ActionProtocol.features()))
+
+        case .deviceProps:
+            let raw = Data(body.readableBytesView)
+            guard let request = try? JSONDecoder().decode(
+                DaemonProtocol.DeviceRequest.self, from: raw)
+            else { return (.badRequest, encoded(DaemonProtocol.badRequest)) }
+            do {
+                let properties = try await backend.deviceProperties(serial: request.serial)
+                return (.ok, encoded(DaemonProtocol.DevicePropsResponse(properties: properties)))
+            } catch {
+                // adb's answer, not a daemon fault — the same 502 the app
+                // list uses, carrying adb's own words.
+                return (.badGateway, encoded(DaemonProtocol.ErrorBody(
+                    code: "adb_failed", message: "Could not read the device properties.",
+                    detail: "\(error)")))
+            }
 
         case .actionsRun:
             let raw = Data(body.readableBytesView)

--- a/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
@@ -65,6 +65,10 @@ import FoundationNetworking
             await log.recordApp(serial, packageId, action)
             return result
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private func withServer(

--- a/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
@@ -30,6 +30,10 @@ import FoundationNetworking
         ) async throws -> FeatureResult {
             FeatureResult(ok: true, message: "stub")
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private static func device(_ serial: String) -> Device {
@@ -58,10 +62,12 @@ import FoundationNetworking
 
     private func send(
         port: Int, path: String = DaemonProtocol.Route.devicesList.rawValue,
-        method: String = "POST", token: String?, host: String? = nil, origin: String? = nil
+        method: String = "POST", token: String?, host: String? = nil, origin: String? = nil,
+        body: String? = nil
     ) async throws -> (status: Int, body: Data) {
         var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         request.httpMethod = method
+        if let body { request.httpBody = Data(body.utf8) }
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
         if let host { request.setValue(host, forHTTPHeaderField: "Host") }
         if let origin { request.setValue(origin, forHTTPHeaderField: "Origin") }
@@ -125,6 +131,30 @@ import FoundationNetworking
 
             let wrongMethod = try await send(port: port, method: "GET", token: token)
             #expect(wrongMethod.status == 405)
+        }
+    }
+
+    @Test func devicePropsPassesGetpropStraightThrough() async throws {
+        // The daemon picks no subset: which property matters is the reader's
+        // question, and a client that got a curated list could not ask it.
+        try await withServer { port, token in
+            let (status, body) = try await send(
+                port: port, path: DaemonProtocol.Route.deviceProps.rawValue, token: token,
+                body: #"{"serial":"emulator-5554"}"#)
+            #expect(status == 200)
+            let decoded = try JSONDecoder().decode(
+                DaemonProtocol.DevicePropsResponse.self, from: body)
+            #expect(decoded.properties["ro.product.model"] == "Pixel")
+            #expect(decoded.properties["ro.build.version.release"] == "14")
+        }
+    }
+
+    @Test func devicePropsRefusesABodyItCannotRead() async throws {
+        try await withServer { port, token in
+            let (status, _) = try await send(
+                port: port, path: DaemonProtocol.Route.deviceProps.rawValue, token: token,
+                body: "not json")
+            #expect(status == 400)
         }
     }
 

--- a/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
@@ -48,6 +48,10 @@ private let hasWebSocketClient: Bool = {
         ) async throws -> FeatureResult {
             FeatureResult(ok: true, message: "stub")
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private struct FixedSource: StreamSource {


### PR DESCRIPTION
Stacked on #258.

The first screen that needed all four layers, so it is deliberately the smallest one: a daemon route, a Rust command, a pane, and tests at both ends. **The rest of the screens copy this shape** — the backlog in #258 points at it as the worked example.

## The route passes getprop through

`/v1/device/props` answers with a dictionary rather than named fields. Which property matters is the reader's question — the Mac's Device Info screen is a search box over the same raw set — and a daemon that picked a subset would be answering it for them.

## The arranging is testable

`lib/deviceinfo.ts` holds it, so it can be checked against a real dump instead of eyeballed in a list:

- a **summary header** of the handful worth reading first, in the order the Mac shows them. A key the device did not answer is skipped rather than rendered as "unknown" — a phone and an emulator do not answer the same set;
- **grouping by two dotted segments**, not one. `ro` alone would be most of the dump in a single heap; `ro.build` against `ro.product` is the split someone reading it already has in mind;
- **search across key and value**, since what a property *says* is as often the thing you are looking for as its name.

Plus copy-all and export, reusing the `export_text` command from #257.

## Daemon

`DaemonBackend` gains `deviceProperties(serial:)`, so all three test stubs conform to it. `everyRouteIsReachable` already covers the new route; two behaviour tests cover the happy path and an unreadable body.

## Verified

`swift test` in `droidectived` green (76). `make desktop-test` green (typecheck, oxlint, 190 vitest, cargo fmt/clippy/test). Opened against `emulator-5554` after rebuilding the sidecar: **633 real properties**, summary reading Android 15 / API 35 / arm64-v8a / EMULATOR36X6X11X0, grouped below it. The filter is covered by unit tests rather than driven live — synthetic keystrokes lost focus to the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)