### PR TITLE
Wrap long values in the Reactotron object tree

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/JSONTreeLayout.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/JSONTreeLayout.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Row geometry for the Reactotron object tree. A value wraps with the pane
+/// rather than being cut at one line, so the only thing the view has to decide
+/// per row is whether the value still overflows those wrapped lines — that row
+/// earns a disclosure that opens the value in full. Pure, so the decision is
+/// testable without laying out a view.
+public enum JSONTreeLayout {
+    /// Wrapped lines a collapsed value gets before the rest is hidden.
+    public static let collapsedLines = 3
+
+    /// A monospaced glyph's advance as a fraction of the point size — SF Mono,
+    /// what `.monospaced` resolves to, is exactly 0.6 em. Estimating from the
+    /// font size lets one measurement of the tree's width answer for every row,
+    /// and it tracks the user's text-size scale for free.
+    public static let advanceRatio: Double = 0.6
+
+    /// Indent a nesting level adds ahead of the disclosure column.
+    public static let indentPerDepth: Double = 12
+
+    /// Fixed width ahead of the value on every row: the disclosure column (14)
+    /// plus the four 4pt gaps `HStack(spacing: 4)` puts between the row's parts.
+    public static let gutter: Double = 14 + 16
+
+    /// Characters one wrapped line of the value column holds, for a row at
+    /// `depth` whose key is `keyCharacters` long. Never below 1: a
+    /// pathologically narrow pane reports a line that holds something instead
+    /// of dividing a value by zero.
+    public static func columnCharacters(
+        rowWidth: Double, fontSize: Double, depth: Int, keyCharacters: Int
+    ) -> Int {
+        let advance = fontSize * advanceRatio
+        guard advance > 0, rowWidth.isFinite else { return 1 }
+        let indent = Double(max(0, depth)) * indentPerDepth
+        // The key and its ":" sit on the value's first line — charge the value
+        // column for both, plus the space between them.
+        let key = Double(max(0, keyCharacters) + 2) * advance
+        let capacity = (rowWidth - indent - gutter - key) / advance
+        guard capacity.isFinite, capacity > 1 else { return 1 }
+        // Bounded before the Int conversion — an absurd width would trap, and
+        // no real value is longer than this anyway.
+        return Int(min(capacity, 100_000))
+    }
+
+    /// True when a value of `characters` still overflows `lines` wrapped lines
+    /// of a `columnCharacters`-wide column, i.e. the row keeps its disclosure.
+    public static func overflows(
+        characters: Int, columnCharacters: Int, lines: Int = collapsedLines
+    ) -> Bool {
+        characters > max(1, columnCharacters) * max(1, lines)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/JSONTreeLayout.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/JSONTreeLayout.swift
@@ -42,11 +42,27 @@ public enum JSONTreeLayout {
         return Int(min(capacity, 100_000))
     }
 
-    /// True when a value of `characters` still overflows `lines` wrapped lines
-    /// of a `columnCharacters`-wide column, i.e. the row keeps its disclosure.
+    /// Collapsed budget for a row whose pane hasn't reported its width yet —
+    /// roughly three lines of a typical pane, so the frame before the first
+    /// measurement neither flashes a three-character value nor lays out a whole
+    /// payload.
+    public static let unmeasuredBudget = 240
+
+    /// Characters a collapsed value shows before it is cut: `lines` of the
+    /// column, less one glyph per line so an estimate that runs a hair
+    /// optimistic can't spill onto a line the row didn't reserve. The row cuts
+    /// the *string* to this rather than asking for a line limit — a limit is a
+    /// drawing instruction the height doesn't always follow, a shorter string
+    /// can't be drawn taller than it is.
+    public static func collapsedBudget(columnCharacters: Int, lines: Int = collapsedLines) -> Int {
+        max(1, (max(1, columnCharacters) - 1) * max(1, lines))
+    }
+
+    /// True when a value of `characters` doesn't fit the collapsed budget, i.e.
+    /// the row is cut and keeps its disclosure.
     public static func overflows(
         characters: Int, columnCharacters: Int, lines: Int = collapsedLines
     ) -> Bool {
-        characters > max(1, columnCharacters) * max(1, lines)
+        characters > collapsedBudget(columnCharacters: columnCharacters, lines: lines)
     }
 }

--- a/ADBKit/Tests/ADBKitTests/JSONTreeLayoutTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONTreeLayoutTests.swift
@@ -55,20 +55,43 @@ import Testing
         )
     }
 
