### PR TITLE
Reactotron: parse stringified payloads, open long API URLs in place; copy a mirror screenshot

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/EmbeddedJSON.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/EmbeddedJSON.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// A JSON *string* that is itself JSON: an API request whose `data` field
+/// carries a stringified body, a log whose message is a serialized object.
+/// Reactotron shows what the app sent — a wall of escaped text — where the
+/// reader wants the object.
+///
+/// The two halves are deliberately separate. `looksLikeJSON` is what a row
+/// asks on every render to decide whether to offer the parse, so it only
+/// touches the string's first and last non-whitespace characters. `parse` is
+/// the walk of the whole payload, and is only ever called for the one value a
+/// reader opened — a streaming timeline must never parse what nobody looked at.
+public enum EmbeddedJSON {
+    /// Longest string (in UTF-8 bytes) worth parsing. Past this the parse is
+    /// itself the stall, so the value keeps its raw text and offers nothing.
+    public static let maxBytes = 1_000_000
+
+    /// True when `text` is *shaped* like a JSON object or array — the cheap
+    /// check, whitespace-tolerant, made per row render.
+    public static func looksLikeJSON(_ text: String) -> Bool {
+        guard text.utf8.count <= maxBytes else { return false }
+        guard let opener = text.first(where: { !$0.isWhitespace }) else { return false }
+        let closer: Character
+        switch opener {
+        case "{": closer = "}"
+        case "[": closer = "]"
+        default: return false
+        }
+        // Scanning back from the end, not `trimmingCharacters`, so a megabyte
+        // of body is never copied to look at one character.
+        var index = text.endIndex
+        while index > text.startIndex {
+            index = text.index(before: index)
+            guard text[index].isWhitespace else { return text[index] == closer }
+        }
+        return false
+    }
+
+    /// The parsed object or array, or nil when the string isn't one (or is
+    /// bigger than `maxBytes`). Call this when the value is opened, never while
+    /// building a row.
+    public static func parse(_ text: String) -> JSONValue? {
+        guard looksLikeJSON(text), let data = text.data(using: .utf8) else { return nil }
+        guard let value = try? JSONDecoder().decode(JSONValue.self, from: data) else { return nil }
+        switch value {
+        case .object, .array: return value
+        default: return nil
+        }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/JSONSearch.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/JSONSearch.swift
@@ -5,12 +5,25 @@ import Foundation
 /// order — object children sorted by key, array items in order — so the view
 /// can expand straight to a clicked result.
 public enum JSONSearch {
+    /// Longest stringified payload expanded during a search. A find runs per
+    /// keystroke, so the parse it may trigger is capped well below the display
+    /// parse's `EmbeddedJSON.maxBytes`; a bigger string is searched as text.
+    public static let maxStringifiedBytes = 262_144
+
     /// Every node whose own key or scalar value contains `query`
     /// (case-insensitive), in render order. Bounded by `limit` results and
     /// `maxVisited` visited nodes so a pathological payload can't stall a
     /// keystroke.
+    ///
+    /// - Parameter expandingStringifiedJSON: search a string that is itself JSON
+    ///   as the object it holds, matching what the tree view renders — the
+    ///   escaped text is not what the reader sees, and `data.params.storeId` is
+    ///   the row they want, not the 4 KB blob that contains it. Ordinal paths
+    ///   stay aligned with the view, which grafts a parse's rows in the string's
+    ///   place. Strings past `maxStringifiedBytes` are left as text.
     public static func matches(
-        in root: JSONValue, query: String, limit: Int = 200, maxVisited: Int = 40_000
+        in root: JSONValue, query: String, limit: Int = 200, maxVisited: Int = 40_000,
+        expandingStringifiedJSON: Bool = false
     ) -> [TreeMatch] {
         let query = query.lowercased()
         guard !query.isEmpty else { return [] }
@@ -27,9 +40,21 @@ public enum JSONSearch {
             }
         }
 
+        /// The object a stringified payload holds, when the caller asked for
+        /// that and it is small enough to parse mid-keystroke.
+        func expansion(of value: JSONValue) -> JSONValue? {
+            guard expandingStringifiedJSON, case let .string(text) = value,
+                  text.utf8.count <= maxStringifiedBytes else { return nil }
+            return EmbeddedJSON.parse(text)
+        }
+
         func walk(_ value: JSONValue, key: String, path: [Int], displayPath: String) {
             guard out.count < limit, visited < maxVisited else { return }
             visited += 1
+            // Search the value the reader sees: for a stringified payload that
+            // is its object, so the escaped text neither matches on its own nor
+            // hides the leaves inside it.
+            let value = expansion(of: value) ?? value
             if !path.isEmpty, matchesSelf(value, key: key) {
                 let isContainer = value.objectValue != nil || value.arrayValue != nil
                 out.append(TreeMatch(

--- a/ADBKit/Tests/ADBKitTests/EmbeddedJSONTests.swift
+++ b/ADBKit/Tests/ADBKitTests/EmbeddedJSONTests.swift
@@ -1,0 +1,75 @@
+import Testing
+@testable import ADBKit
+
+/// Recognizing and parsing a stringified payload — the `data: "{…}"` field an
+/// RN app sends on an `api.response`. The recognition half runs per row render,
+/// so it must answer without walking (or copying) the payload.
+@Suite struct EmbeddedJSONTests {
+    @Test func recognizesAnObjectString() {
+        #expect(EmbeddedJSON.looksLikeJSON(#"{"id":"graphData_v1.3"}"#))
+    }
+
+    @Test func recognizesAnArrayString() {
+        #expect(EmbeddedJSON.looksLikeJSON("[1,2,3]"))
+    }
+
+    @Test func toleratesSurroundingWhitespace() {
+        #expect(EmbeddedJSON.looksLikeJSON("\n  {\"a\":1}\t\n"))
+    }
+
+    @Test func rejectsPlainText() {
+        #expect(!EmbeddedJSON.looksLikeJSON("not json at all"))
+        #expect(!EmbeddedJSON.looksLikeJSON(""))
+        #expect(!EmbeddedJSON.looksLikeJSON("   "))
+        #expect(!EmbeddedJSON.looksLikeJSON("42"))
+        #expect(!EmbeddedJSON.looksLikeJSON("\"{\\\"a\\\":1}\""))
+    }
+
+    @Test func rejectsAnUnclosedShape() {
+        #expect(!EmbeddedJSON.looksLikeJSON(#"{"a":1"#))
+        #expect(!EmbeddedJSON.looksLikeJSON("[1,2"))
+        // Opener and closer must match each other, not just be brackets.
+        #expect(!EmbeddedJSON.looksLikeJSON("{1,2]"))
+    }
+
+    @Test func rejectsAPayloadPastTheParseCap() {
+        let huge = "{\"a\":\"" + String(repeating: "x", count: EmbeddedJSON.maxBytes) + "\"}"
+        #expect(!EmbeddedJSON.looksLikeJSON(huge))
+        #expect(EmbeddedJSON.parse(huge) == nil)
+    }
+
+    @Test func parsesAStringifiedRequestBody() {
+        let text = #"{"id":"graphData_v1.3","params":{"storeId":"8052321","interval":"hour"}}"#
+        let parsed = EmbeddedJSON.parse(text)
+        #expect(parsed?["id"]?.stringValue == "graphData_v1.3")
+        #expect(parsed?["params"]?["storeId"]?.stringValue == "8052321")
+    }
+
+    @Test func parsesAnArrayBody() {
+        #expect(EmbeddedJSON.parse("[1,2,3]")?.arrayValue?.count == 3)
+    }
+
+    @Test func parsesNestedStringifiedJSONOneLevelAtATime() {
+        // The inner value stays a string — the row that opens it parses it in
+        // turn, so a doubly-encoded payload isn't walked all at once.
+        let inner = #"{\"deep\":true}"#
+        let parsed = EmbeddedJSON.parse("{\"data\":\"\(inner)\"}")
+        let nested = parsed?["data"]?.stringValue
+        #expect(nested == #"{"deep":true}"#)
+        #expect(EmbeddedJSON.parse(nested ?? "")?["deep"]?.boolValue == true)
+    }
+
+    @Test func malformedJSONIsNotParsed() {
+        #expect(EmbeddedJSON.parse("{oops}") == nil)
+        #expect(EmbeddedJSON.parse(#"{"a":}"#) == nil)
+        #expect(EmbeddedJSON.parse("[1,2]]") == nil)
+    }
+
+    @Test func aScalarIsNeverAParsedTree() {
+        // Shaped like neither an object nor an array: there is nothing to show
+        // as a tree, so these must not offer the toggle.
+        #expect(EmbeddedJSON.parse("42") == nil)
+        #expect(EmbeddedJSON.parse("\"quoted\"") == nil)
+        #expect(EmbeddedJSON.parse("null") == nil)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/JSONSearchTests.swift
+++ b/ADBKit/Tests/ADBKitTests/JSONSearchTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import ADBKit
+
+/// Searching a payload whose value is a *stringified* JSON body — the tree view
+/// renders it as its object, so the find has to agree with what is on screen.
+@Suite struct JSONSearchStringifiedTests {
+    /// An API request the way `reactotron-react-native` reports one: `data` is
+    /// the raw string handed to `xhr.send`.
+    private var request: JSONValue {
+        let body = #"{"id":"graphData_v1.3","params":{"storeId":"8052321","interval":"hour"}}"#
+        return .object([
+            "data": .string(body),
+            "method": .string("POST"),
+            "url": .string("https://example.test/stats"),
+        ])
+    }
+
+    @Test func withoutExpansionOnlyTheBlobMatches() {
+        let matches = JSONSearch.matches(in: request, query: "storeId")
+        #expect(matches.count == 1)
+        // The escaped body, as one line — the old behavior, kept for callers
+        // that render the string as a string.
+        #expect(matches.first?.displayPath == "data")
+        #expect(matches.first?.preview.contains("graphData_v1.3") == true)
+    }
+
+    @Test func expansionFindsTheLeafInsideTheStringifiedBody() {
+        let matches = JSONSearch.matches(in: request, query: "storeId", expandingStringifiedJSON: true)
+        #expect(matches.map(\.displayPath) == ["data.params.storeId"])
+        #expect(matches.first?.preview == "\"8052321\"")
+    }
+
+    @Test func anExpandedPayloadPreviewsAsItsObject() {
+        // `data` matches by key, and `graphData_v1.3` by value — the point here
+        // is the first: its preview is the object the reader sees, not the
+        // escaped text it arrived as.
+        let matches = JSONSearch.matches(in: request, query: "data", expandingStringifiedJSON: true)
+        #expect(matches.map(\.displayPath) == ["data", "data.id"])
+        #expect(matches.first?.preview == "{ 2 }")
+        #expect(matches.first?.isContainer == true)
+    }
+
+    @Test func ordinalPathsStayAlignedWithTheTreesRows() {
+        // The view grafts a parse's rows in the string's place, so the path to a
+        // leaf is the string's own path plus the parse's ordinals (keys sorted:
+        // id, params → params is 1; interval, storeId → storeId is 1).
+        let matches = JSONSearch.matches(in: request, query: "8052321", expandingStringifiedJSON: true)
+        #expect(matches.map(\.path) == [[0, 1, 1]])
+    }
+
+    @Test func nestedStringifiedPayloadsExpandTheirWholeChain() {
+        let inner = #"{"deep":{"flag":true}}"#
+        let outer = #"{"payload":"\#(inner.replacingOccurrences(of: "\"", with: "\\\""))"}"#
+        let root = JSONValue.object(["body": .string(outer)])
+        let matches = JSONSearch.matches(in: root, query: "flag", expandingStringifiedJSON: true)
+        #expect(matches.map(\.displayPath) == ["body.payload.deep.flag"])
+    }
+
+    @Test func aStringThatIsNotJSONStillMatchesAsText() {
+        let root = JSONValue.object(["note": .string("storeId was missing")])
+        let matches = JSONSearch.matches(in: root, query: "storeId", expandingStringifiedJSON: true)
+        #expect(matches.map(\.displayPath) == ["note"])
+    }
+
+    @Test func aPayloadPastTheSearchCapIsSearchedAsText() {
+        let huge = "{\"pad\":\"" + String(repeating: "x", count: JSONSearch.maxStringifiedBytes) + "\",\"k\":1}"
+        let root = JSONValue.object(["data": .string(huge)])
+        let matches = JSONSearch.matches(in: root, query: "pad", expandingStringifiedJSON: true)
+        // Found, but as the string it is — the parse is skipped at this size.
+        #expect(matches.count == 1)
+        #expect(matches.first?.isContainer == false)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2383,11 +2383,12 @@ private struct RtRow: View {
         .background(.bgSurface, in: RoundedRectangle(cornerRadius: 6))
     }
 
+    /// A response body arrives as a string; show the object when it is one.
+    /// Only ever called from the expanded body, so nothing parses until the row
+    /// is opened.
     private func parseBody(_ value: JSONValue?) -> JSONValue? {
-        guard case let .string(text) = value,
-              let data = text.data(using: .utf8),
-              let parsed = try? JSONDecoder().decode(JSONValue.self, from: data) else { return nil }
-        return parsed
+        guard case let .string(text) = value else { return nil }
+        return EmbeddedJSON.parse(text)
     }
 
     private func formatMs(_ ms: Double) -> String {
@@ -2589,6 +2590,19 @@ private struct JSONTreeView: View {
     /// `JSONTreeLayout.collapsedLines` so one 20 KB payload can't bury the
     /// timeline.
     @State private var expandedValues: Set<String> = []
+    /// Parsed stringified payloads, keyed by row path: an API's `data: "{…}"`, a
+    /// serialized body. Filled when the row appears — which only happens inside
+    /// an *expanded* event — and never while building a row, so a streaming
+    /// timeline parses nothing until someone opens the event.
+    @State private var parsedStrings: [String: JSONValue] = [:]
+    /// Paths the reader switched back to the raw text. A parsed payload is the
+    /// default (it's the readable form); some are only readable raw — a
+    /// signature, whitespace that matters, a diff against a server log.
+    @State private var rawPaths: Set<String> = []
+    /// Paths whose value looked like JSON but didn't parse (malformed, or cut off
+    /// by the client). Tried once, then the row is plain text — an offer that
+    /// does nothing when clicked is worse than no offer.
+    @State private var unparseable: Set<String> = []
     @State private var search = ""
     /// The last find result revealed by a click, tinted in the tree until the
     /// next search.
@@ -2659,10 +2673,27 @@ private struct JSONTreeView: View {
         var out: [JSONNode] = []
         func walk(_ node: JSONNode) {
             out.append(node)
-            guard node.isContainer, expanded.contains(node.path) else { return }
-            for child in node.children { walk(child) }
+            if node.isContainer {
+                guard expanded.contains(node.path) else { return }
+                for child in node.children { walk(child) }
+            } else if let parsed = shownParse(node.path) {
+                // The string's own tree hangs off the row that carried it, one
+                // level deeper — a nested stringified value is a row of its own
+                // and parses when *it* is opened.
+                let host = JSONNode(path: node.path, key: "", value: parsed, depth: node.depth)
+                for child in host.children { walk(child) }
+            }
         }
-        for child in JSONNode(path: "", key: "", value: root, depth: -1).children { walk(child) }
+        let host = JSONNode(path: "", key: "", value: root, depth: -1)
+        // A scalar root is a payload too — a plain-text or stringified response
+        // body. Showing its children (none) read as "(empty)"; show the value.
+        guard host.isContainer else {
+            let node = JSONNode(path: ".0", key: "", value: root, depth: 0)
+            if case .null = root { return [] }
+            walk(node)
+            return out
+        }
+        for child in host.children { walk(child) }
         return out
     }
 
@@ -2709,15 +2740,21 @@ private struct JSONTreeView: View {
 
     @ViewBuilder
     private func rowView(_ node: JSONNode) -> some View {
+        // A stringified payload, shown as its object: the tree below the row is
+        // the parse, and the row itself reads like the container it really is.
+        let parsed = shownParse(node.path)
+        // The value shaped like JSON but still escaped — the cheap check, made
+        // per render; the parse waits for a tap.
+        let embedded = embeddedJSONString(node)
         // Built once per row: on a big payload the preview is a full copy of
         // the value, and the cut, the disclosure, and the row all need it.
-        let preview = node.valuePreview
-        let showsAll = expandedValues.contains(node.path)
+        let preview = parsed.map(Self.containerPreview) ?? node.valuePreview
+        let showsAll = parsed == nil && expandedValues.contains(node.path)
         let budget = collapsedBudget(for: node)
-        let isCut = !node.isContainer && preview.prefix(budget + 1).count > budget
+        let isCut = parsed == nil && !node.isContainer && preview.prefix(budget + 1).count > budget
         // An opened row keeps its disclosure even if a wider pane has since
         // made the value fit — otherwise the only way to close it disappears.
-        let disclosesValue = !node.isContainer && (showsAll || isCut)
+        let disclosesValue = parsed == nil && !node.isContainer && (showsAll || isCut)
         HStack(alignment: .top, spacing: 4) {
             // The gutter is incompressible, so the value below is the row's one
             // flexible child: it's proposed exactly the width it renders at, and
@@ -2727,8 +2764,9 @@ private struct JSONTreeView: View {
             // over the event below it.
             HStack(alignment: .top, spacing: 4) {
                 Color.clear.frame(width: CGFloat(max(0, node.depth)) * JSONTreeLayout.indentPerDepth, height: 1)
-                if node.isContainer {
-                    Image(systemName: expanded.contains(node.path) ? "chevron.down" : "chevron.right")
+                if node.isContainer || parsed != nil {
+                    Image(systemName: (parsed != nil || expanded.contains(node.path))
+                        ? "chevron.down" : "chevron.right")
                         .font(.app(size: 10, weight: .bold))
                         .foregroundStyle(.secondary)
                         .frame(width: 14)
@@ -2764,14 +2802,21 @@ private struct JSONTreeView: View {
             // stale line count can spill over the event below.
             Text(valueText(preview, showingAll: showsAll, budget: budget, isCut: isCut))
                 .font(.app(size: 11, design: .monospaced))
-                .foregroundStyle(node.valueColor)
+                .foregroundStyle(parsed == nil ? node.valueColor : .secondary)
                 // Selectable text eats the click, and the value spans the whole
                 // row — so a row whose click means "open this" hands the click
                 // to the row instead. A cut value has nothing worth selecting
                 // (it's an excerpt); once open, the full text selects again.
-                .modifier(SelectableValue(enabled: !node.isContainer && (showsAll || !isCut)))
+                .modifier(SelectableValue(
+                    enabled: parsed == nil && !node.isContainer && (showsAll || !isCut)
+                ))
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            if let embedded {
+                // Incompressible, so the value stays the row's one flexible
+                // child (see the gutter note above).
+                parsedToggle(path: node.path, text: embedded, showingParsed: parsed != nil)
+            }
         }
         // Rows were 13pt slivers — give container rows a real click target.
         .padding(.vertical, 2)
@@ -2784,6 +2829,12 @@ private struct JSONTreeView: View {
         .onTapGesture {
             if node.isContainer {
                 toggle(node.path)
+            } else if parsed != nil {
+                rawPaths.insert(node.path)          // close the tree, back to the excerpt
+            } else if showsAll {
+                toggleValue(node.path)              // close the raw text
+            } else if let embedded {
+                showParsed(embedded, at: node.path)
             } else if disclosesValue {
                 toggleValue(node.path)
             }
@@ -2791,9 +2842,76 @@ private struct JSONTreeView: View {
         .contextMenu {
             Button("Copy value") {
                 NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(node.value.prettyJSON, forType: .string)
+                // What the row shows: the parsed object while it stands, the raw
+                // string the app sent once it's switched back.
+                let text = parsed?.prettyJSON ?? node.value.prettyJSON
+                NSPasteboard.general.setString(text, forType: .string)
             }
         }
+        // Keyed by path, so it runs once per row rather than per render — the
+        // one place a parse is started for a value nobody clicked, and only for
+        // a row that exists, i.e. inside an event the reader expanded.
+        .task(id: node.path) {
+            guard let embedded, parsedStrings[node.path] == nil else { return }
+            showParsed(embedded, at: node.path)
+        }
+    }
+
+    /// The parse a row is currently showing: the cached value unless the reader
+    /// asked for the raw text.
+    private func shownParse(_ path: String) -> JSONValue? {
+        rawPaths.contains(path) ? nil : parsedStrings[path]
+    }
+
+    /// The row's value as a JSON-shaped string, when it is one. Cheap by
+    /// construction (`EmbeddedJSON.looksLikeJSON` reads two characters), because
+    /// every visible row asks this on every render.
+    private func embeddedJSONString(_ node: JSONNode) -> String? {
+        guard !unparseable.contains(node.path),
+              case let .string(text) = node.value,
+              EmbeddedJSON.looksLikeJSON(text) else { return nil }
+        return text
+    }
+
+    /// Chrome DevTools' "View parsed / View source", per row: a stringified
+    /// payload shows as an object, and the raw text the app sent stays one click
+    /// away.
+    private func parsedToggle(path: String, text: String, showingParsed: Bool) -> some View {
+        Button {
+            if showingParsed {
+                rawPaths.insert(path)
+                expandedValues.insert(path)     // the raw text, in full
+            } else {
+                showParsed(text, at: path)
+            }
+        } label: {
+            Text(showingParsed ? "raw" : "parsed")
+                .font(.app(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .overlay(Capsule().strokeBorder(Color.secondary.opacity(0.35)))
+        }
+        .buttonStyle(.plain)
+        .help(showingParsed
+            ? "Show the raw text the app sent"
+            : "Parse this value and show it as an object")
+    }
+
+    /// Parses one stringified value and shows its tree. The only parse site — a
+    /// row render never reaches it.
+    private func showParsed(_ text: String, at path: String) {
+        rawPaths.remove(path)
+        expandedValues.remove(path)
+        guard parsedStrings[path] == nil else { return }
+        guard let value = EmbeddedJSON.parse(text) else { unparseable.insert(path); return }
+        parsedStrings[path] = value
+    }
+
+    /// `{ n }` / `[ n ]` for a parsed value, the same summary a container row
+    /// shows in place of its contents.
+    private static func containerPreview(_ value: JSONValue) -> String {
+        JSONNode(path: "", key: "", value: value, depth: 0).valuePreview
     }
 
     private func toggle(_ path: String) {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2121,6 +2121,12 @@ private struct RtRow: View {
     @State private var apiTab: ApiTab = .response
     @State private var hovering = false
     @State private var copiedLine = false
+    /// The API row's URL, shown whole. A signed S3 link runs to several hundred
+    /// characters, so the collapsed form is an excerpt and this opens it in place.
+    @State private var urlExpanded = false
+    /// The URL line's laid-out width — how much of the URL one line holds is a
+    /// function of the pane's current width, the same as an object row's value.
+    @State private var urlWidth: CGFloat = 0
 
     private static let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -2280,11 +2286,7 @@ private struct RtRow: View {
         method: String, url: String, status: Int, duration: Double, request: JSONValue?, response: JSONValue?
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(url)
-                .font(.app(size: 11, design: .monospaced))
-                .foregroundStyle(.rtKey)
-                .textSelection(.enabled)
-                .lineLimit(3)
+            urlLine(url)
             VStack(alignment: .leading, spacing: 3) {
                 metaRow("Status", "\(status)", color: statusColor(status))
                 metaRow("Method", method.uppercased(), color: .rtNumber)
@@ -2305,6 +2307,53 @@ private struct RtRow: View {
             }
             treeSection(title: nil, object: apiObject(request: request, response: response))
         }
+    }
+
+    /// The request URL, cut to what the line holds and opened in place by a
+    /// click — never line-limited. A limit is a drawing instruction the reported
+    /// height doesn't follow: a long query string drew its full ten lines over
+    /// the status rows and the tab strip below it while the layout had reserved
+    /// three. A shortened *string* can't be drawn taller than it is, and the
+    /// open form lays out at its real height, so the rest of the body moves down
+    /// the way a disclosure should. (Same reasoning as the object tree's rows.)
+    @ViewBuilder
+    private func urlLine(_ url: String) -> some View {
+        let budget = urlBudget()
+        let isCut = url.prefix(budget + 1).count > budget
+        let shown = urlExpanded || !isCut ? url : String(url.prefix(budget)) + "…"
+        HStack(alignment: .top, spacing: 4) {
+            if isCut {
+                Image(systemName: urlExpanded ? "chevron.down" : "chevron.right")
+                    .font(.app(size: 9))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 14)
+                    .help(urlExpanded ? "Show less" : "Show the whole URL")
+            }
+            Text(shown)
+                .font(.app(size: 11, design: .monospaced))
+                .foregroundStyle(.rtKey)
+                // An excerpt has nothing worth selecting, and selectable text
+                // eats the click that opens it; the whole URL selects again.
+                .modifier(SelectableValue(enabled: urlExpanded || !isCut))
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { if isCut { urlExpanded.toggle() } }
+        .measuringWidth(into: $urlWidth)
+    }
+
+    /// Characters the collapsed URL shows: two wrapped lines of the measured
+    /// line width, from the same pure geometry the object tree uses.
+    private func urlBudget() -> Int {
+        guard urlWidth > 0 else { return JSONTreeLayout.unmeasuredBudget }
+        let column = JSONTreeLayout.columnCharacters(
+            rowWidth: Double(urlWidth),
+            fontSize: 11 * AppFontPrefs.sizeScale,
+            depth: 0,
+            keyCharacters: 0
+        )
+        return JSONTreeLayout.collapsedBudget(columnCharacters: column, lines: 2)
     }
 
     private var apiTabPicker: some View {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2305,7 +2305,12 @@ private struct RtRow: View {
                 apiTabPicker.pickerStyle(.segmented)
                 apiTabPicker.pickerStyle(.menu)
             }
+            // The tree's opened rows, raw/parsed choices and find text belong to
+            // the payload on screen. Without this the four tabs share one tree
+            // and one set of positional paths, so switching tabs carried the
+            // other tab's opened rows onto this one.
             treeSection(title: nil, object: apiObject(request: request, response: response))
+                .id(apiTab)
         }
     }
 
@@ -2378,6 +2383,10 @@ private struct RtRow: View {
             if let message = object?["message"] {
                 switch message {
                 case .object, .array:
+                    treeSection(title: nil, object: message)
+                // A logged payload is often `JSON.stringify`d too — the same
+                // escaped wall, so it gets the same tree and raw toggle.
+                case let .string(text) where EmbeddedJSON.looksLikeJSON(text):
                     treeSection(title: nil, object: message)
                 default:
                     Text(String((message.stringValue ?? message.jsonString).prefix(20_000)))
@@ -2643,15 +2652,21 @@ private struct JSONTreeView: View {
     /// serialized body. Filled when the row appears — which only happens inside
     /// an *expanded* event — and never while building a row, so a streaming
     /// timeline parses nothing until someone opens the event.
-    @State private var parsedStrings: [String: JSONValue] = [:]
+    ///
+    /// Each entry carries the string it was parsed from, because a path alone
+    /// does not identify a value: a tree that swaps its root — the API event's
+    /// Response/Request tabs are one tree — reuses `.0` for a different payload,
+    /// and a cache hit from the other tab rendered *its* object on this row.
+    @State private var parsedStrings: [String: ParsedPayload] = [:]
     /// Paths the reader switched back to the raw text. A parsed payload is the
     /// default (it's the readable form); some are only readable raw — a
     /// signature, whitespace that matters, a diff against a server log.
     @State private var rawPaths: Set<String> = []
-    /// Paths whose value looked like JSON but didn't parse (malformed, or cut off
-    /// by the client). Tried once, then the row is plain text — an offer that
-    /// does nothing when clicked is worse than no offer.
-    @State private var unparseable: Set<String> = []
+    /// The string at each path that looked like JSON but didn't parse (malformed,
+    /// or cut off by the client). Tried once, then the row is plain text — an
+    /// offer that does nothing when clicked is worse than no offer. Keyed with
+    /// its source for the same reason the parses are.
+    @State private var unparseable: [String: String] = [:]
     @State private var search = ""
     /// The last find result revealed by a click, tinted in the tree until the
     /// next search.
@@ -2725,7 +2740,7 @@ private struct JSONTreeView: View {
             if node.isContainer {
                 guard expanded.contains(node.path) else { return }
                 for child in node.children { walk(child) }
-            } else if let parsed = shownParse(node.path) {
+            } else if let parsed = shownParse(node) {
                 // The string's own tree hangs off the row that carried it, one
                 // level deeper — a nested stringified value is a row of its own
                 // and parses when *it* is opened.
@@ -2791,7 +2806,7 @@ private struct JSONTreeView: View {
     private func rowView(_ node: JSONNode) -> some View {
         // A stringified payload, shown as its object: the tree below the row is
         // the parse, and the row itself reads like the container it really is.
-        let parsed = shownParse(node.path)
+        let parsed = shownParse(node)
         // The value shaped like JSON but still escaped — the cheap check, made
         // per render; the parse waits for a tap.
         let embedded = embeddedJSONString(node)
@@ -2860,12 +2875,18 @@ private struct JSONTreeView: View {
                     enabled: parsed == nil && !node.isContainer && (showsAll || !isCut)
                 ))
                 .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                // A parsed row's value is a two-glyph summary (`{ 9 }`): let it
+                // size to its content so the toggle sits beside it rather than
+                // stranded at the pane's far edge. A raw value keeps the row's
+                // whole width — it has to be the one flexible child, or the
+                // height it reports stops matching the height it draws.
+                .frame(maxWidth: parsed == nil ? .infinity : nil, alignment: .leading)
             if let embedded {
                 // Incompressible, so the value stays the row's one flexible
                 // child (see the gutter note above).
                 parsedToggle(path: node.path, text: embedded, showingParsed: parsed != nil)
             }
+            if parsed != nil { Spacer(minLength: 0) }
         }
         // Rows were 13pt slivers — give container rows a real click target.
         .padding(.vertical, 2)
@@ -2901,23 +2922,28 @@ private struct JSONTreeView: View {
         // one place a parse is started for a value nobody clicked, and only for
         // a row that exists, i.e. inside an event the reader expanded.
         .task(id: node.path) {
-            guard let embedded, parsedStrings[node.path] == nil else { return }
+            guard let embedded, parsedStrings[node.path]?.source != embedded else { return }
             showParsed(embedded, at: node.path)
         }
     }
 
-    /// The parse a row is currently showing: the cached value unless the reader
-    /// asked for the raw text.
-    private func shownParse(_ path: String) -> JSONValue? {
-        rawPaths.contains(path) ? nil : parsedStrings[path]
+    /// The parse a row is currently showing: the cached value for *this* row's
+    /// string, unless the reader asked for the raw text. A container never has
+    /// one — only a string can be a stringified payload.
+    private func shownParse(_ node: JSONNode) -> JSONValue? {
+        guard case let .string(text) = node.value,
+              !rawPaths.contains(node.path),
+              let entry = parsedStrings[node.path],
+              entry.source == text else { return nil }
+        return entry.value
     }
 
     /// The row's value as a JSON-shaped string, when it is one. Cheap by
     /// construction (`EmbeddedJSON.looksLikeJSON` reads two characters), because
     /// every visible row asks this on every render.
     private func embeddedJSONString(_ node: JSONNode) -> String? {
-        guard !unparseable.contains(node.path),
-              case let .string(text) = node.value,
+        guard case let .string(text) = node.value,
+              unparseable[node.path] != text,
               EmbeddedJSON.looksLikeJSON(text) else { return nil }
         return text
     }
@@ -2952,9 +2978,9 @@ private struct JSONTreeView: View {
     private func showParsed(_ text: String, at path: String) {
         rawPaths.remove(path)
         expandedValues.remove(path)
-        guard parsedStrings[path] == nil else { return }
-        guard let value = EmbeddedJSON.parse(text) else { unparseable.insert(path); return }
-        parsedStrings[path] = value
+        guard parsedStrings[path]?.source != text else { return }
+        guard let value = EmbeddedJSON.parse(text) else { unparseable[path] = text; return }
+        parsedStrings[path] = ParsedPayload(source: text, value: value)
     }
 
     /// `{ n }` / `[ n ]` for a parsed value, the same summary a container row
@@ -3002,6 +3028,13 @@ private struct JSONTreeView: View {
         )
         return JSONTreeLayout.collapsedBudget(columnCharacters: column)
     }
+}
+
+/// One parsed stringified payload, with the string it came from — the pair is
+/// what makes a path-keyed cache safe when the tree's root can change under it.
+private struct ParsedPayload {
+    let source: String
+    let value: JSONValue
 }
 
 /// `textSelection` takes two different concrete types, so the choice can't be a

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -2710,7 +2710,11 @@ private struct JSONTreeView: View {
                     // Clickable results (JSONSearch, pure in ADBKit): clicking
                     // one expands the tree along its path and highlights the
                     // node in place.
-                    let matches = JSONSearch.matches(in: root, query: search)
+                    // Expanded, because the rows below are: a find that only
+                    // knew the escaped string would point at a 4 KB blob
+                    // instead of the leaf the tree shows.
+                    let matches = JSONSearch.matches(
+                        in: root, query: search, expandingStringifiedJSON: true)
                     ForEach(Array(matches.enumerated()), id: \.offset) { _, match in
                         matchRow(match)
                     }
@@ -2797,6 +2801,9 @@ private struct JSONTreeView: View {
         for index in match.path {
             path += ".\(index)"
             expanded.insert(path)
+            // A match can sit inside a stringified payload the reader switched
+            // back to raw — the row it lives on only exists in the parse.
+            rawPaths.remove(path)
         }
         highlightedPath = path
         search = ""
@@ -2963,9 +2970,12 @@ private struct JSONTreeView: View {
             Text(showingParsed ? "raw" : "parsed")
                 .font(.app(size: 9, weight: .medium))
                 .foregroundStyle(.secondary)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
                 .overlay(Capsule().strokeBorder(Color.secondary.opacity(0.35)))
+                // A 9pt label is a small target: take the whole capsule, padding
+                // included, rather than just the glyphs.
+                .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .help(showingParsed

--- a/App/Sources/FeatureDetail/Views/RecordingDecision.swift
+++ b/App/Sources/FeatureDetail/Views/RecordingDecision.swift
@@ -3,8 +3,9 @@ import AppKit
 import SwiftUI
 
 /// After a recording or screenshot is captured, ask what to do with it — shown
-/// as a sheet with a preview and Edit / Save / Discard. Cancelling the sheet
-/// discards, so nothing is orphaned. Shared by Screen Record and Mirror Screen.
+/// as a sheet with a preview and Edit / Save / Discard, plus Copy for a
+/// screenshot. Cancelling the sheet discards, so nothing is orphaned. Shared by
+/// Screen Record and Mirror Screen.
 private struct MediaDecisionView: View {
     let title: String
     let preview: NSImage?
@@ -12,6 +13,12 @@ private struct MediaDecisionView: View {
     let onEdit: () -> Void
     let onSave: () -> Void
     let onDiscard: () -> Void
+    /// Screenshots only: put the image on the clipboard. Deliberately *not* a
+    /// decision like the other three — the sheet stays up, so a copy can still
+    /// be followed by Save, Edit, or Discard, and nothing lands on the clipboard
+    /// unless it was asked for. nil for a recording, which has no pasteable image.
+    var onCopy: (() -> Void)?
+    @State private var copied = false
 
     var body: some View {
         VStack(spacing: 18) {
@@ -33,6 +40,18 @@ private struct MediaDecisionView: View {
                 Button(role: .destructive) { onDiscard() } label: {
                     Text("Discard").frame(maxWidth: .infinity)
                 }
+                if let onCopy {
+                    Button {
+                        onCopy()
+                        copied = true
+                        Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
+                    } label: {
+                        // The confirmation is in the button: a toast would be
+                        // behind this sheet.
+                        Text(copied ? "Copied" : "Copy").frame(maxWidth: .infinity)
+                    }
+                    .help("Copy the screenshot to the clipboard — Save and Edit still work after")
+                }
                 Button { onSave() } label: { Text("Save").frame(maxWidth: .infinity) }
                 Button { onEdit() } label: { Text("Edit").frame(maxWidth: .infinity) }
                     .buttonStyle(.borderedProminent)
@@ -41,7 +60,7 @@ private struct MediaDecisionView: View {
             .controlSize(.large)
         }
         .padding(20)
-        .frame(width: 420)
+        .frame(width: 460)
     }
 }
 
@@ -126,7 +145,8 @@ private struct ImageDecisionModifier: ViewModifier {
                     loadingPreview: false,
                     onEdit: { act(onEdit) },
                     onSave: { act(save) },
-                    onDiscard: { act { _ in } })
+                    onDiscard: { act { _ in } },
+                    onCopy: { copyToClipboard(image) })
             }
         }
     }
@@ -139,6 +159,13 @@ private struct ImageDecisionModifier: ViewModifier {
         guard let pending = image else { return }
         image = nil
         body(pending)
+    }
+
+    /// The clipboard form the Screenshot editor's Copy writes, so pasting a
+    /// screenshot behaves the same wherever it was copied from.
+    private func copyToClipboard(_ pending: NSImage) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([pending])
     }
 
     private func save(_ pending: NSImage) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1806 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1817 tests, keep green
 make test-app      # the AppTests logic bundle — 99 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ opening it — verify those by hand.
 ## Build / test / run
 
 ```
-make test          # ADBKit unit tests (cd ADBKit && swift test) — 1817 tests, keep green
+make test          # ADBKit unit tests (cd ADBKit && swift test) — 1824 tests, keep green
 make test-app      # the AppTests logic bundle — 99 tests
 make verify        # tiers 0-1: warnings-as-errors + both test bundles
 make test-linux    # the same suite on Linux (Apple `container` CLI; the port gate)


### PR DESCRIPTION
Three changes, each verified against the running app.

## Reactotron shows a stringified payload as an object

An API request's `data` field arrives as a string — the app's own
`JSON.stringify` — so the timeline showed escaped text where the reader wanted
the body. Expanding an event now renders such a value as a real tree, with a
`raw` capsule on the row for the payloads that only read in their escaped form
(and `parsed` to switch back).

`EmbeddedJSON` (ADBKit, pure, 11 tests) splits the two halves the timeline
needs: `looksLikeJSON` is the per-render check and reads the first and last
non-whitespace characters; `parse` is the walk and runs once per row from the
row's `task` — a row only exists inside an expanded event, so a streaming
timeline parses nothing until someone opens one. A parse that fails is
remembered and the row stays plain text. The response body's existing parse now
goes through the same helper.

Also: a scalar tree root shows its value instead of `(empty)` — a plain-text or
stringified response body had no children to build rows from.

## A long API URL opens in place instead of over the rows below it

The expanded API event drew its URL with `lineLimit(3)`. A limit is a drawing
instruction the reported height doesn't follow: a signed S3 link drew all ten of
its lines over the status rows and the tab strip while the layout had reserved
three, and clicking it to read the endpoint was what triggered it.

The line now carries a shortened *string* cut to the measured width — the
technique the object tree's rows already use — and a click opens it whole at its
real height, so the rest of the body moves down. Selection follows the tree's
rule: off for an excerpt (the click has to reach the row), on once the whole URL
shows.

## Copy a mirror screenshot from the capture sheet

Closes #261. A screenshot taken on Mirror Screen (or the Mirror Wall) offered
Discard / Save / Edit, so getting the image into a chat or a ticket meant going
through the editor. `Copy` puts it on the clipboard in the same form the
editor's Copy writes.

It is deliberately not a decision like the other three: the sheet stays up, so a
copy can still be followed by Save, Edit, or Discard, and nothing reaches the
clipboard unless it was asked for. The confirmation is in the button — a toast
would be behind the sheet.

## Verification

- `make verify`: ADBKit 1817, ReactotronMCP 99, droidectived 91, AppTests 99;
  ADBKit compiles clean under `-warnings-as-errors`, app builds with no warnings.
- Live, against the relay fed real-shaped `api.response` frames (stringified
  `data`, a 500-character signed S3 URL): the request payload renders as
  `data { 2 } → id / params { 9 }`, the `raw` toggle returns the escaped string
  with an honest row height, and the long URL is cut with a disclosure while
  Status/Method/Duration sit below it rather than under it.
- The capture sheet's `Copy` was pressed on a real build: the clipboard held the
  captured image and the sheet stayed open on "Copied".