### PR TITLE
Redesign sidebar footer as a two-row split layout

### DIFF
--- a/App/Sources/Root/SidebarPaletteView.swift
+++ b/App/Sources/Root/SidebarPaletteView.swift
@@ -233,6 +233,7 @@ struct SidebarPaletteView: View {
             }
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
+            .contentMargins(.vertical, 8)
             .onChange(of: state.searchHighlightID) { _, id in
                 if let id { proxy.scrollTo(id, anchor: .center) }
             }
@@ -284,46 +285,63 @@ struct SidebarPaletteView: View {
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 16) {
-            Button {
-                state.requestFeature("catalog")
-            } label: {
-                Label(
-                    state.hiddenFeatureCount > 0 ? "+ \(state.hiddenFeatureCount) more features" : "Manage features",
-                    systemImage: "square.grid.2x2"
-                )
-                .font(.app(.body))
-                .lineLimit(1)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(state.activeTabID == "catalog" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+        VStack(spacing: 0) {
+            // ── Navigation row: Home + Manage Features ──
+            HStack {
+                SidebarNavButton(
+                    title: "Home",
+                    systemImage: "house",
+                    isActive: state.activeTabID == "home"
+                ) {
+                    state.requestFeature("home")
+                }
 
-            Spacer()
+                Spacer()
 
-            Button {
-                state.requestFeature("about")
-            } label: {
-                Image(systemName: "info.circle")
-                    .font(.app(.title2))
-                    .frame(height: 22)
-                    .contentShape(Rectangle())
+                SidebarNavButton(
+                    title: state.hiddenFeatureCount > 0
+                        ? "+ \(state.hiddenFeatureCount) more features"
+                        : "Manage features",
+                    systemImage: "square.grid.2x2",
+                    isActive: state.activeTabID == "catalog"
+                ) {
+                    state.requestFeature("catalog")
+                }
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(state.activeTabID == "about" ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
-            .help("About & Feedback — version, report an issue, star on GitHub")
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
 
-            SettingsLink {
-                Image(systemName: "gearshape")
-                    .font(.app(.title2))
-                    .frame(height: 22)
-                    .contentShape(Rectangle())
+            Divider()
+                .padding(.horizontal, 10)
+
+            // ── Utility row: version + Info + Settings ──
+            HStack(spacing: 0) {
+                Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")")
+                    .font(.app(size: 11, weight: .regular))
+                    .foregroundStyle(.textMuted)
+                    .monospacedDigit()
+
+                Spacer()
+
+                Button {
+                    state.requestFeature("about")
+                } label: {
+                    Image(systemName: "info.circle")
+                }
+                .buttonStyle(IconButtonStyle(size: .small))
+                .foregroundStyle(state.activeTabID == "about" ? .brandAccent : .textMuted)
+                .help("About & Feedback — version, report an issue, star on GitHub")
+
+                SettingsLink {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(IconButtonStyle(size: .small))
+                .foregroundStyle(.textMuted)
+                .help("Settings (⌘,)")
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.textMuted)
-            .help("Settings (⌘,)")
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
     }
 
     /// ⌘1–⌘9/⌘0 hints: id → 0-based rank while ⌘ is held in the key window
@@ -763,5 +781,36 @@ private struct HotkeyPopover: View {
         }
         .padding(14)
         .frame(width: 300)
+    }
+}
+
+/// A labeled sidebar-footer button with a rounded-rect hover/press wash,
+/// matching ``IconButtonStyle``'s interaction feel for icon+text buttons.
+private struct SidebarNavButton: View {
+    let title: String
+    let systemImage: String
+    let isActive: Bool
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.app(.body))
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isActive ? .brandAccent : .textMuted)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(isActive
+                    ? Color.brandAccent.opacity(0.12)
+                    : Color.primary.opacity(hovering ? 0.07 : 0))
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .onHover { hovering = $0 }
+        .animation(.easeOut(duration: 0.12), value: hovering)
     }
 }

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -23,9 +23,8 @@ struct TabStripView: View {
     /// Where the insertion guideline shows during a reorder drag (nil = none).
     @State private var dropSlot: TabDropSlot?
 
-    /// Home never renders as a chip — it rides the permanent house button at
-    /// the strip's start instead, so it can't be closed away or lost in the
-    /// tab overflow.
+    /// Home lives in the sidebar footer — exclude it from tab chips so it
+    /// can't be closed away.
     private var tabIDs: [String] { state.openTabIDs(inGroup: group).filter { $0 != "home" } }
     private var activeID: String? { state.activeTab(inGroup: group) }
     /// The tabs are wider than the visible strip — show the ‹ › scroll arrows.
@@ -34,11 +33,7 @@ struct TabStripView: View {
     var body: some View {
         ScrollViewReader { proxy in
             HStack(spacing: 0) {
-                if group == 0 {
-                    homeButton
-                        .padding(.horizontal, 6)
-                    Divider().frame(height: 20)
-                }
+                // Home moved to the sidebar footer's navigation row.
                 if overflowing {
                     scrollArrow("chevron.left", by: -1, help: "Scroll tabs left", proxy)
                     Divider().frame(height: 20)
@@ -203,29 +198,6 @@ struct TabStripView: View {
         Button("Close Tab") { state.closeTab(id) }
         Button("Close Other Tabs") { state.closeOtherTabs(than: id, inGroup: group) }
             .disabled(tabIDs.count < 2)
-    }
-
-    /// The fixed Home entry leading the strip — an icon-only chip that opens
-    /// (or re-focuses) Home; accented while Home is the active tab anywhere.
-    private var homeButton: some View {
-        Button {
-            state.requestFeature("home")
-        } label: {
-            Image(systemName: "house")
-                .font(.app(.callout).weight(.medium))
-                .foregroundStyle(state.activeTabID == "home"
-                    ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
-                .frame(width: 28, height: 28)
-                .background(
-                    RoundedRectangle(cornerRadius: 7)
-                        .fill(state.activeTabID == "home"
-                            ? AnyShapeStyle(.brandAccent.opacity(0.14)) : AnyShapeStyle(.clear))
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help("Home — overview & getting started")
-        .accessibilityLabel("Home")
     }
 
     private var newTabButton: some View {


### PR DESCRIPTION
Move Home from the tab strip into the sidebar footer alongside Manage Features, Info, and Settings. The footer now has two distinct rows: a navigation row (Home left, Manage Features right) with labeled hover-wash buttons, and a utility row (version label left, Info and Settings icons right) using IconButtonStyle for consistent hover feedback. Adds vertical content margin to the feature list for breathing room when scrolling.

<img width="346" height="355" alt="Screenshot 2026-08-05 at 4 29 09 PM" src="https://github.com/user-attachments/assets/1482ced2-b8d9-4daa-99fc-5bc7b895f8e8" />


<!--
PR guidelines: docs/PULL_REQUESTS.md
Describe what the code does NOW — not discarded approaches. Plain, factual
language. No AI attribution (no co-author trailer, no "Generated with…").
-->

## What changed

<!-- One or two sentences. What does the code do now? -->

## Why

<!-- The problem or motivation. Closes #NN if applicable. -->

## Impact area

<!-- What else could this affect? Delete the lines that don't apply. -->

- [ ] Shared `ADBKit` service used by other features
- [ ] `FeatureRegistry` / `FeatureNotes` / hub membership
- [ ] Persisted state schema (`Persistence/`, `~/Library/Application Support/Droidective/`)
- [ ] Bundled tools / release / signing / appcast
- [ ] None — isolated to one feature

## How verified

<!-- swift test + build, and what you exercised live. Screenshots/GIF for UI. -->

- [ ] `make test` green
- [ ] `make build` succeeds with **zero warnings**
- [ ] Ran the app and verified live (device/emulator + Android version): …

## Checklist

- [ ] Logic lives in `ADBKit`, not in a SwiftUI view
- [ ] New parsers / command construction are tested
- [ ] New feature registered in `FeatureRegistry` **and** has a `FeatureNotes` entry
- [ ] `prek run` passes (gitleaks secret scan)
- [ ] No secrets, no commented-out code, no relative `..` imports, no AI attribution
