### PR TITLE
Build the daemon artifacts only on the channel that ships them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,12 @@ jobs:
   # Windows binaries cannot be produced on the macOS release runner; the release
   # job downloads what this uploads.
   daemon-artifacts:
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Beta tags only. A stable release is macOS-only, so
+    # stage-release-artifacts.sh would refuse to publish a Linux or Windows
+    # daemon anyway — building them for a stable tag is work nothing consumes,
+    # and it put the whole release behind two runners that don't need to run.
+    # Same hyphen rule release-channel.sh uses to pick the channel.
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-')
     strategy:
       fail-fast: true
       matrix:
@@ -256,7 +261,17 @@ jobs:
           if-no-files-found: error
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    # A skipped dependency skips its dependents by default, and a stable tag
+    # skips daemon-artifacts — so the gate names the results that are actually
+    # acceptable instead. Writing an `if` at all drops the implicit success()
+    # check, which is why test and build are asserted explicitly.
+    if: >-
+      startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
+      && needs.test.result == 'success'
+      && needs.build.result == 'success'
+      && (needs['daemon-artifacts'].result == 'success'
+      || needs['daemon-artifacts'].result == 'skipped')
     needs: [test, build, daemon-artifacts]
     runs-on: macos-15
     permissions:
@@ -363,7 +378,9 @@ jobs:
           ./scripts/package-daemon.sh "$VERSION" macos-universal \
             droidectived/.build/apple/Products/Release/droidectived \
             DerivedData/Build/Products/Release
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+      # Only a beta has them — daemon-artifacts doesn't run for a stable tag.
+      - if: contains(github.ref_name, '-')
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: daemon-*
           merge-multiple: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,6 @@ jobs:
       - name: Build and package droidectived
         shell: bash
         run: |
-          command -v zip >/dev/null || (apt-get update -q && apt-get install -y -q zip)
           VERSION="${GITHUB_REF_NAME#v}"
           (cd droidectived && swift build -c release --product droidectived)
           BIN="droidectived/.build/release/droidectived"

--- a/scripts/package-daemon.sh
+++ b/scripts/package-daemon.sh
@@ -45,9 +45,32 @@ else
 fi
 cp LICENSE "$STAGE/LICENSE" 2>/dev/null || true
 
+# Zip the staged directory with whatever the machine actually has. `zip` is not
+# on a Windows runner's PATH, and installing it there isn't an option — the job
+# used to try `apt-get`, which a Windows runner doesn't have either, so the
+# Windows leg exited 127 and took the whole release with it. 7-Zip ships on the
+# GitHub Windows images, and Compress-Archive is in any Windows PowerShell.
+zip_stage() {
+  local archive="$1"
+  if command -v zip >/dev/null 2>&1; then
+    zip -q -r "$archive" .
+  elif command -v 7z >/dev/null 2>&1; then
+    7z a -tzip -bso0 -bsp0 "$archive" . >/dev/null
+  elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoProfile -Command "Compress-Archive -Path * -DestinationPath '$archive' -Force"
+  else
+    echo "error: no zip, 7z, or powershell available to build $archive" >&2
+    return 1
+  fi
+  [[ -f "$archive" ]] || {
+    echo "error: $archive was not produced" >&2
+    return 1
+  }
+}
+
 ARCHIVE="droidectived-${VERSION}-${PLATFORM}"
 if [[ "$PLATFORM" == windows-x86_64 ]]; then
-  (cd "$STAGE" && zip -q -r "${ARCHIVE}.zip" .)
+  (cd "$STAGE" && zip_stage "${ARCHIVE}.zip")
   mv "$STAGE/${ARCHIVE}.zip" "$OUT_DIR/"
   echo "packaged $OUT_DIR/${ARCHIVE}.zip"
 else


### PR DESCRIPTION
The `v3.8.1` tag didn't publish. `daemon-artifacts` runs on **every** tag,
and `release` has `needs: [test, build, daemon-artifacts]` — so a macOS-only
stable release was gated on building Linux and Windows daemons. The Windows
leg then failed on a step that runs `apt-get install zip`, which a Windows
runner doesn't have:

```
D:\a\_temp\….sh: line 1: apt-get: command not found
##[error]Process completed with exit code 127.
```

`fail-fast` cancelled the Linux leg, and `release` was skipped. No release
was published and no appcast entry was written.

## The fix

**A stable tag doesn't build them at all.** Windows and Linux daemons ship
on beta only — `stage-release-artifacts.sh` refuses to publish them for a
stable tag anyway, so building them there is work nothing consumes.
`daemon-artifacts` is now gated on the same hyphen rule
`release-channel.sh` uses to pick the channel, and so is the `daemon-*`
download in `release`.

**`release` survives the skip.** A skipped dependency skips its dependents
by default, so the job now names the results it accepts. Writing an `if` at
all drops the implicit `success()` check, which is why `test` and `build`
are asserted explicitly there.

**When beta does build them, the zip works.** The `apt-get` line is gone —
the Linux leg packages a `.tar.gz` and never called `zip` — and
`package-daemon.sh` falls through `zip` → 7-Zip (on the GitHub Windows
images) → `Compress-Archive` (in any Windows PowerShell), failing with a
clear message if none is present rather than producing no archive.

`daemon-artifacts` only runs on tags, so no PR has exercised it; v3.8.1 was
the first tag since the daemon started publishing.

## Verification

`actionlint` clean (it validates the `needs['daemon-artifacts'].result`
form). `shellcheck` and `shfmt -i 2` clean. `make verify-self` green.
Locally on macOS both platforms package correctly — `.zip` carrying
`droidectived.exe` + `LICENSE`, `.tar.gz` carrying `droidectived` +
`LICENSE`.

Gate behaviour: `v3.8.1` → `daemon-artifacts` skipped, `release` runs,
download step skipped, `SHA256SUMS` still covers the macOS daemon the
release job builds itself. `v3.9.0-beta.1` → both run as before.

Unrelated, seen on the same tag run: `build-windows` failed two
`AabConvertServiceTests` cases that passed on this same ADBKit code in the
PR and main-push runs. It's a flake and it isn't in `release`'s `needs`, so
it never blocked the release — worth its own look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
