### PR TITLE
Palette, logcat, device info and the backlog

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -171,11 +171,13 @@ pub fn export_text(app: AppHandle, name: String, contents: String) -> Result<Str
         .download_dir()
         .map_err(|error| DaemonError::Host(format!("no Downloads folder: {error}")))?
         .join("Droidective");
-    std::fs::create_dir_all(&folder)
-        .map_err(|error| DaemonError::Host(format!("could not create {}: {error}", folder.display())))?;
+    std::fs::create_dir_all(&folder).map_err(|error| {
+        DaemonError::Host(format!("could not create {}: {error}", folder.display()))
+    })?;
     let path = folder.join(name);
-    std::fs::write(&path, contents)
-        .map_err(|error| DaemonError::Host(format!("could not write {}: {error}", path.display())))?;
+    std::fs::write(&path, contents).map_err(|error| {
+        DaemonError::Host(format!("could not write {}: {error}", path.display()))
+    })?;
     Ok(path.to_string_lossy().into_owned())
 }
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_opener::OpenerExt;
 
@@ -147,6 +147,36 @@ pub fn reveal_path(app: AppHandle, path: String) -> Result<(), DaemonError> {
     app.opener()
         .reveal_item_in_dir(&path)
         .map_err(|error| DaemonError::Host(format!("could not open {path}: {error}")))
+}
+
+/// Writes text into `~/Downloads/Droidective/<name>` and returns the path.
+///
+/// The Mac exports there too, so someone moving between the two finds their
+/// files in the same place. A fixed folder rather than a save dialog: it is one
+/// fewer plugin, one fewer capability, and the path comes back for the Show in
+/// folder button to use.
+#[tauri::command]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "tauri's command macro hands AppHandle in by value"
+)]
+pub fn export_text(app: AppHandle, name: String, contents: String) -> Result<String, DaemonError> {
+    // A name is built from a feature id and a timestamp, never from device
+    // output — but it ends up in a path, so it is checked rather than trusted.
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(DaemonError::Host(format!("refusing to write {name}")));
+    }
+    let folder = app
+        .path()
+        .download_dir()
+        .map_err(|error| DaemonError::Host(format!("no Downloads folder: {error}")))?
+        .join("Droidective");
+    std::fs::create_dir_all(&folder)
+        .map_err(|error| DaemonError::Host(format!("could not create {}: {error}", folder.display())))?;
+    let path = folder.join(name);
+    std::fs::write(&path, contents)
+        .map_err(|error| DaemonError::Host(format!("could not write {}: {error}", path.display())))?;
+    Ok(path.to_string_lossy().into_owned())
 }
 
 /// Subscribes to the device list. Returns the id to pass to `stop_watching`.

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -14,8 +14,8 @@ use tauri_plugin_opener::OpenerExt;
 
 use crate::daemon::stream::StreamMessage;
 use crate::daemon::wire::{
-    AppControlRequest, AppsResponse, Device, FeatureSummary, RunRequest, RunResponse,
-    SubscribeParams,
+    AppControlRequest, AppsResponse, Device, DevicePropsResponse, FeatureSummary, RunRequest,
+    RunResponse, SubscribeParams,
 };
 use crate::daemon::{DaemonStatus, Supervisor};
 use crate::error::DaemonError;
@@ -117,6 +117,14 @@ pub async fn control_app(
             action,
         })
         .await
