### PR TITLE
Memoise a console row's measurement per width

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleRowMeasurementCache.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleRowMeasurementCache.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// One width's worth of a console row's measurement: every segment's own size
+/// and the arrangement `ConsoleRowLayout` derived from them.
+public struct ConsoleRowMeasurement: Sendable, Equatable {
+    public let segments: [ConsoleRowSegment]
+    public let arrangement: ConsoleRowArrangement
+
+    public init(segments: [ConsoleRowSegment], arrangement: ConsoleRowArrangement) {
+        self.segments = segments
+        self.arrangement = arrangement
+    }
+}
+
+/// A console row's measurements, memoised by the width they were taken at.
+///
+/// Measuring is the expensive half of laying a row out: every segment is an
+/// attributed `Text` up to the console's display cap, and sizing one lays the
+/// text out for real. SwiftUI asks a `Layout` for its size several times per
+/// pass — the enclosing stack probing its children, then the frame around the
+/// row, then the placement call — and an unmemoised row re-measured all of its
+/// text on each of them. Across a feed of a thousand rows that is the
+/// difference between a scroll and a multi-second main-thread stall.
+///
+/// Bounded on purpose: a layout pass probes a handful of distinct widths, but a
+/// live window resize walks through a new one every frame, so an unbounded memo
+/// would grow for as long as the row is mounted.
+public struct ConsoleRowMeasurementCache: Sendable {
+    /// How many distinct widths are kept at once.
+    public static let capacity = 4
+
+    private var entries: [Double: ConsoleRowMeasurement] = [:]
+
+    public init() {}
+
+    /// How many widths are currently memoised.
+    public var count: Int { entries.count }
+
+    /// The measurement taken at `width`, if it is still held.
+    ///
+    /// A non-finite width other than infinity (SwiftUI proposes `.infinity` for
+    /// an unconstrained row) is never a usable key, so it always misses.
+    public func measurement(atWidth width: Double) -> ConsoleRowMeasurement? {
+        guard !width.isNaN else { return nil }
+        return entries[width]
+    }
+
+    /// Memoise `measurement` under `width`, evicting everything held once the
+    /// cache is full. Wholesale eviction rather than a least-recently-used pick
+    /// because the case that overflows is a resize, where every held width is
+    /// equally stale a frame later.
+    public mutating func store(_ measurement: ConsoleRowMeasurement, atWidth width: Double) {
+        guard !width.isNaN else { return }
+        if entries[width] == nil, entries.count >= Self.capacity {
+            entries.removeAll(keepingCapacity: true)
+        }
+        entries[width] = measurement
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ConsoleRowMeasurementCacheTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ConsoleRowMeasurementCacheTests.swift
@@ -1,0 +1,79 @@
+import Testing
+
+@testable import ADBKit
+
+@Suite("Console row measurement cache")
+struct ConsoleRowMeasurementCacheTests {
+    private func measurement(height: Double) -> ConsoleRowMeasurement {
+        ConsoleRowMeasurement(
+            segments: [ConsoleRowSegment(width: 100, height: height, baseline: 10)],
+            arrangement: ConsoleRowArrangement(
+                slots: [ConsoleRowSlot(x: 0, y: 0)], width: 100, height: height
+            )
+        )
+    }
+
+    @Test func returnsWhatWasStoredAtTheSameWidth() {
+        var cache = ConsoleRowMeasurementCache()
+        cache.store(measurement(height: 17), atWidth: 320)
+
+        #expect(cache.measurement(atWidth: 320) == measurement(height: 17))
+    }
+
+    @Test func missesAtAnotherWidth() {
+        var cache = ConsoleRowMeasurementCache()
+        cache.store(measurement(height: 17), atWidth: 320)
+
+        #expect(cache.measurement(atWidth: 321) == nil)
+    }
+
+    /// A row with no width constraint is proposed `.infinity`, and that pass is
+    /// worth memoising like any other.
+    @Test func memoisesTheUnconstrainedWidth() {
+        var cache = ConsoleRowMeasurementCache()
+        cache.store(measurement(height: 17), atWidth: .infinity)
+
+        #expect(cache.measurement(atWidth: .infinity) == measurement(height: 17))
+    }
+
+    @Test func startsEmpty() {
+        #expect(ConsoleRowMeasurementCache().measurement(atWidth: 320) == nil)
+    }
+
+    /// Re-measuring a width already held replaces it rather than counting
+    /// against the capacity a second time.
+    @Test func restoringAWidthDoesNotGrowTheCache() {
+        var cache = ConsoleRowMeasurementCache()
+        cache.store(measurement(height: 17), atWidth: 320)
+        cache.store(measurement(height: 24), atWidth: 320)
+
+        #expect(cache.count == 1)
+        #expect(cache.measurement(atWidth: 320) == measurement(height: 24))
+    }
+
+    /// The bound is what keeps a live resize — a new width every frame — from
+    /// growing the memo for as long as the row stays mounted.
+    @Test func evictsOnceFull() {
+        var cache = ConsoleRowMeasurementCache()
+        for step in 0..<ConsoleRowMeasurementCache.capacity {
+            cache.store(measurement(height: 17), atWidth: Double(300 + step))
+        }
+        #expect(cache.count == ConsoleRowMeasurementCache.capacity)
+
+        cache.store(measurement(height: 17), atWidth: 999)
+
+        #expect(cache.count == 1)
+        #expect(cache.measurement(atWidth: 999) != nil)
+        #expect(cache.measurement(atWidth: 300) == nil)
+    }
+
+    /// A NaN width is never a usable key — it must neither be stored nor ever
+    /// match, since every NaN compares unequal to itself.
+    @Test func ignoresANonNumericWidth() {
+        var cache = ConsoleRowMeasurementCache()
+        cache.store(measurement(height: 17), atWidth: .nan)
+
+        #expect(cache.count == 0)
+        #expect(cache.measurement(atWidth: .nan) == nil)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleRow.swift
@@ -14,16 +14,31 @@ struct ConsoleFlowLayout: Layout {
     var spacing: CGFloat = 5
     var lineSpacing: CGFloat = 3
 
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout Void) -> CGSize {
-        let arranged = arrange(subviews, maxWidth: proposal.width ?? .infinity).arrangement
+    /// Measurements already taken, keyed by width. SwiftUI asks a row for its
+    /// size several times per layout pass and then places it, and measuring is
+    /// the expensive half — see `ConsoleRowMeasurementCache`. The default
+    /// `updateCache` throws the whole memo away whenever the subviews change,
+    /// which is what keeps a memoised row honest about its own content.
+    func makeCache(subviews _: Subviews) -> ConsoleRowMeasurementCache {
+        ConsoleRowMeasurementCache()
+    }
+
+    func sizeThatFits(
+        proposal: ProposedViewSize, subviews: Subviews, cache: inout ConsoleRowMeasurementCache
+    ) -> CGSize {
+        let arranged = measure(subviews, maxWidth: proposal.width ?? .infinity, cache: &cache).arrangement
         return CGSize(width: arranged.width, height: arranged.height)
     }
 
-    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout Void) {
+    func placeSubviews(
+        in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews,
+        cache: inout ConsoleRowMeasurementCache
+    ) {
         // Measured against the width actually allocated, not the proposal — the
         // two can differ, and laying a row out against anything but its real
         // bounds is how it ends up drawn wider than the pane holding it.
-        let (segments, arranged) = arrange(subviews, maxWidth: bounds.width)
+        let measured = measure(subviews, maxWidth: bounds.width, cache: &cache)
+        let (segments, arranged) = (measured.segments, measured.arrangement)
         for (index, subview) in subviews.enumerated() {
             let slot = arranged.slots[index]
             // Never offer a segment more width than the row has. A value with
@@ -39,12 +54,21 @@ struct ConsoleFlowLayout: Layout {
         }
     }
 
+    /// This row measured at `maxWidth`, from the memo when it's already been
+    /// asked for at that width and freshly otherwise.
+    private func measure(
+        _ subviews: Subviews, maxWidth: CGFloat, cache: inout ConsoleRowMeasurementCache
+    ) -> ConsoleRowMeasurement {
+        if let memoised = cache.measurement(atWidth: maxWidth) { return memoised }
+        let fresh = arrange(subviews, maxWidth: maxWidth)
+        cache.store(fresh, atWidth: maxWidth)
+        return fresh
+    }
+
     /// Measure each segment at the row's width, then hand the arithmetic to
     /// `ConsoleRowLayout` — it's pure, and it's where the wrapping height has to
     /// be right.
-    private func arrange(
-        _ subviews: Subviews, maxWidth: CGFloat
-    ) -> (segments: [ConsoleRowSegment], arrangement: ConsoleRowArrangement) {
+    private func arrange(_ subviews: Subviews, maxWidth: CGFloat) -> ConsoleRowMeasurement {
         var segments: [ConsoleRowSegment] = []
         segments.reserveCapacity(subviews.count)
         for subview in subviews {
@@ -58,7 +82,7 @@ struct ConsoleFlowLayout: Layout {
         let arrangement = ConsoleRowLayout.arrange(
             segments, maxWidth: maxWidth, spacing: spacing, lineSpacing: lineSpacing
         )
-        return (segments, arrangement)
+        return ConsoleRowMeasurement(segments: segments, arrangement: arrangement)
     }
 }
 


### PR DESCRIPTION
Every event Sentry recorded against v3.8.2 is an app hang — 2055 of them across
5 users in 7 days, `mechanism: AppHang`, no crashes at all. Sentry splits them
across ~40 issue groups, but that is where the 2-second sampler landed rather
than 40 separate faults: `ConsoleFlowLayout.arrange`/`.placeSubviews`,
`ConsoleRowLayout.arrange`, `JSEntryRow.body`/`.messageSegments`,
`coloredTokenText`, `applyLinkAttributes`, `ConsoleArguments.chunks`,
`LogTailViewV2.orderedRows`, `LayoutProxy.size`. 2030 of the 2055 events carry
`active_feature: react-native` with `js-console` among the open features.

The event context says the hang is not ingest: `buffered_entries: 1300`,
`ingest_per_min: 0`, `connected: false`. Nothing is arriving, and the app still
stalls — it is re-laying-out rows that are already there.

`ConsoleFlowLayout` declared no `Layout` cache, so `sizeThatFits` and
`placeSubviews` each ran `arrange()`, and `arrange()` calls
`subview.dimensions(in:)` on every segment — real text layout of an attributed
string up to the console's 10,000-character display cap. SwiftUI asks a row for
its size several times per pass (the enclosing `HStack` prioritising, the frame
around the row, the `LazyVStack` measuring estimates) before placing it, so a
row measured all of its text three or four times per layout pass.

Measurements now go through `ConsoleRowMeasurementCache` — pure, in ADBKit,
keyed by the width they were taken at and bounded at four widths so a live
resize cannot grow the memo for as long as the row stays mounted. The default
`updateCache` still discards everything when the subviews change, so a row
cannot report a stale size.

## Still open

The JS Console was a hidden background tab in these sessions, and its 1300 rows
still take part in every layout pass; `PaneFreezePolicy` pins hidden tabs only
while `isResizing`. This change narrows the per-row cost but does not stop a
hidden feed from being laid out. The invalidation source is not identifiable
from stack samples alone.

## Testing

- `swift test` — 1766 pass, 7 new covering hit, miss, `.infinity`, replacement,
  eviction and NaN
- AppTests bundle green
- `make build` clean with warnings-as-errors

Not verified at runtime: reproducing a 1300-entry feed needs the RN harness and
a device, and this machine's shell has neither Accessibility nor Screen
Recording permission. `make test-smoke` is red for that same missing
permission — it fails identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
