### PR TITLE
Ignore graphify-out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ website/dist/
 # Where stage-release-artifacts.sh collects a release's artifacts.
 /dist/
 App/Resources/ffmpeg
+# Knowledge-graph output from the graphify skill — regenerable, and ~100 MB
+# across 15k files (graph.json, graph.html, an Obsidian vault, the cache).
+/graphify-out/


### PR DESCRIPTION
The graphify skill writes its knowledge graph to `graphify-out/` at the repo root — `graph.json`, `graph.html`, an Obsidian vault, and the extraction cache. On this repo that is ~100 MB across 15,094 files.

It's all regenerable from the sources, so it shouldn't be committable by accident. One entry, placed with the other build-output ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)