### PR TITLE
Add a Mirror Wall for up to six devices at once

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -127,7 +127,7 @@ public struct FeatureEngine: Sendable {
         "terminal",
         "send-text", "get-ip", "reverse-port",
         "open-dev-menu", "reload-js", "screenshot",
-        "scrcpy", "deep-link", "app-management", "logcat", "ios-logs",
+        "scrcpy", "mirror-wall", "deep-link", "app-management", "logcat", "ios-logs",
         "demo-mode", "dark-mode", "animation-scale", "fake-battery",
         "layout-overrides", "locale", "network-toggles", "http-proxy",
         "permissions", "app-info", "current-activity", "foreground-package",

--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -177,6 +177,16 @@ public enum FeatureRegistry {
             category: .screen, icon: "display", kind: .view, needsScrcpy: true
         ),
         FeatureDef(
+            id: "mirror-wall", title: "Mirror Wall",
+            subtitle: "Mirror up to six devices side by side",
+            keywords: ["mirror", "wall", "grid", "multi", "devices", "all", "scrcpy",
+                       "side by side", "several", "farm"],
+            // Not scoped to the device bar: the wall picks its own devices, so a
+            // simulator (or nothing) being selected must not gate it.
+            category: .screen, icon: "square.grid.2x2", kind: .view,
+            needsDevice: false, needsScrcpy: true
+        ),
+        FeatureDef(
             id: "screenshot", title: "Screenshot",
             subtitle: "Capture the screen and save it to your Mac",
             keywords: ["screenshot", "capture", "screencap", "png", "image"],
@@ -675,7 +685,7 @@ public enum FeatureRegistry {
             "react-native", "reactotron", "js-console",
             "logcat", "ios-logs", "crash-catcher", "performance", "network-speed",
             "apps", "install-app", "apk-studio", "aab-convert",
-            "device-info", "simulate", "scrcpy", "screenshot", "send-text",
+            "device-info", "simulate", "scrcpy", "mirror-wall", "screenshot", "send-text",
             "emulators", "connection",
             "api-client", "terminal", "custom-commands",
         ],
@@ -691,7 +701,7 @@ public enum FeatureRegistry {
         // Capture first (the QA staple), then repro/report, state simulation,
         // perf/fuzz, app install, and device context.
         .qaTester: [
-            "screenshot", "screen-record", "scrcpy", "video-editor",
+            "screenshot", "screen-record", "scrcpy", "mirror-wall", "video-editor",
             "bug-report", "crash-catcher", "logcat",
             "simulate", "performance", "monkey",
             "apps", "install-app", "send-text", "demo-mode",

--- a/ADBKit/Sources/ADBKit/Features/MirrorWall.swift
+++ b/ADBKit/Sources/ADBKit/Features/MirrorWall.swift
@@ -120,6 +120,25 @@ public enum MirrorWall {
         Array(serials.prefix(maximumDevices))
     }
 
+    /// Which of a wall's tiles should hold a live session: the picked order
+    /// minus the ones the user paused and the ones something else already
+    /// mirrors. Order is kept, so the caller's start pass follows the grid.
+    public static func streamingSerials(
+        order: [String], paused: Set<String>, blocked: Set<String>
+    ) -> [String] {
+        order.filter { !paused.contains($0) && !blocked.contains($0) }
+    }
+
+    /// How long a burst of device arrivals is allowed to settle before tiles
+    /// start.
+    ///
+    /// Devices show up across `adb devices` polls, so the count is unknown for
+    /// the first moment of a wall's life — starting on the first one gave the
+    /// first tile the *one-tile* quality (a heavier encoder than a six-tile wall
+    /// wants) while its neighbours got the right one. Stops are never delayed:
+    /// releasing a device is always safe to do at once.
+    public static let startCoalescingDelay = Duration.milliseconds(250)
+
     // MARK: - Pop-out window tiling
 
     /// A rectangle in screen coordinates. Deliberately not `CGRect`: this math

--- a/ADBKit/Sources/ADBKit/Features/MirrorWall.swift
+++ b/ADBKit/Sources/ADBKit/Features/MirrorWall.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Pure layout and selection math for the Mirror Wall — several devices
+/// mirrored side by side in one pane, each on its own scrcpy session.
+///
+/// UI-free so the grid shape, the per-tile stream quality, the selection cap
+/// and the pop-out window tiling are unit-tested without a device or a view.
+public enum MirrorWall {
+    /// How many devices one wall streams at once. Every tile is a separate
+    /// device-side H.264 encoder and a separate decoder on the Mac, so the cap
+    /// is a real ceiling rather than a UI convenience.
+    public static let maximumDevices = 6
+
+    /// Narrowest tile that still shows a usable phone screen. Below this the
+    /// auto grid drops a column instead of shrinking further.
+    public static let minimumTileWidth = 260.0
+
+    // MARK: - Grid
+
+    /// Columns the auto layout uses for `tiles` tiles in a pane `paneWidth`
+    /// wide.
+    ///
+    /// The preferred shape is picked per count rather than from a square root:
+    /// phone tiles are portrait, so three across reads better than 2 + 1 for
+    /// three devices, while four want a 2 × 2. The pane then clamps it — a
+    /// narrow split drops columns rather than squeezing tiles below
+    /// `minimumTileWidth`.
+    public static func columns(paneWidth: Double, tiles: Int) -> Int {
+        guard tiles > 1 else { return 1 }
+        let preferred = switch min(tiles, maximumDevices) {
+        case 2: 2
+        case 3: 3
+        case 4: 2
+        default: 3
+        }
+        return min(preferred, max(1, fittingColumns(paneWidth: paneWidth)))
+    }
+
+    /// Columns for an explicit user choice, clamped to something drawable: at
+    /// least one, never more than there are tiles. Deliberately *not* clamped
+    /// by pane width — a manual choice is the user overruling the auto layout,
+    /// so it stands even when the tiles get small.
+    public static func columns(manual: Int, tiles: Int) -> Int {
+        min(max(manual, 1), max(tiles, 1))
+    }
+
+    private static func fittingColumns(paneWidth: Double) -> Int {
+        guard paneWidth.isFinite, paneWidth > 0 else { return 1 }
+        return Int(paneWidth / minimumTileWidth)
+    }
+
+    // MARK: - Per-tile stream quality
+
+    /// What one tile asks the device-side server for. A tile is a fraction of
+    /// the pane, so full-mirror resolution is decode work nobody can see.
+    public struct Quality: Sendable, Equatable {
+        /// scrcpy `max_size` — longest side in px.
+        public var maxSize: Int
+        /// scrcpy `max_fps` — 0 leaves the device uncapped.
+        public var maxFps: Int
+
+        public init(maxSize: Int, maxFps: Int) {
+            self.maxSize = maxSize
+            self.maxFps = maxFps
+        }
+    }
+
+    /// The single mirror's quality — what one tile gets, so a one-device wall
+    /// looks exactly like the Mirror Screen tab.
+    public static let fullQuality = Quality(maxSize: 1280, maxFps: 0)
+
+    /// Quality for each tile of a `tiles`-tile wall. Frame rate is capped only
+    /// once several encoders are running: it costs the least of what's on
+    /// offer, and mirroring six devices is triage, not video review.
+    public static func quality(tiles: Int) -> Quality {
+        switch max(tiles, 1) {
+        case 1: fullQuality
+        case 2: Quality(maxSize: 1024, maxFps: 0)
+        case 3, 4: Quality(maxSize: 800, maxFps: 30)
+        default: Quality(maxSize: 640, maxFps: 24)
+        }
+    }
+
+    // MARK: - Selection
+
+    /// Reconcile a stored selection against what's connected: keep the chosen
+    /// order and drop devices that left.
+    ///
+    /// `nil` means nobody has picked yet — a wall opened for the first time —
+    /// which fills with the first `maximumDevices` connected devices so the
+    /// feature shows something immediately. An *explicitly emptied* selection
+    /// (`[]`) stays empty: refilling it would undo the unchecking that emptied
+    /// it.
+    public static func reconciled(selection: [String]?, connected: [String]) -> [String] {
+        guard let selection else { return capped(connected) }
+        let live = Set(connected)
+        return capped(selection.filter { live.contains($0) })
+    }
+
+    /// Add or remove one device, keeping selection order and the cap. Adding
+    /// past the cap is refused rather than evicting someone else's tile — the
+    /// checkbox that would exceed it is disabled, and this is the guard behind
+    /// that.
+    public static func toggled(_ serial: String, in selection: [String]) -> [String] {
+        if let index = selection.firstIndex(of: serial) {
+            var result = selection
+            result.remove(at: index)
+            return result
+        }
+        guard selection.count < maximumDevices else { return selection }
+        return selection + [serial]
+    }
+
+    /// Whether one more device can join.
+    public static func canAdd(to selection: [String]) -> Bool {
+        selection.count < maximumDevices
+    }
+
+    private static func capped(_ serials: [String]) -> [String] {
+        Array(serials.prefix(maximumDevices))
+    }
+
+    // MARK: - Pop-out window tiling
+
+    /// A rectangle in screen coordinates. Deliberately not `CGRect`: this math
+    /// is portable ADBKit, and the App layer converts.
+    public struct TileFrame: Sendable, Equatable {
+        public var x: Double
+        public var y: Double
+        public var width: Double
+        public var height: Double
+
+        public init(x: Double, y: Double, width: Double, height: Double) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+        }
+    }
+
+    /// Frames that tile `count` pop-out mirror windows across `area` (a
+    /// screen's visible frame), left to right then top to bottom — what
+    /// "Arrange Windows" applies. The user can drag them anywhere afterwards;
+    /// this only supplies the starting grid.
+    ///
+    /// `area` is in screen coordinates, whose origin is bottom-left, so the
+    /// first row is laid out at the *top* of the area. Rows come from the same
+    /// column shape the in-pane grid uses, so a wall broken out into windows
+    /// keeps its arrangement.
+    public static func windowFrames(in area: TileFrame, count: Int) -> [TileFrame] {
+        guard count > 0, area.width > 0, area.height > 0 else { return [] }
+        let columnCount = max(1, min(columns(paneWidth: area.width, tiles: count), count))
+        let rowCount = Int((Double(count) / Double(columnCount)).rounded(.up))
+        let width = area.width / Double(columnCount)
+        let height = area.height / Double(rowCount)
+        var frames: [TileFrame] = []
+        for index in 0 ..< count {
+            let column = index % columnCount
+            let row = index / columnCount
+            frames.append(TileFrame(
+                x: area.x + Double(column) * width,
+                y: area.y + area.height - Double(row + 1) * height,
+                width: width,
+                height: height))
+        }
+        return frames
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/WorkspaceRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/WorkspaceRegistry.swift
@@ -60,15 +60,35 @@ public struct WorkspaceRegistry: Sendable, Equatable {
         public var serial: String?
         /// Feature ids currently open as tabs in this window.
         public var openFeatureIDs: Set<String>
+        /// Exclusive work this window runs against devices *other than* its
+        /// selected one — the Mirror Wall's live tiles and its pop-out mirror
+        /// windows. Everything else is device-scoped to `serial`, so this stays
+        /// empty for them.
+        public var claims: Set<Claim>
 
         public init(
             id: WorkspaceID,
             serial: String? = nil,
-            openFeatureIDs: Set<String> = []
+            openFeatureIDs: Set<String> = [],
+            claims: Set<Claim> = []
         ) {
             self.id = id
             self.serial = serial
             self.openFeatureIDs = openFeatureIDs
+            self.claims = claims
+        }
+    }
+
+    /// One window holding one exclusive feature against one device. The
+    /// window's own selection can't express this: a wall streams up to six
+    /// devices from a window pointed at just one of them.
+    public struct Claim: Hashable, Sendable {
+        public let featureID: String
+        public let serial: String
+
+        public init(featureID: String, serial: String) {
+            self.featureID = featureID
+            self.serial = serial
         }
     }
 
@@ -98,6 +118,11 @@ public struct WorkspaceRegistry: Sendable, Equatable {
     /// `scrcpy-window` is the pop-out mirror's pseudo-id (`MirrorWindow
     /// .featureID`), not a registry feature — it shares the encoder with
     /// `scrcpy`, so it carries the same exclusivity.
+    ///
+    /// `mirror-wall` is deliberately *absent*: it streams several devices at
+    /// once, so blocking the whole pane over the window's selected device would
+    /// be wrong in both directions. It contends per tile instead — see
+    /// `owner(ofMirroredDevice:excluding:)`.
     public static let exclusiveFeatureIDs: Set<String> = [
         "scrcpy", "scrcpy-window", "screen-record", "js-console", "frida-console",
     ]
@@ -105,6 +130,12 @@ public struct WorkspaceRegistry: Sendable, Equatable {
     public static func isExclusive(_ featureID: String) -> Bool {
         exclusiveFeatureIDs.contains(featureID)
     }
+
+    /// Every way to open the live mirror. All three drive one scrcpy display
+    /// session on the device, so they contend as one family rather than by id:
+    /// a wall tile for a device already mirrored in another window shows that
+    /// instead of starting a second encoder on it.
+    public static let mirrorFeatureIDs: Set<String> = ["scrcpy", "scrcpy-window", "mirror-wall"]
 
     // MARK: - Window tint
 
@@ -160,7 +191,42 @@ public struct WorkspaceRegistry: Sendable, Equatable {
     ) -> WorkspaceID? {
         guard Self.isExclusive(featureID) else { return nil }
         return entries.first {
-            $0.id != excluding && $0.serial == serial && $0.openFeatureIDs.contains(featureID)
+            $0.id != excluding
+                && (($0.serial == serial && $0.openFeatureIDs.contains(featureID))
+                    || $0.claims.contains(Claim(featureID: featureID, serial: serial)))
+        }?.id
+    }
+
+    /// The window holding a live *claim* for `featureID` on `serial`.
+    ///
+    /// Unlike `owner(ofFeature:on:)` this counts only claims — which are
+    /// registered by running sessions — so a feature whose tab is merely open
+    /// (a hidden keep-alive tab that isn't streaming) doesn't answer yes.
+    public func claimant(
+        ofFeature featureID: String, on serial: String, excluding: WorkspaceID? = nil
+    ) -> WorkspaceID? {
+        entries.first {
+            $0.id != excluding
+                && $0.claims.contains(Claim(featureID: featureID, serial: serial))
+        }?.id
+    }
+
+    /// The window already mirroring `serial` in any of the three ways
+    /// (`mirrorFeatureIDs`), ignoring `excluding`. What a Mirror Wall tile asks
+    /// before it starts a session, so two windows never put two encoders on one
+    /// device.
+    public func owner(
+        ofMirroredDevice serial: String, excluding: WorkspaceID? = nil
+    ) -> WorkspaceID? {
+        entries.first { entry in
+            guard entry.id != excluding else { return false }
+            let mirrors = Self.mirrorFeatureIDs
+            if entry.serial == serial, !entry.openFeatureIDs.isDisjoint(with: mirrors) {
+                return true
+            }
+            return entry.claims.contains {
+                mirrors.contains($0.featureID) && $0.serial == serial
+            }
         }?.id
     }
 
@@ -212,5 +278,14 @@ public struct WorkspaceRegistry: Sendable, Equatable {
         register(id)
         guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[index].openFeatureIDs = featureIDs
+    }
+
+    /// Replace this window's off-selection claims (the wall's live tiles and
+    /// its pop-out mirror windows). Replacing rather than adding means a tile
+    /// that stops streaming releases its device without anyone tracking pairs.
+    public mutating func setClaims(_ claims: Set<Claim>, for id: WorkspaceID) {
+        register(id)
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        entries[index].claims = claims
     }
 }

--- a/ADBKit/Sources/ADBKit/Persistence/Stores.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/Stores.swift
@@ -144,6 +144,10 @@ public struct WindowState: Codable, Sendable, Equatable, Identifiable {
     /// Working directories of this window's terminal tabs at the last implicit
     /// teardown (see `TerminalResume`).
     public var terminalResumeDirs: [String]?
+    /// Devices this window's Mirror Wall shows, in tile order — the picked set
+    /// and the arrangement, which are per window like everything else here.
+    /// nil (or a set whose devices all left) opens on the connected devices.
+    public var mirrorWallSerials: [String]?
 
     public init(
         id: WorkspaceID,
@@ -151,7 +155,8 @@ public struct WindowState: Codable, Sendable, Equatable, Identifiable {
         bundleId: String? = nil,
         tabGroups: [TabGroupState]? = nil,
         focusedGroup: Int? = nil,
-        terminalResumeDirs: [String]? = nil
+        terminalResumeDirs: [String]? = nil,
+        mirrorWallSerials: [String]? = nil
     ) {
         self.id = id
         self.serial = serial
@@ -159,6 +164,7 @@ public struct WindowState: Codable, Sendable, Equatable, Identifiable {
         self.tabGroups = tabGroups
         self.focusedGroup = focusedGroup
         self.terminalResumeDirs = terminalResumeDirs
+        self.mirrorWallSerials = mirrorWallSerials
     }
 }
 

--- a/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeatureEngineTests.swift
@@ -535,9 +535,9 @@ import Testing
 }
 
 @Suite struct FeatureRegistryTests {
-    @Test func hasAll60Features() {
-        #expect(FeatureRegistry.all.count == 60)
-        #expect(FeatureRegistry.byID.count == 60)
+    @Test func hasAll61Features() {
+        #expect(FeatureRegistry.all.count == 61)
+        #expect(FeatureRegistry.byID.count == 61)
     }
 
     @Test func everyFeatureSupportsAtLeastOnePlatform() {

--- a/ADBKit/Tests/ADBKitTests/MirrorWallTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorWallTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct MirrorWallTests {
+    // MARK: - Auto columns
+
+    @Test func oneTileIsOneColumn() {
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 1) == 1)
+        #expect(MirrorWall.columns(paneWidth: 300, tiles: 1) == 1)
+    }
+
+    /// Portrait tiles: three across reads better than 2 + 1, and four want a
+    /// 2 × 2 rather than a single row of narrow slivers.
+    @Test func autoColumnsPreferSquarishGridsExceptForThree() {
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 2) == 2)
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 3) == 3)
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 4) == 2)
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 5) == 3)
+        #expect(MirrorWall.columns(paneWidth: 1600, tiles: 6) == 3)
+    }
+
+    @Test func aNarrowPaneDropsColumnsInsteadOfShrinkingTiles() {
+        // 600 fits two 260-wide tiles, not three.
+        #expect(MirrorWall.columns(paneWidth: 600, tiles: 6) == 2)
+        // A 30% split fits one.
+        #expect(MirrorWall.columns(paneWidth: 300, tiles: 6) == 1)
+        #expect(MirrorWall.columns(paneWidth: 0, tiles: 4) == 1)
+    }
+
+    @Test func autoColumnsSurviveAnUnmeasuredPane() {
+        #expect(MirrorWall.columns(paneWidth: .nan, tiles: 4) == 1)
+        #expect(MirrorWall.columns(paneWidth: -100, tiles: 4) == 1)
+    }
+
+    // MARK: - Manual columns
+
+    @Test func manualColumnsStandEvenInANarrowPane() {
+        // The user overruling the auto layout is not second-guessed.
+        #expect(MirrorWall.columns(manual: 3, tiles: 6) == 3)
+        #expect(MirrorWall.columns(manual: 1, tiles: 6) == 1)
+    }
+
+    @Test func manualColumnsNeverExceedTheTileCount() {
+        #expect(MirrorWall.columns(manual: 3, tiles: 2) == 2)
+        #expect(MirrorWall.columns(manual: 3, tiles: 0) == 1)
+        #expect(MirrorWall.columns(manual: 0, tiles: 4) == 1)
+        #expect(MirrorWall.columns(manual: -2, tiles: 4) == 1)
+    }
+
+    // MARK: - Per-tile quality
+
+    @Test func aOneTileWallLooksLikeTheFullMirror() {
+        #expect(MirrorWall.quality(tiles: 1) == MirrorWall.fullQuality)
+        #expect(MirrorWall.fullQuality.maxSize == 1280)
+        #expect(MirrorWall.fullQuality.maxFps == 0)
+    }
+
+    @Test func qualityStepsDownAsTilesAreAdded() {
+        #expect(MirrorWall.quality(tiles: 2).maxSize == 1024)
+        #expect(MirrorWall.quality(tiles: 4).maxSize == 800)
+        #expect(MirrorWall.quality(tiles: 6).maxSize == 640)
+        // Frame rate is capped only once several encoders are running.
+        #expect(MirrorWall.quality(tiles: 2).maxFps == 0)
+        #expect(MirrorWall.quality(tiles: 3).maxFps == 30)
+        #expect(MirrorWall.quality(tiles: 6).maxFps == 24)
+    }
+
+    @Test func qualityNeverGrowsPastTheCapOrBelowOneTile() {
+        #expect(MirrorWall.quality(tiles: 7) == MirrorWall.quality(tiles: 6))
+        #expect(MirrorWall.quality(tiles: 0) == MirrorWall.fullQuality)
+    }
+
+    // MARK: - Selection
+
+    @Test func aWallNobodyHasPickedForOpensOnTheConnectedDevices() {
+        #expect(MirrorWall.reconciled(selection: nil, connected: ["a", "b"]) == ["a", "b"])
+    }
+
+    @Test func openingOnConnectedDevicesStopsAtTheCap() {
+        let connected = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        #expect(MirrorWall.reconciled(selection: nil, connected: connected).count
+            == MirrorWall.maximumDevices)
+    }
+
+    @Test func reconcilingKeepsTheChosenOrderAndDropsDevicesThatLeft() {
+        #expect(MirrorWall.reconciled(selection: ["c", "a"], connected: ["a", "b", "c"])
+            == ["c", "a"])
+        #expect(MirrorWall.reconciled(selection: ["c", "a"], connected: ["a", "b"]) == ["a"])
+    }
+
+    /// An emptied wall stays empty: refilling it from the connected devices
+    /// would undo the unchecking that emptied it, and every uncheck would
+    /// re-add the device it just removed.
+    @Test func anExplicitlyEmptiedSelectionIsNotRefilled() {
+        #expect(MirrorWall.reconciled(selection: [], connected: ["a", "b"]) == [])
+        #expect(MirrorWall.reconciled(selection: ["x", "y"], connected: ["a"]) == [])
+    }
+
+    @Test func togglingAddsAtTheEndAndRemovesInPlace() {
+        #expect(MirrorWall.toggled("b", in: ["a"]) == ["a", "b"])
+        #expect(MirrorWall.toggled("a", in: ["a", "b"]) == ["b"])
+    }
+
+    @Test func togglingRefusesToPassTheCap() {
+        let full = ["a", "b", "c", "d", "e", "f"]
+        #expect(full.count == MirrorWall.maximumDevices)
+        #expect(MirrorWall.toggled("g", in: full) == full)
+        #expect(!MirrorWall.canAdd(to: full))
+        #expect(MirrorWall.canAdd(to: Array(full.dropLast())))
+        // Removing still works at the cap — that's how you make room.
+        #expect(MirrorWall.toggled("a", in: full) == ["b", "c", "d", "e", "f"])
+    }
+
+    // MARK: - Pop-out window tiling
+
+    private let screen = MirrorWall.TileFrame(x: 0, y: 0, width: 1600, height: 1000)
+
+    @Test func nothingToArrangeYieldsNoFrames() {
+        #expect(MirrorWall.windowFrames(in: screen, count: 0).isEmpty)
+        #expect(MirrorWall.windowFrames(
+            in: MirrorWall.TileFrame(x: 0, y: 0, width: 0, height: 0), count: 3).isEmpty)
+    }
+
+    @Test func fourWindowsTileTwoByTwoFillingTheScreen() {
+        let frames = MirrorWall.windowFrames(in: screen, count: 4)
+        #expect(frames.count == 4)
+        #expect(frames.allSatisfy { $0.width == 800 && $0.height == 500 })
+        // Screen coordinates are bottom-left, so the first row sits at the top.
+        #expect(frames[0] == MirrorWall.TileFrame(x: 0, y: 500, width: 800, height: 500))
+        #expect(frames[1] == MirrorWall.TileFrame(x: 800, y: 500, width: 800, height: 500))
+        #expect(frames[2] == MirrorWall.TileFrame(x: 0, y: 0, width: 800, height: 500))
+        #expect(frames[3] == MirrorWall.TileFrame(x: 800, y: 0, width: 800, height: 500))
+    }
+
+    @Test func windowFramesNeverOverlap() {
+        for count in 1 ... MirrorWall.maximumDevices {
+            let frames = MirrorWall.windowFrames(in: screen, count: count)
+            #expect(frames.count == count)
+            for (index, frame) in frames.enumerated() {
+                for other in frames[(index + 1)...] {
+                    let separated = frame.x + frame.width <= other.x
+                        || other.x + other.width <= frame.x
+                        || frame.y + frame.height <= other.y
+                        || other.y + other.height <= frame.y
+                    #expect(separated, "\(count) windows overlap at \(index)")
+                }
+            }
+        }
+    }
+
+    @Test func windowFramesStayInsideTheGivenArea() {
+        let area = MirrorWall.TileFrame(x: 120, y: 60, width: 1200, height: 800)
+        for frame in MirrorWall.windowFrames(in: area, count: 5) {
+            #expect(frame.x >= area.x)
+            #expect(frame.y >= area.y)
+            #expect(frame.x + frame.width <= area.x + area.width)
+            #expect(frame.y + frame.height <= area.y + area.height)
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MirrorWallTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MirrorWallTests.swift
@@ -112,6 +112,33 @@ import Testing
         #expect(MirrorWall.toggled("a", in: full) == ["b", "c", "d", "e", "f"])
     }
 
+    // MARK: - Which tiles hold a session
+
+    @Test func everyPickedDeviceStreamsByDefault() {
+        #expect(MirrorWall.streamingSerials(order: ["a", "b"], paused: [], blocked: [])
+            == ["a", "b"])
+    }
+
+    @Test func pausedAndTakenDevicesDoNotStream() {
+        #expect(MirrorWall.streamingSerials(order: ["a", "b", "c"], paused: ["b"], blocked: ["c"])
+            == ["a"])
+        #expect(MirrorWall.streamingSerials(order: ["a"], paused: ["a"], blocked: ["a"]) == [])
+    }
+
+    /// The start pass follows the grid, so bring-up order matches what the user
+    /// sees rather than a dictionary's whim.
+    @Test func streamingKeepsTileOrder() {
+        #expect(MirrorWall.streamingSerials(order: ["c", "a", "b"], paused: ["a"], blocked: [])
+            == ["c", "b"])
+    }
+
+    /// Starts wait for the device list to settle (a tile's quality comes from
+    /// the tile *count*); stops never do.
+    @Test func startsAreCoalescedButNotForLong() {
+        #expect(MirrorWall.startCoalescingDelay > .zero)
+        #expect(MirrorWall.startCoalescingDelay < .seconds(1))
+    }
+
     // MARK: - Pop-out window tiling
 
     private let screen = MirrorWall.TileFrame(x: 0, y: 0, width: 1600, height: 1000)

