### PR TITLE
Measure a console row against its settled baseline

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleRowLayout.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleRowLayout.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// One measured piece of a console row — a run of scalars, an object's inline
+/// disclosure, whatever the row is built from.
+public struct ConsoleRowSegment: Sendable, Equatable {
+    public let width: Double
+    public let height: Double
+    /// Distance from the segment's own top down to its first text baseline.
+    public let baseline: Double
+
+    public init(width: Double, height: Double, baseline: Double) {
+        self.width = width
+        self.height = height
+        self.baseline = baseline
+    }
+}
+
+/// Where a segment sits, relative to the row's top-left.
+public struct ConsoleRowSlot: Sendable, Equatable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct ConsoleRowArrangement: Sendable, Equatable {
+    public let slots: [ConsoleRowSlot]
+    public let width: Double
+    public let height: Double
+
+    public init(slots: [ConsoleRowSlot], width: Double, height: Double) {
+        self.slots = slots
+        self.width = width
+        self.height = height
+    }
+}
+
+/// The geometry behind the JS console's wrapping row — Chrome puts a log's
+/// whole argument list on one line and wraps only when it runs out of width.
+///
+/// Pure, because the arithmetic is where it went wrong: the height of a line
+/// can only be known once every segment on it has been measured. Growing it as
+/// segments arrive under-measures a tall one that a later, lower-baselined
+/// segment pushes down — the row then draws past the height it reported, and a
+/// feed of rows that each under-report leaves blank gaps that shift every time
+/// the pane changes width.
+public enum ConsoleRowLayout {
+    public static func arrange(
+        _ segments: [ConsoleRowSegment],
+        maxWidth: Double,
+        spacing: Double = 5,
+        lineSpacing: Double = 3
+    ) -> ConsoleRowArrangement {
+        guard !segments.isEmpty else { return ConsoleRowArrangement(slots: [], width: 0, height: 0) }
+
+        // Break into lines first, so a line's baseline is settled before
+        // anything is positioned against it.
+        var lines: [[Int]] = []
+        var line: [Int] = []
+        var cursor = 0.0
+        for (index, segment) in segments.enumerated() {
+            if !line.isEmpty, cursor + segment.width > maxWidth + 0.5 {
+                lines.append(line)
+                line = []
+                cursor = 0
+            }
+            line.append(index)
+            cursor += segment.width + spacing
+        }
+        if !line.isEmpty { lines.append(line) }
+
+        var slots = [ConsoleRowSlot](repeating: ConsoleRowSlot(x: 0, y: 0), count: segments.count)
+        var y = 0.0
+        var widest = 0.0
+        for line in lines {
+            let baseline = line.map { segments[$0].baseline }.max() ?? 0
+            var x = 0.0
+            var height = 0.0
+            for index in line {
+                let segment = segments[index]
+                slots[index] = ConsoleRowSlot(x: x, y: y + baseline - segment.baseline)
+                x += segment.width + spacing
+                height = max(height, baseline - segment.baseline + segment.height)
+            }
+            widest = max(widest, x - spacing)
+            y += height + lineSpacing
+        }
+        // Never wider than it was offered: a row that advertises more than the
+        // pane can give it makes the pane lay the row out off its own edge.
+        return ConsoleRowArrangement(
+            slots: slots, width: min(widest, maxWidth), height: max(0, y - lineSpacing)
+        )
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleRowLayoutTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleRowLayoutTests.swift
@@ -1,0 +1,94 @@
+@testable import ADBKit
+import Testing
+
+/// `ConsoleRowLayout` — the wrapping geometry of a JS console row.
+struct ConsoleRowLayoutTests {
+    private func segment(_ width: Double, _ height: Double, baseline: Double) -> ConsoleRowSegment {
+        ConsoleRowSegment(width: width, height: height, baseline: baseline)
+    }
+
+    /// Every segment has to end up inside the height the row reports. This is
+    /// the regression: the height used to grow as segments arrived, against the
+    /// baseline known at that moment — so a tall segment that a later,
+    /// lower-baselined one pushed down drew past the reported height, and a
+    /// feed of under-reporting rows left gaps that moved on every resize.
+    @Test func everySegmentFitsInsideTheReportedHeight() {
+        // A message wrapped to three lines (tall, baseline near its top) next to
+        // a single-line object chip whose baseline sits lower.
+        let segments = [segment(200, 48, baseline: 11), segment(80, 18, baseline: 30)]
+        let arranged = ConsoleRowLayout.arrange(segments, maxWidth: 400)
+        for (index, slot) in arranged.slots.enumerated() {
+            let bottom = slot.y + segments[index].height
+            #expect(bottom <= arranged.height + 0.001, "segment \(index) draws past the row's height")
+        }
+        // The tall segment is pushed down onto the shared baseline, and the
+        // height covers where it lands.
+        #expect(arranged.slots[0].y == 19)
+        #expect(arranged.height == 67)
+    }
+
+    @Test func segmentsShareOneBaselineAcrossALine() {
+        let segments = [segment(50, 20, baseline: 15), segment(50, 30, baseline: 22)]
+        let arranged = ConsoleRowLayout.arrange(segments, maxWidth: 400, spacing: 5)
+        // Both sit so their baselines line up at the larger of the two.
+        #expect(arranged.slots[0].y + 15 == arranged.slots[1].y + 22)
+        #expect(arranged.slots[0].x == 0)
+        #expect(arranged.slots[1].x == 55)
+    }
+
+    @Test func aSegmentThatWouldOverflowStartsANewLine() {
+        let segments = [segment(60, 20, baseline: 15), segment(60, 20, baseline: 15), segment(60, 20, baseline: 15)]
+        let arranged = ConsoleRowLayout.arrange(segments, maxWidth: 130, spacing: 5, lineSpacing: 3)
+        // 60 + 5 + 60 = 125 fits; the third would reach 190.
+        #expect(arranged.slots[0].y == 0)
+        #expect(arranged.slots[1].y == 0)
+        #expect(arranged.slots[2].y == 23)
+        #expect(arranged.slots[2].x == 0)
+        #expect(arranged.height == 43)
+    }
+
+    /// A row that advertises more width than it was offered makes the pane lay
+    /// it out past its own edge.
+    @Test func theReportedWidthNeverExceedsWhatWasOffered() {
+        let wide = [segment(900, 20, baseline: 15)]
+        #expect(ConsoleRowLayout.arrange(wide, maxWidth: 300).width == 300)
+        let narrow = [segment(80, 20, baseline: 15)]
+        #expect(ConsoleRowLayout.arrange(narrow, maxWidth: 300).width == 80)
+    }
+
+    /// A single segment wider than the row still gets placed rather than
+    /// looping or vanishing — a long unbreakable token has to go somewhere.
+    @Test func aSegmentWiderThanTheRowIsStillPlaced() {
+        let segments = [segment(500, 20, baseline: 15), segment(40, 20, baseline: 15)]
+        let arranged = ConsoleRowLayout.arrange(segments, maxWidth: 100)
+        #expect(arranged.slots.count == 2)
+        #expect(arranged.slots[0] == ConsoleRowSlot(x: 0, y: 0))
+        #expect(arranged.slots[1].y > 0)
+    }
+
+    /// Asked for its minimum, the layout answers one segment per line rather
+    /// than dividing by zero or reporting nothing.
+    @Test func aZeroWidthProposalPutsEverySegmentOnItsOwnLine() {
+        let segments = [segment(40, 20, baseline: 15), segment(40, 20, baseline: 15)]
+        let arranged = ConsoleRowLayout.arrange(segments, maxWidth: 0)
+        #expect(arranged.slots[0].y == 0)
+        #expect(arranged.slots[1].y == 23)
+        #expect(arranged.width == 0)
+    }
+
+    @Test func anEmptyRowHasNoSizeAndNoSlots() {
+        let arranged = ConsoleRowLayout.arrange([], maxWidth: 300)
+        #expect(arranged.slots.isEmpty)
+        #expect(arranged.width == 0)
+        #expect(arranged.height == 0)
+    }
+
+    /// One segment is the common case (a log with no object) — no trailing
+    /// line spacing should leak into its height.
+    @Test func aSingleSegmentIsExactlyItsOwnSize() {
+        let arranged = ConsoleRowLayout.arrange([segment(120, 22, baseline: 16)], maxWidth: 300)
+        #expect(arranged.slots == [ConsoleRowSlot(x: 0, y: 0)])
+        #expect(arranged.width == 120)
+        #expect(arranged.height == 22)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -361,7 +361,6 @@ struct JSEntryRow: View {
                         } else {
                             Text(source.label)
                                 .font(.app(.caption2).monospacedDigit())
-                                .underline(hovering)
                                 .lineLimit(1)
                         }
                     }
@@ -369,6 +368,14 @@ struct JSEntryRow: View {
                 }
                 .buttonStyle(.plain)
                 .help(sourceHelp(source))
+                // Revealed on hover, like the copy buttons — a feed of blue
+                // file paths competes with the messages for attention, and the
+                // location is what you go looking for, not what you scan. Kept
+                // in the layout rather than removed so hovering can't reflow
+                // the row's text, and held open while its stack is showing so
+                // the toggle stays reachable.
+                .opacity(hovering || stackShown ? 1 : 0)
+                .allowsHitTesting(hovering || stackShown)
             }
             Text(entry.at, format: .dateTime.hour().minute().second())
                 .font(.app(.caption2).monospacedDigit())

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -15,59 +15,44 @@ struct ConsoleFlowLayout: Layout {
     var lineSpacing: CGFloat = 3
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout Void) -> CGSize {
-        arrange(subviews, maxWidth: proposal.width ?? .infinity).size
+        let arranged = arrange(subviews, maxWidth: proposal.width ?? .infinity).arrangement
+        return CGSize(width: arranged.width, height: arranged.height)
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache _: inout Void) {
-        let placement = arrange(subviews, maxWidth: proposal.width ?? bounds.width)
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout Void) {
+        // Measured against the width actually allocated, not the proposal — the
+        // two can differ, and laying a row out against anything but its real
+        // bounds is how it ends up drawn wider than the pane holding it.
+        let (segments, arranged) = arrange(subviews, maxWidth: bounds.width)
         for (index, subview) in subviews.enumerated() {
-            let frame = placement.frames[index]
+            let slot = arranged.slots[index]
             subview.place(
-                at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY + frame.minY),
-                proposal: ProposedViewSize(width: frame.width, height: frame.height)
+                at: CGPoint(x: bounds.minX + slot.x, y: bounds.minY + slot.y),
+                proposal: ProposedViewSize(width: segments[index].width, height: segments[index].height)
             )
         }
     }
 
