### PR TITLE
Skip the whole daemon block on a stable tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,12 @@ jobs:
       # fail_on_unmatched_files breaking on the set that varies.
       # Universal, like the app: the daemon is a sidecar next to it, and an
       # arm64-only binary would break Intel Macs that the app itself supports.
+      # Beta only — release-channel.sh lists the macOS daemon tarball and
+      # SHA256SUMS alongside the Linux and Windows ones, so a stable tag
+      # publishes neither and building them for one is ten minutes nothing
+      # consumes.
       - name: Build and package droidectived (macOS universal)
+        if: contains(github.ref_name, '-')
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           (cd droidectived && swift build -c release --arch arm64 --arch x86_64 \
@@ -386,8 +391,11 @@ jobs:
           merge-multiple: true
           path: DerivedData/Build/Products/Release
       # Checksums cover exactly what ships, so they are generated after every
-      # artifact is in place and before staging asserts the set.
+      # artifact is in place and before staging asserts the set. SHA256SUMS is
+      # itself a beta artifact, and on a stable tag there are no archives to
+      # sum — the glob would match nothing and shasum would fail the release.
       - name: Checksum the daemon archives
+        if: contains(github.ref_name, '-')
         run: |
           cd DerivedData/Build/Products/Release
           shasum -a 256 droidectived-* > SHA256SUMS


### PR DESCRIPTION
`v3.8.1` still didn't publish. #267 gated the Linux/Windows job, but the
release job's own **macOS universal daemon build** stayed ungated, and that's
where the tag failed:

```
missing target configuration for 'ADBKit'
Build failed
```

The DMG was already built, signed, stapled and notarized by then — the
publish and appcast steps never ran, so nothing shipped.

## The fix

`release-channel.sh` lists `droidectived-*-macos-universal.tar.gz` and
`SHA256SUMS` as **beta** artifacts, next to the Linux and Windows ones. A
stable tag publishes neither, so both the universal build and the checksum
step now carry the same beta gate the job and the artifact download already
have. Gating only two of the four left a stable release depending on the
other two.

The checksum step would have failed right after it anyway: its
`droidectived-*` glob matches nothing once the archives aren't built.

A stable release now stops at the DMG it actually publishes, and saves the
~10 minutes it was spending on a universal build nothing consumes.

## Still open, separately

The universal daemon build failing is a real bug and **still blocks the
first beta tag**. It builds clean locally
(`swift build -c release --arch arm64 --arch x86_64 --product droidectived`,
exit 0), so it needs reproducing on a runner rather than a guess — the
`duplicate output file` / `missing target configuration` pair points at
xcbuild resolving ADBKit twice, probably interacting with the app build that
runs earlier in the same job.

Worth knowing: none of this block has ever run on a tag. `1bf5a30 Publish
droidectived on the beta channel` landed after v3.8.0, so v3.8.1 is the first
tag to exercise any of it, which is why it's surfacing a bug at a time.

## Verification

`actionlint` clean; `make verify-self` green. All four daemon steps now share
one gate — the job (line 224), the universal build, the artifact download,
and the checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
