### PR TITLE
Say why a keystore password file couldn't be written

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AabConvertService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AabConvertService.swift
@@ -137,18 +137,15 @@ public struct AabConvertService: Sendable {
         return arguments
     }
 
-    /// Write a secret to a temp file created with 0600 permissions and return
-    /// its path. The per-user temp dir (0700) covers any instant between
-    /// creation and the attribute landing. Callers delete it.
+    /// Write the keystore password to an owner-only temp file (never argv) and
+    /// return its path. Callers delete it.
     private func writeSecret(_ secret: String) throws -> String {
-        let path = FileManager.default.temporaryDirectory.appendingPathComponent("aab-sign-\(UUID().uuidString)")
-        guard FileManager.default.createFile(
-            atPath: path.path, contents: Data(secret.utf8),
-            attributes: [.posixPermissions: 0o600]
-        ) else {
-            throw ConvertError.buildFailed("Couldn't write the keystore password file.")
+        do {
+            return try SecretFile.write(secret, prefix: "aab-sign-")
+        } catch {
+            throw ConvertError.buildFailed(
+                "Couldn't write the keystore password file. \(error.localizedDescription)")
         }
-        return path.path
     }
 
     static func extractArguments(apks: String, destination: String) -> [String] {

--- a/ADBKit/Sources/ADBKit/Services/ApkSigningService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ApkSigningService.swift
@@ -204,16 +204,14 @@ public struct ApkSigningService: Sendable {
         ]
     }
 
-    /// Write a secret to a temp file created 0600 from the start (no window
-    /// where it exists world-readable) and return its path. Callers delete it.
+    /// Write the keystore password to an owner-only temp file (never argv) and
+    /// return its path. Callers delete it.
     private func writeSecret(_ secret: String) throws -> String {
-        let path = FileManager.default.temporaryDirectory.appendingPathComponent("apksign-\(UUID().uuidString)")
-        guard FileManager.default.createFile(
-            atPath: path.path, contents: Data(secret.utf8),
-            attributes: [.posixPermissions: 0o600]
-        ) else {
-            throw SigningError.stepFailed("Couldn't write the keystore password file.")
+        do {
+            return try SecretFile.write(secret, prefix: "apksign-")
+        } catch {
+            throw SigningError.stepFailed(
+                "Couldn't write the keystore password file. \(error.localizedDescription)")
         }
-        return path.path
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/SecretFile.swift
+++ b/ADBKit/Sources/ADBKit/Services/SecretFile.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// A short-lived file holding a secret — a keystore password — so it never has
+/// to ride on a command line, where every process on the machine can read it
+/// out of the process table.
+///
+/// Shared by the two signing paths (`ApkSigningService`, `AabConvertService`)
+/// because it's the security boundary for both, and one implementation is one
+/// place to get the permissions right.
+public enum SecretFile {
+    public enum Failure: Error, LocalizedError, Sendable {
+        case writeFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case let .writeFailed(detail): detail
+            }
+        }
+    }
+
+    /// Write `secret` to a uniquely named file in the per-user temp directory
+    /// and return its path. Callers delete it when the tool is done with it.
+    ///
+    /// The file is created and *then* tightened to 0600. That leaves a moment
+    /// where it carries the default mode, which the per-user temp directory's
+    /// own 0700 covers; creating it 0600 in one step would mean raw `open(2)`,
+    /// which isn't portable.
+    public static func write(_ secret: String, prefix: String) throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)\(UUID().uuidString)")
+        do {
+            try Data(secret.utf8).write(to: url)
+        } catch {
+            // Say *why*. The previous implementation used
+            // `FileManager.createFile`, whose Bool result threw away the reason
+            // — which is how a one-off Windows CI failure ("Couldn't write the
+            // keystore password file") arrived with nothing to diagnose.
+            throw Failure.writeFailed(
+                "Couldn't write the secret file at \(url.path): \(error.localizedDescription)")
+        }
+        try restrictToOwner(url)
+        return url.path
+    }
+
+    /// Make the file readable only by its owner.
+    ///
+    /// On Windows this is best-effort *by design*: the POSIX mode isn't the
+    /// mechanism there (the per-user temp directory's ACL is — `_wchmod` only
+    /// toggles the read-only bit), and the call can fail transiently while
+    /// something else still holds the freshly written file. Failing a signing
+    /// run over an attribute the platform doesn't enforce would trade a real
+    /// capability for no security.
+    private static func restrictToOwner(_ url: URL) throws {
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } catch {
+            #if os(Windows)
+            return
+            #else
+            try? FileManager.default.removeItem(at: url)
+            throw Failure.writeFailed(
+                "Couldn't restrict the secret file's permissions: \(error.localizedDescription)")
+            #endif
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/SecretFileTests.swift
+++ b/ADBKit/Tests/ADBKitTests/SecretFileTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct SecretFileTests {
+    @Test func writesTheSecretAndReturnsItsPath() throws {
+        let path = try SecretFile.write("s3cret", prefix: "test-secret-")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == "s3cret")
+    }
+
+    @Test func namesTheFileByItsPrefixInsideTheTempDirectory() throws {
+        let path = try SecretFile.write("x", prefix: "test-prefix-")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        #expect(name.hasPrefix("test-prefix-"))
+        // Same directory the caller's cleanup and the tool both expect.
+        #expect(URL(fileURLWithPath: path).deletingLastPathComponent().standardizedFileURL
+            == FileManager.default.temporaryDirectory.standardizedFileURL)
+    }
+
+    /// Two signing runs at once must not hand the same path to two tools —
+    /// one would delete the other's password file mid-run.
+    @Test func everyCallGetsItsOwnFile() throws {
+        let first = try SecretFile.write("a", prefix: "test-unique-")
+        let second = try SecretFile.write("b", prefix: "test-unique-")
+        defer {
+            try? FileManager.default.removeItem(atPath: first)
+            try? FileManager.default.removeItem(atPath: second)
+        }
+        #expect(first != second)
+        #expect(try String(contentsOfFile: first, encoding: .utf8) == "a")
+        #expect(try String(contentsOfFile: second, encoding: .utf8) == "b")
+    }
+
+    /// The whole point of the file: the password is unreadable to anyone else.
+    /// Windows doesn't enforce POSIX modes (the temp directory's ACL does), and
+    /// `restrictToOwner` is best-effort there, so this asserts where it means
+    /// something.
+    #if !os(Windows)
+    @Test func theFileIsReadableOnlyByItsOwner() throws {
+        let path = try SecretFile.write("s3cret", prefix: "test-mode-")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let mode = try FileManager.default.attributesOfItem(atPath: path)[.posixPermissions] as? NSNumber
+        #expect(mode?.int16Value == 0o600)
+    }
+    #endif
+
+    @Test func anEmptySecretStillProducesAFile() throws {
+        let path = try SecretFile.write("", prefix: "test-empty-")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == "")
+    }
+
+    /// A failure has to name the path and carry the underlying reason — the
+    /// Bool-returning API it replaced is why a Windows CI failure arrived with
+    /// nothing to diagnose.
+    @Test func aFailureSaysWhereAndWhy() {
+        #expect(throws: SecretFile.Failure.self) {
+            try SecretFile.write("x", prefix: "no/such/directory/test-")
+        }
+        let failure = SecretFile.Failure.writeFailed("Couldn't write the secret file at /x: nope")
+        #expect(failure.errorDescription?.contains("/x") == true)
+        #expect(failure.errorDescription?.contains("nope") == true)
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1806 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1812 tests, keep green
 make test-app      # the AppTests logic bundle — 99 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)


