### PR TITLE
Update feature-contract docs to match the shipped code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ All logic lives in **`ADBKit/`** (a SwiftPM package with no UI imports); the
 SwiftUI shell lives in **`App/`**. When you add a feature:
 
 1. Put the adb/Process logic in an `ADBKit` service, with a parser/runner test.
-2. Add the feature to `FeatureRegistry` and a how-it-works note to `FeatureNotes`.
+2. Add the feature to `FeatureRegistry` (unique `id`, title, keywords, category, `kind`).
 3. Add the SwiftUI view under `App/Sources/FeatureDetail/Views/`.
 
 Never call `adb`/`Process` directly from a SwiftUI view — go through `ADBKit`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -510,6 +510,11 @@ Recorded because they're the kind that repeat.
 
 ## 10. Roadmap
 
+> **Dated plan.** Phases 1 and 2 have since landed, and the daemon ships loopback
+> HTTP + WebSocket rather than the stdio JSON-RPC this section proposes — see
+> [droidectived-protocol.md](droidectived-protocol.md) and
+> [cross-platform.md](cross-platform.md) for current state.
+
 Estimates in working sessions, from the approved plan and partly validated by
 this session's throughput (Phase A + Phase 0 + 6 fix PRs in one).
 
@@ -541,6 +546,12 @@ it needs no Linux desktop and no certificate.
 commitment.
 
 ### Why stdio and not localhost HTTP
+
+> **Superseded — not what shipped.** The daemon that landed uses loopback HTTP +
+> WebSocket with a token file, per
+> [droidectived-protocol.md](droidectived-protocol.md) §3: `droidectived --port 0
+> --token-file <path>`, 127.0.0.1 only. The argument below is kept as the record
+> of what was considered; read the protocol doc for the contract.
 
 The original port doc proposed HTTP + WebSocket with a token file. stdio sidesteps
 the hardest blocker: swift-nio's Windows support is partial and #3647 blocks

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -36,13 +36,12 @@ A feature's string `id` is a contract spread across several files, and most
 omissions fail *silently* (a "Coming Soon" screen, an empty Recent tab), not at
 compile time. **`CLAUDE.md` → "Adding a feature — the checklist" is the
 authoritative step-by-step** — follow it in order rather than working from
-memory. In short: define the `FeatureDef` in `FeatureRegistry`, add a
-`FeatureNotes` how-it-works note and a `FeatureCommands` reference, then either
+memory. In short: define the `FeatureDef` in `FeatureRegistry`, then either
 wire the runner (`FeatureEngine.dispatch` + `implementedIDs` + an arg-vector
-test) for an action, or build the view (`App/Sources/FeatureDetail/Views/` +
-`FeatureDetailView.detailByKind` + `implementedIDs`) for a view feature. Several
-of those steps have enforcing tests; the silent ones you verify by opening the
-feature.
+test) for an action, or build the view (`App/Sources/FeatureDetail/Views/` + a
+`FeatureDetailRoute` case + its `FeatureDetailView.pane` case +
+`implementedIDs`) for a view feature. Several of those steps have enforcing
+tests; the silent ones you verify by opening the feature.
 
 ## 4. Commits
 
@@ -64,8 +63,7 @@ This is exactly what the PR template asks you to confirm.
 - [ ] New/changed parsers and command construction have tests
       ([review/TESTING.md](review/TESTING.md)).
 - [ ] New feature follows the `CLAUDE.md` "Adding a feature" checklist
-      (`FeatureRegistry` + `FeatureNotes` + `FeatureCommands`, then runner or
-      view wiring).
+      (`FeatureRegistry`, then runner or view wiring).
 - [ ] `prek run` passes (the gitleaks secret scan in particular).
 - [ ] You ran the app and verified the change live if it touches UI or
       device behavior — tests don't cover rendering or real adb output.

--- a/docs/review/ARCHITECTURE.md
+++ b/docs/review/ARCHITECTURE.md
@@ -44,24 +44,26 @@ ADBKit. Views render; they don't compute. Built via XcodeGen + xcodebuild; the
 ## The feature system
 
 A feature's string `id` is a contract spread across several files —
