### PR TITLE
Match Chrome DevTools in the JS Console

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/CDPProtocol.swift
@@ -320,10 +320,24 @@ public struct CDPCallFrame: Sendable, Equatable, Identifiable {
     }
 
     /// `functionName  file:line` — CDP line numbers are 0-based, shown 1-based.
+    /// The file is the script's own name: Metro's bundle URL carries a query
+    /// string longer than the rest of the frame, and eight of those turn a
+    /// stack trace into a wall of `&excludeSource=true&sourcePaths=url-server`.
     public var display: String {
         let fn = functionName.isEmpty ? "(anonymous)" : functionName
         guard !url.isEmpty else { return fn }
-        return "\(fn)  \(url):\(lineNumber + 1)"
+        return "\(fn)  \(Self.scriptName(url)):\(lineNumber + 1)"
+    }
+
+    /// The last path component of a script URL, without its query or fragment.
+    public static func scriptName(_ url: String) -> String {
+        var name = url
+        if let cut = name.firstIndex(where: { $0 == "?" || $0 == "#" }) { name = String(name[..<cut]) }
+        // Metro appends its parameters after a bare `&`, with no `?` at all.
+        if let cut = name.firstIndex(of: "&") { name = String(name[..<cut]) }
+        while name.hasSuffix("/") { name.removeLast() }
+        let last = name.split(separator: "/").last.map(String.init) ?? name
+        return last.isEmpty ? url : last
     }
 }
 

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleANSI.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleANSI.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Terminal escape sequences in console text.
+///
+/// React Native's own dev-server notices arrive coloured for a terminal
+/// (`\u{1B}[1mNOTE:\u{1B}[22m You are using an unsupported debugging client…`),
+/// and so does anything logged through a library that formats for stdout.
+/// Chrome's console renders those sequences as styling; printing them verbatim
+/// buries the message in `[48;2;253;247;231m[30m[1m` noise, so they come out
+/// here instead.
+public enum ConsoleANSI {
+    private static let escape: UInt8 = 0x1B
+    private static let bell: UInt8 = 0x07
+
+    /// Whether the text carries an escape at all — the cheap guard before
+    /// rebuilding a string that almost never needs it.
+    public static func containsEscapes(_ text: String) -> Bool {
+        text.utf8.contains(escape)
+    }
+
+    /// The text without its escape sequences: CSI (`ESC [ … final`), OSC
+    /// (`ESC ] … BEL` or `ESC ] … ESC \`), and the two-byte C1 forms. Anything
+    /// that isn't a recognised sequence is left alone, so a lone `ESC` in real
+    /// data survives rather than eating the rest of the line.
+    public static func strip(_ text: String) -> String {
+        guard containsEscapes(text) else { return text }
+        var out: [UInt8] = []
+        out.reserveCapacity(text.utf8.count)
+        let bytes = Array(text.utf8)
+        var index = 0
+        while index < bytes.count {
+            guard bytes[index] == escape, index + 1 < bytes.count else {
+                out.append(bytes[index])
+                index += 1
+                continue
+            }
+            switch bytes[index + 1] {
+            case UInt8(ascii: "["):
+                // CSI: parameter and intermediate bytes, then one final byte.
+                var cursor = index + 2
+                while cursor < bytes.count, (0x30 ... 0x3F).contains(bytes[cursor]) { cursor += 1 }
+                while cursor < bytes.count, (0x20 ... 0x2F).contains(bytes[cursor]) { cursor += 1 }
+                if cursor < bytes.count, (0x40 ... 0x7E).contains(bytes[cursor]) {
+                    index = cursor + 1
+                } else {
+                    // Unterminated — keep it rather than swallowing the tail.
+                    out.append(bytes[index])
+                    index += 1
+                }
+            case UInt8(ascii: "]"):
+                // OSC: runs to BEL or the ST pair.
+                var cursor = index + 2
+                var terminated = false
+                while cursor < bytes.count {
+                    if bytes[cursor] == bell {
+                        cursor += 1
+                        terminated = true
+                        break
+                    }
+                    if bytes[cursor] == escape, cursor + 1 < bytes.count,
+                       bytes[cursor + 1] == UInt8(ascii: "\\") {
+                        cursor += 2
+                        terminated = true
+                        break
+                    }
+                    cursor += 1
+                }
+                if terminated {
+                    index = cursor
+                } else {
+                    out.append(bytes[index])
+                    index += 1
+                }
+            case 0x40 ... 0x5F:
+                index += 2
+            default:
+                out.append(bytes[index])
+                index += 1
+            }
+        }
+        return String(decoding: out, as: UTF8.self)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleArguments.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleArguments.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// One chunk of a `console.*` call's argument list.
+///
+/// Chrome reads a log as a message with values in it: consecutive scalars run
+/// together as text, and each object is a thing of its own — inline it gets a
+/// disclosure triangle, and copied it gets its own JSON block instead of the
+/// `{…}` placeholder that a paste can't use.
+public enum ConsoleArgumentChunk: Sendable, Equatable {
+    case scalars([JSToken])
+    case object(RemoteObject)
+}
+
+public enum ConsoleArguments {
+    /// Split a call's arguments into chunks, in argument order. Scalars carry
+    /// their rendered tokens (with the separating spaces already in place), so
+    /// the row and the clipboard can't drift apart.
+    public static func chunks(_ args: [RemoteObject]) -> [ConsoleArgumentChunk] {
+        var chunks: [ConsoleArgumentChunk] = []
+        var run: [JSToken] = []
+        func flushRun() {
+            guard !run.isEmpty else { return }
+            chunks.append(.scalars(run))
+            run = []
+        }
+        for arg in args {
+            if arg.isExpandable {
+                flushRun()
+                chunks.append(.object(arg))
+            } else {
+                if !run.isEmpty { run.append(JSToken(" ", .plain)) }
+                run.append(contentsOf: arg.tokens(style: .consoleArgument))
+            }
+        }
+        flushRun()
+        return chunks
+    }
+
+    /// The clipboard form of a call whose objects have already been stringified:
+    /// the message first, then each object's JSON on its own line. Copying a log
+    /// has to carry the data it was logged with — a pasted `{…}` is the one part
+    /// of the row nobody can act on.
+    public static func copyText(_ chunks: [ConsoleArgumentChunk], json: [Int: String]) -> String {
+        var parts: [String] = []
+        for (index, chunk) in chunks.enumerated() {
+            switch chunk {
+            case let .scalars(tokens):
+                parts.append(tokens.map(\.text).joined())
+            case let .object(object):
+                parts.append(json[index] ?? object.inlineSummary(style: .consoleArgument))
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleGrouping.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleGrouping.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// What a `console.*` call means for the feed's group nesting.
+public enum ConsoleGroupPlacement: Sendable, Equatable {
+    /// An ordinary row, indented `depth` levels, nested inside the group
+    /// headers in `path` (outermost first).
+    case entry(depth: Int, path: [Int])
+    /// A `console.group` / `console.groupCollapsed` header. It sits at the
+    /// *outer* depth — the rows after it are the ones that indent.
+    case groupStart(depth: Int, path: [Int], collapsed: Bool)
+    /// A `console.groupEnd` — it closes the innermost group and shows no row of
+    /// its own. Rendering one produced the empty rows trailing a grouped burst.
+    case groupEnd
+}
+
+/// The running `console.group` nesting of a console stream. Chrome indents the
+/// rows between a `group` and its `groupEnd`, draws a rule down the left of the
+/// block, and lets the header collapse it; this is the pure half — which depth
+/// each incoming call belongs to, and which headers it hangs under.
+///
+/// Unbalanced groups are the normal case (an app that throws between `group` and
+/// `groupEnd` never closes it), so a stray `groupEnd` is a no-op and the nesting
+/// resets whenever the stream restarts: a JS reload or a clear must not leave
+/// the rest of the session indented under a group that no longer exists.
+public struct ConsoleGroupTracker: Sendable, Equatable {
+    /// Ids of the group headers currently open, outermost first.
+    public private(set) var open: [Int] = []
+
+    /// The depth the next ordinary row lands at.
+    public var depth: Int { open.count }
+
+    public init() {}
+
+    /// Where a console call of this type belongs. `id` is the entry id the
+    /// produced row will carry — a group header registers it so its own rows
+    /// can name the header they hang under (which is how collapsing one hides
+    /// exactly its block).
+    public mutating func placement(for consoleType: String, id: Int) -> ConsoleGroupPlacement {
+        switch consoleType {
+        case "startGroup", "startGroupCollapsed":
+            let placement = ConsoleGroupPlacement.groupStart(
+                depth: open.count, path: open, collapsed: consoleType == "startGroupCollapsed"
+            )
+            open.append(id)
+            return placement
+        case "endGroup":
+            if !open.isEmpty { open.removeLast() }
+            return .groupEnd
+        default:
+            return .entry(depth: open.count, path: open)
+        }
+    }
+
+    /// Back to the top level — a JS context replacement, a clear, or a fresh
+    /// connection all start the nesting over.
+    public mutating func reset() {
+        open.removeAll()
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleTable.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleTable.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// One row of a `console.table`.
+public struct ConsoleTableRow: Sendable, Equatable {
+    /// The array index or object key that names the row.
+    public let index: String
+    /// Cell text per column, empty where the row has no such key.
+    public let cells: [String]
+    /// Set when the row itself is a primitive — Chrome files those under a
+    /// single `Value` column rather than inventing keys for them.
+    public let value: String?
+
+    public init(index: String, cells: [String], value: String?) {
+        self.index = index
+        self.cells = cells
+        self.value = value
+    }
+}
+
+/// The grid `console.table(data)` prints — Chrome renders one, and a log that
+/// shows only `(3) [{…}, {…}, {…}]` is the shape of the data without any of it.
+///
+/// Built from the same bounded snapshot the expandable rows use, so it costs no
+/// extra device round-trip. Chrome's rules: a row per element (or per key, for
+/// an object), a column per key in first-seen order across the rows, and a
+/// `Value` column for any element that isn't an object.
+public struct ConsoleTable: Sendable, Equatable {
+    public let columns: [String]
+    public let rows: [ConsoleTableRow]
+    /// Whether any row was a primitive, so the view draws the `Value` column.
+    public let hasValueColumn: Bool
+    /// Rows beyond `rowLimit` that aren't drawn.
+    public let hiddenRows: Int
+
+    public init(columns: [String], rows: [ConsoleTableRow], hasValueColumn: Bool, hiddenRows: Int) {
+        self.columns = columns
+        self.rows = rows
+        self.hasValueColumn = hasValueColumn
+        self.hiddenRows = hiddenRows
+    }
+
+    /// The table for a snapshotted `console.table` argument, or nil when the
+    /// value isn't tabular (a primitive — Chrome falls back to a plain log).
+    public static func from(_ node: SnapNode, columnLimit: Int = 20, rowLimit: Int = 200) -> ConsoleTable? {
+        guard node.isContainer else { return nil }
+        let entries: [(String, SnapNode)] = if node.type == "array" {
+            (node.items ?? []).enumerated().map { (String($0.offset), $0.element) }
+        } else {
+            (node.entries ?? []).map { ($0.name, $0.node) }
+        }
+        guard !entries.isEmpty else { return nil }
+
+        var columns: [String] = []
+        var seen: Set<String> = []
+        for (_, child) in entries.prefix(rowLimit) where child.type == "object" {
+            for entry in child.entries ?? [] where !seen.contains(entry.name) {
+                guard columns.count < columnLimit else { break }
+                seen.insert(entry.name)
+                columns.append(entry.name)
+            }
+        }
+
+        var hasValueColumn = false
+        var rows: [ConsoleTableRow] = []
+        for (index, child) in entries.prefix(rowLimit) {
+            if child.type == "object" {
+                let byName = Dictionary(
+                    (child.entries ?? []).map { ($0.name, $0.node) }, uniquingKeysWith: { first, _ in first }
+                )
+                let cells = columns.map { byName[$0].map(cellText) ?? "" }
+                rows.append(ConsoleTableRow(index: index, cells: cells, value: nil))
+            } else {
+                hasValueColumn = true
+                rows.append(ConsoleTableRow(
+                    index: index, cells: Array(repeating: "", count: columns.count), value: cellText(child)
+                ))
+            }
+        }
+        return ConsoleTable(
+            columns: columns,
+            rows: rows,
+            hasValueColumn: hasValueColumn,
+            hiddenRows: max(0, entries.count - rows.count)
+        )
+    }
+
+    /// A cell is one line: nested containers collapse the way Chrome collapses
+    /// them inside a table, since the row below the table is where you open one.
+    private static func cellText(_ node: SnapNode) -> String {
+        switch node.type {
+        case "array": "Array(\(node.length ?? node.items?.count ?? 0))"
+        case "object": (node.ctor ?? "Object") == "Object" ? "{…}" : (node.ctor ?? "Object")
+        default: node.primitivePreview
+        }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/MetroSymbolicator.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/MetroSymbolicator.swift
@@ -1,0 +1,205 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One call frame after Metro resolved it back through the bundle's source map.
+public struct SymbolicatedFrame: Sendable, Equatable, Identifiable {
+    public var id: String { "\(file):\(lineNumber):\(column):\(methodName)" }
+    public let file: String
+    /// 1-based, as Metro reports it (and as an editor counts).
+    public let lineNumber: Int
+    public let column: Int
+    public let methodName: String
+    /// Metro's own ignore-list flag — framework plumbing between the app's code
+    /// and the console call, which Chrome hides for the same reason.
+    public let collapse: Bool
+
+    public init(file: String, lineNumber: Int, column: Int, methodName: String, collapse: Bool) {
+        self.file = file
+        self.lineNumber = lineNumber
+        self.column = column
+        self.methodName = methodName
+        self.collapse = collapse
+    }
+
+    /// `emitComplexError  StreamScreen.tsx:192` — one stack line.
+    public var display: String {
+        let method = methodName.isEmpty ? "(anonymous)" : methodName
+        return "\(method)  \((file as NSString).lastPathComponent):\(lineNumber)"
+    }
+
+    /// Whether this frame is plumbing rather than the reader's own code —
+    /// Metro's own flag, or a dependency's file. Drawn dimmer, the way Chrome
+    /// greys its ignore-listed frames.
+    public var isLibrary: Bool { collapse || MetroSymbolicator.isDependency(file) }
+}
+
+/// Where a console call came from — what Chrome prints, right-aligned, at the
+/// end of every console row.
+public struct ConsoleSourceLocation: Sendable, Equatable {
+    /// Absolute path on the Mac running Metro.
+    public let file: String
+    public let line: Int
+    public let function: String
+
+    public init(file: String, line: Int, function: String) {
+        self.file = file
+        self.line = line
+        self.function = function
+    }
+
+    /// `StreamScreen.tsx:142` — the file's own name and its line.
+    public var label: String {
+        "\((file as NSString).lastPathComponent):\(line)"
+    }
+}
+
+/// Resolves a console call's bundle coordinates back to the file the developer
+/// wrote, through Metro's `/symbolicate` endpoint — the same service React
+/// Native's redbox uses, so nothing here has to parse a source map.
+///
+/// Chrome's console shows this at the right edge of every row. Two rules make it
+/// read the same way here: line numbers cross the wire 1-based (CDP counts from
+/// zero), and the frame shown is the first one the *app* owns — Metro flags its
+/// own plumbing with `collapse`, and anything under `node_modules` is a library
+/// the reader didn't write, which is exactly Chrome's ignore-list default.
+///
+/// The actor is a cache in front of the endpoint: identical stacks (the common
+/// case — a console call in a loop) resolve once, concurrent asks for the same
+/// stack share one request, and a Metro that can't symbolicate at all stops
+/// being asked after a few failures rather than costing a request per row.
+public actor MetroSymbolicator {
+    private let host: String
+    private let port: Int
+    private let timeout: TimeInterval
+    /// Resolved (or definitively unresolvable) stacks, keyed by the frames sent.
+    private var cache: [String: [SymbolicatedFrame]] = [:]
+    /// Requests in flight, so N rows asking for the same stack make one call.
+    private var inFlight: [String: Task<[SymbolicatedFrame], Never>] = [:]
+    /// Consecutive transport failures — a Metro too old to symbolicate, or one
+    /// that went away, must not be asked once per rendered row.
+    private var failures = 0
+    private var maximumCacheEntries = 512
+
+    private static let failureLimit = 3
+
+    public init(host: String = "127.0.0.1", port: Int = 8081, timeout: TimeInterval = 8) {
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+    }
+
+    /// A console call's stack resolved back to source: `location(in:)` picks the
+    /// one frame the row labels itself with, and the whole list is what opening
+    /// the row shows instead of eight repetitions of the bundle URL. Empty when
+    /// there's nothing to resolve or Metro can't — never throws, because a
+    /// missing source label is a cosmetic loss and the console keeps streaming.
+    public func symbolicate(_ frames: [CDPCallFrame]) async -> [SymbolicatedFrame] {
+        let sendable = Self.sendableFrames(frames)
+        guard !sendable.isEmpty, failures < Self.failureLimit else { return [] }
+        let key = Self.cacheKey(sendable)
+        if let cached = cache[key] { return cached }
+        if let running = inFlight[key] { return await running.value }
+        let task = Task<[SymbolicatedFrame], Never> { [weak self] in
+            guard let self else { return [] }
+            return await self.resolve(sendable, key: key)
+        }
+        inFlight[key] = task
+        return await task.value
+    }
+
+    private func resolve(_ frames: [CDPCallFrame], key: String) async -> [SymbolicatedFrame] {
+        defer { inFlight[key] = nil }
+        guard let url = URL(string: "http://\(host):\(port)/symbolicate") else { return [] }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Self.requestBody(frames)
+        let data: Data
+        do {
+            let (payload, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
+                failures += 1
+                return []
+            }
+            data = payload
+        } catch {
+            failures += 1
+            return []
+        }
+        failures = 0
+        let resolved = Self.parse(data)
+        // The call sites of a console stream are few; a runaway one still can't
+        // grow the cache without bound. Dropping it whole beats an LRU nobody
+        // would ever exercise.
+        if cache.count >= maximumCacheEntries { cache.removeAll(keepingCapacity: true) }
+        cache[key] = resolved
+        return resolved
+    }
+
+    // MARK: - Pure
+
+    /// The frames worth sending: those with a real script URL, capped — Metro
+    /// resolves the whole stack, and only the top few can be the app's own call.
+    public static func sendableFrames(_ frames: [CDPCallFrame], limit: Int = 8) -> [CDPCallFrame] {
+        frames.filter { !$0.url.isEmpty }.prefix(limit).map { $0 }
+    }
+
+    public static func cacheKey(_ frames: [CDPCallFrame]) -> String {
+        frames.map { "\($0.url)|\($0.lineNumber)|\($0.columnNumber)" }.joined(separator: "\n")
+    }
+
+    /// Metro's request shape. CDP counts lines from zero and Metro from one, so
+    /// every line crosses the wire incremented — off by one here silently
+    /// reports the wrong source line rather than failing.
+    public static func requestBody(_ frames: [CDPCallFrame]) -> Data {
+        var stack: [JSONValue] = []
+        for frame in frames {
+            let method: String = frame.functionName.isEmpty ? "(anonymous)" : frame.functionName
+            let fields: [String: JSONValue] = [
+                "file": .string(frame.url),
+                "lineNumber": .number(Double(frame.lineNumber + 1)),
+                "column": .number(Double(frame.columnNumber)),
+                "methodName": .string(method),
+            ]
+            stack.append(.object(fields))
+        }
+        let body: JSONValue = .object(["stack": .array(stack)])
+        return Data(body.jsonString.utf8)
+    }
+
+    public static func parse(_ data: Data) -> [SymbolicatedFrame] {
+        guard let root = try? JSONDecoder().decode(JSONValue.self, from: data),
+              let stack = root["stack"]?.arrayValue else { return [] }
+        return stack.compactMap { entry in
+            guard let file = entry["file"]?.stringValue, !file.isEmpty,
+                  let line = entry["lineNumber"]?.intValue else { return nil }
+            return SymbolicatedFrame(
+                file: file,
+                lineNumber: line,
+                column: entry["column"]?.intValue ?? 0,
+                methodName: entry["methodName"]?.stringValue ?? "",
+                collapse: entry["collapse"]?.boolValue ?? false
+            )
+        }
+    }
+
+    /// The frame to show: the first one the app owns. Metro marks React
+    /// Native's own console plumbing `collapse`, and a `node_modules` path is a
+    /// dependency's code — Chrome ignore-lists both by default, so pointing at
+    /// either would name a file the reader never wrote. With nothing but
+    /// library frames (a log from inside a dependency), the top one is honest.
+    public static func location(in frames: [SymbolicatedFrame]) -> ConsoleSourceLocation? {
+        guard !frames.isEmpty else { return nil }
+        let owned = frames.first { !$0.collapse && !isDependency($0.file) }
+            ?? frames.first { !$0.collapse }
+            ?? frames[0]
+        return ConsoleSourceLocation(file: owned.file, line: owned.lineNumber, function: owned.methodName)
+    }
+
+    public static func isDependency(_ path: String) -> Bool {
+        path.contains("/node_modules/")
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/MetroSymbolicator.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/MetroSymbolicator.swift
@@ -26,7 +26,7 @@ public struct SymbolicatedFrame: Sendable, Equatable, Identifiable {
     /// `emitComplexError  StreamScreen.tsx:192` — one stack line.
     public var display: String {
         let method = methodName.isEmpty ? "(anonymous)" : methodName
-        return "\(method)  \((file as NSString).lastPathComponent):\(lineNumber)"
+        return "\(method)  \(MetroSymbolicator.fileName(file)):\(lineNumber)"
     }
 
     /// Whether this frame is plumbing rather than the reader's own code —
@@ -51,7 +51,7 @@ public struct ConsoleSourceLocation: Sendable, Equatable {
 
     /// `StreamScreen.tsx:142` — the file's own name and its line.
     public var label: String {
-        "\((file as NSString).lastPathComponent):\(line)"
+        "\(MetroSymbolicator.fileName(file)):\(line)"
     }
 }
 
@@ -201,5 +201,14 @@ public actor MetroSymbolicator {
 
     public static func isDependency(_ path: String) -> Bool {
         path.contains("/node_modules/")
+    }
+
+    /// A path's last component. Plain string work rather than `NSString`
+    /// bridging, which ADBKit keeps out of portable code — and it takes both
+    /// separators, since the path is whatever the machine running Metro
+    /// reports.
+    public static func fileName(_ path: String) -> String {
+        let last = path.split(whereSeparator: { $0 == "/" || $0 == "\\" }).last.map(String.init)
+        return last ?? path
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/RemoteObjectDisplay.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/RemoteObjectDisplay.swift
@@ -17,17 +17,32 @@ public struct JSToken: Sendable, Equatable {
     }
 }
 
+/// Where a value is being rendered, which is what decides whether a string is
+/// quoted. Chrome prints a *top-level* `console.log` string argument bare
+/// (`console.log('hi')` → `hi`, newlines and all) and quotes strings
+/// everywhere else — nested in a preview, or returned from the prompt.
+public enum JSRenderStyle: Sendable, Equatable {
+    case value
+    case consoleArgument
+}
+
 /// Pure value→tokens rendering for the console, tuned to how **Hermes** (not V8)
 /// serializes over CDP: `bigint` arrives as `type: ""`, `-0`/`Infinity`/`NaN` as
 /// `unserializableValue` with no `value`, and `Date`/`Map`/`Set`/`RegExp` as
 /// plain `"Object"` (Hermes doesn't tag those subtypes). Kept here so it's
 /// unit-tested against recorded payloads.
 public extension RemoteObject {
+    /// The compact one-line rendering as colorable tokens, quoting strings.
+    var tokens: [JSToken] { tokens(style: .value) }
+
     /// The compact one-line rendering as colorable tokens.
-    var tokens: [JSToken] {
+    func tokens(style: JSRenderStyle) -> [JSToken] {
         switch type {
         case "string":
-            return [JSToken("\"\(value?.stringValue ?? description ?? "")\"", .string)]
+            let text = ConsoleANSI.strip(value?.stringValue ?? description ?? "")
+            return style == .consoleArgument
+                ? [JSToken(text, .plain)]
+                : [JSToken(Self.quoted(text), .string)]
         case "boolean":
             return [JSToken(description ?? value.map(CDP.displayString) ?? "false", .boolean)]
         case "number":
@@ -48,7 +63,11 @@ public extension RemoteObject {
 
     /// The plain one-line summary — the tokens joined. Used for search, find,
     /// and copy, so they never diverge from what's shown.
-    var inlineSummary: String { tokens.map(\.text).joined() }
+    var inlineSummary: String { inlineSummary(style: .value) }
+
+    func inlineSummary(style: JSRenderStyle) -> String {
+        tokens(style: style).map(\.text).joined()
+    }
 
     /// `inlineSummary` bounded to roughly `limit` characters. String values
     /// take a prefix without materializing the full value — a multi-megabyte
@@ -56,11 +75,14 @@ public extension RemoteObject {
     /// (that copy, once per replayed entry, was the reload CPU spike).
     /// Non-string values are already small (object previews are truncated on
     /// the device).
-    func inlineSummary(limit: Int) -> String {
+    func inlineSummary(limit: Int, style: JSRenderStyle = .value) -> String {
         if type == "string", let text = value?.stringValue, text.utf8.count > limit {
-            return "\"\(String(text.prefix(limit)))"
+            // Strip the prefix, not the whole value — the point of this path is
+            // never to walk a multi-megabyte string.
+            let head = ConsoleANSI.strip(String(text.prefix(limit)))
+            return style == .consoleArgument ? head : "\"\(head)"
         }
-        let full = inlineSummary
+        let full = inlineSummary(style: style)
         return full.utf8.count <= limit ? full : String(full.prefix(limit))
     }
 
@@ -82,8 +104,27 @@ public extension RemoteObject {
             return [JSToken(message, .plain)]
         }
         if let preview { return Self.previewTokens(preview) }
+        // No preview: Hermes replays its buffered console history without one,
+        // so the whole pre-connect backlog lands here. `Array(2)` or a class
+        // name still says something; the bare word "Object" says less than
+        // Chrome's `{…}`, which reads as "open me".
         if let description, description != "Object" { return [JSToken(description, .className)] }
-        return [JSToken(className ?? "Object", .className)]
+        if let className, className != "Object" { return [JSToken(className, .className)] }
+        return [JSToken("{…}", .punctuation)]
+    }
+
+    /// Chrome's string literal: single quotes, switching to double quotes when
+    /// the text already contains one, with the escapes a one-line preview needs
+    /// so a logged multi-line string can't break the row into several.
+    static func quoted(_ text: String) -> String {
+        var escaped = text
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+        if escaped.contains("'"), !escaped.contains("\"") { return "\"\(escaped)\"" }
+        escaped = escaped.replacingOccurrences(of: "'", with: "\\'")
+        return "'\(escaped)'"
     }
 
     /// "function adder(a0, a1) { [bytecode] }" → "ƒ adder(a0, a1)".
@@ -97,7 +138,13 @@ public extension RemoteObject {
 
     static func previewTokens(_ preview: ObjectPreview) -> [JSToken] {
         if preview.subtype == "array" || preview.description?.hasPrefix("Array(") == true {
-            var tokens = [JSToken("[", .punctuation)]
+            var tokens: [JSToken] = []
+            // Chrome leads a multi-element array with its length — `(3) [1, 2, 3]`
+            // — and leaves `[]` / `[x]` to speak for themselves.
+            if let count = arrayLength(preview), count > 1 {
+                tokens.append(JSToken("(\(count)) ", .className))
+            }
+            tokens.append(JSToken("[", .punctuation))
             for (index, property) in preview.properties.enumerated() {
                 if index > 0 { tokens.append(JSToken(", ", .punctuation)) }
                 tokens.append(elementToken(property))
@@ -124,18 +171,31 @@ public extension RemoteObject {
         return tokens
     }
 
+    /// The element count out of an array preview's `Array(n)` description.
+    private static func arrayLength(_ preview: ObjectPreview) -> Int? {
+        guard let description = preview.description,
+              description.hasPrefix("Array("), description.hasSuffix(")") else { return nil }
+        return Int(description.dropFirst("Array(".count).dropLast())
+    }
+
     private static func elementToken(_ property: PropertyPreview) -> JSToken {
         switch property.type {
-        case "string": JSToken("\"\(property.value ?? "")\"", .string)
+        case "string": JSToken(quoted(ConsoleANSI.strip(property.value ?? "")), .string)
         case "number", "bigint": JSToken(property.value ?? "", .number)
         case "boolean": JSToken(property.value ?? "", .boolean)
         case "undefined": JSToken("undefined", .undefined)
         case "symbol": JSToken(property.value ?? "Symbol()", .symbol)
         case "function": JSToken("ƒ", .function)
         case "object":
-            property.subtype == "null"
-                ? JSToken("null", .null)
-                : JSToken(property.value ?? "Object", .className)
+            if property.subtype == "null" {
+                JSToken("null", .null)
+            } else if let value = property.value, value != "Object" {
+                // `Array(3)`, or a class name — Chrome shows both verbatim.
+                JSToken(value, .className)
+            } else {
+                // A plain nested object is Chrome's `{…}`, not the word "Object".
+                JSToken("{…}", .punctuation)
+            }
         default: JSToken(property.value ?? "", .plain)
         }
     }

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNodeDisplay.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/SnapNodeDisplay.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// How a snapshot node reads on one line — the collapsed rows of an expanded
+/// value tree. Chrome previews a collapsed object by its first few properties
+/// (`{at: '2026-…', session: {…}, tags: Array(3), …}`) rather than by a count,
+/// and the snapshot already holds every child, so the preview is built here
+/// instead of costing another device round-trip.
+public extension SnapNode {
+    /// Display text for a primitive node — strings quoted the way the console's
+    /// value previews quote them, so the tree and the collapsed row agree.
+    var primitivePreview: String {
+        let text = text ?? "—"
+        return type == "string" ? RemoteObject.quoted(ConsoleANSI.strip(text)) : text
+    }
+
+    /// Collapsed one-liner for a container node, e.g. `Array(200)`, `{3}`,
+    /// `Map {2}` — the location line of a find result, where the node's own
+    /// contents would be noise.
+    var containerSummary: String {
+        if type == "array" {
+            return "Array(\(length ?? items?.count ?? 0))"
+        }
+        let count = entries?.count ?? 0
+        let ctor = ctor ?? "Object"
+        return ctor == "Object" ? "{\(count)}" : "\(ctor) {\(count)}"
+    }
+
+    /// Chrome's inline preview of this node: primitives render as themselves,
+    /// containers as their first few children. Nested containers stop at
+    /// `{…}` / `Array(n)`, so the preview is always one shallow line.
+    func previewTokens(objectLimit: Int = 5, arrayLimit: Int = 10) -> [JSToken] {
+        guard isContainer else { return [JSToken(primitivePreview, Self.tokenKind(type))] }
+        if type == "array" {
+            let items = items ?? []
+            var tokens: [JSToken] = []
+            let count = length ?? items.count
+            if count > 1 { tokens.append(JSToken("(\(count)) ", .className)) }
+            tokens.append(JSToken("[", .punctuation))
+            for (index, item) in items.prefix(arrayLimit).enumerated() {
+                if index > 0 { tokens.append(JSToken(", ", .punctuation)) }
+                tokens.append(item.childToken)
+            }
+            if items.count > arrayLimit || truncated == true { tokens.append(JSToken(", …", .punctuation)) }
+            tokens.append(JSToken("]", .punctuation))
+            return tokens
+        }
+        let entries = entries ?? []
+        var tokens: [JSToken] = []
+        if let ctor, ctor != "Object" { tokens.append(JSToken("\(ctor) ", .className)) }
+        tokens.append(JSToken("{", .punctuation))
+        for (index, entry) in entries.prefix(objectLimit).enumerated() {
+            if index > 0 { tokens.append(JSToken(", ", .punctuation)) }
+            tokens.append(JSToken(entry.name, .key))
+            tokens.append(JSToken(": ", .punctuation))
+            tokens.append(entry.node.childToken)
+        }
+        if entries.count > objectLimit || truncated == true { tokens.append(JSToken(", …", .punctuation)) }
+        tokens.append(JSToken("}", .punctuation))
+        return tokens
+    }
+
+    /// How this node appears *inside* another node's preview: never recursive.
+    private var childToken: JSToken {
+        switch type {
+        case "array": JSToken("Array(\(length ?? items?.count ?? 0))", .className)
+        case "object":
+            (ctor ?? "Object") == "Object"
+                ? JSToken("{…}", .punctuation)
+                : JSToken(ctor ?? "Object", .className)
+        default: JSToken(primitivePreview, Self.tokenKind(type))
+        }
+    }
+
+    /// Total nodes in the subtree, bounded — the tree view uses it to decide
+    /// whether a value is big enough to deserve its own find field, so it stops
+    /// counting the moment the answer can't change.
+    func nodeCount(limit: Int = 1000) -> Int {
+        var total = 0
+        func walk(_ node: SnapNode) {
+            guard total < limit else { return }
+            total += 1
+            for entry in node.entries ?? [] { walk(entry.node) }
+            for item in node.items ?? [] { walk(item) }
+        }
+        walk(self)
+        return total
+    }
+
+    /// The token kind for a snapshot node's `type` string.
+    static func tokenKind(_ type: String) -> JSTokenKind {
+        switch type {
+        case "string": .string
+        case "number", "bigint": .number
+        case "boolean": .boolean
+        case "null": .null
+        case "undefined": .undefined
+        case "function": .function
+        case "symbol": .symbol
+        default: .plain
+        }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/TreeSearch.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/TreeSearch.swift
@@ -24,23 +24,6 @@ public struct TreeMatch: Sendable, Equatable {
 }
 
 public extension SnapNode {
-    /// Collapsed one-liner for a container node, e.g. `Array(200)`, `{3}`,
-    /// `Map {2}` — shared by the tree rows and the find-result previews.
-    var containerSummary: String {
-        if type == "array" {
-            return "Array(\(length ?? items?.count ?? 0))"
-        }
-        let count = entries?.count ?? 0
-        let ctor = ctor ?? "Object"
-        return ctor == "Object" ? "{\(count)}" : "\(ctor) {\(count)}"
-    }
-
-    /// Display text for a primitive node (strings quoted, like the tree rows).
-    var primitivePreview: String {
-        let text = text ?? "—"
-        return type == "string" ? "\"\(text)\"" : text
-    }
-
     /// Every descendant whose own key or primitive value contains `query`
     /// (case-insensitive), in render order, capped at `limit`. The root itself
     /// is never a match — it has no key of its own.

--- a/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CDPProtocolTests.swift
@@ -175,6 +175,10 @@ import Testing
         ]))
         let summary = huge.inlineSummary(limit: 100)
         #expect(summary == "\"" + String(repeating: "x", count: 100))
+        // A console argument's bounded head skips the opening quote too, so the
+        // filter matches the same text the bare row shows.
+        #expect(huge.inlineSummary(limit: 100, style: .consoleArgument)
+            == String(repeating: "x", count: 100))
         // Small values render exactly like the unbounded summary.
         let small = remote(#"{"type":"string","value":"hi"}"#)
         #expect(small.inlineSummary(limit: 100) == small.inlineSummary)
@@ -191,7 +195,7 @@ import Testing
     }
 
     @Test func inlineSummaryRendersPrimitives() {
-        #expect(remote(#"{"type":"string","value":"hi"}"#).inlineSummary == "\"hi\"")
+        #expect(remote(#"{"type":"string","value":"hi"}"#).inlineSummary == "'hi'")
         #expect(remote(#"{"type":"number","value":42}"#).inlineSummary == "42")
         #expect(remote(#"{"type":"number","value":3.5}"#).inlineSummary == "3.5")
         #expect(remote(#"{"type":"boolean","value":true}"#).inlineSummary == "true")
@@ -220,13 +224,83 @@ import Testing
          "description":"Array(3)","overflow":false,"properties":[{"name":"0","type":"number","value":"1"},
          {"name":"1","type":"string","value":"two"},{"name":"2","type":"object","value":"Array(2)"}]}}
         """#
-        #expect(remote(array).inlineSummary == "[1, \"two\", Array(2)]")
+        // Chrome leads a multi-element array with its length.
+        #expect(remote(array).inlineSummary == "(3) [1, 'two', Array(2)]")
 
         let object = #"""
         {"type":"object","className":"Object","description":"Object","preview":{"type":"object","description":"Object",
          "overflow":true,"properties":[{"name":"id","type":"number","value":"1"},{"name":"name","type":"string","value":"x"}]}}
         """#
-        #expect(remote(object).inlineSummary == "{id: 1, name: \"x\", …}")
+        #expect(remote(object).inlineSummary == "{id: 1, name: 'x', …}")
+    }
+
+    /// Chrome's array length prefix appears only where it says something: an
+    /// empty or single-element array reads fine without it.
+    @Test func arrayLengthPrefixOnlyForMultipleElements() {
+        func array(_ length: Int, _ properties: String) -> String {
+            #"""
+            {"type":"object","subtype":"array","description":"Array(\#(length))","preview":{"type":"object",
+             "subtype":"array","description":"Array(\#(length))","overflow":false,"properties":[\#(properties)]}}
+            """#
+        }
+        #expect(remote(array(0, "")).inlineSummary == "[]")
+        #expect(remote(array(1, #"{"name":"0","type":"number","value":"7"}"#)).inlineSummary == "[7]")
+        #expect(remote(array(2, #"{"name":"0","type":"number","value":"7"},{"name":"1","type":"number","value":"8"}"#))
+            .inlineSummary == "(2) [7, 8]")
+    }
+
+    /// A nested plain object is Chrome's `{…}`; a nested array or class instance
+    /// keeps the name Hermes reports.
+    @Test func nestedObjectsRenderAsChromeEllipsis() {
+        let object = #"""
+        {"type":"object","description":"Object","preview":{"type":"object","description":"Object","overflow":false,
+         "properties":[{"name":"meta","type":"object","value":"Object"},
+         {"name":"list","subtype":"array","type":"object","value":"Array(3)"},
+         {"name":"widget","type":"object","value":"Widget"},
+         {"name":"none","type":"object","subtype":"null","value":"null"}]}}
+        """#
+        #expect(remote(object).inlineSummary == "{meta: {…}, list: Array(3), widget: Widget, none: null}")
+    }
+
+    /// A top-level `console.log` string argument prints bare, the way Chrome
+    /// prints it; the same value quoted anywhere else.
+    @Test func consoleArgumentStringsPrintBare() {
+        let text = remote(#"{"type":"string","value":"[StreamLab] hello"}"#)
+        #expect(text.inlineSummary(style: .consoleArgument) == "[StreamLab] hello")
+        #expect(text.tokens(style: .consoleArgument).first?.kind == .plain)
+        #expect(text.inlineSummary(style: .value) == "'[StreamLab] hello'")
+        // Newlines survive a bare argument (Chrome prints a multi-line log
+        // across lines) and are escaped in the quoted form so a preview stays
+        // on one row.
+        let multiline = remote(#"{"type":"string","value":"a\nb"}"#)
+        #expect(multiline.inlineSummary(style: .consoleArgument) == "a\nb")
+        #expect(multiline.inlineSummary(style: .value) == "'a\\nb'")
+        // Only strings differ between the styles.
+        let number = remote(#"{"type":"number","value":42}"#)
+        #expect(number.inlineSummary(style: .consoleArgument) == number.inlineSummary)
+    }
+
+    /// The quoting rule: single quotes, switching to double when the text has
+    /// one of its own, and escapes so a value can't break its row.
+    @Test func stringQuotingFollowsChrome() {
+        #expect(RemoteObject.quoted("plain") == "'plain'")
+        #expect(RemoteObject.quoted("it's") == "\"it's\"")
+        #expect(RemoteObject.quoted("it's \"both\"") == #"'it\'s "both"'"#)
+        #expect(RemoteObject.quoted("tab\there") == #"'tab\there'"#)
+        #expect(RemoteObject.quoted(#"back\slash"#) == #"'back\\slash'"#)
+    }
+
+    /// Hermes replays its buffered console history without previews, so the
+    /// whole pre-connect backlog renders from the fallbacks alone.
+    @Test func objectsWithoutAPreviewFallBackTheWayChromeDoes() {
+        #expect(remote(#"{"type":"object","className":"Object","description":"Object","objectId":"1"}"#)
+            .inlineSummary == "{…}")
+        #expect(remote(#"{"type":"object","objectId":"1"}"#).inlineSummary == "{…}")
+        // An array or a class instance still names itself.
+        #expect(remote(#"{"type":"object","subtype":"array","description":"Array(2)","objectId":"1"}"#)
+            .inlineSummary == "Array(2)")
+        #expect(remote(#"{"type":"object","className":"Widget","description":"Object","objectId":"1"}"#)
+            .inlineSummary == "Widget")
     }
 
     @Test func tokensCarrySemanticKindsForColoring() {
@@ -237,10 +311,27 @@ import Testing
         let tokens = object.tokens
         #expect(tokens.contains { $0.text == "id" && $0.kind == .key })
         #expect(tokens.contains { $0.text == "1" && $0.kind == .number })
-        #expect(tokens.contains { $0.text == "\"x\"" && $0.kind == .string })
+        #expect(tokens.contains { $0.text == "'x'" && $0.kind == .string })
         #expect(remote(#"{"type":"string","value":"hi"}"#).tokens.first?.kind == .string)
         #expect(remote(#"{"type":"boolean","value":true}"#).tokens.first?.kind == .boolean)
         #expect(remote(#"{"type":"object","subtype":"null","value":null}"#).tokens.first?.kind == .null)
+    }
+
+    /// Metro's bundle URL carries a query string longer than the frame itself;
+    /// eight of those turn an unsymbolicated stack into a wall of parameters.
+    @Test func stackFrameDisplayNamesTheScriptNotItsURL() {
+        let bundle = "http://localhost:8081/index.bundle//&platform=android&dev=true&app=com.streamlab"
+        #expect(CDPCallFrame.scriptName(bundle) == "index.bundle")
+        #expect(CDPCallFrame.scriptName("http://h/a/b/main.js?v=2#frag") == "main.js")
+        #expect(CDPCallFrame.scriptName("plain.js") == "plain.js")
+        #expect(CDPCallFrame.scriptName("http://h/dir/") == "dir")
+        let frame = CDPCallFrame(json: .object([
+            "functionName": .string("emitLog"),
+            "url": .string(bundle),
+            "lineNumber": .number(87_065),
+            "columnNumber": .number(28),
+        ]))
+        #expect(frame.display == "emitLog  index.bundle:87066")
     }
 
     @Test func stackFrameDisplayIsOneBasedWithFile() {

--- a/ADBKit/Tests/ADBKitTests/ConsoleANSITests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleANSITests.swift
@@ -1,0 +1,54 @@
+@testable import ADBKit
+import Testing
+
+/// `ConsoleANSI` — terminal escape sequences in console text.
+struct ConsoleANSITests {
+    /// The real React Native dev-server notice, verbatim off the wire.
+    @Test func stripsTheReactNativeDevServerNotice() {
+        let raw = "\u{1B}[48;2;253;247;231m\u{1B}[30m\u{1B}[1mNOTE:\u{1B}[22m You are using an "
+            + "unsupported debugging client.\u{1B}[39m\u{1B}[49m"
+        #expect(ConsoleANSI.strip(raw) == "NOTE: You are using an unsupported debugging client.")
+    }
+
+    @Test func leavesPlainTextUntouched() {
+        #expect(ConsoleANSI.strip("plain text") == "plain text")
+        #expect(ConsoleANSI.strip("") == "")
+        #expect(ConsoleANSI.strip("brackets [1m] survive") == "brackets [1m] survive")
+        #expect(!ConsoleANSI.containsEscapes("plain"))
+        #expect(ConsoleANSI.containsEscapes("\u{1B}[1mbold"))
+    }
+
+    @Test func stripsEveryEscapeForm() {
+        // CSI with intermediates, cursor moves, erase.
+        #expect(ConsoleANSI.strip("a\u{1B}[2Jb\u{1B}[1;31mc\u{1B}[Kd") == "abcd")
+        // OSC terminated by BEL and by ST.
+        #expect(ConsoleANSI.strip("a\u{1B}]0;title\u{07}b") == "ab")
+        #expect(ConsoleANSI.strip("a\u{1B}]8;;https://x\u{1B}\\b") == "ab")
+        // Two-byte C1.
+        #expect(ConsoleANSI.strip("a\u{1B}Mb") == "ab")
+    }
+
+    /// A truncated sequence must not swallow the rest of the message — the text
+    /// after it is the part worth reading.
+    @Test func unterminatedSequencesKeepTheirText() {
+        #expect(ConsoleANSI.strip("head\u{1B}[48;2") == "head\u{1B}[48;2")
+        #expect(ConsoleANSI.strip("head\u{1B}]0;no-terminator") == "head\u{1B}]0;no-terminator")
+        #expect(ConsoleANSI.strip("trailing\u{1B}") == "trailing\u{1B}")
+    }
+
+    @Test func multiByteTextSurvives() {
+        #expect(ConsoleANSI.strip("\u{1B}[32m✅ déjà vu — 日本語\u{1B}[0m") == "✅ déjà vu — 日本語")
+    }
+
+    /// Console rows, search text, and copies all read the stripped form, so a
+    /// pasted log carries the message rather than the escapes.
+    @Test func consoleValuesRenderStripped() {
+        let object = RemoteObject(json: .object([
+            "type": .string("string"),
+            "value": .string("\u{1B}[1mNOTE:\u{1B}[22m hello"),
+        ]))
+        #expect(object.inlineSummary(style: .consoleArgument) == "NOTE: hello")
+        #expect(object.inlineSummary == "'NOTE: hello'")
+        #expect(object.inlineSummary(limit: 200, style: .consoleArgument) == "NOTE: hello")
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleArgumentsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleArgumentsTests.swift
@@ -1,0 +1,84 @@
+@testable import ADBKit
+import Foundation
+import Testing
+
+/// `ConsoleArguments` — how a console call's arguments split into the chunks the
+/// row renders and the clipboard carries.
+struct ConsoleArgumentsTests {
+    private func remote(_ json: String) -> RemoteObject {
+        RemoteObject(json: (try? JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))) ?? .null)
+    }
+
+    private var text: RemoteObject { remote(#"{"type":"string","value":"[app] loaded"}"#) }
+    private var number: RemoteObject { remote(#"{"type":"number","value":42}"#) }
+    private var object: RemoteObject {
+        remote(#"""
+        {"type":"object","className":"Object","description":"Object","objectId":"7","preview":{"type":"object",
+         "description":"Object","overflow":false,"properties":[{"name":"id","type":"number","value":"1"}]}}
+        """#)
+    }
+
+    private var array: RemoteObject {
+        remote(#"""
+        {"type":"object","subtype":"array","description":"Array(2)","objectId":"8","preview":{"type":"object",
+         "subtype":"array","description":"Array(2)","overflow":false,
+         "properties":[{"name":"0","type":"string","value":"a"},{"name":"1","type":"string","value":"b"}]}}
+        """#)
+    }
+
+    @Test func consecutiveScalarsRunTogetherAndObjectsStandAlone() {
+        let chunks = ConsoleArguments.chunks([text, number, object])
+        #expect(chunks.count == 2)
+        guard case let .scalars(tokens) = chunks[0] else {
+            Issue.record("expected a scalar run first")
+            return
+        }
+        // The separating space is already in the tokens.
+        #expect(tokens.map(\.text).joined() == "[app] loaded 42")
+        guard case .object = chunks[1] else {
+            Issue.record("expected the object to stand alone")
+            return
+        }
+    }
+
+    /// Argument order is preserved — an object logged first stays first.
+    @Test func chunksKeepArgumentOrder() {
+        let chunks = ConsoleArguments.chunks([object, text, array])
+        #expect(chunks.count == 3)
+        if case .object = chunks[0] {} else { Issue.record("object should lead") }
+        if case .scalars = chunks[1] {} else { Issue.record("scalars should follow") }
+        if case .object = chunks[2] {} else { Issue.record("array should trail") }
+    }
+
+    @Test func scalarOnlyAndEmptyCallsAreOneChunkOrNone() {
+        #expect(ConsoleArguments.chunks([]).isEmpty)
+        #expect(ConsoleArguments.chunks([text, number]).count == 1)
+        #expect(ConsoleArguments.chunks([object]).count == 1)
+    }
+
+    /// A copied log carries the data it was logged with: the message, then each
+    /// object's JSON. A pasted `{…}` is the one part of the row nobody can act on.
+    @Test func copyTextPutsTheMessageFirstAndEachObjectsJSONBelow() {
+        let chunks = ConsoleArguments.chunks([text, number, object])
+        let copied = ConsoleArguments.copyText(chunks, json: [1: #"{\#n  "id": 1\#n}"#])
+        #expect(copied == "[app] loaded 42\n{\n  \"id\": 1\n}")
+    }
+
+    @Test func copyTextKeepsEveryObjectOnItsOwnLine() {
+        let chunks = ConsoleArguments.chunks([text, array, object])
+        let copied = ConsoleArguments.copyText(chunks, json: [1: #"["a","b"]"#, 2: #"{"id":1}"#])
+        #expect(copied == "[app] loaded\n[\"a\",\"b\"]\n{\"id\":1}")
+    }
+
+    /// A value the runtime couldn't stringify still copies as something —
+    /// the preview beats an empty line.
+    @Test func copyTextFallsBackToThePreviewWhenAValueWontStringify() {
+        let chunks = ConsoleArguments.chunks([text, object])
+        #expect(ConsoleArguments.copyText(chunks, json: [:]) == "[app] loaded\n{id: 1}")
+    }
+
+    @Test func copyTextOfAScalarOnlyCallIsJustItsText() {
+        #expect(ConsoleArguments.copyText(ConsoleArguments.chunks([text, number]), json: [:]) == "[app] loaded 42")
+        #expect(ConsoleArguments.copyText([], json: [:]).isEmpty)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleGroupingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleGroupingTests.swift
@@ -1,0 +1,66 @@
+@testable import ADBKit
+import Testing
+
+/// `ConsoleGroupTracker` — the JS console's `console.group` nesting.
+struct ConsoleGroupingTests {
+    @Test func groupHeaderSitsAtTheOuterDepthAndItsRowsIndent() {
+        var tracker = ConsoleGroupTracker()
+        #expect(tracker.placement(for: "log", id: 1) == .entry(depth: 0, path: []))
+        #expect(tracker.placement(for: "startGroup", id: 2) == .groupStart(depth: 0, path: [], collapsed: false))
+        #expect(tracker.placement(for: "log", id: 3) == .entry(depth: 1, path: [2]))
+        #expect(tracker.placement(for: "startGroupCollapsed", id: 4)
+            == .groupStart(depth: 1, path: [2], collapsed: true))
+        #expect(tracker.placement(for: "log", id: 5) == .entry(depth: 2, path: [2, 4]))
+        #expect(tracker.placement(for: "endGroup", id: 6) == .groupEnd)
+        #expect(tracker.placement(for: "log", id: 7) == .entry(depth: 1, path: [2]))
+        #expect(tracker.placement(for: "endGroup", id: 8) == .groupEnd)
+        #expect(tracker.placement(for: "log", id: 9) == .entry(depth: 0, path: []))
+    }
+
+    /// `console.groupEnd` shows no row — rendering it produced the empty rows
+    /// that trailed every grouped burst.
+    @Test func groupEndNeverProducesARow() {
+        var tracker = ConsoleGroupTracker()
+        #expect(tracker.placement(for: "endGroup", id: 1) == .groupEnd)
+    }
+
+    /// An app that throws between `group` and `groupEnd` never closes it, and a
+    /// stray `groupEnd` is just as common — neither may drive the depth negative
+    /// or strand the rest of the feed indented.
+    @Test func unbalancedGroupsClampAndReset() {
+        var tracker = ConsoleGroupTracker()
+        _ = tracker.placement(for: "endGroup", id: 1)
+        _ = tracker.placement(for: "endGroup", id: 2)
+        #expect(tracker.depth == 0)
+        #expect(tracker.placement(for: "log", id: 3) == .entry(depth: 0, path: []))
+
+        _ = tracker.placement(for: "startGroup", id: 4)
+        _ = tracker.placement(for: "startGroup", id: 5)
+        #expect(tracker.depth == 2)
+        #expect(tracker.open == [4, 5])
+        tracker.reset()
+        #expect(tracker.placement(for: "log", id: 6) == .entry(depth: 0, path: []))
+    }
+
+    /// The path is what a collapsed header hides by: every row inside it, at
+    /// any nesting, names it.
+    @Test func everyRowInsideAGroupNamesIt() {
+        var tracker = ConsoleGroupTracker()
+        _ = tracker.placement(for: "startGroup", id: 10)
+        _ = tracker.placement(for: "startGroup", id: 20)
+        guard case let .entry(_, path) = tracker.placement(for: "log", id: 30) else {
+            Issue.record("expected an ordinary row")
+            return
+        }
+        #expect(path.contains(10))
+        #expect(path.contains(20))
+    }
+
+    @Test func everyOtherConsoleTypeIsAnOrdinaryRow() {
+        var tracker = ConsoleGroupTracker()
+        for type in ["log", "warning", "error", "info", "debug", "table", "assert", "dir", "trace"] {
+            #expect(tracker.placement(for: type, id: 1) == .entry(depth: 0, path: []),
+                    "\(type) should be an ordinary row")
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleTableTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleTableTests.swift
@@ -1,0 +1,116 @@
+@testable import ADBKit
+import Testing
+
+/// `ConsoleTable` — the grid `console.table(data)` prints.
+struct ConsoleTableTests {
+    private func node(_ json: String) -> SnapNode {
+        guard let node = SnapNode.parse(json) else {
+            Issue.record("fixture failed to parse")
+            return SnapNode.parse(#"{"type":"object","entries":[]}"#)!
+        }
+        return node
+    }
+
+    /// StreamLab's own call: `console.table([{endpoint, status, ms}, …])`.
+    @Test func arrayOfObjectsBecomesIndexedRows() {
+        let table = ConsoleTable.from(node("""
+        {"type":"array","length":2,"items":[
+          {"type":"object","ctor":"Object","entries":[
+            {"name":"endpoint","node":{"type":"string","text":"/users"}},
+            {"name":"status","node":{"type":"number","text":"200"}}]},
+          {"type":"object","ctor":"Object","entries":[
+            {"name":"endpoint","node":{"type":"string","text":"/broken"}},
+            {"name":"status","node":{"type":"number","text":"404"}}]}
+        ]}
+        """))
+        #expect(table?.columns == ["endpoint", "status"])
+        #expect(table?.rows.map(\.index) == ["0", "1"])
+        #expect(table?.rows[0].cells == ["'/users'", "200"])
+        #expect(table?.rows[1].cells == ["'/broken'", "404"])
+        #expect(table?.hasValueColumn == false)
+        #expect(table?.hiddenRows == 0)
+    }
+
+    /// Columns are the union across rows, in first-seen order, and a row missing
+    /// one leaves the cell blank rather than shifting the others.
+    @Test func columnsUniteInFirstSeenOrder() {
+        let table = ConsoleTable.from(node("""
+        {"type":"array","length":2,"items":[
+          {"type":"object","ctor":"Object","entries":[
+            {"name":"a","node":{"type":"number","text":"1"}},
+            {"name":"b","node":{"type":"number","text":"2"}}]},
+          {"type":"object","ctor":"Object","entries":[
+            {"name":"b","node":{"type":"number","text":"3"}},
+            {"name":"c","node":{"type":"number","text":"4"}}]}
+        ]}
+        """))
+        #expect(table?.columns == ["a", "b", "c"])
+        #expect(table?.rows[0].cells == ["1", "2", ""])
+        #expect(table?.rows[1].cells == ["", "3", "4"])
+    }
+
+    /// A primitive element gets Chrome's single `Value` column instead of
+    /// inventing keys for it.
+    @Test func primitiveRowsUseTheValueColumn() {
+        let table = ConsoleTable.from(node("""
+        {"type":"array","length":2,"items":[
+          {"type":"object","ctor":"Object","entries":[{"name":"a","node":{"type":"number","text":"1"}}]},
+          {"type":"string","text":"loose"}
+        ]}
+        """))
+        #expect(table?.hasValueColumn == true)
+        #expect(table?.rows[1].value == "'loose'")
+        #expect(table?.rows[1].cells == [""])
+        #expect(table?.rows[0].value == nil)
+    }
+
+    /// An object argument indexes by key, the way Chrome labels those rows.
+    @Test func objectArgumentIndexesByKey() {
+        let table = ConsoleTable.from(node("""
+        {"type":"object","ctor":"Object","entries":[
+          {"name":"first","node":{"type":"object","ctor":"Object","entries":[
+            {"name":"ok","node":{"type":"boolean","text":"true"}}]}},
+          {"name":"second","node":{"type":"object","ctor":"Object","entries":[
+            {"name":"ok","node":{"type":"boolean","text":"false"}}]}}
+        ]}
+        """))
+        #expect(table?.rows.map(\.index) == ["first", "second"])
+        #expect(table?.columns == ["ok"])
+        #expect(table?.rows.map(\.cells) == [["true"], ["false"]])
+    }
+
+    /// Nested values collapse to one line — the disclosure under the table is
+    /// where you open one.
+    @Test func nestedCellsCollapseToOneLine() {
+        let table = ConsoleTable.from(node("""
+        {"type":"array","length":1,"items":[
+          {"type":"object","ctor":"Object","entries":[
+            {"name":"nested","node":{"type":"object","ctor":"Object","entries":[]}},
+            {"name":"list","node":{"type":"array","length":3,"items":[]}},
+            {"name":"inst","node":{"type":"object","ctor":"Widget","entries":[]}}]}
+        ]}
+        """))
+        #expect(table?.rows[0].cells == ["{…}", "Array(3)", "Widget"])
+    }
+
+    @Test func nonTabularAndEmptyValuesHaveNoTable() {
+        #expect(ConsoleTable.from(node(#"{"type":"string","text":"hi"}"#)) == nil)
+        #expect(ConsoleTable.from(node(#"{"type":"array","length":0,"items":[]}"#)) == nil)
+        #expect(ConsoleTable.from(node(#"{"type":"object","ctor":"Object","entries":[]}"#)) == nil)
+    }
+
+    /// A `console.table` of a huge array must not build a thousand-column grid,
+    /// and the rows it doesn't draw are counted so the view can say so.
+    @Test func rowsAndColumnsAreCapped() {
+        let keys = (0 ..< 8).map { #"{"name":"k\#($0)","node":{"type":"number","text":"1"}}"# }
+        let row = #"{"type":"object","ctor":"Object","entries":[\#(keys.joined(separator: ","))]}"#
+        let items = Array(repeating: row, count: 30).joined(separator: ",")
+        let table = ConsoleTable.from(
+            node(#"{"type":"array","length":30,"items":[\#(items)]}"#), columnLimit: 5, rowLimit: 4
+        )
+        #expect(table?.columns == ["k0", "k1", "k2", "k3", "k4"])
+        #expect(table?.rows.count == 4)
+        #expect(table?.rows[0].cells.count == 5)
+        #expect(table?.hiddenRows == 26)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MetroSymbolicatorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MetroSymbolicatorTests.swift
@@ -1,0 +1,146 @@
+@testable import ADBKit
+import Foundation
+import Testing
+
+/// `MetroSymbolicator` — resolving a console call's bundle coordinates back to
+/// the file the developer wrote, through Metro's `/symbolicate` endpoint.
+/// Payloads here are recorded from a live Metro (React Native 0.82, Hermes).
+struct MetroSymbolicatorTests {
+    private let bundleURL = "http://localhost:8081/index.bundle//&platform=android&dev=true&app=com.streamlab"
+
+    private func frame(_ line: Int, column: Int = 28, function: String = "anonymous", url: String? = nil) -> CDPCallFrame {
+        CDPCallFrame(json: .object([
+            "functionName": .string(function),
+            "url": .string(url ?? bundleURL),
+            "lineNumber": .number(Double(line)),
+            "columnNumber": .number(Double(column)),
+        ]))
+    }
+
+    /// CDP counts lines from zero and Metro from one. Getting this wrong points
+    /// at the wrong source line instead of failing, so it's asserted directly.
+    @Test func requestBodyIncrementsLineNumbersForMetro() throws {
+        let body = MetroSymbolicator.requestBody([frame(87_065, column: 28, function: "emitLog")])
+        let root = try JSONDecoder().decode(JSONValue.self, from: body)
+        let entry = try #require(root["stack"]?.arrayValue?.first)
+        #expect(entry["lineNumber"]?.intValue == 87_066)
+        #expect(entry["column"]?.intValue == 28)
+        #expect(entry["file"]?.stringValue == bundleURL)
+        #expect(entry["methodName"]?.stringValue == "emitLog")
+    }
+
+    @Test func requestBodyNamesAnonymousFrames() throws {
+        let body = MetroSymbolicator.requestBody([frame(1, function: "")])
+        let root = try JSONDecoder().decode(JSONValue.self, from: body)
+        #expect(root["stack"]?.arrayValue?.first?["methodName"]?.stringValue == "(anonymous)")
+    }
+
+    /// Hermes tops some stacks with a `global` frame carrying no URL; Metro
+    /// can't resolve one and it would only waste the request.
+    @Test func framesWithoutAURLAreNotSent() {
+        let frames = [frame(1), frame(2, url: ""), frame(3)]
+        let sendable = MetroSymbolicator.sendableFrames(frames)
+        #expect(sendable.count == 2)
+        #expect(sendable.map(\.lineNumber) == [1, 3])
+        #expect(MetroSymbolicator.sendableFrames(Array(repeating: frame(1), count: 40), limit: 8).count == 8)
+        #expect(MetroSymbolicator.sendableFrames([]).isEmpty)
+    }
+
+    /// The same call site must key to the same cache entry, and different ones
+    /// must not collide.
+    @Test func cacheKeyFollowsTheFrameCoordinates() {
+        #expect(MetroSymbolicator.cacheKey([frame(10)]) == MetroSymbolicator.cacheKey([frame(10)]))
+        #expect(MetroSymbolicator.cacheKey([frame(10)]) != MetroSymbolicator.cacheKey([frame(11)]))
+        #expect(MetroSymbolicator.cacheKey([frame(10, column: 1)]) != MetroSymbolicator.cacheKey([frame(10, column: 2)]))
+        #expect(MetroSymbolicator.cacheKey([frame(10)]) != MetroSymbolicator.cacheKey([frame(10), frame(11)]))
+    }
+
+    /// A real `/symbolicate` reply: React Native's console plumbing arrives
+    /// flagged `collapse`, and the app's own frame is the one Chrome names.
+    @Test func picksTheFirstFrameTheAppOwns() {
+        let recorded = """
+        {"codeFrame":null,"stack":[
+          {"file":"/w/node_modules/@react-native/js-polyfills/console.js","lineNumber":667,"column":37,
+           "methodName":"methodName","collapse":true},
+          {"file":"/w/node_modules/reactotron-react-native/dist/plugins/trackGlobalLogs.js","lineNumber":18,
+           "column":26,"methodName":"console.log","collapse":false},
+          {"file":"/w/src/StreamScreen.tsx","lineNumber":142,"column":10,"methodName":"emitComplexLog",
+           "collapse":false}
+        ]}
+        """
+        let frames = MetroSymbolicator.parse(Data(recorded.utf8))
+        #expect(frames.count == 3)
+        #expect(frames[0].collapse)
+        let location = try? #require(MetroSymbolicator.location(in: frames))
+        #expect(location?.file == "/w/src/StreamScreen.tsx")
+        #expect(location?.line == 142)
+        #expect(location?.function == "emitComplexLog")
+        #expect(location?.label == "StreamScreen.tsx:142")
+    }
+
+    /// A log genuinely emitted from inside a dependency has no app frame — name
+    /// the library rather than showing nothing.
+    @Test func fallsBackWhenEveryFrameIsALibrary() {
+        let json = """
+        {"stack":[
+          {"file":"/w/node_modules/a/index.js","lineNumber":3,"column":1,"methodName":"warn","collapse":true},
+          {"file":"/w/node_modules/b/index.js","lineNumber":9,"column":1,"methodName":"emit","collapse":false}
+        ]}
+        """
+        let location = MetroSymbolicator.location(in: MetroSymbolicator.parse(Data(json.utf8)))
+        #expect(location?.label == "index.js:9")
+
+        let allCollapsed = """
+        {"stack":[{"file":"/w/node_modules/a/index.js","lineNumber":3,"column":1,"methodName":"w","collapse":true}]}
+        """
+        #expect(MetroSymbolicator.location(in: MetroSymbolicator.parse(Data(allCollapsed.utf8)))?.label == "index.js:3")
+    }
+
+    @Test func malformedAndEmptyRepliesResolveToNothing() {
+        #expect(MetroSymbolicator.parse(Data("not json".utf8)).isEmpty)
+        #expect(MetroSymbolicator.parse(Data(#"{"stack":[]}"#.utf8)).isEmpty)
+        #expect(MetroSymbolicator.parse(Data(#"{}"#.utf8)).isEmpty)
+        // Metro answers an unresolvable frame with an empty file — nothing to name.
+        #expect(MetroSymbolicator.parse(Data(#"{"stack":[{"file":"","lineNumber":1}]}"#.utf8)).isEmpty)
+        #expect(MetroSymbolicator.location(in: []) == nil)
+    }
+
+    /// A resolved stack reads as source lines, with the frames the reader
+    /// didn't write marked so the view can dim them.
+    @Test func resolvedFramesReadAsSourceLines() {
+        let json = """
+        {"stack":[
+          {"file":"/w/node_modules/@react-native/js-polyfills/console.js","lineNumber":667,"column":37,
+           "methodName":"methodName","collapse":true},
+          {"file":"/w/src/StreamScreen.tsx","lineNumber":192,"column":10,"methodName":"emitComplexError",
+           "collapse":false},
+          {"file":"/w/src/App.tsx","lineNumber":15,"column":2,"methodName":"","collapse":false}
+        ]}
+        """
+        let frames = MetroSymbolicator.parse(Data(json.utf8))
+        #expect(frames[0].display == "methodName  console.js:667")
+        #expect(frames[0].isLibrary)
+        #expect(frames[1].display == "emitComplexError  StreamScreen.tsx:192")
+        #expect(!frames[1].isLibrary)
+        // An anonymous frame is named, not blank.
+        #expect(frames[2].display == "(anonymous)  App.tsx:15")
+        // Identity survives a re-render without collapsing distinct frames.
+        #expect(Set(frames.map(\.id)).count == 3)
+    }
+
+    @Test func dependencyPathsAreRecognizedAnywhereInTheTree() {
+        #expect(MetroSymbolicator.isDependency("/w/node_modules/react-native/index.js"))
+        #expect(MetroSymbolicator.isDependency("/w/packages/app/node_modules/x/y.js"))
+        #expect(!MetroSymbolicator.isDependency("/w/src/node_modules_helper.ts"))
+        #expect(!MetroSymbolicator.isDependency("/w/src/StreamScreen.tsx"))
+    }
+
+    /// Nothing to symbolicate must never reach the network.
+    @Test func emptyStacksResolveWithoutARequest() async {
+        // Port 1 has nothing listening; a request would fail slowly instead of
+        // returning at once.
+        let symbolicator = MetroSymbolicator(port: 1, timeout: 30)
+        #expect(await symbolicator.symbolicate([]).isEmpty)
+        #expect(await symbolicator.symbolicate([frame(1, url: "")]).isEmpty)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MetroSymbolicatorTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MetroSymbolicatorTests.swift
@@ -71,7 +71,7 @@ struct MetroSymbolicatorTests {
         let frames = MetroSymbolicator.parse(Data(recorded.utf8))
         #expect(frames.count == 3)
         #expect(frames[0].collapse)
-        let location = try? #require(MetroSymbolicator.location(in: frames))
+        let location = MetroSymbolicator.location(in: frames)
         #expect(location?.file == "/w/src/StreamScreen.tsx")
         #expect(location?.line == 142)
         #expect(location?.function == "emitComplexLog")
@@ -126,6 +126,17 @@ struct MetroSymbolicatorTests {
         #expect(frames[2].display == "(anonymous)  App.tsx:15")
         // Identity survives a re-render without collapsing distinct frames.
         #expect(Set(frames.map(\.id)).count == 3)
+    }
+
+    /// The label's file name, without `NSString` bridging — ADBKit compiles for
+    /// Linux and Windows, and the path is whatever the machine running Metro
+    /// reports.
+    @Test func fileNameTakesTheLastPathComponent() {
+        #expect(MetroSymbolicator.fileName("/w/src/StreamScreen.tsx") == "StreamScreen.tsx")
+        #expect(MetroSymbolicator.fileName(#"D:\w\src\App.tsx"#) == "App.tsx")
+        #expect(MetroSymbolicator.fileName("bare.js") == "bare.js")
+        #expect(MetroSymbolicator.fileName("") == "")
+        #expect(MetroSymbolicator.fileName("/") == "/")
     }
 
     @Test func dependencyPathsAreRecognizedAnywhereInTheTree() {

--- a/ADBKit/Tests/ADBKitTests/SnapNodeDisplayTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SnapNodeDisplayTests.swift
@@ -1,0 +1,103 @@
+@testable import ADBKit
+import Testing
+
+/// `SnapNode` display — the one-line previews of an expanded value's collapsed
+/// rows, which Chrome fills with the node's own first few children rather than a
+/// count.
+struct SnapNodeDisplayTests {
+    private func node(_ json: String) -> SnapNode {
+        guard let node = SnapNode.parse(json) else {
+            Issue.record("fixture failed to parse")
+            return SnapNode.parse(#"{"type":"object","entries":[]}"#)!
+        }
+        return node
+    }
+
+    private func text(_ node: SnapNode) -> String {
+        node.previewTokens().map(\.text).joined()
+    }
+
+    @Test func objectPreviewShowsItsFirstProperties() {
+        let root = node("""
+        {"type":"object","ctor":"Object","entries":[
+          {"name":"at","node":{"type":"string","text":"2026-08-07"}},
+          {"name":"session","node":{"type":"object","ctor":"Object","entries":[
+            {"name":"id","node":{"type":"string","text":"s1"}}]}},
+          {"name":"tags","node":{"type":"array","length":3,"items":[
+            {"type":"string","text":"a"},{"type":"string","text":"b"},{"type":"string","text":"c"}]}},
+          {"name":"ok","node":{"type":"boolean","text":"true"}}
+        ]}
+        """)
+        // Nested containers stop at one level so the preview stays a single line.
+        #expect(text(root) == "{at: '2026-08-07', session: {…}, tags: Array(3), ok: true}")
+    }
+
+    @Test func objectPreviewCapsItsPropertiesAndMarksTheRest() {
+        let entries = (0 ..< 8).map { #"{"name":"k\#($0)","node":{"type":"number","text":"\#($0)"}}"# }
+        let root = node(#"{"type":"object","ctor":"Object","entries":[\#(entries.joined(separator: ","))]}"#)
+        #expect(text(root) == "{k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, …}")
+        // A level the device already cut is marked even when it fits.
+        let cut = node(#"""
+        {"type":"object","ctor":"Object","truncated":true,"entries":[
+          {"name":"a","node":{"type":"number","text":"1"}}]}
+        """#)
+        #expect(text(cut) == "{a: 1, …}")
+    }
+
+    @Test func arrayPreviewLeadsWithItsLength() {
+        let two = node(#"""
+        {"type":"array","length":2,"items":[{"type":"number","text":"1"},{"type":"string","text":"two"}]}
+        """#)
+        #expect(text(two) == "(2) [1, 'two']")
+        #expect(text(node(#"{"type":"array","length":1,"items":[{"type":"number","text":"1"}]}"#)) == "[1]")
+        #expect(text(node(#"{"type":"array","length":0,"items":[]}"#)) == "[]")
+        // The reported length wins over the items actually sent.
+        let capped = node(#"""
+        {"type":"array","length":500,"truncated":true,"items":[{"type":"number","text":"1"}]}
+        """#)
+        #expect(text(capped) == "(500) [1, …]")
+    }
+
+    @Test func classInstancesKeepTheirConstructorName() {
+        let root = node(#"""
+        {"type":"object","ctor":"Widget","entries":[{"name":"id","node":{"type":"number","text":"1"}}]}
+        """#)
+        #expect(text(root) == "Widget {id: 1}")
+        let nested = node(#"""
+        {"type":"object","ctor":"Object","entries":[
+          {"name":"w","node":{"type":"object","ctor":"Widget","entries":[]}}]}
+        """#)
+        #expect(text(nested) == "{w: Widget}")
+    }
+
+    @Test func primitivesPreviewAsThemselvesWithTheirKind() {
+        #expect(text(node(#"{"type":"string","text":"hi"}"#)) == "'hi'")
+        #expect(text(node(#"{"type":"number","text":"42"}"#)) == "42")
+        #expect(node(#"{"type":"number","text":"42"}"#).previewTokens().first?.kind == .number)
+        #expect(node(#"{"type":"string","text":"hi"}"#).previewTokens().first?.kind == .string)
+        #expect(node(#"{"type":"null","text":"null"}"#).previewTokens().first?.kind == .null)
+    }
+
+    /// Quoting matches the collapsed row's, so an expanded value doesn't
+    /// suddenly render its strings a different way.
+    @Test func treeStringsQuoteLikeTheConsoleRows() {
+        #expect(node(#"{"type":"string","text":"hi"}"#).primitivePreview == "'hi'")
+        #expect(node(#"{"type":"string","text":"it's"}"#).primitivePreview == "\"it's\"")
+        #expect(node(#"{"type":"number","text":"7"}"#).primitivePreview == "7")
+    }
+
+    @Test func nodeCountMeasuresTheSubtreeAndStopsAtItsLimit() {
+        let flat = node(#"""
+        {"type":"object","ctor":"Object","entries":[
+          {"name":"a","node":{"type":"number","text":"1"}},
+          {"name":"b","node":{"type":"number","text":"2"}}]}
+        """#)
+        #expect(flat.nodeCount() == 3)
+        #expect(node(#"{"type":"number","text":"1"}"#).nodeCount() == 1)
+
+        let items = (0 ..< 50).map { #"{"type":"number","text":"\#($0)"}"# }.joined(separator: ",")
+        let wide = node(#"{"type":"array","length":50,"items":[\#(items)]}"#)
+        #expect(wide.nodeCount() == 51)
+        #expect(wide.nodeCount(limit: 10) == 10)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TreeSearchTests.swift
@@ -30,7 +30,7 @@ struct SnapNodeFindMatchesTests {
         #expect(matches.count == 1)
         #expect(matches[0].path == [0, 0])
         #expect(matches[0].displayPath == "user.name")
-        #expect(matches[0].preview == "\"Ada\"")
+        #expect(matches[0].preview == "'Ada'")
         #expect(matches[0].isContainer == false)
     }
 

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -1,0 +1,871 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+// MARK: - Row layout
+
+/// A wrapping row of console segments — Chrome puts a log's whole argument list
+/// on one line (`[app] loaded ▶ {id: 1} ▶ (2) ['a', 'b']`) and only wraps when
+/// it runs out of width, rather than stacking each object on a line of its own.
+///
+/// Segments are laid out on their first text baseline so a disclosure triangle,
+/// a run of scalars, and an object preview sit on one visual line.
+struct ConsoleFlowLayout: Layout {
+    var spacing: CGFloat = 5
+    var lineSpacing: CGFloat = 3
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout Void) -> CGSize {
+        arrange(subviews, maxWidth: proposal.width ?? .infinity).size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout Void) {
+        let placement = arrange(subviews, maxWidth: proposal.width ?? bounds.width)
+        for (index, subview) in subviews.enumerated() {
+            let frame = placement.frames[index]
+            subview.place(
+                at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY + frame.minY),
+                proposal: ProposedViewSize(width: frame.width, height: frame.height)
+            )
+        }
+    }
+
+    private func arrange(_ subviews: Subviews, maxWidth: CGFloat) -> (frames: [CGRect], size: CGSize) {
+        var frames: [CGRect] = []
+        var rowStart = 0
+        var rowBaseline: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var baselines: [CGFloat] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var widest: CGFloat = 0
+
+        /// Shift a finished row's segments down onto a shared baseline.
+        func settleRow(through index: Int) {
+            for slot in rowStart ..< index {
+                frames[slot].origin.y = y + rowBaseline - baselines[slot]
+            }
+            y += rowHeight + lineSpacing
+        }
+
+        for subview in subviews {
+            let dimensions = subview.dimensions(in: ProposedViewSize(width: maxWidth, height: nil))
+            let size = CGSize(width: dimensions.width, height: dimensions.height)
+            let baseline = dimensions[VerticalAlignment.firstTextBaseline]
+            if x > 0, x + size.width > maxWidth + 0.5 {
+                settleRow(through: frames.count)
+                rowStart = frames.count
+                rowBaseline = 0
+                rowHeight = 0
+                x = 0
+            }
+            frames.append(CGRect(x: x, y: 0, width: size.width, height: size.height))
+            baselines.append(baseline)
+            rowBaseline = max(rowBaseline, baseline)
+            rowHeight = max(rowHeight, size.height + max(0, rowBaseline - baseline))
+            x += size.width + spacing
+            widest = max(widest, x - spacing)
+        }
+        guard !frames.isEmpty else { return ([], .zero) }
+        settleRow(through: frames.count)
+        return (frames, CGSize(width: min(widest, maxWidth), height: max(0, y - lineSpacing)))
+    }
+}
+
+// MARK: - Entry row
+
+/// One console line: the level glyph, the message and its inline object
+/// previews, whatever objects the reader expanded, and — at the right edge, the
+/// way Chrome ends every row — where the call was made.
+struct JSEntryRow: View {
+    let entry: JSEntry
+    let session: JSConsoleSession
+    @State private var hovering = false
+    @State private var copied = false
+    /// Per-argument disclosure state. It lives on the row rather than inside
+    /// each value because the collapsed preview sits inline in the message line
+    /// while its expanded tree renders below the whole line — two places that
+    /// can't share a child view's own `@State`.
+    @State private var expansion: [Int: ArgExpansion] = [:]
+    /// The call's stack resolved back to source files, empty until Metro
+    /// answers (or forever, when it can't).
+    @State private var symbolicatedStack: [SymbolicatedFrame] = []
+    @State private var stackShown = false
+    /// The grid for a `console.table` row, which Chrome draws above the value's
+    /// own disclosure.
+    @State private var table: ConsoleTable?
+    @Environment(\.logTailScrollToHeader) private var scrollToHeader
+    @Environment(\.logTailPauseFollow) private var pauseFollow
+
+    private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
+    private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
+
+    /// Disclosure state for one expandable argument.
+    private struct ArgExpansion {
+        var expanded = false
+        var snapshot: SnapNode?
+        var loading = false
+        var failed = false
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            groupIndent
+            glyph
+            VStack(alignment: .leading, spacing: 3) {
+                if let table { ConsoleTableView(table: table) }
+                ConsoleFlowLayout { messageSegments }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                expandedObjects
+                // Chrome keeps a console call's stack folded behind its source
+                // link — unfolding every error's would bury the message under
+                // eight frames of framework plumbing. A thrown exception is the
+                // exception: there the frames *are* the message.
+                if stackShown || isThrownException, let stack = entry.stack {
+                    StackView(stack: stack, symbolicated: symbolicatedStack)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            // Always in the layout — hidden, not removed, when idle — so
+            // hovering can't change the row's width and reflow its text.
+            copyButtons
+                .opacity(hovering || copied ? 1 : 0)
+                .allowsHitTesting(hovering || copied)
+            trailingLocation
+        }
+        .contentShape(Rectangle())
+        // The row's own click sits *behind* its content rather than over it, so
+        // it can never compete with the copy icons, the source link, or a
+        // disclosure inside an expanded value — those get every click that
+        // lands on one, and the row keeps the rest.
+        //
+        // And it only ever *opens* the first object. A click that also
+        // collapsed would fire from anywhere inside the expanded tree —
+        // including a nested leaf — and fold the whole thing back up under the
+        // reader.
+        .background {
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture { expandPrimaryObject() }
+        }
+        .onHover { hovering = $0 }
+        // Hovering the row is what reveals its URLs' underlines.
+        .environment(\.consoleLinkUnderline, hovering)
+        .contextMenu { copyMenu }
+        .task(id: entry.id) { symbolicatedStack = await session.symbolicated(entry.stack) }
+        .task(id: entry.id) {
+            guard let objectId = tableArgumentID else { return }
+            table = await session.table(for: entry.id, objectId: objectId)
+        }
+    }
+
+    /// An uncaught exception — the only row whose stack shows unasked.
+    private var isThrownException: Bool {
+        if case .evalError = entry.kind { return true }
+        return false
+    }
+
+    private var source: ConsoleSourceLocation? { MetroSymbolicator.location(in: symbolicatedStack) }
+
+    /// The handle behind a `console.table` call's data, when this row is one.
+    private var tableArgumentID: String? {
+        guard case let .log(_, args, _, isTable) = entry.kind, isTable else { return nil }
+        return args.first(where: \.isExpandable)?.objectId
+    }
+
+    // MARK: Message segments
+
+    /// The row's message as flow segments: runs of scalars merge into one text
+    /// block, each expandable object becomes its own inline disclosure.
+    @ViewBuilder private var messageSegments: some View {
+        switch entry.kind {
+        case let .input(text):
+            line(text, base: JSConsoleTheme.muted)
+        case let .notice(text):
+            line(text, base: JSConsoleTheme.muted)
+        case let .evalError(details):
+            line(details.message, base: JSConsoleTheme.errorText)
+        case let .result(object):
+            valueSegment(index: 0, object: object, style: .value, tint: nil)
+        case let .log(level, args, _, _):
+            let tint: Color? = (level == .error || level == .warning) ? level.consoleTextColor : nil
+            ForEach(argRows(args)) { row in
+                switch row.kind {
+                case let .scalars(tokens):
+                    scalarSegment(tokens, tint: tint)
+                case let .object(object):
+                    valueSegment(index: row.id, object: object, style: .consoleArgument, tint: tint)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func scalarSegment(_ tokens: [JSToken], tint: Color?) -> some View {
+        if let tint {
+            line(tokens.map(\.text).joined(), base: tint)
+        } else {
+            coloredTokenText(tokens, query: query, current: isCurrentFind, underlineLinks: hovering)
+                .font(.app(.callout, design: .monospaced))
+                .lineSpacing(2)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// A group header is its own toggle: Chrome folds the block from the header
+    /// row, and the triangle says which way it goes.
+    @ViewBuilder private func valueSegment(
+        index: Int, object: RemoteObject, style: JSRenderStyle, tint: Color?
+    ) -> some View {
+        if object.isExpandable {
+            Button {
+                toggle(index, object: object)
+            } label: {
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    disclosureTriangle(open: expansion[index]?.expanded == true)
+                    coloredTokenText(
+                        object.tokens(style: style), query: query, current: false, underlineLinks: hovering
+                    )
+                    .font(.app(.callout, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Show this value's properties")
+        } else {
+            scalarSegment(object.tokens(style: style), tint: tint)
+        }
+    }
+
+    /// Every expanded argument's tree, below the message line the way Chrome
+    /// renders one.
+    @ViewBuilder private var expandedObjects: some View {
+        ForEach(expandedIndices, id: \.self) { index in
+            if let state = expansion[index] {
+                if state.loading {
+                    ProgressView().controlSize(.small)
+                } else if let snapshot = state.snapshot {
+                    ExpandedTree(node: snapshot, session: session)
+                        .padding(.leading, 14)
+                } else if state.failed {
+                    Text("Couldn't read this value.").font(.app(.caption)).foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    private var expandedIndices: [Int] {
+        expansion.filter(\.value.expanded).keys.sorted()
+    }
+
+    // MARK: Gutter, glyph, trailing edge
+
+    /// Chrome's group nesting: an indent per level with a rule down the left of
+    /// the block. Capped so a runaway `console.group` can't push a narrow pane's
+    /// text off the right edge.
+    @ViewBuilder private var groupIndent: some View {
+        let levels = min(entry.group.depth, 6)
+        if levels > 0 {
+            HStack(spacing: 0) {
+                ForEach(0 ..< levels, id: \.self) { _ in
+                    Rectangle()
+                        .fill(JSConsoleTheme.muted.opacity(0.35))
+                        .frame(width: 1)
+                        .padding(.leading, 11)
+                        .padding(.trailing, 4)
+                }
+            }
+            .frame(height: 14)
+        }
+    }
+
+    /// Chrome marks only the levels that need marking — errors and warnings.
+    /// A log/info/debug row starts at its text, so a plain feed reads as text
+    /// rather than a column of identical glyphs; the gutter stays reserved so
+    /// nothing shifts when one arrives.
+    @ViewBuilder private var glyph: some View {
+        switch entry.kind {
+        case .input:
+            icon("chevron.right", JSConsoleTheme.muted)
+        case .result:
+            icon("arrow.turn.down.right", JSConsoleTheme.muted)
+        case .evalError:
+            icon("xmark.octagon.fill", JSConsoleTheme.errorText)
+        case .notice:
+            icon("info.circle", JSConsoleTheme.muted)
+        case let .log(level, _, _, _):
+            if entry.group.isHeader {
+                Button { session.toggleGroup(entry.id) } label: {
+                    disclosureTriangle(open: !session.isGroupCollapsed(entry.id))
+                        .frame(width: 14)
+                        .padding(.top, 3)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(session.isGroupCollapsed(entry.id) ? "Expand this group" : "Collapse this group")
+            } else if level == .error || level == .warning {
+                icon(level.icon, level.consoleIconColor)
+            } else {
+                Color.clear.frame(width: 14, height: 1)
+            }
+        }
+    }
+
+    private func icon(_ name: String, _ style: some ShapeStyle) -> some View {
+        Image(systemName: name)
+            .font(.app(.caption))
+            .foregroundStyle(style)
+            .frame(width: 14)
+            .padding(.top, 2)
+    }
+
+    private func disclosureTriangle(open: Bool) -> some View {
+        Image(systemName: open ? "arrowtriangle.down.fill" : "arrowtriangle.right.fill")
+            .font(.app(size: 8))
+            .foregroundStyle(JSConsoleTheme.muted)
+    }
+
+    /// The right edge: where the call was made, then the clock. Chrome's source
+    /// link is the anchor people scan for, so it leads; clicking it opens the
+    /// rest of the stack, which is the question the file name raises.
+    private var trailingLocation: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            if let source {
+                Button { stackShown.toggle() } label: {
+                    Text(source.label)
+                        .font(.app(.caption2).monospacedDigit())
+                        .foregroundStyle(JSConsoleTheme.sourceLink)
+                        .underline(hovering)
+                        .lineLimit(1)
+                }
+                .buttonStyle(.plain)
+                .help("\(source.function.isEmpty ? "" : source.function + "  ")\(source.file) — click for the full stack")
+            }
+            Text(entry.at, format: .dateTime.hour().minute().second())
+                .font(.app(.caption2).monospacedDigit())
+                .foregroundStyle(JSConsoleTheme.muted)
+        }
+        .fixedSize()
+        .padding(.top, 1)
+    }
+
+    // MARK: Copy
+
+    /// Two affordances rather than one, because a row that carries an object is
+    /// really two things: the whole log — message *and* the data it was logged
+    /// with — and just the data, for pasting somewhere that wants JSON.
+    @ViewBuilder private var copyButtons: some View {
+        HStack(spacing: 6) {
+            Button(action: copyLog) {
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .font(.app(.caption))
+                    .foregroundStyle(copied ? .green : JSConsoleTheme.muted)
+                    // Fixed footprint for both glyphs, so neither hover nor the
+                    // copy→checkmark swap nudges the layout.
+                    .frame(width: 14)
+            }
+            .buttonStyle(.plain)
+            .help(primaryObjectID == nil
+                ? "Copy this log"
+                : "Copy this log — the message and the whole object")
+
+            if primaryObjectID != nil {
+                Button(action: copyObject) {
+                    Image(systemName: "curlybraces")
+                        .font(.app(.caption))
+                        .foregroundStyle(JSConsoleTheme.muted)
+                        .frame(width: 14)
+                }
+                .buttonStyle(.plain)
+                .help("Copy just the object, as JSON")
+            }
+        }
+        .padding(.top, 1)
+    }
+
+    @ViewBuilder private var copyMenu: some View {
+        Button("Copy Log", action: copyLog)
+        if primaryObjectID != nil {
+            Button("Copy Object as JSON", action: copyObject)
+        }
+    }
+
+    private func flashCopied() {
+        copied = true
+        Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
+    }
+
+    /// The whole log: its message, then every object it carries as real JSON.
+    /// The row shows objects as `{…}`, which is exactly the part a paste can't
+    /// act on — so the clipboard resolves them.
+    private func copyLog() {
+        Task {
+            copyToPasteboard(await logText())
+            flashCopied()
+        }
+    }
+
+    private func logText() async -> String {
+        switch entry.kind {
+        case let .log(_, args, _, _):
+            let chunks = ConsoleArguments.chunks(args)
+            var json: [Int: String] = [:]
+            for (index, chunk) in chunks.enumerated() {
+                if case let .object(object) = chunk, let text = await stringify(object) {
+                    json[index] = text
+                }
+            }
+            return ConsoleArguments.copyText(chunks, json: json)
+        case let .result(object):
+            return await stringify(object) ?? object.inlineSummary
+        default:
+            return jsEntryPlainText(entry.kind)
+        }
+    }
+
+    /// Faithful JSON for a value, or nil when it has no handle or the runtime
+    /// couldn't stringify it (the caller falls back to the preview).
+    private func stringify(_ object: RemoteObject) async -> String? {
+        guard object.isExpandable, let objectId = object.objectId else { return nil }
+        return await session.jsonString(of: objectId)
+    }
+
+    private func copyObject() {
+        guard let objectID = primaryObjectID else { return }
+        Task {
+            let json = await session.jsonString(of: objectID) ?? jsEntryPlainText(entry.kind)
+            copyToPasteboard(json)
+            flashCopied()
+        }
+    }
+
+    /// The object handle to deep-copy as JSON (result value, or the first
+    /// expandable log arg).
+    private var primaryObjectID: String? {
+        switch entry.kind {
+        case let .result(object): object.isExpandable ? object.objectId : nil
+        case let .log(_, args, _, _): args.first(where: \.isExpandable)?.objectId
+        default: nil
+        }
+    }
+
+    // MARK: Expansion
+
+    private func toggle(_ index: Int, object: RemoteObject) {
+        var state = expansion[index] ?? ArgExpansion()
+        state.expanded.toggle()
+        expansion[index] = state
+        guard state.expanded else { return }
+        // Expanding means the user is reading — pause tail-follow so streaming
+        // lines can't scroll the object away (the jump button or scrolling back
+        // resumes), and bring the row's own header to the top so a big value
+        // reads from its start instead of the feed reflowing to its end.
+        pauseFollow()
+        if state.snapshot == nil, !state.loading {
+            load(index, object: object)
+        } else {
+            scrollHeaderToTop(index)
+        }
+    }
+
+    /// The child rows aren't lazy, so a big object takes a few frames to lay
+    /// out; re-issue the scroll over a short window so it lands on the settled
+    /// position rather than an early estimate.
+    private func scrollHeaderToTop(_ index: Int) {
+        Task {
+            for delay in [30, 120, 260] {
+                try? await Task.sleep(for: .milliseconds(delay))
+                guard expansion[index]?.expanded == true else { return }
+                scrollToHeader(entry.id)
+            }
+        }
+    }
+
+    /// The row-wide click: open the first expandable argument if it isn't
+    /// already. Never a toggle — see the tap gesture's note.
+    private func expandPrimaryObject() {
+        guard let (index, object) = firstExpandableArgument() else { return }
+        guard expansion[index]?.expanded != true else { return }
+        toggle(index, object: object)
+    }
+
+    private func firstExpandableArgument() -> (Int, RemoteObject)? {
+        switch entry.kind {
+        case let .result(object):
+            return object.isExpandable ? (0, object) : nil
+        case let .log(_, args, _, _):
+            for row in argRows(args) {
+                if case let .object(object) = row.kind { return (row.id, object) }
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    private func load(_ index: Int, object: RemoteObject) {
+        guard let objectId = object.objectId else { return }
+        expansion[index]?.loading = true
+        Task {
+            let node = await session.snapshot(of: objectId)
+            var state = expansion[index] ?? ArgExpansion()
+            state.snapshot = node
+            state.failed = node == nil
+            state.loading = false
+            expansion[index] = state
+            if node != nil { scrollHeaderToTop(index) }
+        }
+    }
+
+    // MARK: Argument grouping
+
+    /// `ConsoleArguments.chunks` with its position attached — the index doubles
+    /// as this row's expansion key, so it has to stay stable across renders.
+    private struct ArgRow: Identifiable {
+        let id: Int
+        let kind: ConsoleArgumentChunk
+    }
+
+    private func argRows(_ args: [RemoteObject]) -> [ArgRow] {
+        ConsoleArguments.chunks(args).enumerated().map { ArgRow(id: $0.offset, kind: $0.element) }
+    }
+
+    private func line(_ text: String, base: Color) -> some View {
+        highlightedText(text, query: query, base: base, current: isCurrentFind, underlineLinks: hovering)
+            .font(.app(.callout, design: .monospaced))
+            .lineSpacing(2)
+            .textSelection(.enabled)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+// MARK: - Snapshot tree (client-side, no getProperties)
+
+/// An expanded object/array rendered inline (the feed grows to fit — no nested
+/// scroll), with a find field for the values big enough to need one. Typing
+/// shows a clickable result list (`SnapNode.findMatches`, pure in ADBKit);
+/// clicking a result expands the tree along its path and highlights the node.
+struct ExpandedTree: View {
+    let node: SnapNode
+    let session: JSConsoleSession
+    @State private var search = ""
+    /// Ordinal paths ("0/3/1") of the containers currently open — hoisted here
+    /// so a clicked find result can expand its whole ancestor chain.
+    @State private var expandedPaths: Set<String> = []
+    /// The last revealed find result, tinted until the next find/reveal.
+    @State private var highlightedPath: String?
+
+    /// Below this the whole value fits on screen, and a search field over four
+    /// properties is a control that costs more room than it saves.
+    private static let searchWorthwhileNodes = 25
+
+    var body: some View {
+        let query = search.trimmingCharacters(in: .whitespaces).lowercased()
+        VStack(alignment: .leading, spacing: 4) {
+            if node.nodeCount(limit: Self.searchWorthwhileNodes) >= Self.searchWorthwhileNodes {
+                SearchField(prompt: "Find in object…", text: $search)
+                    .controlSize(.small)
+                    .frame(maxWidth: 260)
+            }
+            if !query.isEmpty {
+                SnapMatchList(matches: node.findMatches(query: query), onSelect: reveal)
+            } else if node.isContainer {
+                SnapChildrenView(
+                    node: node, session: session, path: "",
+                    expandedPaths: $expandedPaths, highlightedPath: highlightedPath
+                )
+            } else {
+                // A primitive root: a logged `Error` snapshots to its stack
+                // string, and rendering only containers left the disclosure
+                // opening onto nothing.
+                Text(node.text ?? node.primitivePreview)
+                    .font(.app(.caption).monospaced())
+                    .foregroundStyle(JSConsoleTheme.muted)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        // A newly typed query drops the previous reveal's tint (reveal itself
+        // clears the field, so its own highlight survives this).
+        .onChange(of: search) { _, newValue in
+            if !newValue.trimmingCharacters(in: .whitespaces).isEmpty { highlightedPath = nil }
+        }
+    }
+
+    /// Open every container down to the match, mark it, and swap back to the
+    /// tree so the user lands on the node.
+    private func reveal(_ match: TreeMatch) {
+        var path = ""
+        for index in match.path {
+            path = path.isEmpty ? String(index) : "\(path)/\(index)"
+            expandedPaths.insert(path)
+        }
+        highlightedPath = path
+        search = ""
+    }
+}
+
+/// The clickable results of a find inside one object — location, then value.
+private struct SnapMatchList: View {
+    let matches: [TreeMatch]
+    let onSelect: (TreeMatch) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if matches.isEmpty {
+                Text("No matches").font(.app(.caption)).foregroundStyle(.tertiary)
+            }
+            ForEach(Array(matches.enumerated()), id: \.offset) { _, match in
+                Button {
+                    onSelect(match)
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: "arrow.turn.down.right")
+                            .font(.app(size: 10))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 14)
+                        Text("\(match.displayPath):")
+                            .font(.app(.callout, design: .monospaced))
+                            .foregroundStyle(jsColor(.key))
+                        Text(match.preview)
+                            .font(.app(.callout, design: .monospaced))
+                            .foregroundStyle(jsColor(match.isContainer ? .className : .plain))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Reveal in the tree")
+            }
+            if matches.count >= 200 {
+                Text("…first 200 matches — narrow the search")
+                    .font(.app(.caption)).foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// The ordered child rows of a container `SnapNode` — array items with index
+/// labels, or object entries with key labels. `path` is the container's own
+/// ordinal path; expansion state lives in the owning `ExpandedTree` so find
+/// results can drive it.
+private struct SnapChildrenView: View {
+    let node: SnapNode
+    let session: JSConsoleSession
+    let path: String
+    @Binding var expandedPaths: Set<String>
+    let highlightedPath: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if node.type == "array", let items = node.items {
+                if items.isEmpty { emptyRow }
+                ForEach(Array(items.enumerated()), id: \.offset) { index, child in
+                    SnapValueView(
+                        label: String(index), node: child, session: session,
+                        path: childPath(index), expandedPaths: $expandedPaths,
+                        highlightedPath: highlightedPath
+                    )
+                }
+                if let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
+            } else if let entries = node.entries {
+                if entries.isEmpty { emptyRow }
+                ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
+                    SnapValueView(
+                        label: entry.name, node: entry.node, session: session,
+                        path: childPath(index), expandedPaths: $expandedPaths,
+                        highlightedPath: highlightedPath
+                    )
+                }
+                if node.truncated == true { moreRow("…(more)") }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func childPath(_ index: Int) -> String {
+        path.isEmpty ? String(index) : "\(path)/\(index)"
+    }
+
+    private var emptyRow: some View {
+        Text(node.type == "array" ? "(empty array)" : "(no enumerable properties)")
+            .font(.app(.caption)).foregroundStyle(.tertiary)
+    }
+
+    private func moreRow(_ text: String) -> some View {
+        Text(text).font(.app(.caption)).foregroundStyle(.tertiary)
+    }
+}
+
+/// One row in the snapshot tree: a primitive `key: value`, or a collapsible
+/// container header whose children (another `SnapChildrenView`) indent below.
+/// A collapsed container previews its own first few properties the way Chrome
+/// does, so most values can be read without opening them at all.
+private struct SnapValueView: View {
+    let label: String?
+    let node: SnapNode
+    let session: JSConsoleSession
+    let path: String
+    @Binding var expandedPaths: Set<String>
+    let highlightedPath: String?
+    @Environment(\.logTailPauseFollow) private var pauseFollow
+    @Environment(\.consoleLinkUnderline) private var underlineLinks
+
+    /// Text highlighted in rows: the ⌘F find query.
+    private var highlight: String { session.findText.trimmingCharacters(in: .whitespaces) }
+    private var isOpen: Bool { expandedPaths.contains(path) }
+    private var isRevealed: Bool { path == highlightedPath }
+
+    var body: some View {
+        if node.isContainer {
+            VStack(alignment: .leading, spacing: 2) {
+                Button {
+                    if isOpen {
+                        expandedPaths.remove(path)
+                    } else {
+                        expandedPaths.insert(path)
+                        // Reading a nested node is still reading — keep the
+                        // feed from scrolling it away.
+                        pauseFollow()
+                    }
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Image(systemName: isOpen ? "arrowtriangle.down.fill" : "arrowtriangle.right.fill")
+                            .font(.app(size: 8))
+                            .foregroundStyle(JSConsoleTheme.muted)
+                            .frame(width: 14)
+                        labelText
+                        coloredTokenText(node.previewTokens(), query: highlight, current: false)
+                            .font(.app(.callout, design: .monospaced))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .contentShape(Rectangle())
+                    .background(revealTint)
+                }
+                .buttonStyle(.plain)
+                if isOpen {
+                    SnapChildrenView(
+                        node: node, session: session, path: path,
+                        expandedPaths: $expandedPaths, highlightedPath: highlightedPath
+                    )
+                    .padding(.leading, 18)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                labelText
+                highlightedText(
+                    node.primitivePreview, query: highlight, base: jsColor(SnapNode.tokenKind(node.type)),
+                    underlineLinks: underlineLinks
+                )
+                .font(.app(.callout, design: .monospaced))
+                .textSelection(.enabled)
+            }
+            .background(revealTint)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder private var revealTint: some View {
+        if isRevealed {
+            RoundedRectangle(cornerRadius: 3).fill(JSConsoleTheme.findMatch.opacity(0.22))
+        }
+    }
+
+    @ViewBuilder private var labelText: some View {
+        if let label {
+            highlightedText("\(label):", query: highlight, base: jsColor(.key))
+                .font(.app(.callout, design: .monospaced))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+/// `console.table` as a grid, the way Chrome draws it: an `(index)` column,
+/// one column per key across the rows, and a `Value` column for any element
+/// that isn't an object. Cells are one line — the value's own disclosure below
+/// the table is where a nested one opens.
+private struct ConsoleTableView: View {
+    let table: ConsoleTable
+
+    private var headers: [String] {
+        ["(index)"] + table.columns + (table.hasValueColumn ? ["Value"] : [])
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow {
+                    ForEach(Array(headers.enumerated()), id: \.offset) { _, name in
+                        cell(name, isHeader: true)
+                    }
+                }
+                ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
+                    GridRow {
+                        cell(row.index, isHeader: false)
+                        ForEach(Array(row.cells.enumerated()), id: \.offset) { _, text in
+                            cell(text, isHeader: false)
+                        }
+                        if table.hasValueColumn { cell(row.value ?? "", isHeader: false) }
+                    }
+                }
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            if table.hiddenRows > 0 {
+                Text("…\(table.hiddenRows) more rows")
+                    .font(.app(.caption)).foregroundStyle(.tertiary)
+                    .padding(.top, 2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func cell(_ text: String, isHeader: Bool) -> some View {
+        Text(text)
+            .font(.app(.caption, design: .monospaced))
+            .foregroundStyle(isHeader ? JSConsoleTheme.text : JSConsoleTheme.muted)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isHeader ? JSConsoleTheme.muted.opacity(0.14) : .clear)
+            .overlay(Rectangle().strokeBorder(JSConsoleTheme.muted.opacity(0.3), lineWidth: 0.5))
+    }
+}
+
+/// The frames behind a console call — a thrown exception's, or any row whose
+/// source label the reader clicked. Metro's resolved frames when it answered;
+/// the raw bundle coordinates otherwise, so a stack is never simply missing.
+/// Library frames read dimmer, the way Chrome greys its ignore-listed ones.
+struct StackView: View {
+    let stack: CDPStackTrace
+    var symbolicated: [SymbolicatedFrame] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            if symbolicated.isEmpty {
+                ForEach(stack.callFrames.prefix(8)) { frame in
+                    frameText(frame.display, dim: false)
+                }
+            } else {
+                ForEach(symbolicated.prefix(8)) { frame in
+                    frameText(frame.display, dim: frame.isLibrary)
+                }
+            }
+        }
+        .padding(.leading, 4)
+    }
+
+    private func frameText(_ text: String, dim: Bool) -> some View {
+        Text(text)
+            .font(.app(.caption2).monospaced())
+            .foregroundStyle(JSConsoleTheme.muted.opacity(dim ? 0.55 : 1))
+            .textSelection(.enabled)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
@@ -29,6 +29,9 @@ enum JSConsoleTheme {
     /// Info accent (icon), otherwise info reads as normal text (Chrome `#79b8ff`).
     static let info = Color(red: 0.475, green: 0.722, blue: 1.0)
 
+    /// The source location at the right edge of a row — Chrome's link blue.
+    static let sourceLink = Color(red: 0.416, green: 0.643, blue: 1.0)      // #6aa4ff
+
     /// ⌘F find highlights — warm yellow, stronger orange for the current match.
     static let findMatch = Color(red: 0.961, green: 0.773, blue: 0.094)    // #f5c518
     static let findCurrent = Color(red: 1.0, green: 0.549, blue: 0.102)    // #ff8c1a

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -48,19 +48,38 @@ enum JSPhase: Equatable {
     case failed(String)
 }
 
+/// Where a row sits in the `console.group` nesting: how far it indents, which
+/// headers it hangs under (so collapsing one hides exactly its block), and
+/// whether it *is* a header. Everything the console says on its own — input,
+/// results, notices — sits at the top level.
+struct JSGroupSlot: Equatable {
+    var depth = 0
+    var path: [Int] = []
+    var isHeader = false
+
+    /// Whether any of the enclosing headers is collapsed, i.e. this row is
+    /// inside a folded block.
+    func isHidden(by collapsed: Set<Int>) -> Bool {
+        !collapsed.isEmpty && path.contains(where: collapsed.contains)
+    }
+}
+
 /// One line in the console feed.
 struct JSEntry: Identifiable {
     enum Kind {
         case input(String)
         case result(RemoteObject)
         case evalError(ExceptionDetails)
-        case log(level: JSLevel, args: [RemoteObject], stack: CDPStackTrace?)
+        /// `isTable` marks a `console.table` call, which Chrome draws as a grid
+        /// over the argument rather than as its one-line preview.
+        case log(level: JSLevel, args: [RemoteObject], stack: CDPStackTrace?, isTable: Bool = false)
         case notice(String)
     }
 
     let id: Int
     let kind: Kind
     let at: Date
+    let group: JSGroupSlot
     /// Lowercased plain-text head for the filter and ⌘F, derived once at
     /// creation so they never re-tokenize the value tree per flush (a
     /// Sentry-reported main-thread hang during console bursts). Capped like
@@ -72,10 +91,21 @@ struct JSEntry: Identifiable {
     /// drives the buffer's byte budget.
     let approximateBytes: Int
 
-    init(id: Int, kind: Kind, at: Date) {
+    /// The call stack of the `console.*` call behind this row, when there is
+    /// one — what the source label at the right edge is resolved from.
+    var stack: CDPStackTrace? {
+        switch kind {
+        case let .log(_, _, stack, _): stack
+        case let .evalError(details): details.stackTrace
+        default: nil
+        }
+    }
+
+    init(id: Int, kind: Kind, at: Date, group: JSGroupSlot = JSGroupSlot()) {
         self.id = id
         self.kind = kind
         self.at = at
+        self.group = group
         let size = Self.approximateSize(kind)
         approximateBytes = size
         if size > 1_000_000 {
@@ -90,13 +120,15 @@ struct JSEntry: Identifiable {
         case let .result(object): return object.inlineSummary(limit: limit).lowercased()
         case let .evalError(details): return String(details.message.prefix(limit)).lowercased()
         case let .notice(text): return String(text.prefix(limit)).lowercased()
-        case let .log(_, args, _):
+        case let .log(_, args, _, _):
             var out = ""
             for arg in args {
                 let remaining = limit - out.utf8.count
                 guard remaining > 0 else { break }
                 if !out.isEmpty { out += " " }
-                out += arg.inlineSummary(limit: remaining)
+                // The console-argument rendering, so the filter matches the
+                // unquoted text a log row actually shows.
+                out += arg.inlineSummary(limit: remaining, style: .consoleArgument)
             }
             return out.lowercased()
         }
@@ -108,7 +140,7 @@ struct JSEntry: Identifiable {
         case let .result(object): object.approximateBytes
         case let .evalError(details): details.message.utf8.count + 512
         case let .notice(text): text.utf8.count + 256
-        case let .log(_, args, _): args.reduce(256) { $0 + $1.approximateBytes }
+        case let .log(_, args, _, _): args.reduce(256) { $0 + $1.approximateBytes }
         }
     }
 }
@@ -153,6 +185,12 @@ final class JSConsoleSession {
     var port: Int { didSet { UserDefaults.standard.set(port, forKey: Self.portKey) } }
     var searchText = "" { didSet { refilter() } }
     var hiddenLevels: Set<JSLevel> = [] { didSet { refilter() } }
+    /// Entry ids of the `console.group` headers currently folded — every row
+    /// naming one in its path is hidden, which is how Chrome's collapsed groups
+    /// (and `console.groupCollapsed`) behave.
+    private(set) var collapsedGroups: Set<Int> = [] {
+        didSet { if collapsedGroups != oldValue { refilter() } }
+    }
     /// Reversed feed: newest at the top instead of Chrome's newest-at-bottom.
     /// Persisted per feature; the ⌘F match order follows the display order, so
     /// flipping rebuilds the matches and restarts from the first visible one.
@@ -209,6 +247,12 @@ final class JSConsoleSession {
     /// Drops the re-replayed console history on reconnects to the same app so
     /// the persistent feed doesn't duplicate.
     @ObservationIgnored private var replayGate = ConsoleReplayGate()
+    /// The running `console.group` nesting the incoming stream is inside.
+    @ObservationIgnored private var groups = ConsoleGroupTracker()
+    /// Resolves a row's bundle coordinates to the file the developer wrote, for
+    /// the source label at the right edge. Rebuilt whenever the Metro port
+    /// changes — its cache belongs to one dev server.
+    @ObservationIgnored private var symbolicator = MetroSymbolicator()
     /// Auto-connect waits for a target to survive two discovery passes —
     /// attaching the instant it first registered crashed Hermes mid-boot
     /// (`TargetStabilityTracker`). Manual picks bypass this.
@@ -243,8 +287,30 @@ final class JSConsoleSession {
     init(adb: AdbClient) {
         self.adb = adb
         let savedPort = UserDefaults.standard.integer(forKey: Self.portKey)
-        port = (1 ... 65535).contains(savedPort) ? savedPort : 8081
+        let resolvedPort = (1 ... 65535).contains(savedPort) ? savedPort : 8081
+        port = resolvedPort
+        symbolicator = MetroSymbolicator(port: resolvedPort)
         newestFirst = UserDefaults.standard.bool(forKey: Self.newestFirstKey)
+    }
+
+    /// Fold or unfold a `console.group` block from its header row.
+    func toggleGroup(_ id: Int) {
+        if collapsedGroups.contains(id) {
+            collapsedGroups.remove(id)
+        } else {
+            collapsedGroups.insert(id)
+        }
+    }
+
+    func isGroupCollapsed(_ id: Int) -> Bool { collapsedGroups.contains(id) }
+
+    /// Where a row's `console.*` call was made, for the source label Chrome
+    /// prints at the right edge. Resolved lazily by the row that's on screen —
+    /// the feed never pays for rows nobody is looking at — and cached in the
+    /// symbolicator, so scrolling back over a row costs nothing.
+    func symbolicated(_ stack: CDPStackTrace?) async -> [SymbolicatedFrame] {
+        guard let stack else { return [] }
+        return await symbolicator.symbolicate(stack.callFrames)
     }
 
     /// Reset the connection back-references so the next connect re-welcomes.
@@ -493,6 +559,8 @@ final class JSConsoleSession {
             phase = .connected
             receivedCount = 0
             replayGate.connectionOpened(resumingSameApp: resumingSameApp)
+            // A new stream starts outside every group the old one left open.
+            groups.reset()
             // No target identity in the crumb — bundle ids stay out of
             // telemetry (the Settings ▸ Privacy promise).
             Telemetry.shared.breadcrumb(category: "js-console", "connected to a Hermes target")
@@ -526,14 +594,36 @@ final class JSConsoleSession {
             // otherwise wipe the feed the gate is preserving.
             guard replayGate.admit(call.timestamp) else { return }
             if call.type == "clear" { clearFeedEntries(); return }
-            enqueue(.log(level: JSLevel(consoleType: call.type), args: call.args, stack: call.stackTrace))
+            switch groups.placement(for: call.type, id: nextEntryId) {
+            case .groupEnd:
+                // `console.groupEnd` closes the block and shows nothing — a row
+                // for it is the empty line that used to trail every group.
+                return
+            case let .entry(depth, path):
+                enqueue(
+                    .log(
+                        level: JSLevel(consoleType: call.type), args: call.args,
+                        stack: call.stackTrace, isTable: call.type == "table"
+                    ),
+                    group: JSGroupSlot(depth: depth, path: path)
+                )
+            case let .groupStart(depth, path, collapsed):
+                if collapsed { collapsedGroups.insert(nextEntryId) }
+                enqueue(
+                    .log(level: JSLevel(consoleType: call.type), args: call.args, stack: call.stackTrace),
+                    group: JSGroupSlot(depth: depth, path: path, isHeader: true)
+                )
+            }
         case let .exception(details, timestamp):
             guard replayGate.admit(timestamp) else { return }
-            enqueue(.evalError(details))
+            enqueue(.evalError(details), group: JSGroupSlot(depth: groups.depth, path: groups.open))
         case .contextCreated:
             break
         case .contextDestroyed:
             // A JS reload replaced the context — mark it inline (logs keep flowing).
+            // The old context's unclosed groups went with it; leaving them open
+            // would indent the whole next session under a group that's gone.
+            groups.reset()
             enqueue(.notice("App reloaded — JS context replaced."))
         case let .closed(_, takeover):
             // The discovery loop reconnects (device id, then app id) within
@@ -611,6 +701,22 @@ final class JSConsoleSession {
     /// Faithful deep JSON of an object (Copy as JSON), evaluated in the runtime.
     func jsonString(of objectId: String) async -> String? {
         await cdp.deepStringify(objectId: objectId)
+    }
+
+    /// Grids already built for `console.table` rows, keyed by entry. Rows are
+    /// lazy, so without this every scroll back over a table would snapshot the
+    /// value on the device again. Bounded — `console.table` is rare, and a feed
+    /// full of them still can't grow this without limit.
+    @ObservationIgnored private var tables: [Int: ConsoleTable] = [:]
+    private static let maxCachedTables = 50
+
+    /// The grid for a `console.table` row, snapshotted once per entry.
+    func table(for entryID: Int, objectId: String) async -> ConsoleTable? {
+        if let cached = tables[entryID] { return cached }
+        guard let node = await snapshot(of: objectId), let table = ConsoleTable.from(node) else { return nil }
+        if tables.count >= Self.maxCachedTables { tables.removeAll(keepingCapacity: true) }
+        tables[entryID] = table
+        return table
     }
 
     // MARK: Find (⌘F)
@@ -692,8 +798,11 @@ final class JSConsoleSession {
         autoReconnectSuspended = false
         resetWelcome()
         targets = []
-        // Sightings from the old port say nothing about the new one.
+        // Sightings from the old port say nothing about the new one, and a
+        // source map's line numbers belong to one dev server.
         targetStability = TargetStabilityTracker()
+        symbolicator = MetroSymbolicator(port: newPort)
+        groups.reset()
         phase = .searching
         Task { [weak self] in await self?.cdp.disconnect() }
     }
@@ -862,9 +971,11 @@ final class JSConsoleSession {
     private var activeFilter: ((JSEntry) -> Bool)? {
         let query = ConsoleQuery(searchText)
         let hidden = hiddenLevels
-        guard !query.isEmpty || !hidden.isEmpty else { return nil }
+        let collapsed = collapsedGroups
+        guard !query.isEmpty || !hidden.isEmpty || !collapsed.isEmpty else { return nil }
         return { entry in
-            if case let .log(level, _, _) = entry.kind, hidden.contains(level) { return false }
+            if entry.group.isHidden(by: collapsed) { return false }
+            if case let .log(level, _, _, _) = entry.kind, hidden.contains(level) { return false }
             return query.matches(entry.searchableText)
         }
     }
@@ -899,8 +1010,8 @@ final class JSConsoleSession {
     /// Stream events — the post-connect replay burst is the hot path — are buffered
     /// and flushed together so a thousand-message burst causes a handful of renders,
     /// not one per message (the fix for the multi-second open stall).
-    private func enqueue(_ kind: JSEntry.Kind) {
-        let entry = JSEntry(id: nextEntryId, kind: kind, at: Date())
+    private func enqueue(_ kind: JSEntry.Kind, group: JSGroupSlot = JSGroupSlot()) {
+        let entry = JSEntry(id: nextEntryId, kind: kind, at: Date(), group: group)
         pendingEntries.append(entry)
         pendingBytes += entry.approximateBytes
         nextEntryId += 1
@@ -972,6 +1083,11 @@ final class JSConsoleSession {
         pendingBytes = 0
         buffer.removeAll()
         findMatchIDs = []
+        tables.removeAll(keepingCapacity: true)
+        // The headers those ids named are gone; a later group would otherwise
+        // inherit a fold nobody asked for once ids wrap around a long session.
+        collapsedGroups = []
+        groups.reset()
     }
 
     // MARK: Welcome banner
@@ -1343,7 +1459,7 @@ struct JSConsoleView: View {
             case .result: ("result", nil)
             case .evalError: ("error", nil)
             case .notice: ("notice", nil)
-            case let .log(logLevel, _, _): ("log", logLevel.rawValue)
+            case let .log(logLevel, _, _, _): ("log", logLevel.rawValue)
             }
             return ConsoleExportEntry(at: entry.at, type: type, level: level, text: jsEntryPlainText(entry.kind))
         })
@@ -1501,7 +1617,7 @@ struct JSConsoleView: View {
     /// nil for the levels that sit on the plain console surface.
     private func levelBand(_ entry: JSEntry) -> (fill: Color, rule: Color)? {
         switch entry.kind {
-        case let .log(level, _, _): level.consoleBand
+        case let .log(level, _, _, _): level.consoleBand
         case .evalError: (JSConsoleTheme.errorBackground, JSConsoleTheme.errorRule)
         default: nil
         }
@@ -1576,608 +1692,6 @@ struct JSConsoleView: View {
     private func run() {
         session.submit(input)
         input = ""
-    }
-}
-
-// MARK: - Entry row
-
-private struct JSEntryRow: View {
-    let entry: JSEntry
-    let session: JSConsoleSession
-    @State private var hovering = false
-    @State private var copied = false
-    /// Bumped by a click anywhere on the row; the primary expandable value
-    /// observes it and toggles, so the whole row is the disclosure target —
-    /// not just the value's own summary line.
-    @State private var rowToggleToken = 0
-
-    private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
-    private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            glyph
-            content
-                .frame(maxWidth: .infinity, alignment: .leading)
-            // Always in the layout — hidden, not removed, when idle — so
-            // hovering can't change the row's width and reflow its text.
-            copyButton
-                .opacity(hovering || copied ? 1 : 0)
-                .allowsHitTesting(hovering || copied)
-            Text(entry.at, format: .dateTime.hour().minute().second())
-                .font(.app(.caption2).monospacedDigit())
-                .foregroundStyle(JSConsoleTheme.muted)
-                .padding(.top, 1)
-        }
-        .contentShape(Rectangle())
-        // Whitespace, glyph, and timestamp clicks toggle the row's expandable
-        // value too (the value's own header still works). Text keeps its
-        // selection gesture — this only catches clicks nothing else claims.
-        .onTapGesture {
-            if primaryObjectID != nil { rowToggleToken += 1 }
-        }
-        .onHover { hovering = $0 }
-        // Hovering the row is what reveals its URLs' underlines.
-        .environment(\.consoleLinkUnderline, hovering)
-        .contextMenu {
-            Button("Copy") { copyToPasteboard(jsEntryPlainText(entry.kind)) }
-            if let objectID = primaryObjectID {
-                Button("Copy as JSON") {
-                    Task {
-                        let json = await session.jsonString(of: objectID) ?? jsEntryPlainText(entry.kind)
-                        copyToPasteboard(json)
-                    }
-                }
-            }
-        }
-    }
-
-    /// Hover copy affordance (the Reactotron rows' pattern): copies the row's
-    /// plain text with a checkmark flash; the right-click menu keeps the
-    /// deep "Copy as JSON".
-    private var copyButton: some View {
-        Button {
-            copyToPasteboard(jsEntryPlainText(entry.kind))
-            copied = true
-            Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
-        } label: {
-            Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                .font(.app(.caption))
-                .foregroundStyle(copied ? .green : JSConsoleTheme.muted)
-                // Fixed footprint for both glyphs, so neither hover nor the
-                // copy→checkmark swap nudges the layout.
-                .frame(width: 14)
-        }
-        .buttonStyle(.plain)
-        .padding(.top, 1)
-        .help("Copy this entry (right-click for JSON)")
-    }
-
-    /// The object handle to deep-copy as JSON (result value, or the first
-    /// expandable log arg).
-    private var primaryObjectID: String? {
-        switch entry.kind {
-        case let .result(object): object.isExpandable ? object.objectId : nil
-        case let .log(_, args, _): args.first(where: \.isExpandable)?.objectId
-        default: nil
-        }
-    }
-
-    @ViewBuilder private var glyph: some View {
-        switch entry.kind {
-        case .input:
-            icon("chevron.right", JSConsoleTheme.muted)
-        case .result:
-            icon("arrow.turn.down.right", JSConsoleTheme.muted)
-        case .evalError:
-            icon("xmark.octagon.fill", JSConsoleTheme.errorText)
-        case let .log(level, _, _):
-            icon(level.icon, level.consoleIconColor)
-        case .notice:
-            icon("info.circle", JSConsoleTheme.muted)
-        }
-    }
-
-    private func icon(_ name: String, _ style: some ShapeStyle) -> some View {
-        Image(systemName: name)
-            .font(.app(.caption))
-            .foregroundStyle(style)
-            .frame(width: 14)
-            .padding(.top, 2)
-    }
-
-    @ViewBuilder private var content: some View {
-        switch entry.kind {
-        case let .input(text):
-            line(text, base: JSConsoleTheme.muted)
-        case let .result(object):
-            JSValueView(object: object, session: session, scrollTargetID: entry.id, toggleToken: rowToggleToken)
-        case let .evalError(details):
-            errorContent(details)
-        case let .log(level, args, stack):
-            logContent(level: level, args: args, stack: stack)
-        case let .notice(text):
-            line(text, base: JSConsoleTheme.muted)
-        }
-    }
-
-    private func line(_ text: String, base: Color) -> some View {
-        highlightedText(text, query: query, base: base, current: isCurrentFind, underlineLinks: hovering)
-            .font(.app(.callout, design: .monospaced))
-            .lineSpacing(2)
-            .textSelection(.enabled)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private func logContent(level: JSLevel, args: [RemoteObject], stack: CDPStackTrace?) -> some View {
-        let rows = argRows(args)
-        // The row-level click toggles the first expandable object — the one
-        // "Copy as JSON" also targets.
-        let primaryRowID = rows.first { if case .object = $0.kind { true } else { false } }?.id
-        return VStack(alignment: .leading, spacing: 3) {
-            // Each expandable object renders exactly once, as its own disclosure
-            // row in argument order — it used to appear twice (inline in the
-            // message line AND repeated below), which doubled every logged object.
-            // Scalar runs keep the level tint for errors/warnings and VSCode-style
-            // syntax colors otherwise.
-            ForEach(rows) { row in
-                switch row.kind {
-                case let .scalars(text, tokens):
-                    if level == .error || level == .warning {
-                        line(text, base: level.consoleTextColor)
-                    } else {
-                        coloredTokenText(tokens, query: query, current: isCurrentFind, underlineLinks: hovering)
-                            .font(.app(.callout, design: .monospaced))
-                            .lineSpacing(2)
-                            .textSelection(.enabled)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                case let .object(arg):
-                    JSValueView(
-                        object: arg, session: session, scrollTargetID: entry.id,
-                        toggleToken: row.id == primaryRowID ? rowToggleToken : 0
-                    )
-                }
-            }
-            if level == .error, let stack { StackView(stack: stack) }
-        }
-    }
-
-    /// The visual rows for one log call's arguments: consecutive scalars merge
-    /// into one line; each expandable object becomes its own row.
-    private struct ArgRow: Identifiable {
-        enum Kind {
-            case scalars(String, [JSToken])
-            case object(RemoteObject)
-        }
-
-        let id: Int
-        let kind: Kind
-    }
-
-    private func argRows(_ args: [RemoteObject]) -> [ArgRow] {
-        var rows: [ArgRow] = []
-        var run: [RemoteObject] = []
-        func flushRun() {
-            guard !run.isEmpty else { return }
-            let text = run.map(\.inlineSummary).joined(separator: " ")
-            rows.append(ArgRow(id: rows.count, kind: .scalars(text, argTokens(run))))
-            run = []
-        }
-        for arg in args {
-            if arg.isExpandable {
-                flushRun()
-                rows.append(ArgRow(id: rows.count, kind: .object(arg)))
-            } else {
-                run.append(arg)
-            }
-        }
-        flushRun()
-        return rows
-    }
-
-    private func argTokens(_ args: [RemoteObject]) -> [JSToken] {
-        var tokens: [JSToken] = []
-        for (index, arg) in args.enumerated() {
-            if index > 0 { tokens.append(JSToken(" ", .plain)) }
-            tokens.append(contentsOf: arg.tokens)
-        }
-        return tokens
-    }
-
-    private func errorContent(_ details: ExceptionDetails) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            line(details.message, base: JSConsoleTheme.errorText)
-            if let stack = details.stackTrace { StackView(stack: stack) }
-        }
-    }
-}
-
-// MARK: - Expandable value
-
-private struct JSValueView: View {
-    let object: RemoteObject
-    let session: JSConsoleSession
-    /// The owning log row's id — set for a top-level object so expanding it
-    /// scrolls that row's header into view instead of leaving the viewport at
-    /// the object's end (the flipped-layout jump).
-    var scrollTargetID: AnyHashable?
-    /// Bumped by the owning row when the user clicks anywhere on it — the
-    /// whole log row acts as this value's disclosure toggle.
-    var toggleToken = 0
-    @Environment(\.logTailScrollToHeader) private var scrollToHeader
-    @Environment(\.logTailPauseFollow) private var pauseFollow
-    @Environment(\.consoleLinkUnderline) private var underlineLinks
-    @State private var expanded = false
-    @State private var snapshot: SnapNode?
-    @State private var failed = false
-    @State private var loading = false
-
-    private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
-
-    var body: some View {
-        if object.isExpandable {
-            // Custom disclosure (not macOS DisclosureGroup, which right-aligns its
-            // content): a chevron header with children indented straight below.
-            // Collapsed previews truncate Chrome-style instead of wrapping the
-            // whole object — expanding is how you read the rest.
-            VStack(alignment: .leading, spacing: 2) {
-                Button {
-                    toggleExpanded()
-                } label: {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                            .font(.app(size: 10, weight: .bold))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 14)
-                        summaryText
-                            .lineLimit(expanded ? 1 : 2)
-                            .truncationMode(.tail)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .contextMenu { copyButtons }
-                if expanded { expandedChildren.padding(.leading, 18) }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .onChange(of: toggleToken) { _, _ in toggleExpanded() }
-        } else {
-            summaryText
-                .fixedSize(horizontal: false, vertical: true)
-                .contextMenu { copyButtons }
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    private func toggleExpanded() {
-        expanded.toggle()
-        if expanded {
-            // Expanding means the user is reading — pause tail-follow so
-            // streaming lines can't scroll the object away (same affordances
-            // as Reactotron: the jump button or scrolling back resumes).
-            pauseFollow()
-            if snapshot == nil, !loading { load() } else { scrollHeaderToTop() }
-        }
-    }
-
-    private var summaryText: some View {
-        coloredTokenText(object.tokens, query: query, current: false, underlineLinks: underlineLinks)
-            .font(.app(.callout, design: .monospaced))
-            .textSelection(.enabled)
-    }
-
-    @ViewBuilder private var copyButtons: some View {
-        Button("Copy") { copyToPasteboard(object.inlineSummary) }
-        if let objectId = object.objectId, object.isExpandable {
-            Button("Copy as JSON") {
-                Task {
-                    let json = await session.jsonString(of: objectId) ?? object.inlineSummary
-                    copyToPasteboard(json)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder private var expandedChildren: some View {
-        if loading {
-            ProgressView().controlSize(.small)
-        } else if let snapshot {
-            // An interactive tree rendered from a bounded snapshot fetched via
-            // callFunctionOn (not getProperties, which crashes Hermes). All
-            // further expansion is client-side over this snapshot — no more
-            // device round-trips. The owning row scrolls its header to the top
-            // on expand (see scrollHeaderToTop) so the object reads from its
-            // start rather than the feed reflowing to its end.
-            ExpandedTree(node: snapshot, session: session)
-        } else if failed {
-            Text("Couldn't read this value.").font(.app(.caption)).foregroundStyle(.tertiary)
-        }
-    }
-
-    private func load() {
-        guard let objectId = object.objectId else { return }
-        loading = true
-        Task {
-            let node = await session.snapshot(of: objectId)
-            snapshot = node
-            failed = node == nil
-            loading = false
-            if node != nil { scrollHeaderToTop() }
-        }
-    }
-
-    /// Bring the object's header to the top after expanding. The child rows
-    /// aren't lazy, so a big object takes a few frames to lay out; re-issue the
-    /// scroll over a short window so it lands on the settled position, not an
-    /// early estimate (which left the viewport at the object's end).
-    private func scrollHeaderToTop() {
-        guard let id = scrollTargetID else { return }
-        Task {
-            for delay in [30, 120, 260] {
-                try? await Task.sleep(for: .milliseconds(delay))
-                guard expanded else { return }
-                scrollToHeader(id)
-            }
-        }
-    }
-}
-
-// MARK: - Snapshot tree (client-side, no getProperties)
-
-/// An expanded object/array: a "find in object" field over the tree, rendered
-/// inline (the feed grows to fit — no nested scroll). Typing shows a clickable
-/// result list (`SnapNode.findMatches`, pure in ADBKit); clicking a result
-/// expands the tree along its path and highlights the node in place. The
-/// scroll jump on expand is handled by the owning row scrolling its header
-/// into view.
-private struct ExpandedTree: View {
-    let node: SnapNode
-    let session: JSConsoleSession
-    @State private var search = ""
-    /// Ordinal paths ("0/3/1") of the containers currently open — hoisted here
-    /// so a clicked find result can expand its whole ancestor chain.
-    @State private var expandedPaths: Set<String> = []
-    /// The last revealed find result, tinted until the next find/reveal.
-    @State private var highlightedPath: String?
-
-    var body: some View {
-        let query = search.trimmingCharacters(in: .whitespaces).lowercased()
-        VStack(alignment: .leading, spacing: 4) {
-            SearchField(prompt: "Find in object…", text: $search)
-                .controlSize(.small)
-                .frame(maxWidth: 260)
-            if query.isEmpty {
-                SnapChildrenView(
-                    node: node, session: session, path: "",
-                    expandedPaths: $expandedPaths, highlightedPath: highlightedPath
-                )
-            } else {
-                SnapMatchList(matches: node.findMatches(query: query), onSelect: reveal)
-            }
-        }
-        // A newly typed query drops the previous reveal's tint (reveal itself
-        // clears the field, so its own highlight survives this).
-        .onChange(of: search) { _, newValue in
-            if !newValue.trimmingCharacters(in: .whitespaces).isEmpty { highlightedPath = nil }
-        }
-    }
-
-    /// Open every container down to the match, mark it, and swap back to the
-    /// tree so the user lands on the node.
-    private func reveal(_ match: TreeMatch) {
-        var path = ""
-        for index in match.path {
-            path = path.isEmpty ? String(index) : "\(path)/\(index)"
-            expandedPaths.insert(path)
-        }
-        highlightedPath = path
-        search = ""
-    }
-}
-
-/// The clickable results of a find inside one object — location, then value.
-private struct SnapMatchList: View {
-    let matches: [TreeMatch]
-    let onSelect: (TreeMatch) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            if matches.isEmpty {
-                Text("No matches").font(.app(.caption)).foregroundStyle(.tertiary)
-            }
-            ForEach(Array(matches.enumerated()), id: \.offset) { _, match in
-                Button {
-                    onSelect(match)
-                } label: {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Image(systemName: "arrow.turn.down.right")
-                            .font(.app(size: 10))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 14)
-                        Text("\(match.displayPath):")
-                            .font(.app(.callout, design: .monospaced))
-                            .foregroundStyle(jsColor(.key))
-                        Text(match.preview)
-                            .font(.app(.callout, design: .monospaced))
-                            .foregroundStyle(jsColor(match.isContainer ? .className : .plain))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .help("Reveal in the tree")
-            }
-            if matches.count >= 200 {
-                Text("…first 200 matches — narrow the search")
-                    .font(.app(.caption)).foregroundStyle(.tertiary)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-/// The ordered child rows of a container `SnapNode` — array items with index
-/// labels, or object entries with key labels. `path` is the container's own
-/// ordinal path; expansion state lives in the owning `ExpandedTree` so find
-/// results can drive it.
-private struct SnapChildrenView: View {
-    let node: SnapNode
-    let session: JSConsoleSession
-    let path: String
-    @Binding var expandedPaths: Set<String>
-    let highlightedPath: String?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            if node.type == "array", let items = node.items {
-                if items.isEmpty { emptyRow }
-                ForEach(Array(items.enumerated()), id: \.offset) { index, child in
-                    SnapValueView(
-                        label: String(index), node: child, session: session,
-                        path: childPath(index), expandedPaths: $expandedPaths,
-                        highlightedPath: highlightedPath
-                    )
-                }
-                if let hidden = node.hiddenCount, hidden > 0 { moreRow("…(+\(hidden) more)") }
-            } else if let entries = node.entries {
-                if entries.isEmpty { emptyRow }
-                ForEach(Array(entries.enumerated()), id: \.offset) { index, entry in
-                    SnapValueView(
-                        label: entry.name, node: entry.node, session: session,
-                        path: childPath(index), expandedPaths: $expandedPaths,
-                        highlightedPath: highlightedPath
-                    )
-                }
-                if node.truncated == true { moreRow("…(more)") }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func childPath(_ index: Int) -> String {
-        path.isEmpty ? String(index) : "\(path)/\(index)"
-    }
-
-    private var emptyRow: some View {
-        Text(node.type == "array" ? "(empty array)" : "(no enumerable properties)")
-            .font(.app(.caption)).foregroundStyle(.tertiary)
-    }
-
-    private func moreRow(_ text: String) -> some View {
-        Text(text).font(.app(.caption)).foregroundStyle(.tertiary)
-    }
-}
-
-/// One row in the snapshot tree: a primitive `key: value`, or a collapsible
-/// container header whose children (another `SnapChildrenView`) indent below.
-/// The row revealed by a find result carries a highlight tint.
-private struct SnapValueView: View {
-    let label: String?
-    let node: SnapNode
-    let session: JSConsoleSession
-    let path: String
-    @Binding var expandedPaths: Set<String>
-    let highlightedPath: String?
-    @Environment(\.logTailPauseFollow) private var pauseFollow
-    @Environment(\.consoleLinkUnderline) private var underlineLinks
-
-    /// Text highlighted in rows: the ⌘F find query.
-    private var highlight: String { session.findText.trimmingCharacters(in: .whitespaces) }
-    private var isOpen: Bool { expandedPaths.contains(path) }
-    private var isRevealed: Bool { path == highlightedPath }
-
-    var body: some View {
-        if node.isContainer {
-            VStack(alignment: .leading, spacing: 2) {
-                Button {
-                    if isOpen {
-                        expandedPaths.remove(path)
-                    } else {
-                        expandedPaths.insert(path)
-                        // Reading a nested node is still reading — keep the
-                        // feed from scrolling it away.
-                        pauseFollow()
-                    }
-                } label: {
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Image(systemName: isOpen ? "chevron.down" : "chevron.right")
-                            .font(.app(size: 10, weight: .bold))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 14)
-                        labelText
-                        highlightedText(node.containerSummary, query: highlight, base: jsColor(.className))
-                            .font(.app(.callout, design: .monospaced))
-                    }
-                    .contentShape(Rectangle())
-                    .background(revealTint)
-                }
-                .buttonStyle(.plain)
-                if isOpen {
-                    SnapChildrenView(
-                        node: node, session: session, path: path,
-                        expandedPaths: $expandedPaths, highlightedPath: highlightedPath
-                    )
-                    .padding(.leading, 18)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                labelText
-                highlightedText(
-                    node.primitivePreview, query: highlight, base: jsColor(kind),
-                    underlineLinks: underlineLinks
-                )
-                .font(.app(.callout, design: .monospaced))
-                .textSelection(.enabled)
-            }
-            .background(revealTint)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
-    @ViewBuilder private var revealTint: some View {
-        if isRevealed {
-            RoundedRectangle(cornerRadius: 3).fill(JSConsoleTheme.findMatch.opacity(0.22))
-        }
-    }
-
-    @ViewBuilder private var labelText: some View {
-        if let label {
-            highlightedText("\(label):", query: highlight, base: jsColor(.key))
-                .font(.app(.callout, design: .monospaced))
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-
-    private var kind: JSTokenKind {
-        switch node.type {
-        case "string": return .string
-        case "number", "bigint": return .number
-        case "boolean": return .boolean
-        case "null": return .null
-        case "undefined": return .undefined
-        case "function": return .function
-        case "symbol": return .symbol
-        default: return .plain
-        }
-    }
-}
-
-private struct StackView: View {
-    let stack: CDPStackTrace
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            ForEach(stack.callFrames.prefix(8)) { frame in
-                Text(frame.display)
-                    .font(.app(.caption2).monospaced())
-                    .foregroundStyle(JSConsoleTheme.muted)
-            }
-        }
-        .padding(.leading, 4)
     }
 }
 
@@ -2314,7 +1828,9 @@ func jsEntryPlainText(_ kind: JSEntry.Kind) -> String {
     case let .input(text): text
     case let .result(object): object.inlineSummary
     case let .evalError(details): details.message
-    case let .log(_, args, _): args.map(\.inlineSummary).joined(separator: " ")
+    // Log arguments copy the way they render — a `console.log('hi')` pasted
+    // into an issue should read `hi`, not `'hi'`.
+    case let .log(_, args, _, _): args.map { $0.inlineSummary(style: .consoleArgument) }.joined(separator: " ")
     case let .notice(text): text
     }
 }
@@ -2350,7 +1866,7 @@ private struct ConsoleLinkUnderlineKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    fileprivate var consoleLinkUnderline: Bool {
+    var consoleLinkUnderline: Bool {
         get { self[ConsoleLinkUnderlineKey.self] }
         set { self[ConsoleLinkUnderlineKey.self] = newValue }
     }


### PR DESCRIPTION
The JS Console showed the same data Chrome's console does but wrote it
differently enough that the two can't be read side by side, and three
things about it were wrong.

## Copying

A row carrying an object is two things, so it has two affordances on
hover. **Copy log** takes the message *and* every object it carries as
real JSON — `{…}` is the one part of a pasted row nobody can act on.
**Copy object** takes just the JSON, for pasting somewhere that wants
JSON alone. Both are in the right-click menu too.

## Clicking a nested value

Clicking a leaf inside an expanded object folded the whole thing back up:
the row-level click was a toggle and it fired from anywhere inside the
tree. It now only ever *opens*, and it sits behind the row's content so
it can never compete with the buttons inside it.

## Chrome parity

- A log's whole argument list on one line, each object an inline
  disclosure, instead of one object per line
- Bare top-level strings (`console.log('hi')` → `hi`), single-quoted
  nested ones, `(2) ['a', 'b']` length prefixes, `{…}` for nested objects
- Source locations at the right edge — `StreamScreen.tsx:142`, through
  Metro's `/symbolicate`; clicking one opens the full symbolicated stack
  with library frames dimmed, as Chrome greys its ignore-listed ones
- `console.group` indents with a rule and folds from its header;
  `console.groupEnd` no longer emits a blank row
- `console.table` draws its grid
- No glyph on log/info/debug rows, as Chrome marks only what needs it

Found while testing against StreamLab and fixed alongside: the React
Native dev-server notice rendered as raw ANSI escapes; collapsed nodes in
an expanded value showed `{4}` where Chrome shows the first properties;
replayed history rendered the bare word `Object`; expanding a logged
`Error` opened onto an empty box; the find field appeared over
four-property objects; and unsymbolicated stack frames printed Metro's
whole bundle URL per line.

## Verification

ADBKit 1750 tests (65 new), AppTests 99, build warning-free. Driven live
against StreamLab on an emulator: both copy buttons read back off the
clipboard, the nested-leaf click leaves the tree open, groups fold, the
table renders, and the source link opens a real symbolicated stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