-    @Test func overflowIsMeasuredAgainstTheWrappedLines() {
-        // 40 characters per line × 3 lines: 120 fits, 121 doesn't.
-        #expect(!JSONTreeLayout.overflows(characters: 120, columnCharacters: 40))
-        #expect(JSONTreeLayout.overflows(characters: 121, columnCharacters: 40))
+    @Test func budgetKeepsAGlyphPerLineInHand() {
+        // 40-character column × 3 lines, less a glyph a line so a hair-optimistic
+        // estimate can't spill onto a fourth: 117, not 120.
+        #expect(JSONTreeLayout.collapsedBudget(columnCharacters: 40) == 117)
+        #expect(JSONTreeLayout.collapsedBudget(columnCharacters: 40, lines: 1) == 39)
+        // Degenerate columns and line counts still yield a budget of at least
+        // one character — a zero would cut every value to nothing.
+        #expect(JSONTreeLayout.collapsedBudget(columnCharacters: 0) == 1)
+        #expect(JSONTreeLayout.collapsedBudget(columnCharacters: 1) == 1)
+        #expect(JSONTreeLayout.collapsedBudget(columnCharacters: 40, lines: 0) == 39)
+    }
+
+    @Test func overflowIsMeasuredAgainstTheBudget() {
+        #expect(!JSONTreeLayout.overflows(characters: 117, columnCharacters: 40))
+        #expect(JSONTreeLayout.overflows(characters: 118, columnCharacters: 40))
         #expect(!JSONTreeLayout.overflows(characters: 0, columnCharacters: 40))
         // An explicit line count is honoured — one line is the un-wrapped case.
-        #expect(JSONTreeLayout.overflows(characters: 41, columnCharacters: 40, lines: 1))
-        #expect(!JSONTreeLayout.overflows(characters: 41, columnCharacters: 40, lines: 2))
+        #expect(JSONTreeLayout.overflows(characters: 40, columnCharacters: 40, lines: 1))
+        #expect(!JSONTreeLayout.overflows(characters: 40, columnCharacters: 40, lines: 2))
     }
 
     @Test func degenerateColumnStillDecides() {
         #expect(JSONTreeLayout.overflows(characters: 10, columnCharacters: 0))
         #expect(!JSONTreeLayout.overflows(characters: 1, columnCharacters: 0))
         #expect(JSONTreeLayout.overflows(characters: 10, columnCharacters: 3, lines: 0))
+    }
+
+    @Test func theUnmeasuredBudgetIsAboutThreeLinesOfATypicalPane() {
+        // The first frame, before the pane reports its width: enough to look
+        // like a collapsed value, far short of a whole payload.
+        let typical = JSONTreeLayout.collapsedBudget(
+            columnCharacters: JSONTreeLayout.columnCharacters(
+                rowWidth: 660, fontSize: font, depth: 0, keyCharacters: 4
+            )
+        )
+        #expect(JSONTreeLayout.unmeasuredBudget < typical)
+        #expect(JSONTreeLayout.unmeasuredBudget > 100)
     }
 
     @Test func aRealisticPayloadKeepsItsDisclosure() {

--- a/ADBKit/Tests/ADBKitTests/JSONTreeLayoutTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONTreeLayoutTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct JSONTreeLayoutTests {
+    /// 11pt monospaced — the object tree's row font at the default text scale.
+    private let font: Double = 11
+
+    @Test func columnFollowsThePaneWidth() {
+        // 6.6pt per glyph: a 660pt pane holds 100 glyphs, less the 30pt gutter
+        // and a 4-character key ("data" + ":" + a space = 6 glyphs).
+        let wide = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: font, depth: 0, keyCharacters: 4)
+        let narrow = JSONTreeLayout.columnCharacters(rowWidth: 330, fontSize: font, depth: 0, keyCharacters: 4)
+        #expect(wide == 89)
+        #expect(narrow == 39)
+        // Halving the pane roughly halves the line — the property the split
+        // panes depend on.
+        #expect(narrow < wide / 2 + 5)
+    }
+
+    @Test func nestingAndLongKeysEatIntoTheValueColumn() {
+        let shallow = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: font, depth: 0, keyCharacters: 4)
+        let deep = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: font, depth: 5, keyCharacters: 4)
+        let longKey = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: font, depth: 0, keyCharacters: 30)
+        #expect(deep < shallow)
+        #expect(longKey == shallow - 26)
+        // 5 levels × 12pt of indent ≈ 9 glyphs.
+        #expect(shallow - deep == 9)
+    }
+
+    @Test func aBiggerTextScaleFitsFewerCharacters() {
+        let normal = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: 11, depth: 0, keyCharacters: 4)
+        let zoomed = JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: 22, depth: 0, keyCharacters: 4)
+        #expect(zoomed < normal / 2 + 5)
+    }
+
+    @Test func degenerateWidthsReportALineThatHoldsSomething() {
+        // Before the pane reports its width, and at widths the gutter alone
+        // exceeds — a zero column would divide every value into infinite lines.
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: 0, fontSize: font, depth: 0, keyCharacters: 0) == 1)
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: 20, fontSize: font, depth: 0, keyCharacters: 0) == 1)
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: 0, depth: 0, keyCharacters: 0) == 1)
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: font, depth: 900, keyCharacters: 0) == 1)
+    }
+
+    @Test func nonFiniteWidthClampsInsteadOfTrapping() {
+        // A NaN or infinite width reaching the Int conversion is a crash, not a
+        // layout glitch — the same trap `PaneSplit` pins for frame widths.
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: .nan, fontSize: font, depth: 0, keyCharacters: 0) == 1)
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: .infinity, fontSize: font, depth: 0, keyCharacters: 0) == 1)
+        #expect(JSONTreeLayout.columnCharacters(rowWidth: 660, fontSize: .nan, depth: 0, keyCharacters: 0) == 1)
+        // A finite but absurd width clamps below the Int conversion's ceiling.
+        #expect(
+            JSONTreeLayout.columnCharacters(rowWidth: 1e9, fontSize: font, depth: 0, keyCharacters: 0) == 100_000
+        )
+    }
+
+    @Test func overflowIsMeasuredAgainstTheWrappedLines() {
+        // 40 characters per line × 3 lines: 120 fits, 121 doesn't.
+        #expect(!JSONTreeLayout.overflows(characters: 120, columnCharacters: 40))
+        #expect(JSONTreeLayout.overflows(characters: 121, columnCharacters: 40))
+        #expect(!JSONTreeLayout.overflows(characters: 0, columnCharacters: 40))
+        // An explicit line count is honoured — one line is the un-wrapped case.
+        #expect(JSONTreeLayout.overflows(characters: 41, columnCharacters: 40, lines: 1))
+        #expect(!JSONTreeLayout.overflows(characters: 41, columnCharacters: 40, lines: 2))
+    }
+
+    @Test func degenerateColumnStillDecides() {
+        #expect(JSONTreeLayout.overflows(characters: 10, columnCharacters: 0))
+        #expect(!JSONTreeLayout.overflows(characters: 1, columnCharacters: 0))
+        #expect(JSONTreeLayout.overflows(characters: 10, columnCharacters: 3, lines: 0))
+    }
+
+    @Test func aRealisticPayloadKeepsItsDisclosure() {
+        // The reported case: a stringified request body in a split pane.
+        let body = String(repeating: "a", count: 900)
+        let column = JSONTreeLayout.columnCharacters(rowWidth: 420, fontSize: font, depth: 1, keyCharacters: 4)
+        #expect(JSONTreeLayout.overflows(characters: body.count, columnCharacters: column))
+        // A short value in the same pane doesn't.
+        #expect(!JSONTreeLayout.overflows(characters: 24, columnCharacters: column))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2710,48 +2710,64 @@ private struct JSONTreeView: View {
     @ViewBuilder
     private func rowView(_ node: JSONNode) -> some View {
         // Built once per row: on a big payload the preview is a full copy of
-        // the value, and both the overflow test and the row itself need it.
+        // the value, and the cut, the disclosure, and the row all need it.
         let preview = node.valuePreview
         let showsAll = expandedValues.contains(node.path)
+        let budget = collapsedBudget(for: node)
+        let isCut = !node.isContainer && preview.prefix(budget + 1).count > budget
         // An opened row keeps its disclosure even if a wider pane has since
         // made the value fit — otherwise the only way to close it disappears.
-        let disclosesValue = !node.isContainer && (showsAll || overflows(preview, at: node))
+        let disclosesValue = !node.isContainer && (showsAll || isCut)
         HStack(alignment: .top, spacing: 4) {
-            Color.clear.frame(width: CGFloat(max(0, node.depth)) * JSONTreeLayout.indentPerDepth, height: 1)
-            if node.isContainer {
-                Image(systemName: expanded.contains(node.path) ? "chevron.down" : "chevron.right")
-                    .font(.app(size: 10, weight: .bold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 14)
-            } else if disclosesValue {
-                // A long value borrows the containers' disclosure column —
-                // same column, lighter weight, so the two never read alike.
-                Image(systemName: showsAll ? "chevron.down" : "chevron.right")
-                    .font(.app(size: 9))
-                    .foregroundStyle(.tertiary)
-                    .frame(width: 14)
-                    .help(showsAll ? "Show less" : "Show the whole value")
-            } else {
-                Color.clear.frame(width: 14, height: 1)
+            // The gutter is incompressible, so the value below is the row's one
+            // flexible child: it's proposed exactly the width it renders at, and
+            // the height it reports is the height it draws. Leave the key and
+            // the value as peer flexible children and the two passes disagree —
+            // the text wraps to more lines than the row reserved and spills
+            // over the event below it.
+            HStack(alignment: .top, spacing: 4) {
+                Color.clear.frame(width: CGFloat(max(0, node.depth)) * JSONTreeLayout.indentPerDepth, height: 1)
+                if node.isContainer {
+                    Image(systemName: expanded.contains(node.path) ? "chevron.down" : "chevron.right")
+                        .font(.app(size: 10, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14)
+                } else if disclosesValue {
+                    // A long value borrows the containers' disclosure column —
+                    // same column, lighter weight, so the two never read alike.
+                    Image(systemName: showsAll ? "chevron.down" : "chevron.right")
+                        .font(.app(size: 9))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 14)
+                        .help(showsAll ? "Show less" : "Show the whole value")
+                } else {
+                    Color.clear.frame(width: 14, height: 1)
+                }
+                if !node.key.isEmpty {
+                    Text(node.key)
+                        .font(.app(size: 11, design: .monospaced))
+                        .foregroundStyle(.rtKey)
+                        // Keys are payload data too: an incompressible 300-character
+                        // one would leave the value nothing to wrap into.
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 240, alignment: .leading)
+                    Text(":")
+                        .font(.app(size: 11, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                }
             }
-            if !node.key.isEmpty {
-                Text(node.key)
-                    .font(.app(size: 11, design: .monospaced))
-                    .foregroundStyle(.rtKey)
-                Text(":")
-                    .font(.app(size: 11, design: .monospaced))
-                    .foregroundStyle(.tertiary)
-            }
-            // Values wrap with the pane instead of being cut at its edge —
-            // capped at a few lines until the row is opened, so a stringified
-            // payload doesn't push the rest of the object off-screen.
-            Text(displayValue(preview, showingAll: showsAll))
+            .fixedSize()
+            // Values wrap with the pane instead of being cut at its edge. The
+            // collapsed row carries a *shortened string*, not a line limit:
+            // `fixedSize` then reports exactly the height it draws, and no
+            // stale line count can spill over the event below.
+            Text(valueText(preview, showingAll: showsAll, budget: budget, isCut: isCut))
                 .font(.app(size: 11, design: .monospaced))
                 .foregroundStyle(node.valueColor)
-                .lineLimit(showsAll ? nil : JSONTreeLayout.collapsedLines)
-                .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
-            Spacer(minLength: 0)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         // Rows were 13pt slivers — give container rows a real click target.
         .padding(.vertical, 2)
@@ -2789,27 +2805,31 @@ private struct JSONTreeView: View {
     /// "Copy value" still yields the whole thing.
     private static let openValueCap = 20_000
 
-    private func displayValue(_ preview: String, showingAll: Bool) -> String {
-        guard showingAll, preview.prefix(Self.openValueCap + 1).count > Self.openValueCap else { return preview }
+    /// The string the row draws: the whole value when it's open (bounded), the
+    /// first few wrapped lines' worth when it isn't. Cutting the string is what
+    /// keeps the drawn height honest — see the `Text` above.
+    private func valueText(_ preview: String, showingAll: Bool, budget: Int, isCut: Bool) -> String {
+        guard showingAll else {
+            return isCut ? String(preview.prefix(budget)) + "…" : preview
+        }
+        guard preview.prefix(Self.openValueCap + 1).count > Self.openValueCap else { return preview }
         return String(preview.prefix(Self.openValueCap)) + "…"
     }
 
-    /// Whether this row's value still runs past its wrapped lines at the pane's
-    /// current width — estimated from the monospaced advance rather than
-    /// measured per row, which would cost a geometry read on every node of a
-    /// streaming timeline.
-    private func overflows(_ preview: String, at node: JSONNode) -> Bool {
-        guard !node.isContainer, treeWidth > 0 else { return false }
+    /// How many characters this row shows collapsed, from the pane's measured
+    /// width — estimated from the monospaced advance rather than measured per
+    /// row, which would cost a geometry read on every node of a streaming
+    /// timeline. Before the first measurement lands, a width-independent
+    /// fallback keeps the first frame from drawing a whole payload.
+    private func collapsedBudget(for node: JSONNode) -> Int {
+        guard treeWidth > 0 else { return JSONTreeLayout.unmeasuredBudget }
         let column = JSONTreeLayout.columnCharacters(
             rowWidth: Double(treeWidth),
             fontSize: valueFontSize,
             depth: node.depth,
             keyCharacters: node.key.count
         )
-        // Counting a multi-megabyte payload on every render would cost more
-        // than the decision is worth: anything past this bound overflows any
-        // pane the app can be resized to.
-        return JSONTreeLayout.overflows(characters: preview.prefix(8192).count, columnCharacters: column)
+        return JSONTreeLayout.collapsedBudget(columnCharacters: column)
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2765,7 +2765,11 @@ private struct JSONTreeView: View {
             Text(valueText(preview, showingAll: showsAll, budget: budget, isCut: isCut))
                 .font(.app(size: 11, design: .monospaced))
                 .foregroundStyle(node.valueColor)
-                .textSelection(.enabled)
+                // Selectable text eats the click, and the value spans the whole
+                // row — so a row whose click means "open this" hands the click
+                // to the row instead. A cut value has nothing worth selecting
+                // (it's an excerpt); once open, the full text selects again.
+                .modifier(SelectableValue(enabled: !node.isContainer && (showsAll || !isCut)))
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -2830,6 +2834,21 @@ private struct JSONTreeView: View {
             keyCharacters: node.key.count
         )
         return JSONTreeLayout.collapsedBudget(columnCharacters: column)
+    }
+}
+
+/// `textSelection` takes two different concrete types, so the choice can't be a
+/// ternary at the call site — this carries it.
+private struct SelectableValue: ViewModifier {
+    let enabled: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content.textSelection(.enabled)
+        } else {
+            content.textSelection(.disabled)
+        }
     }
 }
 

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2585,10 +2585,22 @@ private struct JSONTreeView: View {
     /// where a search box per row would be clutter).
     var showSearch: Bool = true
     @State private var expanded: Set<String> = []
+    /// Leaf rows whose value is shown in full — the rest wrap to
+    /// `JSONTreeLayout.collapsedLines` so one 20 KB payload can't bury the
+    /// timeline.
+    @State private var expandedValues: Set<String> = []
     @State private var search = ""
     /// The last find result revealed by a click, tinted in the tree until the
     /// next search.
     @State private var highlightedPath: String?
+    /// The tree's laid-out width, measured once for every row: a value wraps
+    /// with the pane, so whether it *still* overflows — and needs its "show all"
+    /// disclosure — is a function of the width the pane currently has.
+    @State private var treeWidth: CGFloat = 0
+
+    /// The row font's point size, scaled the way `Font.app` scales it, so the
+    /// per-line character estimate tracks Settings ▸ Appearance ▸ Text size.
+    private var valueFontSize: Double { 11 * AppFontPrefs.sizeScale }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -2628,6 +2640,7 @@ private struct JSONTreeView: View {
                     if matches.count >= 200 { emptyRow("…first 200 matches — narrow the search") }
                 }
             }
+            .measuringWidth(into: $treeWidth)
         }
         // A newly typed query drops the previous reveal's tint (reveal itself
         // clears the field, so its own highlight survives this).
@@ -2696,13 +2709,28 @@ private struct JSONTreeView: View {
 
     @ViewBuilder
     private func rowView(_ node: JSONNode) -> some View {
+        // Built once per row: on a big payload the preview is a full copy of
+        // the value, and both the overflow test and the row itself need it.
+        let preview = node.valuePreview
+        let showsAll = expandedValues.contains(node.path)
+        // An opened row keeps its disclosure even if a wider pane has since
+        // made the value fit — otherwise the only way to close it disappears.
+        let disclosesValue = !node.isContainer && (showsAll || overflows(preview, at: node))
         HStack(alignment: .top, spacing: 4) {
-            Color.clear.frame(width: CGFloat(max(0, node.depth)) * 12, height: 1)
+            Color.clear.frame(width: CGFloat(max(0, node.depth)) * JSONTreeLayout.indentPerDepth, height: 1)
             if node.isContainer {
                 Image(systemName: expanded.contains(node.path) ? "chevron.down" : "chevron.right")
                     .font(.app(size: 10, weight: .bold))
                     .foregroundStyle(.secondary)
                     .frame(width: 14)
+            } else if disclosesValue {
+                // A long value borrows the containers' disclosure column —
+                // same column, lighter weight, so the two never read alike.
+                Image(systemName: showsAll ? "chevron.down" : "chevron.right")
+                    .font(.app(size: 9))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 14)
+                    .help(showsAll ? "Show less" : "Show the whole value")
             } else {
                 Color.clear.frame(width: 14, height: 1)
             }
@@ -2714,10 +2742,14 @@ private struct JSONTreeView: View {
                     .font(.app(size: 11, design: .monospaced))
                     .foregroundStyle(.tertiary)
             }
-            Text(node.valuePreview)
+            // Values wrap with the pane instead of being cut at its edge —
+            // capped at a few lines until the row is opened, so a stringified
+            // payload doesn't push the rest of the object off-screen.
+            Text(displayValue(preview, showingAll: showsAll))
                 .font(.app(size: 11, design: .monospaced))
                 .foregroundStyle(node.valueColor)
-                .lineLimit(1)
+                .lineLimit(showsAll ? nil : JSONTreeLayout.collapsedLines)
+                .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
             Spacer(minLength: 0)
         }
@@ -2730,7 +2762,11 @@ private struct JSONTreeView: View {
             }
         }
         .onTapGesture {
-            if node.isContainer { toggle(node.path) }
+            if node.isContainer {
+                toggle(node.path)
+            } else if disclosesValue {
+                toggleValue(node.path)
+            }
         }
         .contextMenu {
             Button("Copy value") {
@@ -2742,6 +2778,38 @@ private struct JSONTreeView: View {
 
     private func toggle(_ path: String) {
         if expanded.contains(path) { expanded.remove(path) } else { expanded.insert(path) }
+    }
+
+    private func toggleValue(_ path: String) {
+        if expandedValues.contains(path) { expandedValues.remove(path) } else { expandedValues.insert(path) }
+    }
+
+    /// An opened value is capped the way a log body is — laying an unbounded
+    /// payload out over unlimited lines stalls the pane, and the row's
+    /// "Copy value" still yields the whole thing.
+    private static let openValueCap = 20_000
+
+    private func displayValue(_ preview: String, showingAll: Bool) -> String {
+        guard showingAll, preview.prefix(Self.openValueCap + 1).count > Self.openValueCap else { return preview }
+        return String(preview.prefix(Self.openValueCap)) + "…"
+    }
+
+    /// Whether this row's value still runs past its wrapped lines at the pane's
+    /// current width — estimated from the monospaced advance rather than
+    /// measured per row, which would cost a geometry read on every node of a
+    /// streaming timeline.
+    private func overflows(_ preview: String, at node: JSONNode) -> Bool {
+        guard !node.isContainer, treeWidth > 0 else { return false }
+        let column = JSONTreeLayout.columnCharacters(
+            rowWidth: Double(treeWidth),
+            fontSize: valueFontSize,
+            depth: node.depth,
+            keyCharacters: node.key.count
+        )
+        // Counting a multi-megabyte payload on every render would cost more
+        // than the decision is worth: anything past this bound overflows any
+        // pane the app can be resized to.
+        return JSONTreeLayout.overflows(characters: preview.prefix(8192).count, columnCharacters: column)
     }
 }
 


### PR DESCRIPTION
A long string in a Reactotron payload was drawn on one line: it ran to the pane's edge and stopped there, so a split or a narrow window cut it off with no way to read the rest.

## What changed

- A value wraps with the pane. Collapsed, it shows the characters that fit in three lines at the current width and ends in an ellipsis; the wrap reflows as the pane resizes.
- A value that doesn't fit gets a disclosure in the tree's chevron column. Clicking the row — the chevron or the text — opens the whole value, bounded at 20 000 characters the way a log body is. Right-click ▸ Copy value still yields the full string.
- Text selection is off for a cut value (what's on screen is an excerpt) and for a container row (its preview is a count), which is what lets the click through to the row. An opened value and a short one stay selectable.

## Layout

The row's gutter — indent, disclosure, key — is one incompressible cluster, so the value is the row's only flexible child and is proposed exactly the width it draws at. The collapsed row carries a shortened string rather than a line limit: a limit is a drawing instruction the reported height doesn't always follow, and a row kept drawing its opened line count after collapsing, spilling over the event below it. A shorter string cannot be drawn taller than it is.

`JSONTreeLayout` (ADBKit) does the arithmetic — per-line capacity from the pane width, nesting depth, key length and the text-size scale, and the collapsed character budget — off one measurement of the tree's width, so no row pays for its own geometry read. 10 tests cover the capacity, the budget, degenerate and non-finite widths, and a realistic payload.

## Verification

`make verify` green: ADBKit 1769, ReactotronMCP 99, droidectived 91, AppTests 99. `make build` clean with zero warnings. Checked live against a Reactotron client posting 450-character, 12 KB and 60 KB request bodies, at full width and in a split pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)