### PR DESCRIPTION
## What happened

The Windows CI job on #274 failed once on
`AabConvertServiceTests.convertWithKeystoreNeverPutsThePasswordOnTheCommandLine`:

```
Caught error: buildFailed("Couldn't write the keystore password file.")
```

A re-run of the same job passed
([run 32114298749](https://github.com/Droidective/Droidective/actions/runs/32114298749)),
so it is **intermittent, not a break** — and that message was the entire
diagnostic. It could have been the file write or the permission attribute; there
was no way to tell.

## What this changes

Both signing paths wrote the password with
`FileManager.createFile(atPath:contents:attributes:)`, whose `Bool` result
discards the reason and covers two distinct steps. `SecretFile` replaces both
copies:

- writes with `Data.write(to:)`, so a failure names the path and carries the
  underlying error;
- restricts the file to its owner as a **separate, reportable** step.

The split also makes the Windows behaviour deliberate instead of accidental.
There the POSIX mode isn't the mechanism — the per-user temp directory's ACL is,
and corelibs' `_wchmod` only toggles the read-only bit — and the call can fail
transiently while something else still holds the freshly written file. So the
restriction is best-effort **on Windows only**; everywhere else a failure to
tighten deletes the file and throws, since a readable password file is worse than
a failed signing run.

I could not reproduce the failure on macOS, and I'm not claiming this is a
certain cure: it is the change that makes the *next* occurrence say which step
failed and why. If the write itself is what flakes on that runner, the message
will now name it.

## Checks

`make verify` green — 1812 ADBKit + 99 AppTests, warning-free. Six new tests
cover the contents, the prefix and directory, uniqueness across calls, the 0600
mode (asserted where the platform enforces it), an empty secret, and that a
failure names both the path and the reason. The two services' existing
arg-vector tests still assert the password never reaches the command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