-    private func arrange(_ subviews: Subviews, maxWidth: CGFloat) -> (frames: [CGRect], size: CGSize) {
-        var frames: [CGRect] = []
-        var rowStart = 0
-        var rowBaseline: CGFloat = 0
-        var rowHeight: CGFloat = 0
-        var baselines: [CGFloat] = []
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var widest: CGFloat = 0
-
-        /// Shift a finished row's segments down onto a shared baseline.
-        func settleRow(through index: Int) {
-            for slot in rowStart ..< index {
-                frames[slot].origin.y = y + rowBaseline - baselines[slot]
-            }
-            y += rowHeight + lineSpacing
-        }
-
+    /// Measure each segment at the row's width, then hand the arithmetic to
+    /// `ConsoleRowLayout` — it's pure, and it's where the wrapping height has to
+    /// be right.
+    private func arrange(
+        _ subviews: Subviews, maxWidth: CGFloat
+    ) -> (segments: [ConsoleRowSegment], arrangement: ConsoleRowArrangement) {
+        var segments: [ConsoleRowSegment] = []
+        segments.reserveCapacity(subviews.count)
         for subview in subviews {
             let dimensions = subview.dimensions(in: ProposedViewSize(width: maxWidth, height: nil))
-            let size = CGSize(width: dimensions.width, height: dimensions.height)
-            let baseline = dimensions[VerticalAlignment.firstTextBaseline]
-            if x > 0, x + size.width > maxWidth + 0.5 {
-                settleRow(through: frames.count)
-                rowStart = frames.count
-                rowBaseline = 0
-                rowHeight = 0
-                x = 0
-            }
-            frames.append(CGRect(x: x, y: 0, width: size.width, height: size.height))
-            baselines.append(baseline)
-            rowBaseline = max(rowBaseline, baseline)
-            rowHeight = max(rowHeight, size.height + max(0, rowBaseline - baseline))
-            x += size.width + spacing
-            widest = max(widest, x - spacing)
+            segments.append(ConsoleRowSegment(
+                width: dimensions.width,
+                height: dimensions.height,
+                baseline: dimensions[VerticalAlignment.firstTextBaseline]
+            ))
         }
-        guard !frames.isEmpty else { return ([], .zero) }
-        settleRow(through: frames.count)
-        return (frames, CGSize(width: min(widest, maxWidth), height: max(0, y - lineSpacing)))
+        let arrangement = ConsoleRowLayout.arrange(
+            segments, maxWidth: maxWidth, spacing: spacing, lineSpacing: lineSpacing
+        )
+        return (segments, arrangement)
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -62,25 +62,6 @@ struct ConsoleFlowLayout: Layout {
     }
 }
 
-/// Whether the feed is too narrow to write out each row's source location.
-/// Set by the feed from its own measured width, so every row agrees rather
-/// than each measuring itself.
-struct ConsoleCompactTrailingKey: EnvironmentKey {
-    static let defaultValue = false
-}
-
-extension EnvironmentValues {
-    var consoleCompactTrailing: Bool {
-        get { self[ConsoleCompactTrailingKey.self] }
-        set { self[ConsoleCompactTrailingKey.self] = newValue }
-    }
-}
-
-/// Below this the written-out location costs more than it's worth: a split
-/// pane at the 30% floor is around 450pt, and a path like
-/// `NetworkInterceptors.js:37` takes a third of it.
-let consoleCompactTrailingWidth: CGFloat = 620
-
 // MARK: - Entry row
 
 /// One console line: the level glyph, the message and its inline object
@@ -105,7 +86,6 @@ struct JSEntryRow: View {
     @State private var table: ConsoleTable?
     @Environment(\.logTailScrollToHeader) private var scrollToHeader
     @Environment(\.logTailPauseFollow) private var pauseFollow
-    @Environment(\.consoleCompactTrailing) private var compactTrailing
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
     private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
@@ -139,13 +119,12 @@ struct JSEntryRow: View {
             // Always in the layout — hidden, not removed, when idle — so
             // hovering can't change the row's width and reflow its text.
             copyButtons
-                .opacity(hovering || copied ? 1 : 0)
-                .allowsHitTesting(hovering || copied)
-            // Claims its width before the message does. Compact it is an icon
-            // and a clock — a few dozen points — and without the priority the
-            // message keeps all of it and pushes both off the row entirely,
-            // which loses more than it gains.
-            trailingLocation
+                .opacity(hovering || copied || stackShown ? 1 : 0)
+                .allowsHitTesting(hovering || copied || stackShown)
+            // Claims its width before the message does: a clock is a few dozen
+            // points, and without the priority the message keeps all of it and
+            // pushes the clock off the row entirely.
+            timestamp
                 .layoutPriority(1)
         }
         .contentShape(Rectangle())
@@ -342,61 +321,30 @@ struct JSEntryRow: View {
             .foregroundStyle(JSConsoleTheme.muted)
     }
 
-    /// The right edge: where the call was made, then the clock. Chrome's source
-    /// link is the anchor people scan for, so it leads; clicking it opens the
-    /// rest of the stack, which is the question the file name raises.
-    ///
-    /// In a narrow pane it collapses to its icon. `NetworkInterceptors.js:37`
-    /// is most of a split pane's width, and the message is the thing worth
-    /// reading — spending that width on the location truncates the log to make
-    /// room for where it came from, which is backwards.
-    private var trailingLocation: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            if let source {
-                Button { stackShown.toggle() } label: {
-                    Group {
-                        if compactTrailing {
-                            Image(systemName: "chevron.left.forwardslash.chevron.right")
-                                .font(.app(.caption2))
-                        } else {
-                            Text(source.label)
-                                .font(.app(.caption2).monospacedDigit())
-                                .lineLimit(1)
-                        }
-                    }
-                    .foregroundStyle(JSConsoleTheme.sourceLink)
-                }
-                .buttonStyle(.plain)
-                .help(sourceHelp(source))
-                // Revealed on hover, like the copy buttons — a feed of blue
-                // file paths competes with the messages for attention, and the
-                // location is what you go looking for, not what you scan. Kept
-                // in the layout rather than removed so hovering can't reflow
-                // the row's text, and held open while its stack is showing so
-                // the toggle stays reachable.
-                .opacity(hovering || stackShown ? 1 : 0)
-                .allowsHitTesting(hovering || stackShown)
-            }
-            Text(entry.at, format: .dateTime.hour().minute().second())
-                .font(.app(.caption2).monospacedDigit())
-                .foregroundStyle(JSConsoleTheme.muted)
-        }
-        .fixedSize()
-        .padding(.top, 1)
+    /// The clock, always there — two glanceable words wide, and how you line
+    /// the console up against logcat.
+    private var timestamp: some View {
+        Text(entry.at, format: .dateTime.hour().minute().second())
+            .font(.app(.caption2).monospacedDigit())
+            .foregroundStyle(JSConsoleTheme.muted)
+            .fixedSize()
+            .padding(.top, 1)
     }
 
+    /// The icon says nothing on its own, so the tooltip carries the whole
+    /// location: file and line, the function, and the full path.
     private func sourceHelp(_ source: ConsoleSourceLocation) -> String {
         let function = source.function.isEmpty ? "" : source.function + "  "
-        // Compact rows have no label to read, so the tooltip carries it.
-        let location = compactTrailing ? "\(source.label)\n\(function)\(source.file)" : "\(function)\(source.file)"
-        return "\(location) — click for the full stack"
+        return "\(source.label)\n\(function)\(source.file) — click for the full stack"
     }
 
     // MARK: Copy
 
-    /// Two affordances rather than one, because a row that carries an object is
-    /// really two things: the whole log — message *and* the data it was logged
-    /// with — and just the data, for pasting somewhere that wants JSON.
+    /// What a row lets you do, revealed together on hover: copy the whole log,
+    /// copy just its object, open where it came from. One weight and one
+    /// colour — a written-out `NetworkInterceptors.js:38` costs more width than
+    /// the message beside it can spare, and a blue link among grey icons reads
+    /// as a different kind of thing when it isn't.
     @ViewBuilder private var copyButtons: some View {
         HStack(spacing: 6) {
             Button(action: copyLog) {
@@ -421,6 +369,17 @@ struct JSEntryRow: View {
                 }
                 .buttonStyle(.plain)
                 .help("Copy just the object, as JSON")
+            }
+
+            if let source {
+                Button { stackShown.toggle() } label: {
+                    Image(systemName: "chevron.left.forwardslash.chevron.right")
+                        .font(.app(.caption))
+                        .foregroundStyle(JSConsoleTheme.muted)
+                        .frame(width: 14)
+                }
+                .buttonStyle(.plain)
+                .help(sourceHelp(source))
             }
         }
         .padding(.top, 1)

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -26,9 +26,15 @@ struct ConsoleFlowLayout: Layout {
         let (segments, arranged) = arrange(subviews, maxWidth: bounds.width)
         for (index, subview) in subviews.enumerated() {
             let slot = arranged.slots[index]
+            // Never offer a segment more width than the row has. A value with
+            // no break in it measures wider than the pane, and placed at its
+            // measured width it draws straight over whatever is beside the
+            // pane; clamped, it truncates inside its own row instead.
             subview.place(
                 at: CGPoint(x: bounds.minX + slot.x, y: bounds.minY + slot.y),
-                proposal: ProposedViewSize(width: segments[index].width, height: segments[index].height)
+                proposal: ProposedViewSize(
+                    width: min(segments[index].width, bounds.width), height: segments[index].height
+                )
             )
         }
     }
@@ -56,6 +62,25 @@ struct ConsoleFlowLayout: Layout {
     }
 }
 
+/// Whether the feed is too narrow to write out each row's source location.
+/// Set by the feed from its own measured width, so every row agrees rather
+/// than each measuring itself.
+struct ConsoleCompactTrailingKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var consoleCompactTrailing: Bool {
+        get { self[ConsoleCompactTrailingKey.self] }
+        set { self[ConsoleCompactTrailingKey.self] = newValue }
+    }
+}
+
+/// Below this the written-out location costs more than it's worth: a split
+/// pane at the 30% floor is around 450pt, and a path like
+/// `NetworkInterceptors.js:37` takes a third of it.
+let consoleCompactTrailingWidth: CGFloat = 620
+
 // MARK: - Entry row
 
 /// One console line: the level glyph, the message and its inline object