+}
+
+#[tauri::command]
+pub async fn device_props(
+    supervisor: State<'_, Supervisor>,
+    serial: String,
+) -> Result<DevicePropsResponse, DaemonError> {
+    supervisor.client().await?.device_props(serial).await
 }
 
 /// Puts an action's `copyText` on the system clipboard.

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -53,7 +53,8 @@ impl DaemonClient {
     }
 
     pub async fn device_props(&self, serial: String) -> Result<DevicePropsResponse, DaemonError> {
-        self.post("/v1/device/props", &DeviceRequest { serial }).await
+        self.post("/v1/device/props", &DeviceRequest { serial })
+            .await
     }
 
     pub async fn control_app(

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -4,8 +4,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::daemon::wire::{
-    AppControlRequest, AppsListRequest, AppsResponse, Device, DevicesResponse, ErrorEnvelope,
-    FeatureSummary, FeaturesResponse, RunRequest, RunResponse,
+    AppControlRequest, AppsListRequest, AppsResponse, Device, DevicePropsResponse, DeviceRequest,
+    DevicesResponse, ErrorEnvelope, FeatureSummary, FeaturesResponse, RunRequest, RunResponse,
 };
 use crate::error::DaemonError;
 
@@ -50,6 +50,10 @@ impl DaemonClient {
     pub async fn list_apps(&self, serial: String) -> Result<AppsResponse, DaemonError> {
         self.post("/v1/apps/list", &AppsListRequest { serial })
             .await
+    }
+
+    pub async fn device_props(&self, serial: String) -> Result<DevicePropsResponse, DaemonError> {
+        self.post("/v1/device/props", &DeviceRequest { serial }).await
     }
 
     pub async fn control_app(

--- a/desktop/src-tauri/src/daemon/wire.rs
+++ b/desktop/src-tauri/src/daemon/wire.rs
@@ -150,6 +150,18 @@ pub struct AppsListRequest {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DeviceRequest {
+    pub serial: String,
+}
+
+/// Everything `getprop` printed. Passed through as a map rather than reshaped:
+/// which property matters is the reader's question, not this layer's.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DevicePropsResponse {
+    pub properties: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct AppControlRequest {
     pub serial: String,
     #[serde(rename = "packageId")]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() -> tauri::Result<()> {
             commands::run_action,
             commands::list_apps,
             commands::control_app,
+            commands::device_props,
             commands::watch_devices,
             commands::watch_logcat,
             commands::stop_watching,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() -> tauri::Result<()> {
             commands::stop_watching,
             commands::copy_text,
             commands::reveal_path,
+            commands::export_text,
         ])
         .setup(|app| {
             // Off the setup path: spawning the sidecar and waiting for its

--- a/desktop/src/components/CommandPalette.tsx
+++ b/desktop/src/components/CommandPalette.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from "react"
+import { Pin, Search } from "lucide-react"
+import { cn } from "@/lib/cn"
+import { iconForFeature } from "@/lib/icons"
+import { moveHighlight, paletteResults } from "@/lib/palette"
+import { IS_MAC, shortcutLabel } from "@/lib/platform"
+import type { FeatureSummary } from "@/lib/wire"
+
+/**
+ * The palette: everything openable, one keystroke away.
+ *
+ * Opened with Ctrl/⌘+K or Ctrl/⌘+T, and by the tab strip's `+`. Arrow keys
+ * move, Enter opens in the pane that asked, Ctrl/⌘+P pins or unpins whatever
+ * is highlighted — the same pinned list the sidebar's top section shows.
+ */
+export function CommandPalette({
+  features,
+  favorites,
+  onOpen,
+  onTogglePinned,
+  onDismiss,
+}: {
+  features: FeatureSummary[]
+  favorites: string[]
+  onOpen: (id: string) => void
+  onTogglePinned: (id: string) => void
+  onDismiss: () => void
+}) {
+  const [query, setQuery] = useState("")
+  const [highlight, setHighlight] = useState(0)
+
+  const results = useMemo(
+    () => paletteResults(features, query, favorites),
+    [features, query, favorites],
+  )
+  // Typing narrows the list; the highlight follows it rather than pointing at
+  // a row that is no longer there.
+  const index = Math.min(highlight, Math.max(results.length - 1, 0))
+  const current = results[index]
+
+  useEffect(() => {
+    setHighlight(0)
+  }, [query])
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const modifier = IS_MAC ? event.metaKey : event.ctrlKey
+    if (event.key === "Escape") {
+      event.preventDefault()
+      onDismiss()
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setHighlight(moveHighlight(results.length, index, 1))
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setHighlight(moveHighlight(results.length, index, -1))
+    } else if (modifier && event.key === "p") {
+      event.preventDefault()
+      if (current) onTogglePinned(current.id)
+    } else if (event.key === "Enter" && current) {
+      event.preventDefault()
+      onOpen(current.id)
+      onDismiss()
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-black/40" onPointerDown={onDismiss} />
+      <div className="fixed inset-x-0 top-[12vh] z-50 mx-auto w-[560px] max-w-[90vw] overflow-hidden rounded-xl border border-border-subtle bg-bg-raised shadow-2xl">
+        <div className="flex items-center gap-2.5 border-b border-border-subtle px-3.5 py-3">
+          <Search size={15} className="shrink-0 text-text-tertiary" />
+          <input
+            value={query}
+            // The palette exists to be typed into; landing anywhere else
+            // costs a keystroke every time it opens.
+            // oxlint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            aria-label="Search features"
+            placeholder="Open a feature…"
+            onChange={(event) => {
+              setQuery(event.target.value)
+            }}
+            onKeyDown={onKeyDown}
+            className="min-w-0 flex-1 bg-transparent text-[15px] text-text-primary outline-none placeholder:text-text-tertiary"
+          />
+          <span className="shrink-0 text-[11px] text-text-tertiary">
+            {shortcutLabel("p", IS_MAC)} to pin
+          </span>
+        </div>
+
+        <div className="max-h-[52vh] overflow-y-auto py-1.5">
+          {results.length === 0 ? (
+            <p className="px-4 py-8 text-center text-text-tertiary">Nothing matches “{query}”.</p>
+          ) : (
+            results.map((feature, row) => (
+              <Row
+                key={feature.id}
+                feature={feature}
+                pinned={favorites.includes(feature.id)}
+                highlighted={row === index}
+                onHover={() => {
+                  setHighlight(row)
+                }}
+                onSelect={() => {
+                  onOpen(feature.id)
+                  onDismiss()
+                }}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function Row({
+  feature,
+  pinned,
+  highlighted,
+  onHover,
+  onSelect,
+}: {
+  feature: FeatureSummary
+  pinned: boolean
+  highlighted: boolean
+  onHover: () => void
+  onSelect: () => void
+}) {
+  const Icon = iconForFeature(feature.id, feature.category)
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      onPointerMove={onHover}
+      className={cn(
+        "flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left",
+        highlighted ? "bg-accent/15" : "",
+      )}
+    >
+      <Icon size={16} className="shrink-0 text-accent" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13.5px] text-text-primary">{feature.title}</span>
+        {feature.subtitle ? (
+          <span className="block truncate text-[11.5px] text-text-secondary">
+            {feature.subtitle}
+          </span>
+        ) : null}
+      </span>
+      {pinned ? <Pin size={12} className="shrink-0 text-accent" /> : null}
+    </button>
+  )
+}

--- a/desktop/src/components/DeviceInfoPane.tsx
+++ b/desktop/src/components/DeviceInfoPane.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Clipboard, Download, RefreshCw, Search } from "lucide-react"
+import { Banner, Button } from "@/components/Controls"
+import { asDaemonError, copyText, deviceProps, exportText } from "@/lib/daemon"
+import {
+  countRows,
+  propertiesText,
+  propertyGroups,
+  summary,
+  type PropertyGroup,
+} from "@/lib/deviceinfo"
+import type { DaemonError, Device } from "@/lib/wire"
+
+/**
+ * Every property the device answers, searchable — the Mac's Device Info screen.
+ *
+ * One `getprop` on open rather than a poll: a device answers over a thousand
+ * properties and almost none of them change while you are reading them.
+ */
+export function DeviceInfoPane({ device }: { device: Device | null }) {
+  const [properties, setProperties] = useState<Record<string, string>>({})
+  const [query, setQuery] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<DaemonError | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const serial = device?.serial ?? null
+  const load = useCallback(async () => {
+    if (serial === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      setProperties((await deviceProps(serial)).properties)
+    } catch (thrown) {
+      setError(asDaemonError(thrown))
+    } finally {
+      setLoading(false)
+    }
+  }, [serial])
+
+  useEffect(() => {
+    setProperties({})
+    void load()
+  }, [load])
+
+  const groups = useMemo(() => propertyGroups(properties, query), [properties, query])
+  const total = Object.keys(properties).length
+  const shown = countRows(groups)
+
+  const act = (run: () => Promise<string>) => () => {
+    setError(null)
+    run().then(setNotice, (thrown: unknown) => {
+      setError(asDaemonError(thrown))
+    })
+  }
+
+  if (!device) {
+    return <p className="p-6 text-text-tertiary">Connect a device to read its properties.</p>
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <Toolbar
+        query={query}
+        onQuery={setQuery}
+        total={total}
+        loading={loading}
+        onCopy={act(async () => {
+          await copyText(propertiesText(properties))
+          return "Copied every property to the clipboard."
+        })}
+        onExport={act(
+          async () =>
+            `Saved to ${await exportText(`getprop_${device.serial}.txt`, propertiesText(properties))}`,
+        )}
+        onRefresh={() => void load()}
+      />
+
+      {error ? (
+        <div className="px-3 pt-3">
+          <Banner tone="error">
+            {error.message}
+            {error.detail ? <div className="mt-1 opacity-70">{error.detail}</div> : null}
+          </Banner>
+        </div>
+      ) : null}
+      {notice === null ? null : (
+        <div className="px-3 pt-3">
+          <Banner tone="ok">{notice}</Banner>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4" data-selectable>
+        {loading && total === 0 ? (
+          <p className="py-8 text-center text-text-tertiary">Reading the device…</p>
+        ) : total === 0 ? (
+          <p className="py-8 text-center text-text-tertiary">No properties came back.</p>
+        ) : (
+          <>
+            <Summary properties={properties} />
+            {shown === 0 ? (
+              <p className="py-8 text-center text-text-tertiary">Nothing matches “{query}”.</p>
+            ) : (
+              groups.map((group) => <Group key={group.prefix} group={group} />)
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Toolbar({
+  query,
+  onQuery,
+  total,
+  loading,
+  onCopy,
+  onExport,
+  onRefresh,
+}: {
+  query: string
+  onQuery: (value: string) => void
+  total: number
+  loading: boolean
+  onCopy: () => void
+  onExport: () => void
+  onRefresh: () => void
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border-subtle bg-bg-chrome px-3 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
+        <Search size={13} className="shrink-0 text-text-tertiary" />
+        <input
+          value={query}
+          aria-label="Filter properties"
+          placeholder={total === 0 ? "Filter properties…" : `Filter ${total} properties…`}
+          onChange={(event) => {
+            onQuery(event.target.value)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") onQuery("")
+          }}
+          className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
+        />
+      </div>
+      <Button onClick={onCopy} title="Copy every property">
+        <Clipboard size={13} />
+      </Button>
+      <Button onClick={onExport} title="Export to ~/Downloads/Droidective">
+        <Download size={13} />
+      </Button>
+      <Button onClick={onRefresh} disabled={loading} title="Read the device again">
+        <RefreshCw size={13} className={loading ? "animate-spin" : undefined} />
+      </Button>
+    </div>
+  )
+}
+
+/** The handful worth reading first, before the thousand that follow. */
+function Summary({ properties }: { properties: Record<string, string> }) {
+  const rows = summary(properties)
+  if (rows.length === 0) return null
+  return (
+    <div className="mb-5 grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-2">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="rounded-lg border border-border-subtle bg-bg-surface px-3 py-2"
+        >
+          <div className="text-[10.5px] uppercase tracking-[0.06em] text-text-tertiary">
+            {row.label}
+          </div>
+          <div className="truncate text-[13px] text-text-primary" title={row.value}>
+            {row.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Group({ group }: { group: PropertyGroup }) {
+  return (
+    <section className="mb-4">
+      <h3 className="mb-1 text-[10.5px] font-medium uppercase tracking-[0.06em] text-text-tertiary">
+        {group.prefix}
+      </h3>
+      <div className="overflow-hidden rounded-lg border border-border-subtle">
+        {group.rows.map((row, index) => (
+          <div
+            key={row.key}
+            className={
+              index % 2 === 0
+                ? "flex gap-4 px-3 py-1 font-mono text-[11.5px]"
+                : "flex gap-4 bg-white/[0.02] px-3 py-1 font-mono text-[11.5px]"
+            }
+          >
+            <span className="w-[46%] shrink-0 truncate text-text-secondary" title={row.key}>
+              {row.key}
+            </span>
+            <span className="min-w-0 flex-1 break-all text-text-primary">{row.value}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/desktop/src/components/FeaturePane.tsx
+++ b/desktop/src/components/FeaturePane.tsx
@@ -1,6 +1,7 @@
 import { Construction } from "lucide-react"
 import { ActionForm } from "@/components/ActionForm"
 import { AppsPane } from "@/components/AppsPane"
+import { DeviceInfoPane } from "@/components/DeviceInfoPane"
 import { HomeView } from "@/components/HomeView"
 import { LogcatPane } from "@/components/LogcatPane"
 import { HOME_TAB } from "@/lib/layout"
@@ -52,6 +53,8 @@ export function FeaturePane(props: FeaturePaneProps) {
       )
     case "logcat":
       return <LogcatPane device={props.device} />
+    case "device-info":
+      return <DeviceInfoPane device={props.device} />
     default:
       return isRunnable(props.feature) ? (
         <ActionForm

--- a/desktop/src/components/FeaturePane.tsx
+++ b/desktop/src/components/FeaturePane.tsx
@@ -16,6 +16,7 @@ export interface FeaturePaneProps {
   onOpen: (id: string) => void
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
 }
 
 /**
@@ -33,6 +34,7 @@ export function FeaturePane(props: FeaturePaneProps) {
         features={props.features}
         sidebarOrder={props.sidebarOrder}
         categoryOrder={props.categoryOrder}
+        favorites={props.favorites}
         onOpen={props.onOpen}
       />
     )

--- a/desktop/src/components/HomeView.tsx
+++ b/desktop/src/components/HomeView.tsx
@@ -13,11 +13,13 @@ export function HomeView({
   features,
   sidebarOrder,
   categoryOrder,
+  favorites,
   onOpen,
 }: {
   features: FeatureSummary[]
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
   onOpen: (id: string) => void
 }) {
   const sections = sidebarSections(features, {
@@ -27,6 +29,7 @@ export function HomeView({
     // Collapsing is a sidebar-space affordance, not a preference against the
     // feature, so Home shows a collapsed group's contents anyway.
     collapsedCategories: [],
+    favorites,
   })
   const total = sections.reduce((count, section) => count + section.features.length, 0)
 

--- a/desktop/src/components/LogcatPane.tsx
+++ b/desktop/src/components/LogcatPane.tsx
@@ -1,9 +1,21 @@
-import { useEffect, useRef, useState } from "react"
-import { Pause, Search } from "lucide-react"
+import { useMemo, useRef, useState } from "react"
+import { Eraser, Pause, Play } from "lucide-react"
 import { Banner, Button } from "@/components/Controls"
+import { LogcatToolbar } from "@/components/LogcatToolbar"
 import { useLogcatStream } from "@/hooks/useLogcatStream"
 import { cn } from "@/lib/cn"
-import { LOG_CAPACITY, matchesFilter, type LogBuffer, type LogRow } from "@/lib/logbuffer"
+import { asDaemonError, exportText } from "@/lib/daemon"
+import {
+  emptyFilter,
+  LOG_CAPACITY,
+  logText,
+  matchesFind,
+  matchesLogFilter,
+  tagsByFrequency,
+  type LogBuffer,
+  type LogFilter,
+  type LogRow,
+} from "@/lib/logbuffer"
 import type { Device } from "@/lib/wire"
 
 /** How many rows go into the DOM. The buffer holds more; this is what renders. */
@@ -24,19 +36,32 @@ const LEVEL_STYLES: Record<string, string> = {
 }
 
 export function LogcatPane({ device }: { device: Device | null }) {
-  const { buffer, streaming, error, ended, stop } = useLogcatStream(device?.serial ?? null)
-  const [filter, setFilter] = useState("")
+  const stream = useLogcatStream(device?.serial ?? null)
+  const [filter, setFilter] = useState<LogFilter>(emptyFilter)
+  const [find, setFind] = useState("")
   const [following, setFollowing] = useState(true)
+  const [saved, setSaved] = useState<string | null>(null)
+  const [failure, setFailure] = useState<string | null>(null)
   const scroller = useRef<HTMLDivElement | null>(null)
 
-  const visible = buffer.rows.filter((row) => matchesFilter(row, filter))
+  const { buffer } = stream
+  const visible = useMemo(
+    () => buffer.rows.filter((row) => matchesLogFilter(row, filter)),
+    [buffer.rows, filter],
+  )
   const rendered = visible.slice(Math.max(0, visible.length - RENDER_WINDOW))
+  const tags = useMemo(() => tagsByFrequency(buffer.rows).slice(0, 40), [buffer.rows])
+  const hits = useMemo(
+    () => (find.trim() === "" ? 0 : visible.filter((row) => matchesFind(row, find)).length),
+    [visible, find],
+  )
 
-  useEffect(() => {
-    if (!following) return
-    const element = scroller.current
-    if (element) element.scrollTop = element.scrollHeight
-  }, [rendered.length, following])
+  // Pinning to the bottom is a layout effect in spirit, but it only has to
+  // happen after the rows are in the DOM, which this is.
+  const pin = (element: HTMLDivElement | null) => {
+    scroller.current = element
+    if (element && following) element.scrollTop = element.scrollHeight
+  }
 
   if (!device) {
     return <p className="p-6 text-text-tertiary">Connect a device to read its log.</p>
@@ -44,57 +69,44 @@ export function LogcatPane({ device }: { device: Device | null }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-bg-root">
-      <div className="flex shrink-0 items-center gap-3 border-b border-border-subtle bg-bg-chrome px-3 py-2">
-        <div className="flex w-72 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
-          <Search size={13} className="shrink-0 text-text-tertiary" />
-          <input
-            value={filter}
-            aria-label="Filter lines"
-            placeholder="Search lines…"
-            onChange={(event) => {
-              setFilter(event.target.value)
-            }}
-            className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
-          />
-        </div>
-        <div className="flex-1" />
-        {following ? null : (
-          <Button
-            onClick={() => {
-              setFollowing(true)
-            }}
-          >
-            Jump to newest
-          </Button>
-        )}
-        <Button onClick={() => void stop()} disabled={!streaming} title="Stop streaming">
-          <span className="flex items-center gap-1.5">
-            <Pause size={13} />
-            Stop
-          </span>
-        </Button>
-      </div>
+      <LogcatToolbar
+        filter={filter}
+        onFilter={setFilter}
+        find={find}
+        onFind={setFind}
+        hits={hits}
+        tags={tags}
+        onExport={() => {
+          void saveLog(visible).then(setSaved, (thrown: unknown) => {
+            setFailure(asDaemonError(thrown).message)
+          })
+        }}
+      />
 
       <StatusRow
-        streaming={streaming}
+        streaming={stream.streaming}
         buffer={buffer}
         shown={visible.length}
         rendered={rendered.length}
+        following={following}
+        onFollow={() => {
+          setFollowing(true)
+          if (scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight
+        }}
+        onClear={stream.clear}
+        onStop={() => void stream.stop()}
+        onRestart={stream.restart}
       />
 
-      {error ? (
-        <div className="px-3 pt-3">
-          <Banner tone="error">{error.message}</Banner>
-        </div>
-      ) : null}
-      {ended !== null && !error ? (
-        <div className="px-3 pt-3">
-          <Banner tone="warn">The log stream ended ({ended}).</Banner>
-        </div>
-      ) : null}
+      <Notices
+        error={stream.error?.message ?? null}
+        ended={stream.ended}
+        failure={failure}
+        saved={saved}
+      />
 
       <div
-        ref={scroller}
+        ref={pin}
         onScroll={(event) => {
           // Following is a decision about intent, so it is read from a real
           // scroll position rather than inferred from a programmatic pin.
@@ -105,11 +117,28 @@ export function LogcatPane({ device }: { device: Device | null }) {
         data-selectable
       >
         {rendered.map((row) => (
-          <Row key={row.key} row={row} />
+          <Row
+            key={row.key}
+            row={row}
+            hit={matchesFind(row, find)}
+            onTag={(tag) => {
+              setFilter((current) =>
+                current.tags.includes(tag)
+                  ? current
+                  : { ...current, tags: [...current.tags, tag] },
+              )
+            }}
+          />
         ))}
       </div>
     </div>
   )
+}
+
+/** Writes what is on screen, named for when it was taken. */
+function saveLog(rows: readonly LogRow[]): Promise<string> {
+  const stamp = new Date().toISOString().replaceAll(/[:.]/gu, "-").slice(0, 19)
+  return exportText(`logcat_${stamp}.txt`, logText(rows))
 }
 
 /** The Mac app's thin state strip: what the feed is doing, and how much of it. */
@@ -118,11 +147,21 @@ function StatusRow({
   buffer,
   shown,
   rendered,
+  following,
+  onFollow,
+  onClear,
+  onStop,
+  onRestart,
 }: {
   streaming: boolean
   buffer: LogBuffer
   shown: number
   rendered: number
+  following: boolean
+  onFollow: () => void
+  onClear: () => void
+  onStop: () => void
+  onRestart: () => void
 }) {
   // Every cap says so out loud. A feed that quietly shows a subset is a feed
   // that lies about being complete.
@@ -145,11 +184,46 @@ function StatusRow({
       <span className="text-[11.5px] text-text-tertiary">
         {[`${shown.toLocaleString()} lines`, ...notes].join(" · ")}
       </span>
+      {following ? null : (
+        <Button onClick={onFollow} title="Scroll back to the newest line">
+          Jump to newest
+        </Button>
+      )}
+      <Button onClick={onClear} title="Clear what is on screen">
+        <span className="flex items-center gap-1.5">
+          <Eraser size={13} />
+          Clear
+        </span>
+      </Button>
+      {/* Stop used to be a one-way door: the only way back was a tab switch. */}
+      {streaming ? (
+        <Button onClick={onStop} title="Stop streaming">
+          <span className="flex items-center gap-1.5">
+            <Pause size={13} />
+            Stop
+          </span>
+        </Button>
+      ) : (
+        <Button onClick={onRestart} tone="primary" title="Start streaming again">
+          <span className="flex items-center gap-1.5">
+            <Play size={13} />
+            Start
+          </span>
+        </Button>
+      )}
     </div>
   )
 }
 
-function Row({ row }: { row: LogRow }) {
+function Row({
+  row,
+  hit,
+  onTag,
+}: {
+  row: LogRow
+  hit: boolean
+  onTag: (tag: string) => void
+}) {
   if (row.kind === "gap") {
     return (
       <div className="my-1 flex items-center gap-2 text-warn">
@@ -166,14 +240,54 @@ function Row({ row }: { row: LogRow }) {
       className={cn(
         "whitespace-pre-wrap break-words",
         LEVEL_STYLES[line.level] ?? "text-text-secondary",
+        // Find highlights rather than hides — that is the point of the split.
+        hit ? "rounded-sm bg-warn/20" : "",
       )}
     >
       <span className="text-text-tertiary">{line.time} </span>
       <span className="text-text-tertiary">{line.pid.padStart(5, " ")} </span>
-      <span>
-        {line.level}/{line.tag}:{" "}
-      </span>
+      <span>{line.level}/</span>
+      <button
+        type="button"
+        onClick={() => {
+          onTag(line.tag)
+        }}
+        title={`Show only ${line.tag}`}
+        className="underline decoration-dotted underline-offset-2 hover:text-accent"
+      >
+        {line.tag}
+      </button>
+      <span>: </span>
       {line.message}
+    </div>
+  )
+}
+
+/** Whatever the feed has to say for itself, above the rows. */
+function Notices({
+  error,
+  ended,
+  failure,
+  saved,
+}: {
+  error: string | null
+  ended: string | null
+  failure: string | null
+  saved: string | null
+}) {
+  const notices: { tone: "error" | "warn" | "ok"; text: string }[] = []
+  if (error !== null) notices.push({ tone: "error", text: error })
+  else if (ended !== null) notices.push({ tone: "warn", text: `The log stream ended (${ended}).` })
+  if (failure !== null) notices.push({ tone: "error", text: failure })
+  if (saved !== null) notices.push({ tone: "ok", text: `Saved to ${saved}` })
+  if (notices.length === 0) return null
+  return (
+    <div className="flex shrink-0 flex-col gap-2 px-3 pt-3">
+      {notices.map((notice) => (
+        <Banner key={notice.text} tone={notice.tone}>
+          {notice.text}
+        </Banner>
+      ))}
     </div>
   )
 }

--- a/desktop/src/components/LogcatToolbar.tsx
+++ b/desktop/src/components/LogcatToolbar.tsx
@@ -1,0 +1,187 @@
+import { Download, Filter, Search, X } from "lucide-react"
+import { Select } from "@/components/Controls"
+import { cn } from "@/lib/cn"
+import { LEVELS, type Level, type LogFilter } from "@/lib/logbuffer"
+
+const LEVEL_NAMES: Record<Level, string> = {
+  V: "Verbose",
+  D: "Debug",
+  I: "Info",
+  W: "Warn",
+  E: "Error",
+  F: "Fatal",
+}
+
+/**
+ * Filter, Find, level, tags, export.
+ *
+ * Filter and Find are deliberately two fields, as they are on the Mac: "show me
+ * only this" and "where is this?" are different questions, and one box that did
+ * both would answer neither well.
+ */
+export function LogcatToolbar({
+  filter,
+  onFilter,
+  find,
+  onFind,
+  hits,
+  tags,
+  onExport,
+}: {
+  filter: LogFilter
+  onFilter: (filter: LogFilter) => void
+  find: string
+  onFind: (find: string) => void
+  hits: number
+  tags: string[]
+  onExport: () => void
+}) {
+  return (
+    <div className="shrink-0 border-b border-border-subtle bg-bg-chrome">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Field
+          icon={Filter}
+          value={filter.text}
+          label="Filter lines"
+          placeholder="Filter — hides the rest…"
+          onChange={(text) => {
+            onFilter({ ...filter, text })
+          }}
+        />
+        <Field
+          icon={Search}
+          value={find}
+          label="Find in the log"
+          placeholder="Find — highlights only…"
+          onChange={onFind}
+        />
+        {find.trim() === "" ? null : (
+          <span className="shrink-0 text-[11.5px] text-text-tertiary">
+            {hits.toLocaleString()} {hits === 1 ? "hit" : "hits"}
+          </span>
+        )}
+
+        <div className="w-[124px] shrink-0">
+          <Select
+            value={filter.minLevel}
+            options={LEVELS.map((level) => ({ value: level, label: LEVEL_NAMES[level] }))}
+            onChange={(value) => {
+              onFilter({ ...filter, minLevel: value as Level })
+            }}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onExport}
+          title="Export what is shown to ~/Downloads/Droidective"
+          aria-label="Export the log"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md bg-bg-raised text-text-secondary hover:bg-border-subtle hover:text-text-primary"
+        >
+          <Download size={13} />
+        </button>
+      </div>
+
+      <TagBar
+        chosen={filter.tags}
+        tags={tags}
+        onToggle={(tag) => {
+          onFilter({
+            ...filter,
+            tags: filter.tags.includes(tag)
+              ? filter.tags.filter((entry) => entry !== tag)
+              : [...filter.tags, tag],
+          })
+        }}
+        onClear={() => {
+          onFilter({ ...filter, tags: [] })
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * The tag chips.
+ *
+ * Chosen tags always show; the rest are the most frequent in the buffer, which
+ * is the only ranking that puts the tag you are looking for near the front of a
+ * log with hundreds of them.
+ */
+function TagBar({
+  chosen,
+  tags,
+  onToggle,
+  onClear,
+}: {
+  chosen: readonly string[]
+  tags: string[]
+  onToggle: (tag: string) => void
+  onClear: () => void
+}) {
+  const offered = [...chosen, ...tags.filter((tag) => !chosen.includes(tag))].slice(0, 16)
+  if (offered.length === 0) return null
+  return (
+    <div className="flex items-center gap-1.5 overflow-x-auto px-3 pb-2">
+      {chosen.length === 0 ? null : (
+        <button
+          type="button"
+          onClick={onClear}
+          className="flex shrink-0 items-center gap-1 rounded-full bg-bg-raised px-2 py-0.5 text-[11px] text-text-secondary hover:text-text-primary"
+        >
+          <X size={9} strokeWidth={3} />
+          All tags
+        </button>
+      )}
+      {offered.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          onClick={() => {
+            onToggle(tag)
+          }}
+          className={cn(
+            "shrink-0 rounded-full px-2 py-0.5 text-[11px] transition-colors",
+            chosen.includes(tag)
+              ? "bg-accent/20 text-accent"
+              : "bg-bg-raised text-text-tertiary hover:text-text-primary",
+          )}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function Field({
+  icon: Icon,
+  value,
+  label,
+  placeholder,
+  onChange,
+}: {
+  icon: typeof Search
+  value: string
+  label: string
+  placeholder: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-border-subtle bg-bg-raised px-2.5 py-1 focus-within:border-accent">
+      <Icon size={13} className="shrink-0 text-text-tertiary" />
+      <input
+        value={value}
+        aria-label={label}
+        placeholder={placeholder}
+        onChange={(event) => {
+          onChange(event.target.value)
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onChange("")
+        }}
+        className="min-w-0 flex-1 bg-transparent text-[13px] text-text-primary outline-none placeholder:text-text-tertiary"
+      />
+    </div>
+  )
+}

--- a/desktop/src/components/PaneArea.tsx
+++ b/desktop/src/components/PaneArea.tsx
@@ -20,8 +20,10 @@ export interface PaneAreaProps {
   onSplit: (id: string) => void
   onFocusPane: (pane: number) => void
   onContextMenu: (id: string, x: number, y: number) => void
+  onNewTab: (pane: number) => void
   sidebarOrder: string[]
   categoryOrder: string[]
+  favorites: string[]
   splitFraction: number
   onSplitFraction: (fraction: number) => void
 }
@@ -100,6 +102,7 @@ export function PaneArea(props: PaneAreaProps) {
             onClose={props.onClose}
             onDrop={props.onDrop}
             onContextMenu={props.onContextMenu}
+            onNewTab={props.onNewTab}
             dragging={dragging}
             onDragState={setDragging}
           />
@@ -187,6 +190,7 @@ function PaneBody({
             onOpen={props.onOpen}
             sidebarOrder={props.sidebarOrder}
             categoryOrder={props.categoryOrder}
+            favorites={props.favorites}
           />
         </div>
       ))}

--- a/desktop/src/components/Sidebar.tsx
+++ b/desktop/src/components/Sidebar.tsx
@@ -16,6 +16,8 @@ export interface SidebarProps {
   sidebarOrder: string[]
   categoryOrder: string[]
   collapsedCategories: string[]
+  favorites: string[]
+  onTogglePinned: (id: string) => void
   onSidebarOrder: (order: string[]) => void
   onCategoryOrder: (order: string[]) => void
   onToggleCollapsed: (category: string) => void
@@ -44,8 +46,16 @@ export function Sidebar(props: SidebarProps) {
         sidebarOrder: props.sidebarOrder,
         categoryOrder: props.categoryOrder,
         collapsedCategories: props.collapsedCategories,
+        favorites: props.favorites,
       }),
-    [props.features, props.sidebarOrder, props.categoryOrder, props.collapsedCategories, query],
+    [
+      props.features,
+      props.sidebarOrder,
+      props.categoryOrder,
+      props.collapsedCategories,
+      props.favorites,
+      query,
+    ],
   )
 
   const endDrag = () => {
@@ -99,6 +109,8 @@ export function Sidebar(props: SidebarProps) {
               key={section.category}
               section={section}
               activeID={props.activeID}
+              favorites={props.favorites}
+              onTogglePinned={props.onTogglePinned}
               dragging={dragging}
               slot={slot}
               draggable={!searching}

--- a/desktop/src/components/SidebarSection.tsx
+++ b/desktop/src/components/SidebarSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from "lucide-react"
+import { ChevronRight, Pin, PinOff } from "lucide-react"
 import { pastMidpointY, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
 import { iconForFeature } from "@/lib/icons"
@@ -22,6 +22,8 @@ export interface DropSlot {
 export interface SectionProps {
   section: Section
   activeID: string | null
+  favorites: readonly string[]
+  onTogglePinned: (id: string) => void
   dragging: Dragging | null
   slot: DropSlot | null
   /** Off while searching: relevance order is not an order worth persisting. */
@@ -90,6 +92,10 @@ export function SidebarSection(props: SectionProps) {
               key={feature.id}
               feature={feature}
               active={feature.id === props.activeID}
+              pinned={props.favorites.includes(feature.id)}
+              onTogglePinned={() => {
+                props.onTogglePinned(feature.id)
+              }}
               slot={takesFeature && slot?.id === feature.id ? slot.after : null}
               faded={dragging?.kind === "feature" && dragging.id === feature.id}
               draggable={props.draggable}
@@ -124,6 +130,8 @@ export function SidebarSection(props: SectionProps) {
 function Row({
   feature,
   active,
+  pinned,
+  onTogglePinned,
   slot,
   faded,
   draggable,
@@ -134,6 +142,8 @@ function Row({
 }: {
   feature: FeatureSummary
   active: boolean
+  pinned: boolean
+  onTogglePinned: () => void
   /** Null for no guideline, else which side of the row it sits on. */
   slot: boolean | null
   faded: boolean
@@ -145,32 +155,52 @@ function Row({
 }) {
   const Icon = iconForFeature(feature.id, feature.category)
   return (
-    <button
-      type="button"
+    <div
       draggable={draggable}
-      onClick={onOpen}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDrop={onDrop}
-      title={feature.subtitle ?? feature.title}
       className={cn(
-        "relative flex w-full items-start gap-2.5 px-3 py-1.5 text-left transition-colors",
+        "group relative flex w-full items-start gap-2.5 px-3 py-1.5 transition-colors",
         active ? "bg-accent/12" : "hover:bg-white/[0.04]",
         faded ? "opacity-30" : "",
       )}
     >
-      <Icon
-        size={16}
-        className={cn("mt-[3px] shrink-0", active ? "text-accent" : "text-accent/80")}
-      />
-      <span className="min-w-0">
-        <span className="block truncate text-[13px] text-text-primary">{feature.title}</span>
-        {feature.subtitle ? (
-          <span className="block truncate text-[11px] text-text-secondary">{feature.subtitle}</span>
-        ) : null}
-      </span>
+      <button
+        type="button"
+        onClick={onOpen}
+        title={feature.subtitle ?? feature.title}
+        className="flex min-w-0 flex-1 items-start gap-2.5 text-left"
+      >
+        <Icon
+          size={16}
+          className={cn("mt-[3px] shrink-0", active ? "text-accent" : "text-accent/80")}
+        />
+        <span className="min-w-0">
+          <span className="block truncate text-[13px] text-text-primary">{feature.title}</span>
+          {feature.subtitle ? (
+            <span className="block truncate text-[11px] text-text-secondary">
+              {feature.subtitle}
+            </span>
+          ) : null}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onTogglePinned}
+        title={pinned ? "Unpin" : "Pin to the top"}
+        aria-label={pinned ? `Unpin ${feature.title}` : `Pin ${feature.title}`}
+        className={cn(
+          "mt-[2px] shrink-0 rounded p-0.5 text-text-tertiary hover:text-text-primary",
+          // Reserved space either way, so a row does not shift under the
+          // pointer as it arrives.
+          pinned ? "text-accent" : "opacity-0 group-hover:opacity-100",
+        )}
+      >
+        {pinned ? <Pin size={12} /> : <PinOff size={12} />}
+      </button>
       {slot === null ? null : <Guideline after={slot} />}
-    </button>
+    </div>
   )
 }
 

--- a/desktop/src/components/TabStrip.tsx
+++ b/desktop/src/components/TabStrip.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { House, X } from "lucide-react"
+import { House, Plus, X } from "lucide-react"
 import { pastMidpointX, startDrag } from "@/components/dnd"
 import { cn } from "@/lib/cn"
 import { iconForFeature } from "@/lib/icons"
@@ -22,6 +22,8 @@ export interface TabStripProps {
   /** A drop landing in this pane, before `target` (null = the end). */
   onDrop: (id: string, pane: number, target: string | null) => void
   onContextMenu: (id: string, x: number, y: number) => void
+  /** Open the palette with this pane focused, so the choice lands here. */
+  onNewTab: (pane: number) => void
   /** The tab being dragged anywhere in the window, so a strip can accept it. */
   dragging: string | null
   onDragState: (id: string | null) => void
@@ -65,26 +67,12 @@ export function TabStrip(props: TabStripProps) {
       }}
     >
       {props.pane === 0 ? (
-        <>
-          <button
-            type="button"
-            onClick={() => {
-              props.onSelect(HOME_TAB)
-            }}
-            title="Home"
-            aria-label="Home"
-            aria-current={props.tabs.activeTab === HOME_TAB}
-            className={cn(
-              "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
-              props.tabs.activeTab === HOME_TAB
-                ? "bg-accent/15 text-accent"
-                : "text-text-secondary hover:bg-white/[0.05] hover:text-text-primary",
-            )}
-          >
-            <House size={14} />
-          </button>
-          <span className="mx-1.5 h-5 w-px shrink-0 bg-border-subtle" />
-        </>
+        <HomeButton
+          active={props.tabs.activeTab === HOME_TAB}
+          onSelect={() => {
+            props.onSelect(HOME_TAB)
+          }}
+        />
       ) : null}
 
       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
@@ -127,8 +115,44 @@ export function TabStrip(props: TabStripProps) {
             }}
           />
         ))}
+        <button
+          type="button"
+          onClick={() => {
+            props.onNewTab(props.pane)
+          }}
+          title={`New tab (${shortcutLabel("t", IS_MAC)})`}
+          aria-label="New tab"
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-white/[0.05] hover:text-text-primary"
+        >
+          <Plus size={14} />
+        </button>
       </div>
     </div>
+  )
+}
+
+/** Home rides a permanent button, so it cannot be closed away or lost in the
+ *  tab overflow — the same place it sits on the Mac. */
+function HomeButton({ active, onSelect }: { active: boolean; onSelect: () => void }) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onSelect}
+        title="Home"
+        aria-label="Home"
+        aria-current={active}
+        className={cn(
+          "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
+          active
+            ? "bg-accent/15 text-accent"
+            : "text-text-secondary hover:bg-white/[0.05] hover:text-text-primary",
+        )}
+      >
+        <House size={14} />
+      </button>
+      <span className="mx-1.5 h-5 w-px shrink-0 bg-border-subtle" />
+    </>
   )
 }
 

--- a/desktop/src/components/WorkspaceShell.tsx
+++ b/desktop/src/components/WorkspaceShell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { CommandPalette } from "@/components/CommandPalette"
 import { PaneArea } from "@/components/PaneArea"
 import { Sidebar } from "@/components/Sidebar"
 import { TabContextMenu } from "@/components/TabContextMenu"
@@ -23,6 +24,7 @@ export function WorkspaceShell({
 }) {
   const workspace = useWorkspace(features)
   const [menu, setMenu] = useState<TabMenuTarget | null>(null)
+  const [paletteOpen, setPaletteOpen] = useState(false)
   // Lifted out of the Apps pane: a `needsBundle` action needs the same choice,
   // so it cannot live inside one tab. A package id means nothing on a different
   // device, so the choice is dropped when the selection changes.
@@ -37,12 +39,25 @@ export function WorkspaceShell({
     [features],
   )
 
+  // Focus the pane first, so whatever is chosen opens in the one that asked.
+  const { focusPane } = workspace
+  const onNewTab = useCallback(
+    (pane: number) => {
+      focusPane(pane)
+      setPaletteOpen(true)
+    },
+    [focusPane],
+  )
+
   const focused = activeTab(workspace.workspace)
   useTabShortcuts({
     activeTab: focused,
     onClose: workspace.close,
     onActivateIndex: workspace.activateIndex,
     onSplit: workspace.split,
+    onPalette: () => {
+      setPaletteOpen(true)
+    },
   })
 
   return (
@@ -54,6 +69,8 @@ export function WorkspaceShell({
         sidebarOrder={workspace.layout.sidebarOrder}
         categoryOrder={workspace.layout.categoryOrder}
         collapsedCategories={workspace.layout.collapsedCategories}
+        favorites={workspace.layout.favorites}
+        onTogglePinned={workspace.togglePin}
         onSidebarOrder={workspace.setSidebarOrder}
         onCategoryOrder={workspace.setCategoryOrder}
         onToggleCollapsed={workspace.toggleCategory}
@@ -74,21 +91,60 @@ export function WorkspaceShell({
         onContextMenu={(id, x, y) => {
           setMenu({ id, x, y })
         }}
+        onNewTab={onNewTab}
         sidebarOrder={workspace.layout.sidebarOrder}
         categoryOrder={workspace.layout.categoryOrder}
+        favorites={workspace.layout.favorites}
         splitFraction={workspace.layout.splitFraction}
         onSplitFraction={workspace.setSplitFraction}
       />
 
-      {menu === null ? null : (
-        <TabContextMenu
-          target={menu}
-          workspace={workspace}
-          onDismiss={() => {
-            setMenu(null)
-          }}
-        />
-      )}
+      <Overlays
+        palette={paletteOpen}
+        menu={menu}
+        features={features}
+        workspace={workspace}
+        onDismissPalette={() => {
+          setPaletteOpen(false)
+        }}
+        onDismissMenu={() => {
+          setMenu(null)
+        }}
+      />
     </div>
+  )
+}
+
+/** The two things that float over the panes. */
+function Overlays({
+  palette,
+  menu,
+  features,
+  workspace,
+  onDismissPalette,
+  onDismissMenu,
+}: {
+  palette: boolean
+  menu: TabMenuTarget | null
+  features: FeatureSummary[]
+  workspace: ReturnType<typeof useWorkspace>
+  onDismissPalette: () => void
+  onDismissMenu: () => void
+}) {
+  return (
+    <>
+      {palette ? (
+        <CommandPalette
+          features={features}
+          favorites={workspace.layout.favorites}
+          onOpen={workspace.open}
+          onTogglePinned={workspace.togglePin}
+          onDismiss={onDismissPalette}
+        />
+      ) : null}
+      {menu === null ? null : (
+        <TabContextMenu target={menu} workspace={workspace} onDismiss={onDismissMenu} />
+      )}
+    </>
   )
 }

--- a/desktop/src/hooks/useLogcatStream.ts
+++ b/desktop/src/hooks/useLogcatStream.ts
@@ -10,6 +10,10 @@ export interface LogcatStream {
   /** Why the daemon stopped sending, if it did. */
   ended: string | null
   stop: () => Promise<void>
+  /** Subscribe again after a stop. Keeps whatever is already buffered. */
+  restart: () => void
+  /** Throw away what has been buffered, without touching the subscription. */
+  clear: () => void
 }
 
 /**
@@ -24,6 +28,9 @@ export function useLogcatStream(serial: string | null): LogcatStream {
   const [streaming, setStreaming] = useState(false)
   const [error, setError] = useState<DaemonError | null>(null)
   const [ended, setEnded] = useState<string | null>(null)
+  // Bumping this re-runs the effect, which is the whole restart: Stop used to
+  // be a one-way door, with a tab switch the only way back.
+  const [generation, setGeneration] = useState(0)
   const subscription = useRef<Subscription | null>(null)
 
   const stop = useCallback(async () => {
@@ -33,12 +40,24 @@ export function useLogcatStream(serial: string | null): LogcatStream {
     await live?.stop()
   }, [])
 
+  const restart = useCallback(() => {
+    setGeneration((current) => current + 1)
+  }, [])
+
+  const clear = useCallback(() => {
+    setBuffer(emptyBuffer())
+  }, [])
+
+  // A different device is a different log; a restart is the same one.
+  useEffect(() => {
+    setBuffer(emptyBuffer())
+  }, [serial])
+
   useEffect(() => {
     if (serial === null) return
     // StrictMode runs this twice in development; without the flag the second
     // run's subscription replaces the first, which is then never stopped.
     let cancelled = false
-    setBuffer(emptyBuffer())
     setEnded(null)
     setError(null)
 
@@ -83,7 +102,7 @@ export function useLogcatStream(serial: string | null): LogcatStream {
       cancelled = true
       void stop()
     }
-  }, [serial, stop])
+  }, [serial, generation, stop])
 
-  return { buffer, streaming, error, ended, stop }
+  return { buffer, streaming, error, ended, stop, restart, clear }
 }

--- a/desktop/src/hooks/useTabShortcuts.ts
+++ b/desktop/src/hooks/useTabShortcuts.ts
@@ -12,15 +12,22 @@ export function useTabShortcuts({
   onClose,
   onActivateIndex,
   onSplit,
+  onPalette,
 }: {
   activeTab: string | null
   onClose: (id: string) => void
   onActivateIndex: (index: number) => void
   onSplit: (id: string) => void
+  onPalette: () => void
 }): void {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!hasModifier(event) || event.altKey) return
+      if (event.key === "k" || event.key === "t") {
+        event.preventDefault()
+        onPalette()
+        return
+      }
       if (event.key === "w") {
         event.preventDefault()
         if (activeTab !== null) onClose(activeTab)
@@ -45,5 +52,5 @@ export function useTabShortcuts({
     return () => {
       globalThis.removeEventListener("keydown", onKeyDown)
     }
-  }, [activeTab, onClose, onActivateIndex, onSplit])
+  }, [activeTab, onClose, onActivateIndex, onSplit, onPalette])
 }

--- a/desktop/src/hooks/useWorkspace.ts
+++ b/desktop/src/hooks/useWorkspace.ts
@@ -7,6 +7,7 @@ import {
   type LayoutState,
 } from "@/lib/layout"
 import { clampedFraction } from "@/lib/panes"
+import { togglePinned } from "@/lib/palette"
 import { toggleCollapsed } from "@/lib/sidebar"
 import type { FeatureSummary } from "@/lib/wire"
 import {
@@ -37,6 +38,7 @@ export interface WorkspaceController {
   setSidebarOrder: (order: string[]) => void
   setCategoryOrder: (order: string[]) => void
   toggleCategory: (category: string) => void
+  togglePin: (id: string) => void
 }
 
 /**
@@ -119,6 +121,9 @@ export function useWorkspace(features: FeatureSummary[]): WorkspaceController {
     }, []),
     setCategoryOrder: useCallback((categoryOrder: string[]) => {
       setLayout((current) => ({ ...current, categoryOrder }))
+    }, []),
+    togglePin: useCallback((id: string) => {
+      setLayout((current) => ({ ...current, favorites: togglePinned(current.favorites, id) }))
     }, []),
     toggleCategory: useCallback((category: string) => {
       setLayout((current) => ({

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -76,6 +76,11 @@ export function revealPath(path: string): Promise<void> {
   return invoke("reveal_path", { path })
 }
 
+/** Writes into ~/Downloads/Droidective and returns where it landed. */
+export function exportText(name: string, contents: string): Promise<string> {
+  return invoke<string>("export_text", { name, contents })
+}
+
 /** A live subscription. Always `stop()` it when the view goes away. */
 export interface Subscription {
   id: number

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -55,6 +55,11 @@ export function listApps(serial: string): Promise<AppsResponse> {
   return invoke<AppsResponse>("list_apps", { serial })
 }
 
+/** Everything `getprop` printed, as the daemon passed it through. */
+export function deviceProps(serial: string): Promise<{ properties: Record<string, string> }> {
+  return invoke<{ properties: Record<string, string> }>("device_props", { serial })
+}
+
 export function controlApp(args: {
   serial: string
   packageId: string

--- a/desktop/src/lib/deviceinfo.test.ts
+++ b/desktop/src/lib/deviceinfo.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+import {
+  countRows,
+  matchesProperty,
+  propertiesText,
+  propertyGroups,
+  summary,
+} from "@/lib/deviceinfo"
+
+// A slice of a real emulator dump, keys and shapes unchanged.
+const properties: Record<string, string> = {
+  "ro.product.model": "sdk_gphone64_arm64",
+  "ro.product.manufacturer": "Google",
+  "ro.product.cpu.abi": "arm64-v8a",
+  "ro.build.version.release": "14",
+  "ro.build.version.sdk": "34",
+  "ro.build.id": "UE1A.230829.036",
+  "ro.build.type": "userdebug",
+  "ro.serialno": "EMULATOR34X3X11X0",
+  "persist.sys.timezone": "Europe/London",
+  "debug.force_rtl": "0",
+  "init.svc.adbd": "running",
+}
+
+describe("summary", () => {
+  it("leads with what someone actually wants to know", () => {
+    expect(summary(properties).slice(0, 3)).toEqual([
+      { label: "Model", value: "sdk_gphone64_arm64" },
+      { label: "Manufacturer", value: "Google" },
+      { label: "Android", value: "14" },
+    ])
+  })
+
+  it("skips a key the device did not answer rather than showing 'unknown'", () => {
+    // A phone and an emulator do not answer the same set.
+    const sparse = summary({ "ro.product.model": "Pixel" })
+    expect(sparse).toEqual([{ label: "Model", value: "Pixel" }])
+  })
+
+  it("skips a key answered with nothing", () => {
+    expect(summary({ "ro.product.model": "" })).toEqual([])
+  })
+})
+
+describe("propertyGroups", () => {
+  it("groups by two dotted segments, not one", () => {
+    // `ro` alone would be most of the dump in a single heap.
+    const prefixes = propertyGroups(properties, "").map((group) => group.prefix)
+    expect(prefixes).toContain("ro.build")
+    expect(prefixes).toContain("ro.product")
+    expect(prefixes).not.toContain("ro")
+  })
+
+  it("sorts the groups and the rows inside them", () => {
+    const groups = propertyGroups(properties, "")
+    const prefixes = groups.map((group) => group.prefix)
+    expect(prefixes).toEqual(prefixes.toSorted())
+    const build = groups.find((group) => group.prefix === "ro.build")
+    expect(build?.rows.map((row) => row.key)).toEqual([
+      "ro.build.id",
+      "ro.build.type",
+      "ro.build.version.release",
+      "ro.build.version.sdk",
+    ])
+  })
+
+  it("keeps a key with no dot in it", () => {
+    const groups = propertyGroups({ bare: "yes" }, "")
+    expect(groups).toEqual([{ prefix: "bare", rows: [{ key: "bare", value: "yes" }] }])
+  })
+
+  it("filters on the value as well as the key", () => {
+    // Searching for what a property *says* is as common as searching its name.
+    const groups = propertyGroups(properties, "Europe/London")
+    expect(countRows(groups)).toBe(1)
+    expect(groups[0]?.rows[0]?.key).toBe("persist.sys.timezone")
+  })
+
+  it("drops a group that has nothing left in it", () => {
+    const groups = propertyGroups(properties, "timezone")
+    expect(groups.map((group) => group.prefix)).toEqual(["persist.sys"])
+  })
+
+  it("returns nothing for a query that matches nothing", () => {
+    expect(propertyGroups(properties, "zzzzz")).toEqual([])
+    expect(countRows([])).toBe(0)
+  })
+
+  it("copes with a device that answered nothing", () => {
+    expect(propertyGroups({}, "")).toEqual([])
+  })
+})
+
+describe("matchesProperty", () => {
+  it("is case-insensitive over both halves", () => {
+    const row = { key: "ro.build.type", value: "userdebug" }
+    expect(matchesProperty(row, "BUILD")).toBe(true)
+    expect(matchesProperty(row, "USERDEBUG")).toBe(true)
+    expect(matchesProperty(row, "   ")).toBe(true)
+    expect(matchesProperty(row, "nope")).toBe(false)
+  })
+})
+
+describe("propertiesText", () => {
+  it("writes sorted key=value lines", () => {
+    const lines = propertiesText({ b: "2", a: "1" }).split("\n")
+    expect(lines).toEqual(["a=1", "b=2"])
+  })
+
+  it("is empty for nothing", () => {
+    expect(propertiesText({})).toBe("")
+  })
+})

--- a/desktop/src/lib/deviceinfo.ts
+++ b/desktop/src/lib/deviceinfo.ts
@@ -1,0 +1,96 @@
+/**
+ * Making sense of a `getprop` dump.
+ *
+ * A device answers with well over a thousand properties in no useful order.
+ * The daemon passes them through untouched — which property matters is the
+ * reader's question — so the arranging happens here, where it can be tested
+ * against a real dump rather than eyeballed in a list.
+ */
+
+export interface PropertyRow {
+  key: string
+  value: string
+}
+
+export interface PropertyGroup {
+  /** The `ro.build` in `ro.build.version.sdk` — how getprop already groups. */
+  prefix: string
+  rows: PropertyRow[]
+}
+
+/**
+ * The handful worth reading first, in the order the Mac's Device Info header
+ * shows them. Anything missing is simply skipped: an emulator and a phone do
+ * not answer the same set, and a row reading "unknown" is worse than no row.
+ */
+const SUMMARY_KEYS: readonly { readonly key: string; readonly label: string }[] = [
+  { key: "ro.product.model", label: "Model" },
+  { key: "ro.product.manufacturer", label: "Manufacturer" },
+  { key: "ro.build.version.release", label: "Android" },
+  { key: "ro.build.version.sdk", label: "API level" },
+  { key: "ro.build.id", label: "Build" },
+  { key: "ro.product.cpu.abi", label: "ABI" },
+  { key: "ro.serialno", label: "Serial" },
+  { key: "ro.build.type", label: "Build type" },
+]
+
+export interface SummaryRow {
+  label: string
+  value: string
+}
+
+export function summary(properties: Readonly<Record<string, string>>): SummaryRow[] {
+  return SUMMARY_KEYS.flatMap(({ key, label }) => {
+    const value = properties[key]
+    return value === undefined || value === "" ? [] : [{ label, value }]
+  })
+}
+
+/** Case-insensitive match over the key and the value, both of which get read. */
+export function matchesProperty(row: PropertyRow, query: string): boolean {
+  const needle = query.toLowerCase().trim()
+  if (needle === "") return true
+  return `${row.key} ${row.value}`.toLowerCase().includes(needle)
+}
+
+/**
+ * Every property a query matches, grouped by its first two dotted segments and
+ * sorted within each group.
+ *
+ * Two segments rather than one: `ro` alone would be most of the dump in a
+ * single heap, and `ro.build` against `ro.product` is the split someone reading
+ * it already has in mind.
+ */
+export function propertyGroups(
+  properties: Readonly<Record<string, string>>,
+  query: string,
+): PropertyGroup[] {
+  const groups = new Map<string, PropertyRow[]>()
+  for (const [key, value] of Object.entries(properties)) {
+    const row = { key, value }
+    if (!matchesProperty(row, query)) continue
+    const prefix = key.split(".").slice(0, 2).join(".")
+    const existing = groups.get(prefix)
+    if (existing) existing.push(row)
+    else groups.set(prefix, [row])
+  }
+  return [...groups.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([prefix, rows]) => ({
+      prefix,
+      rows: rows.toSorted((left, right) => left.key.localeCompare(right.key)),
+    }))
+}
+
+/** How many rows survived the query — what the count in the search field says. */
+export function countRows(groups: readonly PropertyGroup[]): number {
+  return groups.reduce((total, group) => total + group.rows.length, 0)
+}
+
+/** The whole dump as `key=value` lines, for export or the clipboard. */
+export function propertiesText(properties: Readonly<Record<string, string>>): string {
+  return Object.keys(properties)
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((key) => `${key}=${properties[key] ?? ""}`)
+    .join("\n")
+}

--- a/desktop/src/lib/layout.test.ts
+++ b/desktop/src/lib/layout.test.ts
@@ -24,6 +24,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat", "apps"],
       categoryOrder: ["logs"],
       collapsedCategories: ["input"],
+      favorites: ["logcat"],
       panes: [
         { tabs: [HOME_TAB, "logcat"], activeTab: "logcat" },
         { tabs: ["apps"], activeTab: "apps" },
@@ -49,6 +50,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat", 7, null],
       categoryOrder: "logs",
       collapsedCategories: [{ nope: true }],
+      favorites: null,
       panes: [{ tabs: [HOME_TAB, 3], activeTab: 9 }, "not a pane", { tabs: [] }],
       focusedPane: "second",
       splitFraction: "half",
@@ -57,6 +59,7 @@ describe("loadLayout", () => {
       sidebarOrder: ["logcat"],
       categoryOrder: [],
       collapsedCategories: [],
+      favorites: [],
       panes: [{ tabs: [HOME_TAB], activeTab: null }],
       focusedPane: 0,
       splitFraction: 0.5,

--- a/desktop/src/lib/layout.ts
+++ b/desktop/src/lib/layout.ts
@@ -24,6 +24,8 @@ export interface LayoutState {
   sidebarOrder: string[]
   categoryOrder: string[]
   collapsedCategories: string[]
+  /** Pinned feature ids, in the order they were pinned. */
+  favorites: string[]
   /** One entry per open pane, left to right. */
   panes: SavedPane[]
   focusedPane: number
@@ -38,6 +40,7 @@ export function emptyLayout(): LayoutState {
     sidebarOrder: [],
     categoryOrder: [],
     collapsedCategories: [],
+    favorites: [],
     panes: [{ tabs: [HOME_TAB], activeTab: HOME_TAB }],
     focusedPane: 0,
     splitFraction: 0.5,
@@ -68,6 +71,7 @@ export function loadLayout(storage: Pick<Storage, "getItem">): LayoutState {
     sidebarOrder: stringArray(saved.sidebarOrder),
     categoryOrder: stringArray(saved.categoryOrder),
     collapsedCategories: stringArray(saved.collapsedCategories),
+    favorites: stringArray(saved.favorites),
     panes: panes.length === 0 ? emptyLayout().panes : panes,
     focusedPane: typeof saved.focusedPane === "number" ? saved.focusedPane : 0,
     splitFraction: typeof saved.splitFraction === "number" ? saved.splitFraction : 0.5,

--- a/desktop/src/lib/logbuffer.test.ts
+++ b/desktop/src/lib/logbuffer.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest"
-import { emptyBuffer, matchesFilter, withGap, withLines } from "@/lib/logbuffer"
+import {
+  emptyBuffer,
+  emptyFilter,
+  logText,
+  matchesFind,
+  matchesLogFilter,
+  tagsByFrequency,
+  withGap,
+  withLines,
+} from "@/lib/logbuffer"
 import type { LogRow } from "@/lib/logbuffer"
 import type { LogLine } from "@/lib/wire"
 
@@ -87,24 +96,107 @@ describe("withGap", () => {
   })
 })
 
-describe("matchesFilter", () => {
-  const row: LogRow = { kind: "line", key: 0, line: line("Boot completed", { tag: "ActivityManager" }) }
+const text = (value: string) => ({ ...emptyFilter(), text: value })
 
+describe("matchesLogFilter", () => {
+  const row: LogRow = {
+    kind: "line",
+    key: 0,
+    line: line("Boot completed", { tag: "ActivityManager" }),
+  }
   it("matches the tag and the message, case-insensitively", () => {
-    expect(matchesFilter(row, "activitymanager")).toBe(true)
-    expect(matchesFilter(row, "BOOT")).toBe(true)
-    expect(matchesFilter(row, "nope")).toBe(false)
+    expect(matchesLogFilter(row, text("activitymanager"))).toBe(true)
+    expect(matchesLogFilter(row, text("BOOT"))).toBe(true)
+    expect(matchesLogFilter(row, text("nope"))).toBe(false)
   })
 
   it("matches everything for an empty filter", () => {
-    expect(matchesFilter(row, "")).toBe(true)
-    expect(matchesFilter(row, "  ")).toBe(true)
+    expect(matchesLogFilter(row, emptyFilter())).toBe(true)
+    expect(matchesLogFilter(row, text("  "))).toBe(true)
   })
 
   it("never filters out a gap", () => {
     // Hiding the marker would turn a visible interruption back into a silent
     // one, which is exactly what it exists to prevent.
     const gap: LogRow = { kind: "gap", key: 1, count: 9 }
-    expect(matchesFilter(gap, "activitymanager")).toBe(true)
+    expect(matchesLogFilter(gap, text("activitymanager"))).toBe(true)
+    expect(matchesLogFilter(gap, { ...emptyFilter(), minLevel: "E", tags: ["Other"] })).toBe(true)
+  })
+
+  it("hides everything quieter than the chosen level", () => {
+    const warn: LogRow = { kind: "line", key: 2, line: line("careful", { level: "W" }) }
+    const debug: LogRow = { kind: "line", key: 3, line: line("chatter", { level: "D" }) }
+    const atWarn = { ...emptyFilter(), minLevel: "W" as const }
+    expect(matchesLogFilter(warn, atWarn)).toBe(true)
+    expect(matchesLogFilter(debug, atWarn)).toBe(false)
+    // Verbose is the floor, so it hides nothing.
+    expect(matchesLogFilter(debug, emptyFilter())).toBe(true)
+  })
+
+  it("shows only the chosen tags, and all of them when none is chosen", () => {
+    const other: LogRow = { kind: "line", key: 4, line: line("hello", { tag: "Zygote" }) }
+    const chosen = { ...emptyFilter(), tags: ["ActivityManager"] }
+    expect(matchesLogFilter(row, chosen)).toBe(true)
+    expect(matchesLogFilter(other, chosen)).toBe(false)
+    expect(matchesLogFilter(other, emptyFilter())).toBe(true)
+  })
+
+  it("applies every part of the filter at once", () => {
+    const loud: LogRow = { kind: "line", key: 5, line: line("boom", { tag: "Zygote", level: "E" }) }
+    expect(
+      matchesLogFilter(loud, { text: "boom", minLevel: "W", tags: ["Zygote"] }),
+    ).toBe(true)
+    expect(
+      matchesLogFilter(loud, { text: "boom", minLevel: "W", tags: ["ActivityManager"] }),
+    ).toBe(false)
+  })
+})
+
+describe("matchesFind", () => {
+  const row: LogRow = {
+    kind: "line",
+    key: 0,
+    line: line("Boot completed", { tag: "ActivityManager" }),
+  }
+
+  it("hits on the tag and the message", () => {
+    expect(matchesFind(row, "boot")).toBe(true)
+    expect(matchesFind(row, "activity")).toBe(true)
+    expect(matchesFind(row, "nope")).toBe(false)
+  })
+
+  it("hits nothing for an empty query, and never a gap", () => {
+    // Find highlights; an empty query highlighting every row would be noise.
+    expect(matchesFind(row, "")).toBe(false)
+    expect(matchesFind({ kind: "gap", key: 1, count: 3 }, "boot")).toBe(false)
+  })
+})
+
+describe("logText", () => {
+  it("writes the shape adb prints, with gaps called out", () => {
+    const rows: LogRow[] = [
+      { kind: "line", key: 0, line: line("up", { tag: "Boot", level: "I" }) },
+      { kind: "gap", key: 1, count: 12 },
+    ]
+    const lines = logText(rows).split("\n")
+    expect(lines[0]).toContain("I/Boot: up")
+    expect(lines[1]).toBe("--- 12 lines dropped ---")
+  })
+
+  it("is empty for nothing", () => {
+    expect(logText([])).toBe("")
+  })
+})
+
+describe("tagsByFrequency", () => {
+  it("puts the loudest tag first, and breaks ties by name", () => {
+    const rows: LogRow[] = [
+      { kind: "line", key: 0, line: line("a", { tag: "Zygote" }) },
+      { kind: "line", key: 1, line: line("b", { tag: "Boot" }) },
+      { kind: "line", key: 2, line: line("c", { tag: "Boot" }) },
+      { kind: "line", key: 3, line: line("d", { tag: "Alarm" }) },
+      { kind: "gap", key: 4, count: 2 },
+    ]
+    expect(tagsByFrequency(rows)).toEqual(["Boot", "Alarm", "Zygote"])
   })
 })

--- a/desktop/src/lib/logbuffer.ts
+++ b/desktop/src/lib/logbuffer.ts
@@ -70,13 +70,73 @@ function trim(buffer: LogBuffer, capacity: number): LogBuffer {
   return { ...buffer, rows: buffer.rows.slice(buffer.rows.length - capacity) }
 }
 
-/** Case-insensitive substring match over the parts a reader can see. */
-export function matchesFilter(row: LogRow, filter: string): boolean {
-  const needle = filter.toLowerCase().trim()
-  if (needle === "") return true
-  // A gap always shows: hiding it would turn a visible interruption back into
-  // a silent one, which is the whole thing the marker exists to prevent.
+/** Android's priorities, quietest first. The order *is* the comparison. */
+export const LEVELS = ["V", "D", "I", "W", "E", "F"] as const
+export type Level = (typeof LEVELS)[number]
+
+export interface LogFilter {
+  /** Hides every line that does not contain it. */
+  text: string
+  /** Hides everything quieter than this. */
+  minLevel: Level
+  /** Tag chips; a line matching any of them shows. Empty means all tags. */
+  tags: readonly string[]
+}
+
+export function emptyFilter(): LogFilter {
+  return { text: "", minLevel: "V", tags: [] }
+}
+
+/**
+ * Whether a row survives the filter.
+ *
+ * A gap always shows, whatever is filtered: hiding it would turn a visible
+ * interruption back into a silent one, which is the whole thing the marker
+ * exists to prevent.
+ */
+export function matchesLogFilter(row: LogRow, filter: LogFilter): boolean {
   if (row.kind === "gap") return true
   const { tag, message, level, pid } = row.line
+  if (LEVELS.indexOf(level as Level) < LEVELS.indexOf(filter.minLevel)) return false
+  if (filter.tags.length > 0 && !filter.tags.includes(tag)) return false
+  const needle = filter.text.toLowerCase().trim()
+  if (needle === "") return true
   return `${tag} ${message} ${level} ${pid}`.toLowerCase().includes(needle)
+}
+
+/**
+ * Whether a row is a Find hit.
+ *
+ * Find highlights without hiding, which is the split the Mac's log view keeps:
+ * "where is this?" and "show me only this" are different questions, and one
+ * control cannot answer both.
+ */
+export function matchesFind(row: LogRow, find: string): boolean {
+  const needle = find.toLowerCase().trim()
+  if (needle === "" || row.kind === "gap") return false
+  const { tag, message } = row.line
+  return `${tag} ${message}`.toLowerCase().includes(needle)
+}
+
+/** The visible rows as text, for export or the clipboard. */
+export function logText(rows: readonly LogRow[]): string {
+  return rows
+    .map((row) =>
+      row.kind === "gap"
+        ? `--- ${row.count.toLocaleString()} lines dropped ---`
+        : `${row.line.time} ${row.line.pid} ${row.line.level}/${row.line.tag}: ${row.line.message}`,
+    )
+    .join("\n")
+}
+
+/** Every tag present, most frequent first — what the tag chips offer. */
+export function tagsByFrequency(rows: readonly LogRow[]): string[] {
+  const counts = new Map<string, number>()
+  for (const row of rows) {
+    if (row.kind !== "line") continue
+    counts.set(row.line.tag, (counts.get(row.line.tag) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .toSorted((a, b) => (b[1] === a[1] ? a[0].localeCompare(b[0]) : b[1] - a[1]))
+    .map(([tag]) => tag)
 }

--- a/desktop/src/lib/palette.test.ts
+++ b/desktop/src/lib/palette.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import raw from "@/lib/__fixtures__/features.json"
-import { rankFeatures, relevance } from "@/lib/palette"
+import { moveHighlight, paletteResults, rankFeatures, relevance, togglePinned } from "@/lib/palette"
 import type { FeatureSummary } from "@/lib/wire"
 
 // Real daemon output, captured from `POST /v1/features/list` rather than
@@ -74,5 +74,51 @@ describe("rankFeatures", () => {
     // Deliberately not filtered here: the sidebar wants views as well as
     // actions, and a palette over commands would choose differently again.
     expect(rankFeatures(features, "").map((feature) => feature.id)).toContain("logcat")
+  })
+})
+
+describe("paletteResults", () => {
+  it("opens on what you pinned, in the order you pinned it", () => {
+    const results = paletteResults(features, "", ["logcat", "screenshot"])
+    expect(results.slice(0, 2).map((feature) => feature.id)).toEqual(["logcat", "screenshot"])
+  })
+
+  it("lists a pinned feature once, not twice", () => {
+    const ids = paletteResults(features, "", ["logcat"]).map((feature) => feature.id)
+    expect(ids.filter((id) => id === "logcat")).toHaveLength(1)
+    expect(ids).toHaveLength(features.length)
+  })
+
+  it("lets relevance decide once there is a query", () => {
+    // A weakly-matching pin sitting above an exact match would make the
+    // ranking a lie, so pins are not promoted here.
+    const results = paletteResults(features, "battery", ["logcat"])
+    expect(results[0]?.id).toBe("fake-battery")
+    expect(results.map((feature) => feature.id)).not.toContain("logcat")
+  })
+
+  it("ignores a pinned id that is no longer served", () => {
+    const ids = paletteResults(features, "", ["gone-feature"]).map((feature) => feature.id)
+    expect(ids).toHaveLength(features.length)
+  })
+})
+
+describe("moveHighlight", () => {
+  it("wraps at both ends", () => {
+    expect(moveHighlight(3, 2, 1)).toBe(0)
+    expect(moveHighlight(3, 0, -1)).toBe(2)
+    expect(moveHighlight(3, 0, 1)).toBe(1)
+  })
+
+  it("stays put with nothing to highlight", () => {
+    expect(moveHighlight(0, 0, 1)).toBe(0)
+  })
+})
+
+describe("togglePinned", () => {
+  it("appends then removes, keeping the pinning order", () => {
+    expect(togglePinned([], "logcat")).toEqual(["logcat"])
+    expect(togglePinned(["apps"], "logcat")).toEqual(["apps", "logcat"])
+    expect(togglePinned(["apps", "logcat"], "apps")).toEqual(["logcat"])
   })
 })

--- a/desktop/src/lib/palette.ts
+++ b/desktop/src/lib/palette.ts
@@ -58,6 +58,39 @@ export function rankFeatures(
     const score = relevance(feature, query)
     if (score > 0) scored.push({ feature, score, order })
   })
-  scored.sort((a, b) => (a.score === b.score ? a.order - b.order : b.score - a.score))
-  return scored.map((entry) => entry.feature)
+  return scored
+    .toSorted((a, b) => (a.score === b.score ? a.order - b.order : b.score - a.score))
+    .map((entry) => entry.feature)
+}
+
+/**
+ * What the palette lists.
+ *
+ * With no query, pinned features lead, in the order they were pinned — the
+ * palette opens on what you actually use. With one, relevance decides and
+ * nothing is promoted: a weakly-matching pin sitting above an exact match
+ * would make the ranking a lie.
+ */
+export function paletteResults(
+  features: readonly FeatureSummary[],
+  query: string,
+  favorites: readonly string[],
+): FeatureSummary[] {
+  if (query.trim() !== "") return rankFeatures(features, query)
+  const pinned = favorites.flatMap((id) => features.filter((feature) => feature.id === id))
+  const rest = features.filter((feature) => !favorites.includes(feature.id))
+  return [...pinned, ...rest]
+}
+
+/** Move a highlighted row by `delta`, wrapping at both ends. */
+export function moveHighlight(count: number, current: number, delta: number): number {
+  if (count <= 0) return 0
+  return (current + delta + count) % count
+}
+
+/** Add or remove `id` from the pinned list. */
+export function togglePinned(favorites: readonly string[], id: string): string[] {
+  return favorites.includes(id)
+    ? favorites.filter((entry) => entry !== id)
+    : [...favorites, id]
 }

--- a/desktop/src/lib/sidebar.test.ts
+++ b/desktop/src/lib/sidebar.test.ts
@@ -19,6 +19,7 @@ const plain = {
   sidebarOrder: [],
   categoryOrder: [],
   collapsedCategories: [],
+  favorites: [],
 }
 
 describe("categories", () => {
@@ -122,6 +123,27 @@ describe("sidebarSections", () => {
       collapsedCategories: [...CATEGORY_ORDER],
     })
     expect(visibleFeatures(sections).map((feature) => feature.id)).toContain("fake-battery")
+  })
+
+  it("puts a Pinned section first and lifts its members out of their groups", () => {
+    const sections = sidebarSections(features, { ...plain, favorites: ["logcat", "screenshot"] })
+    expect(sections[0]?.label).toBe("Pinned")
+    expect(sections[0]?.features.map((feature) => feature.id)).toEqual(["logcat", "screenshot"])
+    // Listed once, not in both places.
+    const elsewhere = sections
+      .slice(1)
+      .flatMap((section) => section.features.map((feature) => feature.id))
+    expect(elsewhere).not.toContain("logcat")
+    expect(elsewhere).not.toContain("screenshot")
+  })
+
+  it("has no Pinned section when nothing is pinned", () => {
+    expect(sidebarSections(features, plain).map((section) => section.label)).not.toContain("Pinned")
+  })
+
+  it("does not pin-order a search", () => {
+    const sections = sidebarSections(features, { ...plain, query: "battery", favorites: ["logcat"] })
+    expect(sections[0]?.features[0]?.id).toBe("fake-battery")
   })
 
   it("returns nothing for a query that matches nothing", () => {

--- a/desktop/src/lib/sidebar.ts
+++ b/desktop/src/lib/sidebar.ts
@@ -69,7 +69,12 @@ export interface SidebarLayout {
   sidebarOrder: readonly string[]
   categoryOrder: readonly string[]
   collapsedCategories: readonly string[]
+  /** Pinned feature ids, in the order they were pinned. */
+  favorites: readonly string[]
 }
+
+/** The pseudo-category the Pinned section uses. Never a real wire value. */
+export const PINNED_SECTION = "pinned"
 
 /**
  * The sections the sidebar renders.
@@ -87,10 +92,23 @@ export function sidebarSections(
   if (layout.query.trim() !== "") return searchSections(ordered, layout.query)
 
   const collapsed = new Set(layout.collapsedCategories)
-  const categories = rankBy(orderedCategoryIDs(ordered), layout.categoryOrder, (id) => id)
   const sections: SidebarSection[] = []
-  for (const category of categories) {
-    const matching = ordered.filter((feature) => feature.category === category)
+
+  // Pinned leads, and its members are lifted out of their categories rather
+  // than listed twice — the same call the Mac's `enabledFeatures(in:)` makes.
+  const pinned = layout.favorites.flatMap((id) => ordered.filter((feature) => feature.id === id))
+  if (pinned.length > 0) {
+    sections.push({
+      category: PINNED_SECTION,
+      label: "Pinned",
+      features: pinned,
+      collapsed: collapsed.has(PINNED_SECTION),
+    })
+  }
+
+  const rest = ordered.filter((feature) => !layout.favorites.includes(feature.id))
+  for (const category of rankBy(orderedCategoryIDs(rest), layout.categoryOrder, (id) => id)) {
+    const matching = rest.filter((feature) => feature.category === category)
     if (matching.length === 0) continue
     sections.push({
       category,

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -52,9 +52,9 @@ split panes and no palette produces something that looks like Droidective in a
 screenshot and does not feel like it in use — and every screen ported before
 the shell exists will need reworking to live inside it.
 
-The sidebar and the tab strip have landed; split panes, the palette and hotkeys
-have not. Screens ported now open in a tab, so they will not need reworking for
-that — but a screen is still not finished until it behaves in a split pane.
+The sidebar, the tab strip, split panes and the palette have landed, so a screen
+ported now opens in a tab, splits, and is reachable from the palette without
+being reworked for any of it. Hotkeys and the chrome are still outstanding.
 
 1. **Shell parity** (below) — tabs, split panes, sidebar, palette, hotkeys.
 2. **The screens people open every day** — logcat, file explorer, device info,
@@ -66,9 +66,8 @@ that — but a screen is still not finished until it behaves in a split pane.
 
 ## Cross-cutting shell
 
-None of this is in `desktop/` yet. It is most of what "does not match the
-macOS version" actually means — the current app is three tabs and a list.
-Sourced from `CLAUDE.md` and the App sources.
+Sourced from `CLAUDE.md` and the App sources. The navigation half has landed;
+the chrome and the device bar have not.
 
 ### Navigation and layout
 
@@ -91,7 +90,7 @@ Sourced from `CLAUDE.md` and the App sources.
       reorder, ⌘W / Ctrl+W to close, ⌘1–⌘9 to jump. Open tabs stay mounted and
       hidden rather than unmounted, so a background tab keeps its log stream and
       its loaded lists. Ported from ADBKit's `TabState`, close-focus rules
-      included. Still missing: the `+` button, which needs the palette below.
+      included.
 - [x] **Split panes** — two panes, clamped 30–70% with the same absolute
       per-pane floor (`PaneSplit`, ported to `lib/panes.ts`), a draggable
       divider that persists, and the pane rules ported from ADBKit's
@@ -106,13 +105,19 @@ Sourced from `CLAUDE.md` and the App sources.
 
 ### Finding things
 
-- [ ] **Command palette** (⌘T / ⌘K) over features *and* commands, using the
-      ranking already ported to `desktop/src/lib/palette.ts`.
+- [x] **Command palette** — Ctrl/⌘ + K or T, and the tab strip's `+`, which
+      focuses its pane first so the choice lands there. Arrows move, Enter
+      opens, Ctrl/⌘ + P pins. With no query it opens on the pinned list; with
+      one, relevance decides and pins are not promoted. Commands are not in it
+      yet — this app has no custom commands to offer.
 - [ ] **Per-feature hotkeys**, recordable, with a live-preview recorder.
 - [ ] **Global hotkey → Quick Actions panel** — the non-activating mini app:
       grid of every runnable action, pinned first, custom commands, pick-device
       interstitial, ⌘⏎ run-on-all.
-- [ ] **Pinned / favourites**, shared between the palette and Quick Actions.
+- [x] **Pinned / favourites** — a Pinned section leading the sidebar and the
+      palette's empty-query list, pinned from either. Members are lifted out of
+      their categories rather than listed twice, as `enabledFeatures(in:)` does
+      on the Mac. Quick Actions does not exist here yet to share them with.
 - [ ] **Manage features catalog** — turn features off; everything is on by
       default.
 

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -209,9 +209,10 @@ The daemon serves devices, features, apps and logcat today and nothing else, so
 that is the real cost of each screen, and it is why they are ordered by how
 often someone opens them rather than by how hard they look.
 
-1. **Device info** — the smallest of the four-layer screens, so it is where the
-   pattern gets established: a route over `DeviceProps`/`DeviceOverview` and a
-   searchable property browser.
+1. ~~**Device info.**~~ Landed — and it is the worked example of the four
+   layers: `DaemonProtocol.Route.deviceProps` + a `DaemonBackend` method, a
+   Rust `device_props` command, `lib/deviceinfo.ts` for the arranging, and a
+   pane. Copy that shape for the rest.
 2. **File explorer** — browse, copy/move/delete, pull, root toggle, new folder,
    context menu. The first screen that *writes* to the device, so its route
    needs the same `shellQuote` care ADBKit applies.
@@ -489,13 +490,15 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 - **Must replicate**
   - [ ] tooltip: Refresh from the device
 
-#### `device-info` — Device Info  ·  ⬜ todo
+#### `device-info` — Device Info  ·  🟡 partial
 > Browse and search every device property
 - **Kind** `view`
-- **Note** Not started on Windows/Linux.
+- **Note** Built. `/v1/device/props` passes `getprop` through untouched; the
+  pane adds a summary header, two-segment grouping, search over key and value,
+  copy and export.
 - **macOS view** `DeviceInfoView` — `App/Sources/FeatureDetail/Views/DeviceInfoView.swift`
 - **Must replicate**
-  - [ ] field: Filter properties…
+  - [x] field: Filter properties…
 
 #### `fake-battery` — Fake Battery  ·  🟡 partial
 > Set a fake battery level and unplugged state

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -174,10 +174,12 @@ Found by driving the app against a live emulator, not by reading it.
       (`lib/confirm.ts`). A Cancel button appears while armed, the window
       losing focus disarms, and an arming on one app never authorises the same
       verb on another.
-- [ ] **Logcat cannot be restarted.** Stop disables the button and the only way
-      back is a tab switch or a device change.
-- [ ] **Logcat has no level or app filter** — the Mac has both, plus a
-      find-vs-filter split, export, clear, and tag-filter chips.
+- [x] ~~**Logcat cannot be restarted.**~~ Stop becomes Start, and the
+      subscription comes back with the buffer intact.
+- [~] **Logcat has no level or app filter.** The level picker, the
+      find-vs-filter split, export, clear and tag chips have landed. The *app*
+      filter has not: it needs a pid → package map the daemon does not serve
+      yet, and matching on the tag would be a filter that quietly misses lines.
 - [x] ~~**The app list re-fetches on every tab switch**, because the pane
       remounts and the data is not lifted.~~ Fixed by the tab shell: an open
       tab stays mounted while it is in the background, so the pane no longer
@@ -547,22 +549,22 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 #### `logcat` — Logcat  ·  🟡 partial
 > Live log stream with search and filters
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane exists; the app filter is what it is still missing.
 - **macOS view** `LogcatView` — `App/Sources/FeatureDetail/Views/LogcatView.swift`
 - **Must replicate**
-  - [ ] picker: Level
-  - [ ] field: Filter lines…
+  - [x] picker: Level
+  - [x] field: Filter lines…
   - [ ] label: All apps
   - [ ] label: Add from installed apps
   - [ ] label: Use app on device screen
   - [ ] label: Add manually / manage…
-  - [ ] tooltip: Show only the lines containing this text
-  - [ ] tooltip: Find & highlight in the log without hiding lines (⌘F)
-  - [ ] tooltip: Export buffer to ~/Downloads/Droidective
-  - [ ] tooltip: Clear
+  - [x] tooltip: Show only the lines containing this text
+  - [x] tooltip: Find & highlight in the log without hiding lines
+  - [x] tooltip: Export buffer to ~/Downloads/Droidective
+  - [x] tooltip: Clear
   - [ ] tooltip: Stream one app's logs — pick a saved bundle or add a new one
-  - [ ] tooltip: Remove tag filter
-  - [ ] export: save/export to a file
+  - [x] tooltip: Remove tag filter
+  - [x] export: save/export to a file
 
 #### `performance` — Performance Monitor  ·  ⬜ todo
 > Live CPU, RAM & FPS with recording and export

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -187,6 +187,79 @@ Found by driving the app against a live emulator, not by reading it.
 
 ---
 
+## Backlog
+
+The order the remaining work is planned in, and what each item actually costs.
+Tick an item here when its PR merges; the detail stays in the sections above.
+
+**Done.**
+
+| | Goal | Landed in |
+| --- | --- | --- |
+| ✅ | Grouped sidebar and feature tabs | #252 |
+| ✅ | A glyph per feature | #253 |
+| ✅ | The three action-result defects | #254 |
+| ✅ | Split panes | #255 |
+| ✅ | Command palette and pinned features | #256 |
+| ✅ | Logcat: level, find-vs-filter, tags, export, restart | #257 |
+
+**Next, in order.** Everything from *File explorer* down needs four layers, not
+one — a daemon route in Swift, a Rust command, a pane, and tests at both ends.
+The daemon serves devices, features, apps and logcat today and nothing else, so
+that is the real cost of each screen, and it is why they are ordered by how
+often someone opens them rather than by how hard they look.
+
+1. **Device info** — the smallest of the four-layer screens, so it is where the
+   pattern gets established: a route over `DeviceProps`/`DeviceOverview` and a
+   searchable property browser.
+2. **File explorer** — browse, copy/move/delete, pull, root toggle, new folder,
+   context menu. The first screen that *writes* to the device, so its route
+   needs the same `shellQuote` care ADBKit applies.
+3. **Crash catcher** — a route over ADBKit's `CrashParser`, then a multi-crash
+   browser: kind/process filters, watch mode, copy-for-Slack, clear buffer.
+4. **Performance monitor** — a *stream*, not a request: live CPU/RAM/FPS with a
+   per-process list, recording, and export.
+5. **Per-feature hotkeys** with a live-preview recorder. Client-side, and the
+   only shell item left that people will miss daily.
+6. **Device bar parity** — wireless pair and connect, run-on-all for
+   `supportsRunAll`, launch an emulator, the pull-progress strip.
+7. **Toasts and the Command Log** — action results as toasts instead of a banner
+   per screen, and every user-initiated adb call recorded the way
+   `CommandLog.userInitiated` records it.
+8. **Settings** — Appearance (accent colour, light theme), General, Hotkeys,
+   Privacy. The light theme is a second set of tokens the asset catalog already
+   has.
+9. **Manage-features catalog** and per-feature "connect a device" empty states.
+10. **The device-state screens** — dev-settings, root-status,
+    system-restrictions. Toggle tables over one route each.
+11. **The connection screens** — wifi, private-dns, network-speed.
+12. **The per-app screens** — app-info, permissions, meminfo, sandbox-browser,
+    manage-app. All hang off the bundle already chosen in Apps.
+13. **Emulators and install-app.**
+14. **Deep links and bug report.**
+15. **Auto-hiding sidebar, UI zoom, window translucency** — `WindowEffects` is
+    already pure-tested in ADBKit; blur needs a per-platform answer.
+
+**Known gaps inside work already called done.**
+
+- **Logcat's per-app filter.** Needs a pid → package map the daemon does not
+  serve. Matching on the tag instead would be a filter that quietly misses
+  lines, which is worse than not having one.
+- **The palette lists features, not commands.** There are no custom commands in
+  this app yet for it to offer.
+- **Drop-to-split is unverified by automation.** Synthetic mouse events do not
+  start an HTML5 drag in WKWebView, so every drag path in this app is checked by
+  hand. Keep the *decision* a drop makes in `lib/` where it can be tested, and
+  only the event wiring uncovered.
+
+**Not planned.** Multi-window, the Quick Actions panel, the welcome tour, and
+the update pill. Each is a whole subsystem, and none of them is why anyone opens
+this app. Reactotron stays blocked until the relay's `Network.framework`
+listener is ported to NIO; mirror, screen-record and the video editor are
+Apple-only by design.
+
+---
+
 ## Per-feature checklists
 
 Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -13,6 +13,7 @@ public enum DaemonProtocol {
         case actionsRun = "/v1/actions/run"
         case appsList = "/v1/apps/list"
         case appsControl = "/v1/apps/control"
+        case deviceProps = "/v1/device/props"
     }
 
     /// The multiplexed stream socket. Not a `Route`: it is a WebSocket upgrade
@@ -23,6 +24,22 @@ public enum DaemonProtocol {
     public struct DevicesResponse: Codable, Equatable, Sendable {
         public let devices: [Device]
         public init(devices: [Device]) { self.devices = devices }
+    }
+
+    public struct DeviceRequest: Codable, Equatable, Sendable {
+        public let serial: String
+        public init(serial: String) { self.serial = serial }
+    }
+
+    /// Everything `getprop` printed, unparsed.
+    ///
+    /// The dictionary is passed through rather than reshaped into named
+    /// fields: which properties matter is the reader's question, and a daemon
+    /// that picked a subset would be deciding it for them — the Mac's Device
+    /// Info screen is a search box over the same raw set.
+    public struct DevicePropsResponse: Codable, Equatable, Sendable {
+        public let properties: [String: String]
+        public init(properties: [String: String]) { self.properties = properties }
     }
 
     /// One error shape everywhere, so the UI has exactly one error path.

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -23,6 +23,8 @@ public protocol DaemonBackend: Sendable {
     func controlApp(
         serial: String, packageId: String, action: AppControlService.AppAction
     ) async throws -> FeatureResult
+    /// Every `getprop` key and value on the device.
+    func deviceProperties(serial: String) async throws -> [String: String]
 }
 
 /// `DeviceMonitor` in production.
@@ -58,6 +60,10 @@ public struct LiveBackend: DaemonBackend {
     ) async throws -> FeatureResult {
         try await AppControlService(client: client)
             .control(serial: serial, packageId: packageId, action: action)
+    }
+
+    public func deviceProperties(serial: String) async throws -> [String: String] {
+        try await DeviceProps.all(client: client, serial: serial)
     }
 }
 
@@ -295,6 +301,22 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
 
         case .featuresList:
             return (.ok, encoded(ActionProtocol.features()))
+
+        case .deviceProps:
+            let raw = Data(body.readableBytesView)
+            guard let request = try? JSONDecoder().decode(
+                DaemonProtocol.DeviceRequest.self, from: raw)
+            else { return (.badRequest, encoded(DaemonProtocol.badRequest)) }
+            do {
+                let properties = try await backend.deviceProperties(serial: request.serial)
+                return (.ok, encoded(DaemonProtocol.DevicePropsResponse(properties: properties)))
+            } catch {
+                // adb's answer, not a daemon fault — the same 502 the app
+                // list uses, carrying adb's own words.
+                return (.badGateway, encoded(DaemonProtocol.ErrorBody(
+                    code: "adb_failed", message: "Could not read the device properties.",
+                    detail: "\(error)")))
+            }
 
         case .actionsRun:
             let raw = Data(body.readableBytesView)

--- a/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ActionRouteTests.swift
@@ -65,6 +65,10 @@ import FoundationNetworking
             await log.recordApp(serial, packageId, action)
             return result
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private func withServer(

--- a/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/DaemonServerTests.swift
@@ -30,6 +30,10 @@ import FoundationNetworking
         ) async throws -> FeatureResult {
             FeatureResult(ok: true, message: "stub")
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private static func device(_ serial: String) -> Device {
@@ -58,10 +62,12 @@ import FoundationNetworking
 
     private func send(
         port: Int, path: String = DaemonProtocol.Route.devicesList.rawValue,
-        method: String = "POST", token: String?, host: String? = nil, origin: String? = nil
+        method: String = "POST", token: String?, host: String? = nil, origin: String? = nil,
+        body: String? = nil
     ) async throws -> (status: Int, body: Data) {
         var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         request.httpMethod = method
+        if let body { request.httpBody = Data(body.utf8) }
         if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
         if let host { request.setValue(host, forHTTPHeaderField: "Host") }
         if let origin { request.setValue(origin, forHTTPHeaderField: "Origin") }
@@ -125,6 +131,30 @@ import FoundationNetworking
 
             let wrongMethod = try await send(port: port, method: "GET", token: token)
             #expect(wrongMethod.status == 405)
+        }
+    }
+
+    @Test func devicePropsPassesGetpropStraightThrough() async throws {
+        // The daemon picks no subset: which property matters is the reader's
+        // question, and a client that got a curated list could not ask it.
+        try await withServer { port, token in
+            let (status, body) = try await send(
+                port: port, path: DaemonProtocol.Route.deviceProps.rawValue, token: token,
+                body: #"{"serial":"emulator-5554"}"#)
+            #expect(status == 200)
+            let decoded = try JSONDecoder().decode(
+                DaemonProtocol.DevicePropsResponse.self, from: body)
+            #expect(decoded.properties["ro.product.model"] == "Pixel")
+            #expect(decoded.properties["ro.build.version.release"] == "14")
+        }
+    }
+
+    @Test func devicePropsRefusesABodyItCannotRead() async throws {
+        try await withServer { port, token in
+            let (status, _) = try await send(
+                port: port, path: DaemonProtocol.Route.deviceProps.rawValue, token: token,
+                body: "not json")
+            #expect(status == 400)
         }
     }
 

--- a/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/WebSocketTests.swift
@@ -48,6 +48,10 @@ private let hasWebSocketClient: Bool = {
         ) async throws -> FeatureResult {
             FeatureResult(ok: true, message: "stub")
         }
+
+        func deviceProperties(serial: String) async throws -> [String: String] {
+            ["ro.product.model": "Pixel", "ro.build.version.release": "14"]
+        }
     }
 
     private struct FixedSource: StreamSource {


### PR DESCRIPTION
Re-lands the tail of the stack. #256 hit a transient conflict during the batch
merge and `--delete-branch` closed it — and #258 behind it — so #257 and #259
merged into their base branches rather than the trunk. No commits were lost:
they were all on `docs/desktop-backlog`, which merges into current trunk
cleanly.

This is the same content, already reviewed and already CI-green as #256, #257,
#258 and #259:

- **#256 — command palette and pinned features.** Ctrl/⌘+K or T, the tab
  strip's `+`, arrows and Enter, Ctrl/⌘+P to pin. Pinned features lead the
  sidebar and the palette's empty-query list; with a query, relevance decides
  and pins are not promoted.
- **#257 — logcat.** Stop is no longer a one-way door. Filter and Find are two
  fields, plus a level picker, tag chips, Clear, and export to
  `~/Downloads/Droidective` through a new `export_text` command.
- **#258 — the backlog** on `docs/desktop-parity.md`: the remaining 15 goals in
  order, the four-layer cost of each screen, and the gaps inside work already
  ticked.
- **#259 — device info.** The first four-layer screen, and the worked example
  for the rest: `/v1/device/props` → a Rust command → `lib/deviceinfo.ts` → a
  pane.

## Verified on the merged result

`make desktop-test` green (typecheck, oxlint, 190 vitest, cargo
fmt/clippy/test) and `swift test` in `droidectived` green (76) — run against
this branch after merging the trunk into it, not just on the originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
