### PR TITLE
Stop a pop-out mirror window from looping the SwiftUI update graph

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/WorkspaceRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/WorkspaceRegistry.swift
@@ -254,6 +254,26 @@ public struct WorkspaceRegistry: Sendable, Equatable {
         return serials.filter { !taken.contains($0) }
     }
 
+    /// The claims `id` should hold once `featureID`'s are replaced by `serials`
+    /// (other features' kept) — or nil when that is already what it holds.
+    ///
+    /// The nil is the load-bearing part, and it has to be decided *before* the
+    /// registry is touched. Claims are published from view updates, and the
+    /// registry lives on an `@Observable`, where writing an equal value still
+    /// invalidates every reader — `RootView`'s body asks it for the window's
+    /// ordinal. A write per update is then an update per write: an endless
+    /// SwiftUI update loop, not a wasted pass. Guarding inside `setClaims`
+    /// cannot help, because a mutating call on an observed property fires its
+    /// `didSet` whether or not the value changed.
+    public func claimsChange(
+        replacing featureID: String, with serials: Set<String>, for id: WorkspaceID
+    ) -> Set<Claim>? {
+        let current = self[id]?.claims ?? []
+        let wanted = current.filter { $0.featureID != featureID }
+            .union(serials.map { Claim(featureID: featureID, serial: $0) })
+        return wanted == current ? nil : wanted
+    }
+
     // MARK: - Mutation
 
     /// Add a window (no-op if already registered, so a re-entrant bind is safe).

--- a/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
@@ -130,6 +130,45 @@ import Testing
         #expect(registry.owner(ofMirroredDevice: "ghi", excluding: w2) == w1)
     }
 