@@ -80,6 +105,7 @@ struct JSEntryRow: View {
     @State private var table: ConsoleTable?
     @Environment(\.logTailScrollToHeader) private var scrollToHeader
     @Environment(\.logTailPauseFollow) private var pauseFollow
+    @Environment(\.consoleCompactTrailing) private var compactTrailing
 
     private var query: String { session.findText.trimmingCharacters(in: .whitespaces) }
     private var isCurrentFind: Bool { session.findVisible && session.currentFindID == entry.id }
@@ -115,7 +141,12 @@ struct JSEntryRow: View {
             copyButtons
                 .opacity(hovering || copied ? 1 : 0)
                 .allowsHitTesting(hovering || copied)
+            // Claims its width before the message does. Compact it is an icon
+            // and a clock — a few dozen points — and without the priority the
+            // message keeps all of it and pushes both off the row entirely,
+            // which loses more than it gains.
             trailingLocation
+                .layoutPriority(1)
         }
         .contentShape(Rectangle())
         // The row's own click sits *behind* its content rather than over it, so
@@ -314,18 +345,30 @@ struct JSEntryRow: View {
     /// The right edge: where the call was made, then the clock. Chrome's source
     /// link is the anchor people scan for, so it leads; clicking it opens the
     /// rest of the stack, which is the question the file name raises.
+    ///
+    /// In a narrow pane it collapses to its icon. `NetworkInterceptors.js:37`
+    /// is most of a split pane's width, and the message is the thing worth
+    /// reading — spending that width on the location truncates the log to make
+    /// room for where it came from, which is backwards.
     private var trailingLocation: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             if let source {
                 Button { stackShown.toggle() } label: {
-                    Text(source.label)
-                        .font(.app(.caption2).monospacedDigit())
-                        .foregroundStyle(JSConsoleTheme.sourceLink)
-                        .underline(hovering)
-                        .lineLimit(1)
+                    Group {
+                        if compactTrailing {
+                            Image(systemName: "chevron.left.forwardslash.chevron.right")
+                                .font(.app(.caption2))
+                        } else {
+                            Text(source.label)
+                                .font(.app(.caption2).monospacedDigit())
+                                .underline(hovering)
+                                .lineLimit(1)
+                        }
+                    }
+                    .foregroundStyle(JSConsoleTheme.sourceLink)
                 }
                 .buttonStyle(.plain)
-                .help("\(source.function.isEmpty ? "" : source.function + "  ")\(source.file) — click for the full stack")
+                .help(sourceHelp(source))
             }
             Text(entry.at, format: .dateTime.hour().minute().second())
                 .font(.app(.caption2).monospacedDigit())
@@ -333,6 +376,13 @@ struct JSEntryRow: View {
         }
         .fixedSize()
         .padding(.top, 1)
+    }
+
+    private func sourceHelp(_ source: ConsoleSourceLocation) -> String {
+        let function = source.function.isEmpty ? "" : source.function + "  "
+        // Compact rows have no label to read, so the tooltip carries it.
+        let location = compactTrailing ? "\(source.label)\n\(function)\(source.file)" : "\(function)\(source.file)"
+        return "\(location) — click for the full stack"
     }
 
     // MARK: Copy
@@ -784,21 +834,13 @@ private struct ConsoleTableView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
-                GridRow {
-                    ForEach(Array(headers.enumerated()), id: \.offset) { _, name in
-                        cell(name, isHeader: true)
-                    }
-                }
-                ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
-                    GridRow {
-                        cell(row.index, isHeader: false)
-                        ForEach(Array(row.cells.enumerated()), id: \.offset) { _, text in
-                            cell(text, isHeader: false)
-                        }
-                        if table.hasValueColumn { cell(row.value ?? "", isHeader: false) }
-                    }
-                }
+            // The grid scrolls inside its own row rather than sizing the feed.
+            // A capped `frame` bounds the maximum but not the *ideal* width, and
+            // that ideal propagates up: one wide table made every row in the
+            // feed as wide as itself, so in a split pane the rest of the rows
+            // ran under the pane beside them.
+            ScrollView(.horizontal, showsIndicators: false) {
+                grid
             }
             .frame(maxWidth: 900, alignment: .leading)
             if table.hiddenRows > 0 {
@@ -810,6 +852,28 @@ private struct ConsoleTableView: View {
         .padding(.vertical, 2)
     }
 
+    private var grid: some View {
+        Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+            GridRow {
+                ForEach(Array(headers.enumerated()), id: \.offset) { _, name in
+                    cell(name, isHeader: true)
+                }
+            }
+            ForEach(Array(table.rows.enumerated()), id: \.offset) { _, row in
+                GridRow {
+                    cell(row.index, isHeader: false)
+                    ForEach(Array(row.cells.enumerated()), id: \.offset) { _, text in
+                        cell(text, isHeader: false)
+                    }
+                    if table.hasValueColumn { cell(row.value ?? "", isHeader: false) }
+                }
+            }
+        }
+    }
+
+    /// Columns size to a readable minimum rather than sharing the row: inside a
+    /// horizontal scroll there is no width to share, and `maxWidth: .infinity`
+    /// against an unbounded proposal would grow without limit.
     private func cell(_ text: String, isHeader: Bool) -> some View {
         Text(text)
             .font(.app(.caption, design: .monospaced))
@@ -818,7 +882,7 @@ private struct ConsoleTableView: View {
             .truncationMode(.tail)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(minWidth: 72, maxWidth: 260, alignment: .leading)
             .background(isHeader ? JSConsoleTheme.muted.opacity(0.14) : .clear)
             .overlay(Rectangle().strokeBorder(JSConsoleTheme.muted.opacity(0.3), lineWidth: 0.5))
     }

--- a/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleTheme.swift
@@ -29,9 +29,6 @@ enum JSConsoleTheme {
     /// Info accent (icon), otherwise info reads as normal text (Chrome `#79b8ff`).
     static let info = Color(red: 0.475, green: 0.722, blue: 1.0)
 
-    /// The source location at the right edge of a row — Chrome's link blue.
-    static let sourceLink = Color(red: 0.416, green: 0.643, blue: 1.0)      // #6aa4ff
-
     /// ⌘F find highlights — warm yellow, stronger orange for the current match.
     static let findMatch = Color(red: 0.961, green: 0.773, blue: 0.094)    // #f5c518
     static let findCurrent = Color(red: 1.0, green: 0.549, blue: 0.102)    // #ff8c1a

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1139,9 +1139,6 @@ struct JSConsoleView: View {
     /// Measured connection-bar width — below ~640pt (a narrow split pane)
     /// the bar reflows to two rows instead of squeezing its labels.
     @State private var connectionBarWidth: CGFloat = 0
-    /// Measured feed width — decides whether rows can afford a written-out
-    /// source location.
-    @State private var feedWidth: CGFloat = 0
     @State private var inputHeight: CGFloat = 26
     @State private var showLevels = false
     /// The "Clear data and restart" confirmation (it signs the user out).
@@ -1325,10 +1322,17 @@ struct JSConsoleView: View {
 
     private var statusBadge: some View {
         HStack(spacing: 6) {
-            Circle().fill(statusColor).frame(width: 8, height: 8)
-            Text(statusText).font(.app(.caption)).foregroundStyle(.secondary).lineLimit(1)
+            Circle().fill(statusColor).frame(width: 8, height: 8).frame(width: 8)
+            Text(statusText)
+                .font(.app(.caption)).foregroundStyle(.secondary)
+                .lineLimit(1).truncationMode(.tail)
         }
-        .fixedSize()
+        // Deliberately NOT fixedSize. Nothing in this bar may demand more width
+        // than the pane it sits in: an incompressible child sets the minimum for
+        // the whole pane, every row below is then laid out at that width, and
+        // the pane's clip cuts the lot — which reads as the tab beside it
+        // covering the console.
+        .layoutPriority(-1)
     }
 
     private var statusColor: Color {
@@ -1368,9 +1372,11 @@ struct JSConsoleView: View {
         } label: {
             Label(session.connectedTarget?.menuLabel ?? "Choose target", systemImage: "iphone.gen3")
                 .lineLimit(1)
+                // The middle goes first: an app id's tail and the device name
+                // are what tell two targets apart.
+                .truncationMode(.middle)
         }
         .menuStyle(.borderlessButton)
-        .fixedSize()
         .disabled(session.targets.isEmpty)
     }
 
@@ -1575,10 +1581,6 @@ struct JSConsoleView: View {
         // card step, not full opacity, whenever the window is translucent.
         .background(JSConsoleFeedBackground())
         .environment(\.colorScheme, .dark)
-        // Measured once for the whole feed, so every row makes the same call
-        // about whether there's room to write out a source location.
-        .measuringWidth(into: $feedWidth)
-        .environment(\.consoleCompactTrailing, feedWidth > 0 && feedWidth < consoleCompactTrailingWidth)
         // Terminal convention for the linkified URLs in the rows: ⌘-click
         // opens the browser; a plain click stays inert so click-drag text
         // selection can't accidentally navigate away.

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1139,6 +1139,9 @@ struct JSConsoleView: View {
     /// Measured connection-bar width — below ~640pt (a narrow split pane)
     /// the bar reflows to two rows instead of squeezing its labels.
     @State private var connectionBarWidth: CGFloat = 0
+    /// Measured feed width — decides whether rows can afford a written-out
+    /// source location.
+    @State private var feedWidth: CGFloat = 0
     @State private var inputHeight: CGFloat = 26
     @State private var showLevels = false
     /// The "Clear data and restart" confirmation (it signs the user out).
@@ -1572,6 +1575,10 @@ struct JSConsoleView: View {
         // card step, not full opacity, whenever the window is translucent.
         .background(JSConsoleFeedBackground())
         .environment(\.colorScheme, .dark)
+        // Measured once for the whole feed, so every row makes the same call
+        // about whether there's room to write out a source location.
+        .measuringWidth(into: $feedWidth)
+        .environment(\.consoleCompactTrailing, feedWidth > 0 && feedWidth < consoleCompactTrailingWidth)
         // Terminal convention for the linkified URLs in the rows: ⌘-click
         // opens the browser; a plain click stays inert so click-drag text
         // selection can't accidentally navigate away.


### PR DESCRIPTION
A JS Console regression I shipped in v3.8.1. In a narrow pane — a split, or
a split with the sidebar open — the feed leaves blank space, and toggling
the sidebar adds more of it each time.

## The defect

`ConsoleFlowLayout` grew a row's height as its segments arrived, measuring
each against the baseline known at that moment. The baseline only grows, so
a tall segment that a later, lower-baselined one pushed down ended up drawn
past the height its row reported. A message wrapped to three lines beside an
object chip is exactly that: **the row claims 48pt and draws 67**.

One row under-reporting is invisible. A feed of them isn't — the scroll
view's idea of its content stops matching what's on screen, so the viewport
parks in space that isn't there, and every width change re-measures in a
different direction and moves the gap again. It only shows in a narrow pane
because that's where rows wrap at all.

## The fix

The arithmetic moves to `ConsoleRowLayout` in ADBKit, where it's pure and
tested: a line's baseline is settled before anything is positioned against
it, and the height covers where each segment actually lands. The SwiftUI
`Layout` becomes the measuring adapter over it.

Two smaller things in the same code:

- placement measures against the **bounds** it was given rather than the
  proposal — those can differ, and only the bounds are real
- the reported width is capped at the width offered, so a row can't ask a
  pane to lay it out past its own edge

## Verification

8 new tests. The regression one asserts every segment lands inside the
height its row reports; re-introducing the shipped accumulation makes it
fail with `bottom → 67.0 <= 48.001`, so it's testing the real thing rather
than passing vacuously.

ADBKit 1759 tests, AppTests 99, build warning-free.

**Not yet confirmed against the reported symptom.** StreamLab's log lines
are much shorter than the Redux-state previews in the report, and I couldn't
get them to wrap hard enough locally to reproduce the accumulating gap. The
defect above is real and provable on its own, and it's the mechanism that
would produce it — but someone should open this build beside a chatty app in
a narrow split before it's called fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