-`FeatureRegistry` (the `FeatureDef`), `FeatureNotes` (how-it-works),
-`FeatureCommands` (command reference), `FeatureEngine` (runner dispatch +
-`implementedIDs`) for actions, and `FeatureDetailView.detailByKind` + a view in
-`App` for view features. **`CLAUDE.md` → "Adding a feature — the checklist" is
-the source of truth** for the order and which steps have enforcing tests vs.
-silent failure modes.
+`FeatureRegistry` (the `FeatureDef`), `FeatureEngine` (runner dispatch +
+`implementedIDs`) for actions, and a `FeatureDetailRoute` case +
+`FeatureDetailView.pane` + a view in `App` for view features. **`CLAUDE.md` →
+"Adding a feature — the checklist" is the source of truth** for the order and
+which steps have enforcing tests vs. silent failure modes.
 
 ### Review checks
 
 - [ ] New feature is in `FeatureRegistry` with a stable id, keywords, and a
-      hotkey, plus a `FeatureNotes` note and a `FeatureCommands` reference (all
-      three have enforcing tests — flag a gap in review so it isn't a CI surprise).
+      hotkey (`hasAll61Features` and `implementedIDsAreAllRealFeatures` enforce
+      the registry side — flag a gap in review so it isn't a CI surprise).
 - [ ] **Actions** wire `FeatureEngine.dispatch` *and* `implementedIDs`
       *and* an arg-vector test asserting the exact adb arguments. A feature in
       `implementedIDs` with no dispatch case, or vice versa, is caught by tests —
       but the arg-vector test (correct/quoted arguments) is on the author.
-- [ ] **View features** add the `detailByKind` case (a missing case renders
-      "Coming Soon" *silently* — no test catches it) and `implementedIDs`.
+- [ ] **View features** add a `FeatureDetailRoute` case *and* its
+      `FeatureDetailView.pane` case *and* `implementedIDs`. `pane` is exhaustive
+      over the enum, so a route with no view is a build error; an id with no
+      route at all still renders "Coming Soon" silently, which
+      `FeatureDetailRouteTests` catches.
 - [ ] If absorbed by a hub (`react-native`, `simulate`, `connection`,
       `apk-studio`), it's in `absorbedByHub` and its keywords fold into the hub
       (a test enforces the hub matches each member's primary keyword). It must

--- a/docs/review/TESTING.md
+++ b/docs/review/TESTING.md
@@ -13,12 +13,12 @@ suite is the contract — keep it green and keep it meaningful.
 - **Every error path the code handles.** If the code branches on a failure
   (device offline, tool not found, malformed output), a test triggers that
   branch.
-- **New feature wiring.** A feature must be in `FeatureRegistry`, have a
-  `FeatureNotes` note and a `FeatureCommands` reference, and (if hub-absorbed)
-  fold its keywords into the hub — there are tests enforcing each
-  (`everyFeatureHasAHowToNote`, `everyFeatureHasACommandReference`,
-  `hubsStaySearchableByTheirMembersPrimaryKeyword`, and the feature count). Don't
-  remove them to make a PR pass.
+- **New feature wiring.** A feature must be in `FeatureRegistry`, route to a
+  pane if it's a view feature, and (if hub-absorbed) fold its keywords into the
+  hub — there are tests enforcing each (`hasAll61Features`,
+  `implementedIDsAreAllRealFeatures`, `FeatureDetailRouteTests`,
+  `hubsStaySearchableByTheirMembersPrimaryKeyword`). Don't remove them to make a
+  PR pass.
 - **Action arg-vectors.** An implemented action needs a test asserting the
   *exact* adb argument vector, including the quoted form of any user value
   (see `FeatureEngineTests`, `OverridesServiceTests`). The dispatch/`implementedIDs`
@@ -67,6 +67,6 @@ the runner.
 - [ ] New parsing/command logic has tests, and they assert on behavior.
 - [ ] Edge and error cases are covered, not just the happy path.
 - [ ] Mocks are at boundaries only; the thing under test isn't mocked.
-- [ ] No enforcement test (FeatureNotes, hub keywords, the 16-process canary) was
-      removed or hollowed out to go green.
+- [ ] No enforcement test (registry invariants, feature routing, hub keywords,
+      the 16-process canary) was removed or hollowed out to go green.
 - [ ] If the change is a bug fix, there's a test that fails without the fix.

--- a/docs/review/UI_UX.md
+++ b/docs/review/UI_UX.md
@@ -32,12 +32,11 @@ touches layout:
 
 Every feature ships a complete, consistent experience:
 
-- [ ] A **how-it-works note** (`FeatureNotes`) renders inline beneath the
-      content, and a **command reference** (`FeatureCommands`) powers the
-      Commands tab. Every feature has both; tests enforce them.
-- [ ] For a `view` feature, the `FeatureDetailView.detailByKind` case exists —
-      a missing case renders a **"Coming Soon"** placeholder *silently* (no test
-      catches it), so confirm the real view shows.
+- [ ] For a `view` feature, the id has a `FeatureDetailRoute` case and a
+      matching `FeatureDetailView.pane` case. `pane` is exhaustive over the
+      enum, so a route with no view is a build error; an id with no route falls
+      through to a **"Coming Soon"** placeholder, which
+      `FeatureDetailRouteTests` catches. Confirm the real view shows.
 - [ ] A **hotkey** is registered (every feature has one; hub-absorbed features
       appear under "Hidden features" in the Hotkeys tab).
 - [ ] **Discoverable in search** — keywords are set; hub members fold their
@@ -76,6 +75,6 @@ Every feature ships a complete, consistent experience:
 - [ ] You ran the app and saw the change.
 - [ ] Loading/empty/error states all handled and tested live.
 - [ ] No toolbar-floats / under-device-bar / title-bar-strip regression.
-- [ ] FeatureNotes + hotkey + search keywords + Recent-tab wiring present.
+- [ ] Hotkey + search keywords + Recent-tab wiring present.
 - [ ] Destructive actions confirm; pulls ask for a destination.
 - [ ] Screenshot/GIF attached for visible changes.


### PR DESCRIPTION
The review and contributing docs described a feature-`id` contract that no longer matches the code. Found while building a knowledge graph over the repo — two independent extraction passes flagged the same drift.

## What was stale

**`FeatureNotes` / `FeatureCommands` (removed in v3.5.0).** Five files still required both as part of adding a feature, and `docs/review/TESTING.md` cited `everyFeatureHasAHowToNote` and `everyFeatureHasACommandReference` as tests enforcing them. Neither test exists; neither type exists outside CLAUDE.md's removal note.

**View-feature wiring.** The docs said a view feature adds a `FeatureDetailView.detailByKind` case and that a missing case renders "Coming Soon" silently with no test catching it. `detailByKind` still exists, but it switches over `FeatureDef.kind`, not per-feature ids — a view feature now adds a `FeatureDetailRoute` case and its `FeatureDetailView.pane` case. The failure mode changed with it: `pane` is exhaustive over the enum, so a route with no view is a **build error**. An id with no route at all does still fall through to "Coming Soon", but `FeatureDetailRouteTests` catches that.

## What changed

| file | change |
| --- | --- |
| `CONTRIBUTING.md` | step 2 no longer asks for a `FeatureNotes` note |
| `docs/PULL_REQUESTS.md` | §3 and §5 checklist: registry, then runner or route+pane |
| `docs/review/ARCHITECTURE.md` | feature-system paragraph and both review checks |
| `docs/review/TESTING.md` | wiring bullet and checklist now name tests that exist |
| `docs/review/UI_UX.md` | feature UX contract and review checklist |
| `docs/HANDOFF.md` | two superseded markers (see below) |

Every test name the docs now cite resolves to a real test: `hasAll61Features`, `implementedIDsAreAllRealFeatures`, `hubsStaySearchableByTheirMembersPrimaryKeyword`, `FeatureDetailRouteTests`.

## HANDOFF.md

§10 argues for a stdio JSON-RPC daemon and explicitly rejects localhost HTTP. What shipped is loopback HTTP + WebSocket with a token file (`droidectived --port 0 --token-file`, 127.0.0.1 only) per `droidectived-protocol.md` §3. HANDOFF is a dated session handoff, so the reasoning is left intact and marked superseded rather than rewritten, with pointers to the current docs.

Docs only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)