+    /// The guard that keeps a claim publisher from spinning the SwiftUI update
+    /// graph: re-publishing what a window already claims is *no change*, so the
+    /// caller never touches the observed registry. The pop-out mirror windows
+    /// publish from a view update, where one needless write beach-balls the app
+    /// for as long as the window is open.
+    @Test func republishingTheSameClaimsIsNoChange() {
+        var registry = self.registry([(w1, "abc", [])])
+        let wanted = registry.claimsChange(replacing: "scrcpy-window", with: ["def"], for: w1)
+        #expect(wanted == [.init(featureID: "scrcpy-window", serial: "def")])
+        registry.setClaims(wanted ?? [], for: w1)
+        #expect(registry.claimsChange(replacing: "scrcpy-window", with: ["def"], for: w1) == nil)
+    }
+
+    @Test func aChangedClaimSetIsReportedAndKeepsOtherFeaturesClaims() {
+        var registry = self.registry([(w1, "abc", [])])
+        registry.setClaims(
+            [
+                .init(featureID: "mirror-wall", serial: "def"),
+                .init(featureID: "scrcpy-window", serial: "ghi"),
+            ], for: w1)
+        #expect(
+            registry.claimsChange(replacing: "mirror-wall", with: ["jkl"], for: w1) == [
+                .init(featureID: "mirror-wall", serial: "jkl"),
+                .init(featureID: "scrcpy-window", serial: "ghi"),
+            ])
+        // Dropping the last tile is a change too — that's how a device is released.
+        #expect(
+            registry.claimsChange(replacing: "mirror-wall", with: [], for: w1)
+                == [.init(featureID: "scrcpy-window", serial: "ghi")])
+    }
+
+    /// An unregistered window claiming nothing must not mint an entry: entries
+    /// are ordered, and `ordinal(of:)` names both the window and its saved frame.
+    @Test func claimingNothingInAnUnknownWindowIsNoChange() {
+        let registry = WorkspaceRegistry()
+        #expect(registry.claimsChange(replacing: "scrcpy-window", with: [], for: w1) == nil)
+        #expect(registry.count == 0)
+    }
+
     @Test func aWindowIsNotBlockedByItsOwnClaims() {
         var registry = self.registry([(w1, "abc", [])])
         registry.setClaims([.init(featureID: "mirror-wall", serial: "def")], for: w1)

--- a/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
@@ -66,6 +66,15 @@ private struct MirrorWindowRegistrar: View {
 
     var body: some View {
         WindowAccessor { window in
+            // Droidective restores its own windows, and a pop-out mirror is not
+            // one of them: it exists because someone asked for this device now.
+            // AppKit's saved-state restoration brought them back at launch
+            // instead — before any workspace existed, so the window had no owner
+            // to read its adb client from, and a device nobody asked about got
+            // an encoder during launch. Saved state also lives outside the
+            // bundle, so reinstalling the app never cleared it. Same opt-out the
+            // workspace windows take in `AppCore.bind`.
+            window.isRestorable = false
             guard let serial else { return }
             state.core.noteMirrorWindow(serial: serial, window: window)
         }

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -527,14 +527,24 @@ final class AppCore {
 
     /// A pop-out mirror window appeared (or moved to a new NSWindow). Records
     /// the device as claimed so no wall tile or tab puts a second encoder on it.
+    ///
+    /// Re-reporting the window it already holds must change *nothing*.
+    /// `WindowAccessor` reports on every view update, and this writes state the
+    /// app scene reads — `RootView`'s body asks the registry for its window
+    /// ordinal, the Window menu reads the entries — so an unconditional write
+    /// invalidated the scene, which ran the update, which reported again: an
+    /// endless SwiftUI update loop that beach-balled the app for as long as a
+    /// pop-out mirror window was open. Same identity guard the workspace
+    /// windows use in `RootView` (`state.nsWindow !== window`).
     func noteMirrorWindow(serial: String, window: NSWindow?) {
+        guard mirrorWindows[serial]?.window !== window else { return }
         mirrorWindows[serial] = WeakWindow(window)
         publishMirrorWindowClaims()
     }
 
     /// A pop-out mirror window went away — its device is free again.
     func forgetMirrorWindow(serial: String) {
-        mirrorWindows.removeValue(forKey: serial)
+        guard mirrorWindows.removeValue(forKey: serial) != nil else { return }
         publishMirrorWindowClaims()
     }
 
@@ -615,10 +625,13 @@ final class AppCore {
     /// conflict rules see them (`WorkspaceRegistry.Claim`). `featureID`'s
     /// previous claims for this window are replaced; other features' are kept.
     func noteMirrorClaims(_ serials: Set<String>, featureID: String, in id: WorkspaceID) {
-        let others: Set<WorkspaceRegistry.Claim> = registry[id]?.claims
-            .filter { $0.featureID != featureID } ?? []
-        let mine = serials.map { WorkspaceRegistry.Claim(featureID: featureID, serial: $0) }
-        registry.setClaims(others.union(mine), for: id)
+        // Decide before writing: publishing the same claims again must not touch
+        // the registry at all. Writing an equal value through `@Observable`
+        // still invalidates every reader, and these are published from view
+        // updates — see `claimsChange` and `noteMirrorWindow`.
+        guard let claims = registry.claimsChange(replacing: featureID, with: serials, for: id)
+        else { return }
+        registry.setClaims(claims, for: id)
     }
 
     /// Whether any *other* window still has `featureID` open — the refcount

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,6 +621,29 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   Xcode** (local passes, CI fails with "unable to type-check in reasonable
   time"). Add cross-cutting concerns as ONE `.modifier(...)` link (see
   `WindowTranslucencyModifier`), never several inline links.
+- **A view update must not write observable state unconditionally — that's an
+  endless update loop, not a wasted pass.** `WindowAccessor` re-reports its
+  window on *every* `updateNSView`, and `AppCore`/`AppState` are `@Observable`
+  that `RootView.body` and the app's menus read (the window ordinal, the
+  registry entries), so a write from inside an update invalidates the scene,
+  whose update writes again — the app beach-balls for as long as the view is
+  mounted, from launch if the window is restored. Writing an *equal* value is
+  just as bad (`@Observable` fires `didSet` regardless), and a guard inside the
+  value type can't save you: a mutating call on an observed property notifies
+  whether or not the value changed. Decide before touching it — a pure "what
+  would change?" query in ADBKit that returns nil for "nothing"
+  (`WorkspaceRegistry.claimsChange`) plus an identity guard at the call site
+  (`AppCore.noteMirrorWindow`, `RootView`'s `state.nsWindow !== window`).
+  Better still, publish from `.onChange`/`.onDisappear`, the way the wall and
+  the in-tab mirror publish their claims.
+- **Windows the app opens itself opt out of AppKit restoration.** Droidective
+  restores its own windows from `LayoutState.windows`; AppKit's saved state
+  would *also* bring them back, before the layout has loaded and with no
+  workspace to own them — `AppCore.bind` and the pop-out mirror windows both set
+  `isRestorable = false`. Saved state lives outside the bundle
+  (`~/Library/Saved Application State/`), so a launch bug it feeds survives
+  deleting and reinstalling the app — worth knowing when a user reports that the
+  reinstall didn't help.
 - **⌘=/⌘- font zoom is a `scaleEffect` on RootView, not dynamic type.** macOS
   ignores SwiftUI `dynamicTypeSize` for rendering, so the content is laid out at
   `size/scale` and scaled up. It's bypassed entirely at 1.0× because the


### PR DESCRIPTION
A pop-out mirror window re-registered itself on every view update, and each
registration wrote observable state the app scene reads — so the write ran the
update and the update ran the write. The app beach-balled for as long as one of
those windows was open, with no way out.

## The loop

`MirrorWindowRegistrar` reports its `NSWindow` through `WindowAccessor`, which
re-reports on every `updateNSView`. `AppCore.noteMirrorWindow` took that
unconditionally: a fresh `WeakWindow` into `mirrorWindows`, then
`publishMirrorWindowClaims` into `AppCore.registry`. `RootView`'s body asks that
registry for its window ordinal (`RootView.swift:144`/`147`) and the Window menu
reads its entries (`ADTApp.swift:303`), so mutating it invalidates the scene,
whose update re-reports the window.

Writing an equal value is enough — `@Observable` fires `didSet` either way,
which is also why a guard inside `WorkspaceRegistry.setClaims` cannot help: a
mutating call on an observed property notifies whether or not the value changed.
The decision has to be made before the registry is touched.

- `WorkspaceRegistry.claimsChange(replacing:with:for:)` returns nil when a
  window already holds the claims being published. Pure, and the nil is what the
  three new tests pin.
- `AppCore.noteMirrorWindow` returns early when handed the window it already
  has, the same identity guard the workspace windows use in `RootView`
  (`state.nsWindow !== window`). `forgetMirrorWindow` publishes only when a
  window was actually removed.

## Restoration

The pop-out windows now opt out of AppKit's saved-state restoration, the way the
workspace windows do in `AppCore.bind`. They were being restored at launch —
before any workspace existed, so a restored window had no owner to read its adb
client from, and a device nobody asked about got an encoder during launch. That
is also what made the loop reproducible from launch and immune to reinstalling
the app, since saved state lives outside the bundle.

## Where it came from

The pop-out mirror became a `WindowGroup(for: String.self)` with a registrar in
#274 (v3.9.0). Reported by a user on 3.9.0 with three devices connected: nine
launch hangs in one morning, every one of them with only Home open. Sentry
`DROIDECTIVE-MAC-B` holds the events; `DROIDECTIVE-MAC-7N` carries the stack
that names the accessor and `RootView.body`.

Fixes DROIDECTIVE-MAC-B

## Verification

`make verify` green: 1833 ADBKit + 99 ReactotronMCP + 91 droidectived + 99
AppTests. `make build` clean with no warnings. The three new registry tests were
checked against a mutant that always reports a change, and go red.

Not covered here: `publishMirrorWindowClaims` still falls back to
`registry.ids.first` when `mirrorWindowOwner` is nil, so a pop-out's claims can
be attributed to an unrelated window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)