--- a/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
@@ -110,6 +110,68 @@ import Testing
         }
     }
 
+    // MARK: - Claims (the Mirror Wall's tiles and the pop-out mirror windows)
+
+    /// A wall streams up to six devices, and a pop-out mirror window shows a
+    /// device its owner window isn't pointed at, so both can only be seen
+    /// through claims — the exclusivity rules read them like an open tab.
+    @Test func aClaimMakesAnotherWindowSeeTheFeatureAsTaken() {
+        var registry = self.registry([(w1, "abc", []), (w2, "def", [])])
+        registry.setClaims([.init(featureID: "scrcpy-window", serial: "def")], for: w1)
+        #expect(registry.owner(ofFeature: "scrcpy-window", on: "def", excluding: w2) == w1)
+        #expect(registry.owner(ofFeature: "scrcpy-window", on: "ghi", excluding: w2) == nil)
+    }
+
+    @Test func claimsAreReplacedNotAccumulated() {
+        var registry = self.registry([(w1, "abc", [])])
+        registry.setClaims([.init(featureID: "mirror-wall", serial: "def")], for: w1)
+        registry.setClaims([.init(featureID: "mirror-wall", serial: "ghi")], for: w1)
+        #expect(registry.owner(ofMirroredDevice: "def", excluding: w2) == nil)
+        #expect(registry.owner(ofMirroredDevice: "ghi", excluding: w2) == w1)
+    }
+
+    @Test func aWindowIsNotBlockedByItsOwnClaims() {
+        var registry = self.registry([(w1, "abc", [])])
+        registry.setClaims([.init(featureID: "mirror-wall", serial: "def")], for: w1)
+        #expect(registry.owner(ofMirroredDevice: "def", excluding: w1) == nil)
+    }
+
+    /// All three routes to the live mirror drive one device-side session, so a
+    /// wall tile asks about the family, not about its own id.
+    @Test func everyRouteToTheMirrorClaimsTheDeviceForTheFamily() {
+        var registry = self.registry([(w1, "abc", ["scrcpy"]), (w2, "def", [])])
+        #expect(registry.owner(ofMirroredDevice: "abc", excluding: w2) == w1)
+
+        registry.setClaims([.init(featureID: "scrcpy-window", serial: "ghi")], for: w1)
+        #expect(registry.owner(ofMirroredDevice: "ghi", excluding: w2) == w1)
+
+        registry.setClaims([.init(featureID: "mirror-wall", serial: "jkl")], for: w1)
+        #expect(registry.owner(ofMirroredDevice: "jkl", excluding: w2) == w1)
+    }
+
+    @Test func aNonMirrorFeatureDoesNotClaimTheDeviceForMirroring() {
+        var registry = self.registry([(w1, "abc", ["logcat"]), (w2, "def", [])])
+        #expect(registry.owner(ofMirroredDevice: "abc", excluding: w2) == nil)
+        registry.setClaims([.init(featureID: "js-console", serial: "ghi")], for: w1)
+        #expect(registry.owner(ofMirroredDevice: "ghi", excluding: w2) == nil)
+    }
+
+    @Test func everyMirrorFamilyIDIsRealOrThePopOutPseudoID() {
+        for id in WorkspaceRegistry.mirrorFeatureIDs where id != "scrcpy-window" {
+            #expect(FeatureRegistry.byID[id] != nil, "\(id) is not a registry feature")
+        }
+    }
+
+    /// The wall contends per tile, so it must NOT take the whole-pane
+    /// Focus / Take Over banner over the window's selected device — that would
+    /// block five working tiles because of the sixth.
+    @Test func theWallIsNotBlockedAsAWhole() {
+        var registry = self.registry([(w1, "abc", ["mirror-wall"]), (w2, "abc", [])])
+        registry.setClaims([.init(featureID: "mirror-wall", serial: "abc")], for: w1)
+        #expect(!WorkspaceRegistry.isExclusive("mirror-wall"))
+        #expect(registry.conflict(opening: "mirror-wall", in: w2) == nil)
+    }
+
     @Test func exclusiveFeatureOnTheSameDeviceConflicts() {
         let registry = self.registry([(w1, "abc", ["scrcpy"]), (w2, "abc", [])])
         #expect(registry.conflict(opening: "scrcpy", in: w2)

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -468,6 +468,16 @@ struct ADTApp: App {
                     appState?.toggleSidebar()
                 }
                 .keyboardShortcut("b", modifiers: .command)
+
+                // ⇧⌘F, not the system's ⌃⌘F: macOS already owns that for plain
+                // full screen, and this does more (it hides the app's chrome
+                // too). A menu key equivalent is also the one exit that always
+                // works — the mirror swallows key events that reach its view,
+                // but NSMenu gets them first.
+                Button(appState?.fullView == true ? "Exit Full View" : "Full View") {
+                    appState?.toggleFullView()
+                }
+                .keyboardShortcut("f", modifiers: [.command, .shift])
             }
 
             CommandGroup(after: .toolbar) {

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -489,11 +489,13 @@ struct ADTApp: App {
             }
         }
 
-        // The pop-out screen mirror (the mirror control bar's window button,
-        // also listed in the Window menu). Sized like a phone by default. It
-        // follows the window that opened it — one pop-out, one owner.
-        Window("Screen Mirror", id: MirrorWindow.windowID) {
-            WorkspaceScopedView(owner: core.mirrorWindowOwner) { MirrorWindowView() }
+        // The pop-out screen mirrors (the mirror control bar's window button,
+        // and the Mirror Wall's per-tile "Open in Its Own Window"). One window
+        // per device: the presented value IS the serial, so several stand side
+        // by side. Sized like a phone by default. They read their adb client and
+        // toasts from the workspace that popped them out.
+        WindowGroup("Screen Mirror", id: MirrorWindow.windowID, for: String.self) { $serial in
+            WorkspaceScopedView(owner: core.mirrorWindowOwner) { MirrorWindowView(serial: serial) }
                 .tint(.brandAccent)
                 .id(appearanceKey)
         }

--- a/App/Sources/FeatureDetail/FeatureDetailRoute.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailRoute.swift
@@ -49,5 +49,6 @@ enum FeatureDetailRoute: String, CaseIterable {
     case performance = "performance"
     case networkSpeed = "network-speed"
     case scrcpy = "scrcpy"
+    case mirrorWall = "mirror-wall"
     case apiClient = "api-client"
 }

--- a/App/Sources/FeatureDetail/FeatureDetailView.swift
+++ b/App/Sources/FeatureDetail/FeatureDetailView.swift
@@ -167,6 +167,8 @@ struct FeatureDetailView: View {
             NetworkView()
         case .scrcpy:
             ScreenMirrorView()
+        case .mirrorWall:
+            MirrorWallView()
         case .apiClient:
             ApiClientView()
         }

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorSessions.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorSessions.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Every live mirror session in the app, so quit can tear them down instead of
+/// dying with them half-open.
+///
+/// A session's teardown is asynchronous — it terminates the `adb shell` child
+/// *and* removes the `adb forward` tunnel it opened (`MirrorTransport.stop`).
+/// At quit the process exits long before a fire-and-forget teardown gets there,
+/// so the tunnel stays registered in the long-lived adb server: one leaked
+/// listening socket per session, per quit, until `adb kill-server`. One mirror
+/// tab leaked one; a six-tile wall leaks six.
+///
+/// `AppCore.finishQuitNow` already defers termination for the MCP server, the
+/// Reactotron relay and the layout flush — this rides the same deferral.
+/// References are weak, so a view model the UI has let go of is never kept
+/// alive here, and `forget` on `stop()` keeps the table from growing.
+@MainActor
+final class MirrorSessions {
+    static let shared = MirrorSessions()
+
+    private var live: [WeakSession] = []
+
+    private struct WeakSession {
+        weak var model: MirrorViewModel?
+    }
+
+    private init() {}
+
+    /// A session started streaming. Compacts released entries as it goes, so
+    /// nothing has to sweep the table separately.
+    func note(_ model: MirrorViewModel) {
+        live.removeAll { $0.model == nil || $0.model === model }
+        live.append(WeakSession(model: model))
+    }
+
+    func forget(_ model: MirrorViewModel) {
+        live.removeAll { $0.model == nil || $0.model === model }
+    }
+
+    var liveCount: Int {
+        live.compactMap(\.model).count
+    }
+
+    /// Stop every live session and wait for it. Concurrently, because six
+    /// sequential teardowns would show as a visibly slow quit — and each is
+    /// independent (one device's tunnel and encoder per session).
+    func stopAllForQuit() async {
+        let models = live.compactMap(\.model)
+        live = []
+        guard !models.isEmpty else { return }
+        await withTaskGroup(of: Void.self) { group in
+            for model in models {
+                group.addTask { await model.stop() }
+            }
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
@@ -54,7 +54,7 @@ final class MirrorLayerNSView: NSView {
     var onCut: (() -> Void)?
     var videoSize: CGSize?
 
-    private let displayLayer: AVSampleBufferDisplayLayer
+    private var displayLayer: AVSampleBufferDisplayLayer
 
     init(displayLayer: AVSampleBufferDisplayLayer) {
         self.displayLayer = displayLayer
@@ -62,6 +62,22 @@ final class MirrorLayerNSView: NSView {
         wantsLayer = true
         layer?.backgroundColor = NSColor.black.cgColor
         layer?.addSublayer(displayLayer)
+    }
+
+    /// Adopt a *new* session's layer in place.
+    ///
+    /// A reconnect replaces the view model — and its renderer — while the
+    /// SwiftUI view keeps its identity, so `updateNSView` is the only chance to
+    /// notice. Without this the tile goes on showing the dead session's layer:
+    /// input still works, no frame ever arrives again, and it reads as a broken
+    /// mirror. (The full-pane mirror only escapes it by rendering a `nil` model
+    /// in between, which the wall's same-turn reconnect never does.)
+    func adopt(displayLayer newLayer: AVSampleBufferDisplayLayer) {
+        guard newLayer !== displayLayer else { return }
+        displayLayer.removeFromSuperlayer()
+        displayLayer = newLayer
+        layer?.addSublayer(newLayer)
+        syncDisplayLayerFrame()
     }
 
     @available(*, unavailable)
@@ -85,7 +101,7 @@ final class MirrorLayerNSView: NSView {
     }
 
     private func syncDisplayLayerFrame() {
-        guard displayLayer.frame != bounds else { return }
+        guard displayLayer.frame != bounds, bounds.width > 0, bounds.height > 0 else { return }
         // Sublayer frame changes are implicitly animated — a 0.25s lag per
         // divider tick reads as the video chasing the drag. Snap instead.
         CATransaction.begin()
@@ -194,6 +210,7 @@ struct MirrorVideoView: NSViewRepresentable {
     }
 
     private func apply(to view: MirrorLayerNSView) {
+        view.adopt(displayLayer: renderer.displayLayer)
         view.videoSize = videoSize
         view.onTouch = onTouch
         view.onKeycode = onKeycode

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -108,6 +108,11 @@ final class MirrorViewModel {
 
     func start() async {
         guard !stopped else { return }
+        // Registered *before* anything is opened, not after the stream is up: a
+        // start that fails or hangs part-way can still have pushed the server
+        // and opened the adb tunnel, and quit has to be able to reach that too
+        // (see `MirrorSessions`).
+        MirrorSessions.shared.note(self)
         status = .connecting
         didStream = false
         // Prefer the bundled server (self-contained); fall back to an installed
@@ -239,6 +244,7 @@ final class MirrorViewModel {
     /// `start()` and the audio-fallback restart are permanently inert.
     func stop() async {
         stopped = true
+        MirrorSessions.shared.forget(self)
         await teardown()
     }
 

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -80,6 +80,11 @@ final class MirrorViewModel {
     /// as the scrcpy `show_touches` start option on every (re)connect, and as
     /// a live settings write (`ShowTouches`) for mid-session flips.
     private var requestShowTouches: Bool
+    /// What this session asks the device-side encoder for. A full-pane mirror
+    /// takes `MirrorWall.fullQuality`; a Mirror Wall tile is a fraction of the
+    /// pane and shares the Mac with up to five other decoders, so it asks for
+    /// less (`MirrorWall.quality(tiles:)`).
+    private let quality: MirrorWall.Quality
     /// Set once video frames begin flowing; gates the video-only fallback so a
     /// session that streamed and later stopped isn't silently restarted.
     private var didStream = false
@@ -89,12 +94,16 @@ final class MirrorViewModel {
     /// stop, each burning ~a core until quit (Sentry DROIDECTIVE-MAC-2K).
     private var stopped = false
 
-    init(adb: AdbClient, locator: ToolLocator, serial: String, includeAudio: Bool, showTouches: Bool) {
+    init(
+        adb: AdbClient, locator: ToolLocator, serial: String, includeAudio: Bool,
+        showTouches: Bool, quality: MirrorWall.Quality = MirrorWall.fullQuality
+    ) {
         self.adb = adb
         self.locator = locator
         self.serial = serial
         requestAudio = includeAudio
         requestShowTouches = showTouches
+        self.quality = quality
     }
 
     func start() async {
@@ -125,8 +134,8 @@ final class MirrorViewModel {
         // session — live writes are for mid-session flips (`setShowTouches`).
         let params = ScrcpyServerParams(
             scid: UInt32.random(in: 1 ... 0x7fff_ffff),
-            audio: requestAudio, control: true, maxSize: 1280,
-            showTouches: requestShowTouches)
+            audio: requestAudio, control: true, maxSize: quality.maxSize,
+            maxFps: quality.maxFps, showTouches: requestShowTouches)
         let config = MirrorTransport.Configuration(
             serial: serial, params: params,
             serverVersion: server.version, localJarPath: server.jarPath)

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorWallModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorWallModel.swift
@@ -1,0 +1,188 @@
+import ADBKit
+import AppKit
+import Foundation
+import Observation
+
+/// Drives the Mirror Wall: one `MirrorViewModel` per streaming tile, plus the
+/// tile state the grid draws (which are paused, which one has focus).
+///
+/// A wall is a set of *independent* sessions — the encoder it contends for is
+/// the device's, so two devices never contend — which makes this bookkeeping
+/// rather than a second mirror implementation. Every tile is the same session
+/// the full-pane mirror runs, asking for less resolution
+/// (`MirrorWall.quality(tiles:)`) because it's drawn a fraction of the size.
+@MainActor
+@Observable
+final class MirrorWallModel {
+    /// Live sessions by serial. No entry means not streaming: paused, taken by
+    /// another window, or still to be started by the next reconcile.
+    private(set) var streams: [String: MirrorViewModel] = [:]
+    /// Tiles the user paused. Kept by serial (not by index) so pausing survives
+    /// a reorder, and a device that drops and comes back stays paused.
+    private(set) var pausedSerials: Set<String> = []
+    /// The tile that takes clipboard and audio. Keyboard follows AppKit's own
+    /// first responder — clicking a tile makes its view first responder — so
+    /// this exists for the focus ring, the audio choice, and the header's
+    /// per-device actions.
+    private(set) var focused: String?
+    /// Whether the focused tile streams device audio. Off by default, like the
+    /// single mirror: six audio graphs is not what a wall is for, and moving
+    /// focus restarts the session that carries it.
+    private(set) var audioOnFocused = false
+
+    private let adb: AdbClient
+    private let locator: ToolLocator
+    /// Tile order (the picked devices) and the devices another window is
+    /// already mirroring — held so the wall's own actions (pause, reconnect,
+    /// focus) can reconcile without the view passing them again.
+    private var order: [String] = []
+    private var blocked: Set<String> = []
+    /// One chain of work per serial. Connects and teardowns for a tile must
+    /// never interleave — that's what leaves an orphaned session streaming with
+    /// nothing holding it (see `ScreenMirrorView.scheduleReconnect`).
+    private var work: [String: Task<Void, Never>] = [:]
+    /// Terminal: set by `stopAll()` and never cleared. A wall going away must
+    /// not start anything else, and it can be *asked* to during its own
+    /// teardown — a mirror tab closing at quit releases its device, which the
+    /// still-mounted wall would otherwise pick up and stream past the app's
+    /// lifetime (the session outlives the process; see `MirrorViewModel.stopped`
+    /// for the same trap one layer down).
+    private var stopped = false
+
+    init(adb: AdbClient, locator: ToolLocator) {
+        self.adb = adb
+        self.locator = locator
+    }
+
+    // MARK: - Reading
+
+    func stream(_ serial: String) -> MirrorViewModel? { streams[serial] }
+
+    func isPaused(_ serial: String) -> Bool { pausedSerials.contains(serial) }
+
+    /// Devices this wall currently holds a session on — what the window
+    /// registers as its claims, so no other window starts a second encoder on
+    /// one of them.
+    var liveSerials: Set<String> { Set(streams.keys) }
+
+    // MARK: - Driving
+
+    /// Point the wall at a tile order and the set of devices another window is
+    /// already mirroring. Starts what's missing, stops what's no longer wanted,
+    /// and keeps focus on a tile that still exists.
+    func sync(order: [String], blocked: Set<String>) {
+        self.order = order
+        self.blocked = blocked
+        reconcile()
+    }
+
+    func togglePause(_ serial: String) {
+        if pausedSerials.contains(serial) {
+            pausedSerials.remove(serial)
+        } else {
+            pausedSerials.insert(serial)
+        }
+        reconcile()
+    }
+
+    /// Drop a tile's session and start a fresh one — the failed/stopped card's
+    /// button.
+    func reconnect(_ serial: String) {
+        guard let model = streams.removeValue(forKey: serial) else {
+            reconcile()
+            return
+        }
+        schedule(serial) { await model.stop() }
+        reconcile()
+    }
+
+    /// Move focus. The audio stream follows it when audio is on, which restarts
+    /// both sessions involved — the reason it's opt-in.
+    func focus(_ serial: String) {
+        guard focused != serial else { return }
+        let previous = focused
+        focused = serial
+        guard audioOnFocused else { return }
+        if let previous { setAudio(false, on: previous) }
+        setAudio(true, on: serial)
+    }
+
+    func setAudioOnFocused(_ on: Bool) {
+        guard audioOnFocused != on else { return }
+        audioOnFocused = on
+        guard let focused else { return }
+        setAudio(on, on: focused)
+    }
+
+    /// Stop every session but stay resumable — the wall has been hidden past
+    /// its grace window, and returning to the tab syncs it back up. Teardown
+    /// outlives the view, the way the single mirror's does.
+    func suspend() {
+        let leaving = streams
+        streams = [:]
+        for (serial, model) in leaving {
+            schedule(serial) { await model.stop() }
+        }
+    }
+
+    /// The wall is gone for good (tab closed, window closing, app quitting).
+    /// Terminal, so nothing can talk it into starting another session on the way
+    /// out — see `stopped`.
+    func shutDown() {
+        stopped = true
+        suspend()
+    }
+
+    /// Grab one tile's current frame. The wall owns the Discard/Save/Edit
+    /// prompt (a tile has no room for it), so the capture is handed back rather
+    /// than left on the tile's own pending slot.
+    func captureScreenshot(_ serial: String) async -> NSImage? {
+        guard let model = streams[serial] else { return nil }
+        await model.takeScreenshot()
+        let image = model.pendingScreenshot
+        model.pendingScreenshot = nil
+        return image
+    }
+
+    // MARK: - Internals
+
+    private func reconcile() {
+        guard !stopped else { return }
+        let wanted = order.filter { !pausedSerials.contains($0) && !blocked.contains($0) }
+        let wantedSet = Set(wanted)
+        for (serial, model) in streams where !wantedSet.contains(serial) {
+            streams.removeValue(forKey: serial)
+            schedule(serial) { await model.stop() }
+        }
+        // Quality is fixed when a tile starts: re-deriving it for every tile
+        // whenever the count changes would restart live sessions just because a
+        // seventh device was plugged in.
+        let quality = MirrorWall.quality(tiles: order.count)
+        for serial in wanted where streams[serial] == nil {
+            let model = MirrorViewModel(
+                adb: adb, locator: locator, serial: serial,
+                includeAudio: audioOnFocused && serial == focused,
+                showTouches: false,
+                quality: quality)
+            streams[serial] = model
+            schedule(serial) { await model.start() }
+        }
+        if let focused, order.contains(focused) { return }
+        focused = wanted.first ?? order.first
+    }
+
+    private func setAudio(_ on: Bool, on serial: String) {
+        guard let model = streams[serial] else { return }
+        schedule(serial) { await model.setAudio(on) }
+    }
+
+    /// Queue work behind whatever this serial is already doing, so a stop can't
+    /// land in the middle of a connect.
+    private func schedule(_ serial: String, _ body: @escaping @Sendable () async -> Void) {
+        let previous = work[serial]
+        work[serial] = Task {
+            await previous?.value
+            await body()
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorWallModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorWallModel.swift
@@ -39,8 +39,14 @@ final class MirrorWallModel {
     private var blocked: Set<String> = []
     /// One chain of work per serial. Connects and teardowns for a tile must
     /// never interleave — that's what leaves an orphaned session streaming with
-    /// nothing holding it (see `ScreenMirrorView.scheduleReconnect`).
+    /// nothing holding it (see `ScreenMirrorView.scheduleReconnect`). One entry
+    /// per serial the wall has ever streamed — a drained `Task` holds nothing of
+    /// its body, and the key set is bounded by the devices the user picked, so
+    /// there's nothing here to prune.
     private var work: [String: Task<Void, Never>] = [:]
+    /// The pending start pass — see `MirrorWall.startCoalescingDelay`. Stops run
+    /// immediately; only starts wait for the device list to settle.
+    private var pendingStart: Task<Void, Never>?
     /// Terminal: set by `stopAll()` and never cleared. A wall going away must
     /// not start anything else, and it can be *asked* to during its own
     /// teardown — a mirror tab closing at quit releases its device, which the
@@ -48,6 +54,11 @@ final class MirrorWallModel {
     /// lifetime (the session outlives the process; see `MirrorViewModel.stopped`
     /// for the same trap one layer down).
     private var stopped = false
+
+    /// Whether this wall has been shut down for good. A view whose `@State`
+    /// outlived its own `onDisappear` must build a fresh model rather than hold
+    /// an inert one, which would show black tiles with no way back.
+    var isShutDown: Bool { stopped }
 
     init(adb: AdbClient, locator: ToolLocator) {
         self.adb = adb
@@ -118,6 +129,8 @@ final class MirrorWallModel {
     /// its grace window, and returning to the tab syncs it back up. Teardown
     /// outlives the view, the way the single mirror's does.
     func suspend() {
+        pendingStart?.cancel()
+        pendingStart = nil
         let leaving = streams
         streams = [:]
         for (serial, model) in leaving {
@@ -148,15 +161,42 @@ final class MirrorWallModel {
 
     private func reconcile() {
         guard !stopped else { return }
-        let wanted = order.filter { !pausedSerials.contains($0) && !blocked.contains($0) }
+        let wanted = MirrorWall.streamingSerials(
+            order: order, paused: pausedSerials, blocked: blocked)
+        // Stop at once: a device this wall no longer wants must be released
+        // without waiting on anything.
         let wantedSet = Set(wanted)
         for (serial, model) in streams where !wantedSet.contains(serial) {
             streams.removeValue(forKey: serial)
             schedule(serial) { await model.stop() }
         }
-        // Quality is fixed when a tile starts: re-deriving it for every tile
-        // whenever the count changes would restart live sessions just because a
-        // seventh device was plugged in.
+        if wanted.contains(where: { streams[$0] == nil }) { scheduleStartPass() }
+        if let focused, order.contains(focused) { return }
+        focused = wanted.first ?? order.first
+    }
+
+    /// Start the tiles that have no session, once the device list has settled.
+    /// Coalesced because devices arrive across `adb devices` polls and a tile's
+    /// quality is chosen from the tile *count* — starting on the first arrival
+    /// gave the first device a one-tile encoder on a six-tile wall.
+    private func scheduleStartPass() {
+        guard pendingStart == nil else { return }
+        pendingStart = Task { [weak self] in
+            try? await Task.sleep(for: MirrorWall.startCoalescingDelay)
+            guard !Task.isCancelled else { return }
+            self?.startPass()
+        }
+    }
+
+    private func startPass() {
+        pendingStart = nil
+        guard !stopped else { return }
+        let wanted = MirrorWall.streamingSerials(
+            order: order, paused: pausedSerials, blocked: blocked)
+        // Quality is fixed when a tile starts. Re-deriving it for the tiles
+        // already streaming would restart live sessions every time a device was
+        // plugged in — the settle delay above is what keeps a wall's tiles
+        // matched in practice.
         let quality = MirrorWall.quality(tiles: order.count)
         for serial in wanted where streams[serial] == nil {
             let model = MirrorViewModel(
@@ -167,8 +207,6 @@ final class MirrorWallModel {
             streams[serial] = model
             schedule(serial) { await model.start() }
         }
-        if let focused, order.contains(focused) { return }
-        focused = wanted.first ?? order.first
     }
 
     private func setAudio(_ on: Bool, on serial: String) {

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
@@ -95,6 +95,7 @@ struct MirrorWallTile: View {
         case .mirrorTab:
             card(icon: "display", text: "Showing in the Mirror Screen tab.") {
                 Button("Go to Mirror Screen") { onOpenFullMirror() }
+                Button("Bring Back") { onBringBack() }
                     .buttonStyle(.borderedProminent)
             }
         case let .otherWindow(owner):
@@ -212,7 +213,10 @@ struct MirrorWallTile: View {
 
             Divider()
 
-            if blocked == .poppedOut {
+            // Both blocks a tile can take itself out of: its own window, and
+            // this window's Mirror Screen tab. Closing whichever holds the
+            // device hands it straight back to the wall.
+            if blocked == .poppedOut || blocked == .mirrorTab {
                 Button("Bring Back Into the Wall") { onBringBack() }
             } else {
                 Button("Open in Its Own Window") { onPopOut() }

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
@@ -1,0 +1,233 @@
+import ADBKit
+import SwiftUI
+
+/// One device in the Mirror Wall: the live video, a caption strip naming the
+/// device, and a menu with the per-device actions. Interactive like the
+/// full-pane mirror — clicking the video taps the device and moves the wall's
+/// focus to it (AppKit makes the clicked video view first responder, so keys
+/// and ⌘C/⌘V follow the click on their own).
+///
+/// The caption strip is the tile's drag handle, deliberately: `.onDrag` on the
+/// video would turn every swipe on the device into a tile drag.
+struct MirrorWallTile: View {
+    /// Why a tile isn't streaming here, when it isn't the user's own choice.
+    /// Every case is the same fact — something else already mirrors this device,
+    /// and the device has one encoder — differing only in where to send the user.
+    enum Blocked: Equatable {
+        /// This device is showing in its own pop-out window.
+        case poppedOut
+        /// This window's own Mirror Screen tab has it (the wall handed it over).
+        case mirrorTab
+        /// Another workspace window is mirroring it.
+        case otherWindow(WorkspaceID)
+    }
+
+    /// Which edge a dragged tile would be inserted at, drawn as a guideline.
+    enum DropEdge {
+        case leading
+        case trailing
+    }
+
+    @Environment(AppState.self) private var state
+    let device: Device
+    let wall: MirrorWallModel
+    let blocked: Blocked?
+    let dropEdge: DropEdge?
+    /// The drag payload for this tile, attached to the caption strip.
+    let dragItem: () -> NSItemProvider
+    let onScreenshot: () -> Void
+    let onPopOut: () -> Void
+    let onBringBack: () -> Void
+    let onOpenFullMirror: () -> Void
+
+    private var model: MirrorViewModel? { wall.stream(device.serial) }
+    private var isFocused: Bool { wall.focused == device.serial }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                Color.black
+                if let model {
+                    MirrorVideoView(
+                        renderer: model.renderer,
+                        videoSize: model.videoSize,
+                        onTouch: { action, point in
+                            if action == .down { wall.focus(device.serial) }
+                            model.touch(action, at: point)
+                        },
+                        onKeycode: { keycode, action in model.key(keycode, action) },
+                        onText: { model.text($0) },
+                        onPaste: { model.pasteToDevice() },
+                        onCopy: { model.copyFromDevice(cut: false) },
+                        onCut: { model.copyFromDevice(cut: true) })
+                }
+                statusOverlay
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            caption
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(isFocused ? Color.accentColor : Color.primary.opacity(0.12),
+                              lineWidth: isFocused ? 2 : 1)
+        }
+        .overlay(alignment: dropEdge == .trailing ? .trailing : .leading) {
+            if dropEdge != nil {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .frame(width: 3)
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    @ViewBuilder private var statusOverlay: some View {
+        switch blocked {
+        case .poppedOut:
+            card(icon: "macwindow", text: "Showing in its own window.") {
+                Button("Focus") { state.core.focusMirrorWindow(device.serial) }
+                Button("Bring Back") { onBringBack() }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .mirrorTab:
+            card(icon: "display", text: "Showing in the Mirror Screen tab.") {
+                Button("Go to Mirror Screen") { onOpenFullMirror() }
+                    .buttonStyle(.borderedProminent)
+            }
+        case let .otherWindow(owner):
+            card(
+                icon: "macwindow.on.rectangle",
+                text: "Mirroring in \(state.core.registry.label(of: owner))."
+            ) {
+                Button("Focus \(state.core.registry.label(of: owner))") {
+                    state.core.focusWindow(owner)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        case nil:
+            unblockedStatus
+        }
+    }
+
+    @ViewBuilder private var unblockedStatus: some View {
+        if wall.isPaused(device.serial) {
+            card(icon: "pause.circle", text: "Paused.") {
+                Button("Stream") { wall.togglePause(device.serial) }
+                    .buttonStyle(.borderedProminent)
+            }
+        } else if let model {
+            switch model.status {
+            case .connecting:
+                ProgressView().controlSize(.small).tint(.white)
+            case let .failed(message):
+                card(icon: "exclamationmark.triangle", text: message) {
+                    Button("Reconnect") { wall.reconnect(device.serial) }
+                        .buttonStyle(.borderedProminent)
+                }
+            case .stopped:
+                card(icon: "stop.circle", text: "Mirror stopped.") {
+                    Button("Reconnect") { wall.reconnect(device.serial) }
+                        .buttonStyle(.borderedProminent)
+                }
+            case .streaming:
+                EmptyView()
+            }
+        }
+    }
+
+    private func card(
+        icon: String, text: String, @ViewBuilder actions: () -> some View
+    ) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon).font(.app(.title3))
+            Text(text)
+                .font(.app(.caption))
+                .multilineTextAlignment(.center)
+            HStack(spacing: 6) { actions() }
+                .controlSize(.small)
+        }
+        .foregroundStyle(.white)
+        .padding(12)
+        .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+        .padding(8)
+    }
+
+    // MARK: - Caption
+
+    private var caption: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(statusTint)
+                .frame(width: 6, height: 6)
+
+            Text(state.deviceDisplayName(device))
+                .font(.app(.caption))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: 4)
+
+            actionsMenu
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(.bar)
+        .contentShape(Rectangle())
+        .onTapGesture { wall.focus(device.serial) }
+        .onDrag { dragItem() }
+        .help("Drag to rearrange")
+    }
+
+    private var statusTint: Color {
+        if blocked != nil { return .orange }
+        if wall.isPaused(device.serial) { return .secondary }
+        switch model?.status {
+        case .streaming: return .green
+        case .failed: return .red
+        case .stopped: return .secondary
+        case .connecting, nil: return .yellow
+        }
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            Section("Device") {
+                Button("Back") { model?.tapKey(4) }
+                Button("Home") { model?.tapKey(3) }
+                Button("Recent Apps") { model?.tapKey(187) }
+            }
+            .disabled(model?.status != .streaming)
+
+            Divider()
+
+            Button("Screenshot…") { onScreenshot() }
+                .disabled(model?.status != .streaming)
+            Button(wall.isPaused(device.serial) ? "Stream" : "Pause") {
+                wall.togglePause(device.serial)
+            }
+            .disabled(blocked != nil)
+
+            Divider()
+
+            if blocked == .poppedOut {
+                Button("Bring Back Into the Wall") { onBringBack() }
+            } else {
+                Button("Open in Its Own Window") { onPopOut() }
+                    .disabled(blocked != nil)
+            }
+            Button("Open in Mirror Screen") { onOpenFullMirror() }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.app(.caption))
+                .frame(width: 18, height: 14)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Device keys, screenshot, and window options")
+    }
+}

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -1,0 +1,405 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// Columns the wall lays out with: 0 = auto (derived from the pane width),
+/// otherwise the user's explicit choice. App-wide, like the terminal's tab
+/// placement — it's a way of looking at things, not a property of one window.
+let mirrorWallColumnsKey = "mirrorWallColumns"
+
+/// The Mirror Wall: up to `MirrorWall.maximumDevices` devices mirrored side by
+/// side in one pane, each interactive, each on its own scrcpy session.
+///
+/// The wall picks its own devices (the header's Devices menu) rather than
+/// following the device bar — the bar selects *one* device and every other
+/// feature is scoped to it. Tiles drag to rearrange, and any tile can be broken
+/// out into its own window.
+struct MirrorWallView: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.tabIsActive) private var tabIsActive
+    @Environment(\.openWindow) private var openWindow
+    @AppStorage(mirrorWallColumnsKey) private var manualColumns = 0
+    @State private var wall: MirrorWallModel?
+    /// Delayed teardown for a hidden wall; cancelled if the tab returns in time.
+    @State private var teardownTask: Task<Void, Never>?
+    @State private var dragging: String?
+    @State private var dropSlot: DropSlot?
+    @State private var pendingScreenshot: NSImage?
+    @State private var editingScreenshot: NSImage?
+
+    /// Where a dragged tile would land: before a serial, or at the end.
+    enum DropSlot: Equatable {
+        case before(String)
+        case end
+    }
+
+    var body: some View {
+        ZStack {
+            if let editingScreenshot {
+                ScreenshotEditorView(image: editingScreenshot) { self.editingScreenshot = nil }
+            } else {
+                wallContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .imageDecision(image: $pendingScreenshot) { editingScreenshot = $0 }
+        .task {
+            if wall == nil {
+                wall = MirrorWallModel(
+                    adb: state.env.engine.client, locator: state.env.engine.locator)
+            }
+            sync()
+        }
+        .onChange(of: selection) { syncSelection() }
+        .onChange(of: connectedSerials) { syncSelection() }
+        .onChange(of: blockedSerials) { sync() }
+        .onChange(of: tabIsActive) { _, active in
+            if active {
+                teardownTask?.cancel()
+                teardownTask = nil
+                sync()
+            } else {
+                scheduleHiddenTeardown()
+            }
+        }
+        .onChange(of: wall?.liveSerials) { _, live in
+            state.noteMirrorClaims(live ?? [], featureID: "mirror-wall")
+        }
+        .onDisappear {
+            teardownTask?.cancel()
+            wall?.shutDown()
+            state.noteMirrorClaims([], featureID: "mirror-wall")
+        }
+    }
+
+    @ViewBuilder private var wallContent: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if connectedDevices.isEmpty {
+                ContentUnavailableView(
+                    "Connect devices to mirror",
+                    systemImage: "square.grid.2x2",
+                    description: Text("Plug in or pair Android devices, then pick up to "
+                        + "\(MirrorWall.maximumDevices) to watch side by side."))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if selection.isEmpty {
+                ContentUnavailableView(
+                    "No devices picked",
+                    systemImage: "square.grid.2x2",
+                    description: Text("Choose the devices this wall shows from the Devices menu."))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let wall {
+                grid(wall: wall)
+            }
+        }
+        .background(.bgRoot)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            devicesMenu
+
+            Text("\(selection.count) of \(MirrorWall.maximumDevices)")
+                .font(.app(.caption))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 8)
+
+            layoutMenu
+            optionsMenu
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private var devicesMenu: some View {
+        Menu {
+            ForEach(connectedDevices) { device in
+                Toggle(state.deviceDisplayName(device), isOn: selectionBinding(device.serial))
+                    // At the cap, only the already-picked boxes still work —
+                    // adding a seventh device would be a seventh encoder.
+                    .disabled(!selection.contains(device.serial)
+                        && !MirrorWall.canAdd(to: selection))
+            }
+        } label: {
+            Label("Devices", systemImage: "checklist")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Pick which devices this wall shows")
+    }
+
+    private var layoutMenu: some View {
+        Menu {
+            Picker("Columns", selection: $manualColumns) {
+                Text("Auto").tag(0)
+                Text("1 Column").tag(1)
+                Text("2 Columns").tag(2)
+                Text("3 Columns").tag(3)
+            }
+            .pickerStyle(.inline)
+        } label: {
+            Label(
+                manualColumns == 0 ? "Auto" : "\(manualColumns) ×",
+                systemImage: "rectangle.split.3x1")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Arrange the tiles automatically, or in a fixed number of columns")
+    }
+
+    private var optionsMenu: some View {
+        Menu {
+            Toggle("Audio from the Focused Device", isOn: Binding(
+                get: { wall?.audioOnFocused ?? false },
+                set: { wall?.setAudioOnFocused($0) }))
+
+            Divider()
+
+            Button("Open Each in Its Own Window") { popOutAll() }
+                .disabled(selection.isEmpty)
+            Button("Arrange Mirror Windows") { state.core.arrangeMirrorWindows() }
+                .disabled(!state.core.hasMirrorWindows)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.app(.title3))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("Audio, and breaking tiles out into windows")
+    }
+
+    // MARK: - Grid
+
+    private func grid(wall: MirrorWallModel) -> some View {
+        GeometryReader { geometry in
+            let columnCount = columnCount(paneWidth: geometry.size.width)
+            let tileWidth = tileWidth(paneWidth: geometry.size.width, columns: columnCount)
+            ScrollView {
+                LazyVGrid(columns: gridItems(columnCount), spacing: 10) {
+                    ForEach(selection, id: \.self) { serial in
+                        if let device = connectedDevices.first(where: { $0.serial == serial }) {
+                            tile(device: device, wall: wall, width: tileWidth)
+                                .frame(height: tileHeight(
+                                    paneHeight: geometry.size.height,
+                                    tiles: selection.count,
+                                    columns: columnCount))
+                        }
+                    }
+                }
+                .padding(10)
+            }
+        }
+    }
+
+    private func tile(device: Device, wall: MirrorWallModel, width: Double) -> some View {
+        MirrorWallTile(
+            device: device,
+            wall: wall,
+            blocked: blocked(device.serial),
+            dropEdge: dropEdge(device.serial),
+            dragItem: {
+                dragging = device.serial
+                return privateDragItem(.mirrorWallTile, device.serial)
+            },
+            onScreenshot: { capture(device.serial, wall: wall) },
+            onPopOut: { popOut(device.serial) },
+            onBringBack: { state.core.closeMirrorWindow(device.serial) },
+            onOpenFullMirror: { openFullMirror(device.serial) })
+            .onDrop(of: [.mirrorWallTile], delegate: MirrorWallDrop(
+                target: device.serial,
+                dragging: dragging,
+                isLast: selection.last == device.serial,
+                tileWidth: width,
+                setSlot: { dropSlot = $0 },
+                perform: moveTile))
+    }
+
+    private func dropEdge(_ serial: String) -> MirrorWallTile.DropEdge? {
+        switch dropSlot {
+        case .before(serial): .leading
+        case .end where selection.last == serial: .trailing
+        default: nil
+        }
+    }
+
+    private func gridItems(_ count: Int) -> [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: 10), count: max(count, 1))
+    }
+
+    private func columnCount(paneWidth: Double) -> Int {
+        guard manualColumns == 0 else {
+            return MirrorWall.columns(manual: manualColumns, tiles: selection.count)
+        }
+        return MirrorWall.columns(paneWidth: paneWidth, tiles: selection.count)
+    }
+
+    private func tileWidth(paneWidth: Double, columns: Int) -> Double {
+        let usable = paneWidth - 20 - Double(max(columns - 1, 0)) * 10
+        return max(usable / Double(max(columns, 1)), 1)
+    }
+
+    /// Fill the pane: rows share its height so a picked set is all visible at
+    /// once, which is the point of a wall. A pane too short for that scrolls
+    /// rather than shrinking tiles into uselessness.
+    private func tileHeight(paneHeight: Double, tiles: Int, columns: Int) -> Double {
+        let rows = max(Int((Double(tiles) / Double(max(columns, 1))).rounded(.up)), 1)
+        let usable = paneHeight - 20 - Double(rows - 1) * 10
+        return max(usable / Double(rows), 180)
+    }
+
+    // MARK: - Devices & selection
+
+    private var connectedDevices: [Device] {
+        state.devices.filter { $0.isReady && $0.platform == .android }
+    }
+
+    private var connectedSerials: [String] { connectedDevices.map(\.serial) }
+
+    /// The picked devices, in tile order, minus any that left. Never picked
+    /// (nil) opens on what's connected; an explicitly emptied wall stays empty.
+    private var selection: [String] {
+        MirrorWall.reconciled(selection: state.mirrorWallSerials, connected: connectedSerials)
+    }
+
+    private var blockedSerials: Set<String> {
+        Set(selection.filter { blocked($0) != nil })
+    }
+
+    /// Why this device can't stream in the wall right now. Every route to the
+    /// live mirror drives one device-side encoder, so a device already mirrored
+    /// — in its own pop-out window, or in another workspace window — shows that
+    /// rather than starting a second session on it.
+    private func blocked(_ serial: String) -> MirrorWallTile.Blocked? {
+        if state.core.mirrorWindowSerials.contains(serial) { return .poppedOut }
+        // This window's *own* Mirror Screen tab counts too — a split pane shows
+        // the wall and that tab at once — and the registry's conflict queries
+        // exclude the window doing the asking, so the wall checks for it by
+        // hand. `claimant` answers for live sessions only, so a mirror tab
+        // sitting hidden and torn down doesn't hold a device hostage.
+        if let owner = state.core.registry.claimant(ofFeature: "scrcpy", on: serial) {
+            return owner == state.id ? .mirrorTab : .otherWindow(owner)
+        }
+        guard let owner = state.core.registry.owner(ofMirroredDevice: serial, excluding: state.id)
+        else { return nil }
+        return .otherWindow(owner)
+    }
+
+    private func selectionBinding(_ serial: String) -> Binding<Bool> {
+        Binding(
+            get: { selection.contains(serial) },
+            // Writing the toggled *reconciled* list is what turns "never
+            // picked" into an explicit choice, so the first uncheck sticks
+            // instead of being refilled from the connected devices.
+            set: { _ in state.mirrorWallSerials = MirrorWall.toggled(serial, in: selection) })
+    }
+
+    private func moveTile(_ serial: String, to slot: DropSlot) {
+        let order = switch slot {
+        case let .before(target): SidebarOrdering.move(serial, before: target, in: selection)
+        case .end: SidebarOrdering.moveToEnd(serial, in: selection)
+        }
+        state.mirrorWallSerials = order
+        dragging = nil
+        dropSlot = nil
+    }
+
+    // MARK: - Lifecycle
+
+    private func sync() {
+        guard tabIsActive else { return }
+        wall?.sync(order: selection, blocked: blockedSerials)
+    }
+
+    /// A device leaving is written back, so the stored wall matches what's on
+    /// screen — the picked set is the user's, and it shouldn't quietly carry
+    /// serials no tile shows.
+    private func syncSelection() {
+        let reconciled = selection
+        if state.mirrorWallSerials != nil, state.mirrorWallSerials != reconciled {
+            state.mirrorWallSerials = reconciled
+        }
+        sync()
+    }
+
+    /// Stop every tile once the wall has been hidden for the grace window — six
+    /// encoders behind another tab is worth reclaiming, and a quick tab flip
+    /// still resumes in place. Same window the single mirror uses.
+    private func scheduleHiddenTeardown() {
+        teardownTask?.cancel()
+        teardownTask = Task {
+            try? await Task.sleep(for: .seconds(mirrorHiddenGraceSeconds))
+            guard !Task.isCancelled else { return }
+            teardownTask = nil
+            wall?.suspend()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func capture(_ serial: String, wall: MirrorWallModel) {
+        Task {
+            guard let image = await wall.captureScreenshot(serial) else { return }
+            pendingScreenshot = image
+        }
+    }
+
+    /// Break one tile out into its own window. The wall keeps its slot: the
+    /// tile shows "Mirroring in …" (the window claims the device) and takes it
+    /// back when the window closes.
+    private func popOut(_ serial: String) {
+        state.core.mirrorWindowOwner = state.id
+        openWindow(id: MirrorWindow.windowID, value: serial)
+    }
+
+    private func popOutAll() {
+        for serial in selection { popOut(serial) }
+    }
+
+    /// Hand this device to the full Mirror Screen tab — the screen with the
+    /// nav bar, recording and the audio sheet.
+    private func openFullMirror(_ serial: String) {
+        state.requestDevice(serial, force: true)
+        if let feature = FeatureRegistry.byID["scrcpy"] { state.openFeature(feature) }
+    }
+}
+
+/// Drop target for one tile: the left half inserts before it, the right half
+/// after — and the last tile's right half is how a tile reaches the end, the
+/// one slot an insertion line before a tile can't express.
+private struct MirrorWallDrop: DropDelegate {
+    let target: String
+    let dragging: String?
+    let isLast: Bool
+    let tileWidth: Double
+    let setSlot: (MirrorWallView.DropSlot?) -> Void
+    let perform: (String, MirrorWallView.DropSlot) -> Void
+
+    func validateDrop(info: DropInfo) -> Bool { slot(info) != nil }
+
+    func dropEntered(info: DropInfo) { setSlot(slot(info)) }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        let here = slot(info)
+        setSlot(here)
+        return here == nil ? nil : DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) { setSlot(nil) }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard let dragging, let slot = slot(info) else { return false }
+        perform(dragging, slot)
+        return true
+    }
+
+    private func slot(_ info: DropInfo) -> MirrorWallView.DropSlot? {
+        guard let dragging, dragging != target else { return nil }
+        if isLast, tileWidth > 0, info.location.x > tileWidth / 2 { return .end }
+        return .before(target)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -44,7 +44,12 @@ struct MirrorWallView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .imageDecision(image: $pendingScreenshot) { editingScreenshot = $0 }
         .task {
-            if wall == nil {
+            // A wall that has been shut down is inert for good (that's what
+            // stops it resurrecting sessions during teardown), so a view whose
+            // `@State` outlived its own `onDisappear` — a tab moved between
+            // panes — must build a fresh one instead of showing black tiles
+            // nothing can revive.
+            if wall == nil || wall?.isShutDown == true {
                 wall = MirrorWallModel(
                     adb: state.env.engine.client, locator: state.env.engine.locator)
             }
@@ -64,6 +69,23 @@ struct MirrorWallView: View {
         }
         .onChange(of: wall?.liveSerials) { _, live in
             state.noteMirrorClaims(live ?? [], featureID: "mirror-wall")
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: NSWindow.didChangeOcclusionStateNotification)
+        ) { notification in
+            // Six encoders behind another app's window — or a miniaturized one —
+            // is device battery and Mac CPU spent on pixels nobody can see. Same
+            // grace window as a hidden tab, so flipping between apps doesn't
+            // stop-and-reconnect the whole wall.
+            guard let window = notification.object as? NSWindow,
+                  window === state.nsWindow else { return }
+            if window.occlusionState.contains(.visible) {
+                teardownTask?.cancel()
+                teardownTask = nil
+                sync()
+            } else {
+                scheduleHiddenTeardown()
+            }
         }
         .onDisappear {
             teardownTask?.cancel()
@@ -239,7 +261,11 @@ struct MirrorWallView: View {
     }
 
     private func dropEdge(_ serial: String) -> MirrorWallTile.DropEdge? {
-        switch dropSlot {
+        // Only ever while a drag is actually in flight: a drag abandoned over a
+        // tile (Esc, or released outside) doesn't always land a `dropExited`,
+        // and a guideline left painted on the grid reads as a stuck drag.
+        guard dragging != nil else { return nil }
+        return switch dropSlot {
         case .before(serial): .leading
         case .end where selection.last == serial: .trailing
         default: nil
@@ -354,6 +380,12 @@ struct MirrorWallView: View {
             try? await Task.sleep(for: .seconds(mirrorHiddenGraceSeconds))
             guard !Task.isCancelled else { return }
             teardownTask = nil
+            // Re-check rather than trusting the reason this was scheduled: an
+            // occlusion notification during window bring-up would otherwise be
+            // able to strand a wall that is plainly on screen.
+            let onScreen = tabIsActive
+                && state.nsWindow?.occlusionState.contains(.visible) != false
+            guard !onScreen else { return }
             wall?.suspend()
         }
     }

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -109,6 +109,7 @@ struct MirrorWallView: View {
             Spacer(minLength: 8)
 
             layoutMenu
+            fullViewButton
             optionsMenu
         }
         .padding(.horizontal, 12)
@@ -131,6 +132,24 @@ struct MirrorWallView: View {
         .menuStyle(.borderlessButton)
         .fixedSize()
         .help("Pick which devices this wall shows")
+    }
+
+    /// Give the wall the whole display: the app's chrome (sidebar, device bar,
+    /// tab strip) goes away and the window enters macOS full screen. This row
+    /// stays — it's the wall's own controls, and the way back out.
+    private var fullViewButton: some View {
+        Button {
+            state.toggleFullView()
+        } label: {
+            Image(systemName: state.fullView
+                ? "arrow.down.right.and.arrow.up.left"
+                : "arrow.up.left.and.arrow.down.right")
+                .font(.app(.body))
+        }
+        .buttonStyle(.plain)
+        .help(state.fullView
+            ? "Exit full view (⇧⌘F)"
+            : "Full view — hide the app chrome (⇧⌘F)")
     }
 
     private var layoutMenu: some View {

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -249,7 +249,7 @@ struct MirrorWallView: View {
             },
             onScreenshot: { capture(device.serial, wall: wall) },
             onPopOut: { popOut(device.serial) },
-            onBringBack: { state.core.closeMirrorWindow(device.serial) },
+            onBringBack: { bringBack(device.serial) },
             onOpenFullMirror: { openFullMirror(device.serial) })
             .onDrop(of: [.mirrorWallTile], delegate: MirrorWallDrop(
                 target: device.serial,
@@ -258,6 +258,19 @@ struct MirrorWallView: View {
                 tileWidth: width,
                 setSlot: { dropSlot = $0 },
                 perform: moveTile))
+    }
+
+    /// Take a device back into the wall by closing whatever holds it: its
+    /// pop-out window, or this window's Mirror Screen tab. Both release the
+    /// claim, and the next reconcile starts the tile. A tab close still routes
+    /// through `closeTab`, so a recording over there gets its own confirmation
+    /// rather than being dropped.
+    private func bringBack(_ serial: String) {
+        switch blocked(serial) {
+        case .poppedOut: state.core.closeMirrorWindow(serial)
+        case .mirrorTab: state.closeTab("scrcpy")
+        case .otherWindow, nil: break
+        }
     }
 
     private func dropEdge(_ serial: String) -> MirrorWallTile.DropEdge? {

--- a/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
@@ -1,7 +1,8 @@
+import ADBKit
 import SwiftUI
 
-/// Identity for the pop-out mirror window (the mirror control bar's window
-/// button opens it).
+/// Identity for the pop-out mirror windows (the mirror control bar's window
+/// button, and the Mirror Wall's per-tile "Open in Its Own Window").
 enum MirrorWindow {
     static let windowID = "mirror"
     /// Environment feature id marking the window host — never a real tab id,
@@ -9,19 +10,69 @@ enum MirrorWindow {
     static let featureID = "scrcpy-window"
 }
 
-/// The pop-out screen mirror: the same live mirror, hosted in its own window
-/// so it can sit beside the main workspace (or other apps) while the tabs do
-/// something else. It follows the device-bar selection exactly like the
-/// in-tab mirror. The tab-host environment defaults keep it always "active",
-/// and the distinct feature id still routes its recording guard through the
-/// device-switch / quit prompts.
+/// A pop-out screen mirror: the same live mirror, hosted in its own window so
+/// it can sit beside the main workspace (or other apps) while the tabs do
+/// something else. One window per device — it is pinned to the serial it was
+/// opened for and does *not* follow the device bar, which is what lets several
+/// stand side by side. The tab-host environment defaults keep it always
+/// "active", and the distinct feature id still routes its recording guard
+/// through the device-switch / quit prompts.
 struct MirrorWindowView: View {
     @Environment(AppState.self) private var state
+    /// The device this window mirrors, from the window's presented value. nil
+    /// when macOS re-presents a window with no value (see `title`).
+    let serial: String?
 
     var body: some View {
-        ScreenMirrorView()
-            .environment(\.tabFeatureID, MirrorWindow.featureID)
-            .navigationTitle(state.selectedDevice.map { "Mirror · \($0.label)" } ?? "Screen Mirror")
-            .frame(minWidth: 320, minHeight: 480)
+        ZStack {
+            if let serial {
+                if let device = state.devices.first(where: { $0.serial == serial && $0.isReady }) {
+                    ScreenMirrorView(pinnedSerial: device.serial)
+                        .environment(\.tabFeatureID, MirrorWindow.featureID)
+                } else {
+                    // A serial that isn't connected: the device was unplugged,
+                    // or macOS restored the window from a previous launch.
+                    ContentUnavailableView(
+                        "Device not connected",
+                        systemImage: "iphone.slash",
+                        description: Text(
+                            "\(serial) isn’t connected. Plug it in, or close this window."))
+                }
+            } else {
+                ContentUnavailableView(
+                    "No device",
+                    systemImage: "iphone.slash",
+                    description: Text("Open a mirror window from a device’s mirror controls."))
+            }
+        }
+        .navigationTitle(title)
+        .frame(minWidth: 320, minHeight: 480)
+        .background(MirrorWindowRegistrar(serial: serial))
+    }
+
+    private var title: String {
+        guard let serial else { return "Screen Mirror" }
+        let device = state.devices.first { $0.serial == serial }
+        return "Mirror · \(device.map(state.deviceDisplayName) ?? serial)"
+    }
+}
+
+/// Registers this window with `AppCore` for the lifetime it's on screen: its
+/// device becomes a claim (so no wall tile or tab starts a second encoder on
+/// it), and its `NSWindow` is what "Arrange Mirror Windows" moves.
+private struct MirrorWindowRegistrar: View {
+    @Environment(AppState.self) private var state
+    let serial: String?
+
+    var body: some View {
+        WindowAccessor { window in
+            guard let serial else { return }
+            state.core.noteMirrorWindow(serial: serial, window: window)
+        }
+        .frame(width: 0, height: 0)
+        .onDisappear {
+            guard let serial else { return }
+            state.core.forgetMirrorWindow(serial: serial)
+        }
     }
 }

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -23,6 +23,12 @@ let mirrorHiddenGraceSeconds: TimeInterval = 120
 /// window. The toolbar takes a screenshot (→ annotate in place) or records
 /// (→ video editor on stop) without interrupting the live, controllable mirror.
 struct ScreenMirrorView: View {
+    /// The device this mirror is pinned to, instead of following the device
+    /// bar. The pop-out windows use it: one window per device, so a window that
+    /// re-targeted on every click in the main window would mirror whatever was
+    /// last selected rather than the device it was opened for.
+    var pinnedSerial: String?
+
     @Environment(AppState.self) private var state
     @Environment(\.tabFeatureID) private var tabFeatureID
     @Environment(\.tabIsActive) private var tabIsActive
@@ -71,13 +77,14 @@ struct ScreenMirrorView: View {
             // Connect if the mirror is the tab on screen when it's first
             // mounted; a hidden tab connects lazily once it becomes active
             // (below). A hidden mirror is heavy video encode for nothing.
-            if tabIsActive, model == nil { scheduleReconnect(to: state.targetSerials.first) }
+            if tabIsActive, model == nil { scheduleReconnect(to: targetSerial) }
         }
         .onChange(of: state.targetSerials.first) { _, serial in
             // Follow the selected device: switching it re-targets the live
             // mirror — but never mid-recording, which stays on its device
-            // (leaving to switch is gated by the recording exit guard).
-            guard tabIsActive, model?.isRecording != true else { return }
+            // (leaving to switch is gated by the recording exit guard). A pinned
+            // mirror ignores the bar entirely.
+            guard pinnedSerial == nil, tabIsActive, model?.isRecording != true else { return }
             scheduleReconnect(to: serial)
         }
         .onChange(of: tabIsActive) { _, active in
@@ -94,8 +101,8 @@ struct ScreenMirrorView: View {
                     hasSession: model != nil,
                     isRecording: model?.isRecording == true,
                     sessionEnded: model?.hasEnded == true,
-                    deviceChanged: model?.serial != state.targetSerials.first)
-                if action == .reconnect { scheduleReconnect(to: state.targetSerials.first) }
+                    deviceChanged: model?.serial != targetSerial)
+                if action == .reconnect { scheduleReconnect(to: targetSerial) }
             } else if MirrorTabPolicy.schedulesTeardownOnHide(isRecording: model?.isRecording == true) {
                 // Hidden — keep streaming for a grace window instead of tearing
                 // down instantly, so a quick tab flip doesn't stop-and-reconnect.
@@ -115,6 +122,16 @@ struct ScreenMirrorView: View {
             // applies on the next connect.
             guard let model else { return }
             Task { await CommandLog.userInitiated { await model.setShowTouches(show) } }
+        }
+        .onChange(of: model?.serial) { _, serial in
+            // Publish what this mirror is actually streaming, so the Mirror Wall
+            // doesn't put a second encoder on the same device (a split pane can
+            // show both at once). Claims come from *live* sessions, which is why
+            // a merely-open tab isn't enough. The pop-out windows are registered
+            // by `AppCore` instead — it holds all of them, and one write here
+            // would clobber its siblings.
+            guard tabFeatureID != MirrorWindow.featureID else { return }
+            state.noteMirrorClaims(serial.map { [$0] } ?? [], featureID: tabFeatureID)
         }
         .onChange(of: model?.recordingError) { _, message in
             guard let message else { return }
@@ -138,6 +155,9 @@ struct ScreenMirrorView: View {
         }
         .onDisappear {
             state.clearExitGuard(exitGuardID)
+            if tabFeatureID != MirrorWindow.featureID {
+                state.noteMirrorClaims([], featureID: tabFeatureID)
+            }
             teardownTask?.cancel()
             connectTask?.cancel()
             let leaving = model
@@ -183,9 +203,12 @@ struct ScreenMirrorView: View {
         state.finishExitSave()
     }
 
-    /// Reconnect the selected device in place — the stopped/failed cards' button.
+    /// The device this view mirrors: its pin, or the device bar's selection.
+    private var targetSerial: String? { pinnedSerial ?? state.targetSerials.first }
+
+    /// Reconnect the current device in place — the stopped/failed cards' button.
     private func reconnectCurrent() {
-        scheduleReconnect(to: state.targetSerials.first)
+        scheduleReconnect(to: targetSerial)
     }
 
     /// Pop-out is offered only in the tab host — the window host has nowhere
@@ -195,15 +218,15 @@ struct ScreenMirrorView: View {
         return { popOut() }
     }
 
-    /// Move the mirror to its own window: open (or focus) the mirror window —
-    /// which connects its own session to the selected device — and close this
-    /// tab so the same device isn't encoded twice.
+    /// Move the mirror to its own window: open (or focus) the window for *this
+    /// device* — which connects its own session — and close this tab so the same
+    /// device isn't encoded twice.
     private func popOut() {
-        // There's one pop-out window, so it belongs to whichever workspace
-        // opened it — otherwise it would swap devices every time the user
-        // clicked between windows.
+        guard let serial = targetSerial else { return }
+        // The windows read their adb client and toasts from whichever workspace
+        // popped one out; the device rides in the window's own presented value.
         state.core.mirrorWindowOwner = state.id
-        openWindow(id: MirrorWindow.windowID)
+        openWindow(id: MirrorWindow.windowID, value: serial)
         state.closeTab(tabFeatureID)
     }
 

--- a/App/Sources/Root/DragTypes.swift
+++ b/App/Sources/Root/DragTypes.swift
@@ -15,6 +15,8 @@ extension UTType {
     static let workspaceTab = UTType(exportedAs: "com.rohindh.droidective.workspace-tab")
     /// A Terminal-rail shell tab or group dragged within the rail.
     static let terminalRailItem = UTType(exportedAs: "com.rohindh.droidective.terminal-rail-item")
+    /// A Mirror Wall tile dragged to rearrange the grid.
+    static let mirrorWallTile = UTType(exportedAs: "com.rohindh.droidective.mirror-wall-tile")
 }
 
 /// A drag item carried under a private `type`. The drop delegates key off view

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -107,6 +107,15 @@ struct RootView: View {
         let showExitDialog = state.pendingExit.map { !$0.saving } ?? false
         return zoomedContent
             .overlay(alignment: .topTrailing) { devMetricsOverlay }
+            .onReceive(NotificationCenter.default.publisher(
+                for: NSWindow.willExitFullScreenNotification)
+            ) { notification in
+                // The green button / ⌃⌘F can leave full screen without going
+                // through `toggleFullView`, and chrome-less-in-a-window is not a
+                // state to leave someone in.
+                guard notification.object as? NSWindow === state.nsWindow else { return }
+                state.setFullView(false)
+            }
             .modifier(PostTourCelebration(state: state))
             .modifier(WindowTranslucencyModifier(state: state))
             .modifier(
@@ -446,7 +455,7 @@ struct RootView: View {
     /// full-height VS Code-style sidebar with a single continuous divider.
     private var split: some View {
         HStack(spacing: 0) {
-            if state.sidebarVisible && !sidebarAutoHide {
+            if state.sidebarVisible && !sidebarAutoHide && !state.fullView {
                 SidebarPaletteView()
                     .frame(width: sidebarDragWidth ?? min(max(sidebarWidth, 300), 460))
                     .transition(.move(edge: .leading).combined(with: .opacity))
@@ -458,7 +467,8 @@ struct RootView: View {
                 // whenever any visible pane needs a device, so focusing the
                 // catalog in one pane of a split doesn't pull the bar (and the
                 // progress strip) out from under a live feature in the other.
-                if state.workspace.groups.contains(where: { $0.activeTab != "catalog" }) {
+                if !state.fullView,
+                   state.workspace.groups.contains(where: { $0.activeTab != "catalog" }) {
                     DeviceBarView()
                     if let operation = state.runningOperation ?? state.installOperation {
                         OperationProgressStrip(operation: operation)
@@ -501,7 +511,7 @@ struct RootView: View {
         // continuous-hover tracker on the whole split decides both — a thin
         // transparent hot-strip never received hover events reliably.
         .onContinuousHover { phase in
-            guard sidebarAutoHide, case .active(let point) = phase else { return }
+            guard sidebarAutoHide, !state.fullView, case .active(let point) = phase else { return }
             if point.x <= 8, !state.sidebarOverlayShown {
                 withAnimation(.easeOut(duration: 0.18)) { state.sidebarOverlayShown = true }
             } else if state.sidebarOverlayShown, point.x > overlaySidebarWidth + 8 {
@@ -509,7 +519,7 @@ struct RootView: View {
             }
         }
         .overlay(alignment: .leading) {
-            if sidebarAutoHide && state.sidebarOverlayShown {
+            if sidebarAutoHide && state.sidebarOverlayShown && !state.fullView {
                 SidebarPaletteView()
                     .frame(width: overlaySidebarWidth)
                     .background(.bgSurface)
@@ -777,7 +787,7 @@ private struct EditorPane: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TabStripView(group: index)
+            if !state.fullView { TabStripView(group: index) }
             TabHostView(group: index)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .onDrop(of: [.workspaceTab], delegate: paneDrop)

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -909,7 +909,7 @@ private struct SplitDivider: View {
 /// Reads the hosting `NSWindow` once it attaches, so the main window can be
 /// sized to fill the screen on launch. `viewDidMoveToWindow` runs on the main
 /// actor with the window in place — no async hop, so it stays Swift-6 clean.
-private final class WindowReaderView: NSView {
+final class WindowReaderView: NSView {
     var onWindow: ((NSWindow) -> Void)?
 
     override func viewDidMoveToWindow() {
@@ -1002,7 +1002,10 @@ final class WindowMinSizeGuard {
     }
 }
 
-private struct WindowAccessor: NSViewRepresentable {
+/// Hands back the `NSWindow` hosting a SwiftUI view. Used by the workspace
+/// windows and by the pop-out mirror windows, which register themselves for
+/// "Arrange Mirror Windows".
+struct WindowAccessor: NSViewRepresentable {
     let onResolve: (NSWindow) -> Void
 
     func makeNSView(context: Context) -> WindowReaderView {

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -488,9 +488,88 @@ final class AppCore {
     /// Device a not-yet-created window should open on (see `openNewWindow`).
     private var pendingWindowTargets: [WorkspaceID: String] = [:]
 
-    /// The workspace the single mirror pop-out window belongs to — set when it
-    /// is popped out, so it keeps showing that window's device.
+    /// The workspace the pop-out mirror windows belong to — set when one is
+    /// popped out, so they read that window's adb client and toasts. The device
+    /// each window shows rides in the window's own presented value, not here.
     var mirrorWindowOwner: WorkspaceID?
+
+    /// Open pop-out mirror windows by device serial. Held by *reference* and
+    /// weakly, for the same reason `AppState.nsWindow` is: SwiftUI re-stamps its
+    /// own window identifiers, so they can't be matched across a close.
+    private var mirrorWindows: [String: WeakWindow] = [:]
+
+    private final class WeakWindow {
+        weak var window: NSWindow?
+        init(_ window: NSWindow?) { self.window = window }
+    }
+
+    var hasMirrorWindows: Bool { !liveMirrorWindows().isEmpty }
+
+    /// Devices currently showing in a pop-out mirror window. The wall reads
+    /// this directly rather than through the registry's claims, because those
+    /// are keyed by the *owner* window — and the owner is usually the very
+    /// window whose wall is asking, which would exclude itself.
+    var mirrorWindowSerials: Set<String> {
+        Set(mirrorWindows.filter { $0.value.window != nil }.keys)
+    }
+
+    /// Bring one device's pop-out mirror window forward.
+    func focusMirrorWindow(_ serial: String) {
+        mirrorWindows[serial]?.window?.makeKeyAndOrderFront(nil)
+    }
+
+    /// Close one device's pop-out mirror window — "Bring Back Into the Wall".
+    /// Closing releases the claim (the window's own teardown), and the wall
+    /// picks the device back up on its next reconcile.
+    func closeMirrorWindow(_ serial: String) {
+        mirrorWindows[serial]?.window?.close()
+    }
+
+    /// A pop-out mirror window appeared (or moved to a new NSWindow). Records
+    /// the device as claimed so no wall tile or tab puts a second encoder on it.
+    func noteMirrorWindow(serial: String, window: NSWindow?) {
+        mirrorWindows[serial] = WeakWindow(window)
+        publishMirrorWindowClaims()
+    }
+
+    /// A pop-out mirror window went away — its device is free again.
+    func forgetMirrorWindow(serial: String) {
+        mirrorWindows.removeValue(forKey: serial)
+        publishMirrorWindowClaims()
+    }
+
+    /// Tile the open pop-out mirror windows across the active screen — the
+    /// starting grid for "Arrange Mirror Windows". They stay freely draggable
+    /// afterwards; this only deals the first hand.
+    func arrangeMirrorWindows() {
+        let windows = liveMirrorWindows()
+        guard !windows.isEmpty else { return }
+        let screen = windows.first?.screen ?? NSScreen.main
+        guard let visible = screen?.visibleFrame else { return }
+        let area = MirrorWall.TileFrame(
+            x: visible.minX, y: visible.minY, width: visible.width, height: visible.height)
+        let frames = MirrorWall.windowFrames(in: area, count: windows.count)
+        for (window, frame) in zip(windows, frames) {
+            window.setFrame(
+                NSRect(x: frame.x, y: frame.y, width: frame.width, height: frame.height),
+                display: true, animate: false)
+        }
+    }
+
+    /// Open mirror windows in serial order, dropping entries whose window has
+    /// been released.
+    private func liveMirrorWindows() -> [NSWindow] {
+        mirrorWindows.keys.sorted().compactMap { mirrorWindows[$0]?.window }
+    }
+
+    /// Mirror the pop-out windows' devices into the registry, under the pop-out
+    /// mirror's pseudo-id. All of them belong to one owner window, so one
+    /// replace-the-set write covers every window.
+    private func publishMirrorWindowClaims() {
+        guard let owner = mirrorWindowOwner ?? registry.ids.first else { return }
+        let serials = Set(mirrorWindows.filter { $0.value.window != nil }.keys)
+        noteMirrorClaims(serials, featureID: MirrorWindow.featureID, in: owner)
+    }
 
     func takeWindowTarget(_ id: WorkspaceID) -> String? {
         pendingWindowTargets.removeValue(forKey: id)
@@ -529,6 +608,17 @@ final class AppCore {
     /// `noteSelection`).
     func noteOpenFeatures(_ ids: Set<String>, in id: WorkspaceID) {
         registry.setOpenFeatures(ids, for: id)
+    }
+
+    /// Mirror the devices a window mirrors *outside* its own selection — the
+    /// Mirror Wall's live tiles and its pop-out mirror windows — so the
+    /// conflict rules see them (`WorkspaceRegistry.Claim`). `featureID`'s
+    /// previous claims for this window are replaced; other features' are kept.
+    func noteMirrorClaims(_ serials: Set<String>, featureID: String, in id: WorkspaceID) {
+        let others: Set<WorkspaceRegistry.Claim> = registry[id]?.claims
+            .filter { $0.featureID != featureID } ?? []
+        let mine = serials.map { WorkspaceRegistry.Claim(featureID: featureID, serial: $0) }
+        registry.setClaims(others.union(mine), for: id)
     }
 
     /// Whether any *other* window still has `featureID` open — the refcount

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -904,6 +904,12 @@ final class AppCore {
         Task {
             await mcp.stopForQuit()
             if reactotronSession.isRunning { await reactotronSession.stopForQuit() }
+            // Mirror sessions own an `adb forward` tunnel each. Their views'
+            // teardown is fire-and-forget, so at quit it never lands and the
+            // tunnels stay registered in the adb server — six of them for a full
+            // Mirror Wall. Tear them down here, where termination is already
+            // deferred.
+            await MirrorSessions.shared.stopAllForQuit()
             // Flush before termination — `persistLayout` saves through a
             // fire-and-forget Task, and that write racing process exit would
             // lose whatever this quit just recorded (the terminal-resume

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -243,6 +243,36 @@ final class AppState {
     /// visibility, driven by the left-edge hover zone and ⌘B.
     var sidebarOverlayShown = false
 
+    /// Full View: the app's own chrome — sidebar, device bar, tab strip — is
+    /// hidden and the window goes into macOS full screen, so the feature on
+    /// screen gets the whole display. Transient by design (a mode you toggle,
+    /// never a state you relaunch into), and per window.
+    private(set) var fullView = false
+
+    /// Enter or leave Full View, taking the window's native full-screen state
+    /// with it. Leaving native full screen by the green button leaves the mode
+    /// too — RootView watches for that, so the two can't disagree.
+    func toggleFullView() {
+        setFullView(!fullView)
+    }
+
+    func setFullView(_ on: Bool) {
+        guard fullView != on else { return }
+        withAnimation(.easeInOut(duration: 0.2)) { fullView = on }
+        if on {
+            // With the chrome gone there's no button left in sight for most
+            // features, so say how to get back instead of leaving the user to
+            // find the menu. Not kept in the notification history.
+            showToast(Toast(
+                message: "Full view — press ⇧⌘F to leave",
+                ok: true, level: .info, important: false))
+        }
+        guard let window = nsWindow else { return }
+        if window.styleMask.contains(.fullScreen) != on {
+            window.toggleFullScreen(nil)
+        }
+    }
+
     func toggleSidebar() {
         if UserDefaults.standard.bool(forKey: sidebarAutoHideDefaultsKey) {
             withAnimation(.easeInOut(duration: 0.18)) { sidebarOverlayShown.toggle() }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -538,6 +538,7 @@ final class AppState {
             selectedSerial = saved.serial
             selectedBundleId = saved.bundleId
             terminalResumeDirs = saved.terminalResumeDirs
+            mirrorWallSerials = saved.mirrorWallSerials
             // Reopen the tabs from the last session (idle — recordings/streams
             // don't resume). Falls back to a single Home tab for a new user or
             // a layout written before tabs existed.
@@ -981,7 +982,8 @@ final class AppState {
                 TabGroupState(tabs: $0.openTabs, activeTab: $0.activeTab)
             },
             focusedGroup: workspace.focusedGroup,
-            terminalResumeDirs: terminalResumeDirs
+            terminalResumeDirs: terminalResumeDirs,
+            mirrorWallSerials: mirrorWallSerials
         ))
         core.persistLayout()
     }
@@ -989,6 +991,24 @@ final class AppState {
     /// Working directories of this window's terminal tabs at the last implicit
     /// teardown — the next Terminal open in *this* window resumes them.
     var terminalResumeDirs: [String]?
+
+    /// Devices this window's Mirror Wall shows, in tile order. Per window (two
+    /// windows can watch different sets), and persisted, so a wall arranged for
+    /// six devices comes back arranged.
+    var mirrorWallSerials: [String]? {
+        didSet {
+            guard mirrorWallSerials != oldValue else { return }
+            persistWindowState()
+        }
+    }
+
+    /// Tell the conflict rules which devices this window is mirroring outside
+    /// its own selection — the wall's live tiles and its pop-out mirror
+    /// windows. Replaces the previous set, so a tile that stops streaming
+    /// releases its device (see `WorkspaceRegistry.setClaims`).
+    func noteMirrorClaims(_ serials: Set<String>, featureID: String) {
+        core.noteMirrorClaims(serials, featureID: featureID, in: id)
+    }
 
     /// Ids that can back a tab: every registry feature plus the standalone
     /// Home / About / Catalog screens and the Finder-opened-APK screen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ opening it — verify those by hand.
 
 1. **Define it** — add a `FeatureDef` to `FeatureRegistry.all` (unique `id`,
    title, keywords, category, `kind`; set `platforms` if it works on iOS
-   Simulators — the default is Android-only). **[test: `hasAll60Features` —
+   Simulators — the default is Android-only). **[test: `hasAll61Features` —
    bump the count; `byID` traps on a duplicate id]**
 2. **If it's an action** (`.instantAction`/`.formAction`/`.toggleAction`):
    - add the runner `case` to `FeatureEngine.dispatch`,
@@ -113,7 +113,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1751 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1802 tests, keep green
 make test-app      # the AppTests logic bundle — 99 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)
@@ -165,7 +165,7 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   twins — booted iOS Simulators surface as `Device`s with
   `platform: .iosSimulator`, merged into the bar in `AppState`), `DeviceProps` (getprop), `DeviceOverview` (RAM/storage/
   battery/CPU/app counts), `DeviceDetails` (picker enrichment).
-- `Features/`: `FeatureRegistry` (60 `FeatureDef`s, declarative; `absorbedByHub`
+- `Features/`: `FeatureRegistry` (61 `FeatureDef`s, declarative; `absorbedByHub`
   maps a hub screen to the features it gathers, flattened to
   `absorbedFeatureIDs`; `catalogFeatureIDs` is the registry minus those),
   `FeatureModel`,
@@ -304,11 +304,11 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   tab/window close; it never restarts a relay the user stopped (status
   goes amber, ghost clients cleared via `noteRelayStopped`).
 
-## The 60 features
+## The 61 features
 
 Most `.view` features are full-screen bespoke panels (file-explorer, apps,
 emulators, device-info, logcat, ios-logs — the simulator unified-log twin (`SimulatorLogStreamer` over `simctl spawn <udid> log stream --style ndjson`, iOS-only, standalone), crash-catcher, sandbox-browser, performance,
-network-speed, wifi, root-status, screen-record, scrcpy, reactotron, js-console,
+network-speed, wifi, root-status, screen-record, scrcpy, mirror-wall, reactotron, js-console,
 terminal — multi-tab PTY login shells via SwiftTerm, with the device selected at
 open exported as ANDROID_SERIAL; tabs split into panes (⌘D/⇧⌘D — the pure
 `TerminalSplitTree` model, tested in ADBKit; ⌘W peels a pane, then the tab), a
@@ -324,7 +324,19 @@ and `connection` gather related instant-/form-/toggle-actions into one scrollabl
 grouped `Form`; `apk-studio` is a tabbed workspace over one loaded APK (Inspect/
 Decompile/Recompile/Sign). (The Apps explorer similarly covers per-app
 management — its detail pane carries the old "Manage App" controls: open,
-force-stop, clear cache/data, plus disable/uninstall). A hub's gathered features
+force-stop, clear cache/data, plus disable/uninstall). **`mirror-wall`** is the
+multi-device mirror: up to `MirrorWall.maximumDevices` (6) devices side by side,
+each interactive, each its own `MirrorViewModel`/scrcpy session at a per-tile
+quality that steps down as tiles are added (`MirrorWall.quality(tiles:)` — a
+one-tile wall is exactly the full mirror). It picks its own devices (header menu,
+persisted per window as `WindowState.mirrorWallSerials`) rather than following
+the device bar, lays out automatically or in a fixed column count, reorders by
+dragging a tile's **caption strip** (never the video — `.onDrag` there would eat
+every swipe on the device), and breaks any tile out into its own window. The
+pop-out mirror is a `WindowGroup(for: String.self)` keyed by serial — one window
+per device, pinned to it (`ScreenMirrorView.pinnedSerial`) rather than following
+the selection — and `AppCore.arrangeMirrorWindows` tiles the open ones across the
+screen via the pure `MirrorWall.windowFrames`. A hub's gathered features
 (`FeatureRegistry.absorbedByHub` → `absorbedFeatureIDs`) are managed only from
 the hub: the display layer filters `FeatureDef.isAbsorbedByHub` out of the
 catalog, the sidebar (`AppState.enabledFeatures`), and search
@@ -336,7 +348,7 @@ Apps hub. They stay hotkey-able (every feature registers a shortcut; the Hotkeys
 tab lists bound members under "Hidden features"). This is a pure display filter —
 no persisted migration — so it also covers a hub that grows later. The rest are generic instant-/form-/toggle-actions
 driven by the registry. The catalog and Home's "All N features" count use
-`catalogFeatureIDs` (38). **Every feature is enabled by default**
+`catalogFeatureIDs` (39). **Every feature is enabled by default**
 (`defaultEnabledIDs == catalogFeatureIDs`); the catalog (Manage features) is for
 turning OFF the ones you don't want, not opting in — there's no Restore button.
 `LayoutState.adoptAllEnabled()` is a one-time migration that turns everything on
@@ -443,6 +455,22 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     encoder, `js-console` loses the CDP target to the newest client,
     `frida-console` owns a port). It then gets the Focus / Take Over banner
     instead of racing. A test asserts every id there is a real feature.
+  - **A feature that runs against devices the window isn't pointed at
+    registers `WorkspaceRegistry.Claim`s.** `Entry.serial` answers "who owns
+    this device?" only for device-bar-scoped features; the Mirror Wall streams
+    up to six devices from one window and the pop-out mirrors show a device
+    each, so both publish claims (`AppCore.noteMirrorClaims`) and the mirror
+    family (`mirrorFeatureIDs` — `scrcpy`, `scrcpy-window`, `mirror-wall`)
+    contends through them. Claims are written by *live sessions*, which is what
+    `claimant(ofFeature:on:)` reads — a hidden keep-alive mirror tab that isn't
+    streaming must not hold a device hostage. `mirror-wall` is deliberately NOT
+    exclusive: a whole-pane banner over the window's selected device would
+    block five working tiles because of the sixth, so it blocks per tile.
+  - **A wall-shaped feature needs a terminal stop.** `MirrorWallModel.suspend()`
+    is the resumable one (hidden past the grace window); `shutDown()` is
+    terminal. Without the terminal flag, a mirror tab closing *during quit*
+    releases its device, the still-mounted wall starts a session on it, and that
+    session outlives the process — the leak this feature was caught doing once.
 
 - **Process runner must never block a cooperative thread.** `SystemProcessRunner`
   uses `terminationHandler` + `readabilityHandler`, not `waitUntilExit`. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,24 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   `\.windowOpacity` is declared in Theme.swift because the AppTests logic
   bundle compiles that file standalone (and links ADBKit for it). JS Console
   keeps its Chrome-dark hue at the card step; CodeMirror webviews stay opaque.
+- **A mirror session's teardown has to be *awaited* at quit.** Every session
+  owns an `adb forward` tunnel that only `MirrorTransport.stop()` removes, and
+  view teardown is fire-and-forget — at quit the process exits first and the
+  tunnel stays registered in the long-lived adb server (one leaked listening
+  socket per session per quit; six for a full Mirror Wall). `MirrorSessions`
+  holds every live `MirrorViewModel` weakly, registered at the *top* of
+  `start()` (a start that fails part-way can still have opened the tunnel), and
+  `AppCore.finishQuitNow` awaits `stopAllForQuit()` alongside the MCP server and
+  the Reactotron relay. Check with `adb forward --list`: it must be empty of
+  `scrcpy_*` entries once the app is gone.
+- **A view model swap needs the display layer swapped with it.**
+  `MirrorVideoView` hands `MirrorRenderer.displayLayer` to its NSView at init,
+  so a *new* session for the same on-screen tile must be adopted in
+  `updateNSView` (`MirrorLayerNSView.adopt(displayLayer:)`) — otherwise the tile
+  keeps drawing the stopped session's layer: input still works, no frame ever
+  arrives, and it reads as a broken mirror. The full-pane mirror only escapes it
+  by rendering a nil model in between; the wall's reconnect replaces the model
+  in one turn.
 - **Recording audio is one AAC track fed by up to two sources.** A recording
   captures the device's audio, the Mac's microphone, both, or neither —
   `RecordAudioOptions`/`DeviceAudioSource` in ScreenTools, persisted by the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,16 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     `sharedBackgroundVisibility`), and titlebar content via
     `.fullSizeContentView` or `NSTitlebarAccessoryViewController` is collapsed
     or clipped. All four were tried.
+  - **Full View is per window and transient.** `AppState.fullView` hides the
+    app's chrome (sidebar, device bar, tab strip) *and* puts the window into
+    macOS full screen — View ▸ Full View / ⇧⌘F (not ⌃⌘F, which macOS owns), the
+    Mirror Wall header's expand button, and a toast naming the way out. It is
+    deliberately not persisted, and RootView watches
+    `NSWindow.willExitFullScreenNotification` so leaving full screen by the
+    green button can't leave a chrome-less window behind. A feature's own
+    controls stay — the wall keeps its header row, which is where the exit
+    button lives. The menu key equivalent is the exit that always works: a
+    mirror view swallows key events that reach it, but NSMenu sees them first.
   - **Only the windows after the first tint their device icon**
     (`DeviceTint`); the app keeps one accent.
   - **A feature that can't run twice on one device** goes in

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -13,8 +13,8 @@ rewriting one when something turns out to be more work than it looked.
 | --- | --- |
 | ⬜ Not started | 32 |
 | 🟡 Partial | 22 |
-| ⛔ Not applicable off-Apple | 6 |
-| **Total registry features** | **60** |
+| ⛔ Not applicable off-Apple | 7 |
+| **Total registry features** | **61** |
 
 "Partial" is doing a lot of work in that table: 19 of the 22 are actions that
 run from the palette but have no screen of their own, and the three that do
@@ -283,9 +283,6 @@ Apple-only by design.
 ---
 
 ## Per-feature checklists
-
-Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
-
 ### Input & Clipboard
 #### `send-text` — Send Text  ·  🟡 partial
 > Type text, URLs, or symbols on the device
@@ -408,8 +405,6 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
   - [ ] button: Hide All
   - [ ] button: Run adb reverse for the device
   - [ ] button: Run
-  - [ ] button: Copy
-  - [ ] button: Copy as JSON
   - [ ] field: Find in console
   - [ ] field: 8081
   - [ ] field: Filter
@@ -423,10 +418,7 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
   - [ ] tooltip: Find & highlight in console (⌘F)
   - [ ] tooltip: Clear the console
   - [ ] tooltip: Choose which log levels to show
-  - [ ] tooltip: Copy this entry (right-click for JSON)
-  - [ ] tooltip: Reveal in the tree
   - [ ] search: searchable list
-  - [ ] menu: right-click context menu
   - [ ] export: save/export to a file
 
 #### `open-dev-menu` — Open Dev Menu  ·  🟡 partial
@@ -471,6 +463,11 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 - **Kind** `toggleAction`
 - **Note** Runs from the palette; no dedicated screen.
 
+#### `mirror-wall` — Mirror Wall  ·  ⛔ n/a
+> Mirror up to six devices side by side
+- **Kind** `view`
+- **Note** Several mirrors at once, on the same Apple-only mirror pipeline as `scrcpy`.
+
 #### `scrcpy` — Mirror Screen  ·  ⛔ n/a
 > Mirror and control the device with scrcpy
 - **Kind** `view`
@@ -511,15 +508,13 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 - **Must replicate**
   - [ ] tooltip: Refresh from the device
 
-#### `device-info` — Device Info  ·  🟡 partial
+#### `device-info` — Device Info  ·  ⬜ todo
 > Browse and search every device property
 - **Kind** `view`
-- **Note** Built. `/v1/device/props` passes `getprop` through untouched; the
-  pane adds a summary header, two-segment grouping, search over key and value,
-  copy and export.
+- **Note** Not started on Windows/Linux.
 - **macOS view** `DeviceInfoView` — `App/Sources/FeatureDetail/Views/DeviceInfoView.swift`
 - **Must replicate**
-  - [x] field: Filter properties…
+  - [ ] field: Filter properties…
 
 #### `fake-battery` — Fake Battery  ·  🟡 partial
 > Set a fake battery level and unplugged state
@@ -646,22 +641,22 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
 #### `logcat` — Logcat  ·  🟡 partial
 > Live log stream with search and filters
 - **Kind** `view`
-- **Note** A pane exists; the app filter is what it is still missing.
+- **Note** A pane exists; the checklist below is what it is missing.
 - **macOS view** `LogcatView` — `App/Sources/FeatureDetail/Views/LogcatView.swift`
 - **Must replicate**
-  - [x] picker: Level
-  - [x] field: Filter lines…
+  - [ ] picker: Level
+  - [ ] field: Filter lines…
   - [ ] label: All apps
   - [ ] label: Add from installed apps
   - [ ] label: Use app on device screen
   - [ ] label: Add manually / manage…
-  - [x] tooltip: Show only the lines containing this text
-  - [x] tooltip: Find & highlight in the log without hiding lines
-  - [x] tooltip: Export buffer to ~/Downloads/Droidective
-  - [x] tooltip: Clear
+  - [ ] tooltip: Show only the lines containing this text
+  - [ ] tooltip: Find & highlight in the log without hiding lines (⌘F)
+  - [ ] tooltip: Export buffer to ~/Downloads/Droidective
+  - [ ] tooltip: Clear
   - [ ] tooltip: Stream one app's logs — pick a saved bundle or add a new one
-  - [x] tooltip: Remove tag filter
-  - [x] export: save/export to a file
+  - [ ] tooltip: Remove tag filter
+  - [ ] export: save/export to a file
 
 #### `performance` — Performance Monitor  ·  ⬜ todo
 > Live CPU, RAM & FPS with recording and export
@@ -930,3 +925,4 @@ Legend: ⬜ not started · 🟡 partial · ⛔ not applicable off-Apple.
   - [ ] drag: drag and drop
 
 
+<!-- counts: {'done': 0, 'partial': 22, 'todo': 32, 'gated': 7} -->

--- a/project.yml
+++ b/project.yml
@@ -146,6 +146,10 @@ targets:
             UTTypeDescription: Droidective terminal rail item
             UTTypeConformsTo:
               - public.data
+          - UTTypeIdentifier: com.rohindh.droidective.mirror-wall-tile
+            UTTypeDescription: Droidective mirror wall tile
+            UTTypeConformsTo:
+              - public.data
         CFBundleDocumentTypes:
           - CFBundleTypeName: Android Package
             CFBundleTypeRole: Viewer

--- a/scripts/generate-parity-tracker.py
+++ b/scripts/generate-parity-tracker.py
@@ -83,6 +83,7 @@ def affordances(view_name):
 # Off-Apple exclusions, with the reason from docs/cross-platform.md.
 GATED = {
     "scrcpy": "Mirror pipeline is Apple-only (VideoToolbox/AVFoundation); other hosts drive the scrcpy desktop app.",
+    "mirror-wall": "Several mirrors at once, on the same Apple-only mirror pipeline as `scrcpy`.",
     "screen-record": "Records through the mirror session, which is Apple-only.",
     "video-editor": "Rides the mirror/ffmpeg export path built on the Apple media stack.",
     "reactotron": "ReactotronServer is a Network.framework listener; needs a portable NIO listener first.",


### PR DESCRIPTION
Mirrors several connected devices side by side in one pane, as the 61st feature
(`mirror-wall`, "Mirror Wall", in Screen & Capture beside Mirror Screen).

## The wall

Up to `MirrorWall.maximumDevices` (6) devices, each a full interactive session —
clicking a tile taps that device, and keys plus ⌘C/⌘V follow the click through
AppKit's own first responder.

- **Selection** — a Devices menu over the ready Android devices, capped at six;
  the boxes that would exceed it disable. The picked set and the tile order are
  per window and persisted (`WindowState.mirrorWallSerials`). A wall nobody has
  picked for opens on what's connected; an explicitly emptied one stays empty.
- **Arrangement** — Auto (columns from the pane width, clamped so tiles never go
  below 260pt) or a fixed 1 / 2 / 3 columns. Tiles reorder by dragging their
  **caption strip**: `.onDrag` on the video would turn every swipe on the device
  into a tile drag.
- **Cost** — per-tile scrcpy quality steps down with the tile count (one tile is
  exactly the full mirror's 1280; six are 640@24), per-tile Pause, audio only on
  the focused tile (opt-in, since moving focus restarts that session), and the
  same 120s grace teardown a hidden mirror tab gets.
- **No double encoders** — a device already mirrored elsewhere shows that on the
  tile with a way to reach it, instead of a second session on it.

## Full View

View ▸ Full View (⇧⌘F) hides the window's chrome — sidebar, device bar, tab
strip — and enters macOS full screen, for the wall above all. ⇧⌘F rather than
the system's ⌃⌘F, which macOS already owns. Per window, deliberately not
persisted, and RootView watches `NSWindow.willExitFullScreenNotification` so
leaving full screen by the green button leaves the mode too.

## Exclusivity grows a second dimension

`Entry.serial` answers "who owns this device?" only for device-bar-scoped
features. A wall streams six devices from a window pointed at one of them, so
the wall and the pop-out mirrors publish `WorkspaceRegistry.Claim`s instead.
Claims come from *live sessions*, which is what `claimant(ofFeature:on:)` reads —
a hidden mirror tab that isn't streaming must not hold a device hostage.
`mirror-wall` is deliberately absent from `exclusiveFeatureIDs`: a whole-pane
banner over the window's selected device would block five working tiles because
of the sixth, so it contends per tile.

## Two changes to existing behaviour

- **The pop-out mirror window is now one window per device.** It became a
  `WindowGroup(for: String.self)` keyed by serial and is pinned to that device
  (`ScreenMirrorView.pinnedSerial`) instead of following the device bar — which
  is what lets several stand side by side, and what stops the single pop-out
  swapping devices whenever you clicked another window. `AppCore
  .arrangeMirrorWindows` tiles the open ones across the screen.
- **Mirror sessions no longer leak their adb tunnel at quit**, which fixes the
  single mirror and the pop-out too. A session's teardown removes the `adb
  forward` it opened, but teardown is fire-and-forget, so the process exited
  first and the tunnel stayed registered in the long-lived adb server: one
  leaked listening socket per session per quit, until `adb kill-server`.
  `MirrorSessions` tracks live sessions weakly and `AppCore.finishQuitNow`
  awaits their teardown, where termination is already deferred for the MCP
  server and the Reactotron relay.

## Other defects fixed in review

- `MirrorVideoView` captured the renderer's display layer at init and never
  adopted a new one, so a tile's Reconnect left it drawing the stopped session's
  layer — input worked, no frame arrived. `MirrorLayerNSView
  .adopt(displayLayer:)` swaps it in place.
- A tile's quality came from a device count that hadn't settled (devices arrive
  across `adb devices` polls, so the first tile of a three-device wall got the
  one-tile encoder). Starts now coalesce; stops still run at once.
- Six encoders kept running behind an occluded or miniaturized window. The wall
  now suspends after the same grace window, re-checking that the window really
  is off screen first.
- A view whose `@State` outlived its own `onDisappear` held a wall that is
  terminal by design — black tiles with no way back. It now rebuilds one.
- A drag guideline could outlive its drag, since an abandoned drag doesn't always
  land a `dropExited`.

## Verification

`make verify` green — 1806 ADBKit + 99 AppTests, warning-free — and `make
test-linux` green at 1726, so ADBKit stayed portable. The pure logic is
`MirrorWall` in ADBKit (grid shape, per-tile quality, selection cap and
reconcile, which tiles stream, pop-out window tiling) with 23 tests; the registry
claims add 8.

Measured against three emulators: one scrcpy session per device at the expected
`max_size`, three `adb forward` tunnels while running and zero after quit, a
device killed mid-stream tearing down cleanly while its neighbours kept
streaming, RSS flat at 59 MB and 3–6% CPU with three tiles, and `sample` showing
the app's time only in the decode path (`MirrorSession`, `H264NAL`,
`renderer.enqueue`). The interaction paths — drag-reorder, the per-device
windows, Arrange, both Bring Backs, Full View, the occlusion suspend — were
click-tested by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
