### PR TITLE
Stop the recording screens throwing recordings away

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -18,15 +18,239 @@
       "devDependencies": {
         "@tailwindcss/vite": "4.3.3",
         "@tauri-apps/cli": "2.11.4",
+        "@testing-library/dom": "10.4.1",
+        "@testing-library/react": "16.3.2",
         "@types/node": "26.1.2",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@vitejs/plugin-react": "6.0.5",
+        "jsdom": "30.0.1",
         "oxlint": "1.76.0",
         "tailwindcss": "4.3.3",
         "typescript": "7.0.2",
         "vite": "8.2.0",
         "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -61,6 +285,24 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1235,6 +1477,54 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1245,6 +1535,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1780,6 +2077,39 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1788,6 +2118,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/chai": {
@@ -1816,12 +2156,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1832,6 +2232,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
@@ -1845,6 +2252,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1914,6 +2334,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -1922,6 +2362,54 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -2185,6 +2673,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
@@ -2192,6 +2690,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -2203,6 +2711,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -2286,6 +2801,19 @@
         }
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2342,6 +2870,31 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -2361,6 +2914,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -2397,6 +2967,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2431,6 +3014,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2509,6 +3099,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2550,6 +3186,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -2988,6 +3634,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3004,6 +3698,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,10 +23,13 @@
   "devDependencies": {
     "@tailwindcss/vite": "4.3.3",
     "@tauri-apps/cli": "2.11.4",
+    "@testing-library/dom": "10.4.1",
+    "@testing-library/react": "16.3.2",
     "@types/node": "26.1.2",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "6.0.5",
+    "jsdom": "30.0.1",
     "oxlint": "1.76.0",
     "tailwindcss": "4.3.3",
     "typescript": "7.0.2",

--- a/desktop/src/components/NetspeedPane.test.tsx
+++ b/desktop/src/components/NetspeedPane.test.tsx
@@ -1,0 +1,137 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Device, NetSample, StreamUpdate } from "@/lib/wire"
+
+const { watchNetspeed, emit, writeRecording, show } = vi.hoisted(() => {
+  let send: ((update: StreamUpdate<NetSample>) => void) | null = null
+  return {
+    watchNetspeed: vi.fn(
+      (_serial: string, onUpdate: (update: StreamUpdate<NetSample>) => void) => {
+        send = onUpdate
+        return Promise.resolve({ stop: () => Promise.resolve() })
+      },
+    ),
+    emit: (update: StreamUpdate<NetSample>) => {
+      send?.(update)
+    },
+    writeRecording: vi.fn((_samples: readonly unknown[], _serial: string) =>
+      Promise.resolve({ ok: true, message: "Exported" }),
+    ),
+    show: vi.fn(),
+  }
+})
+
+vi.mock("@/lib/daemon", () => ({
+  watchNetspeed,
+  asDaemonError: (thrown: unknown) => ({ code: "unknown", message: String(thrown), detail: null }),
+}))
+vi.mock("@/lib/netexport", () => ({ writeRecording }))
+vi.mock("@/hooks/useNotifications", () => ({ useNotifications: () => ({ show }) }))
+
+const { NetspeedPane } = await import("@/components/NetspeedPane")
+
+const device: Device = {
+  serial: "abc",
+  state: "device",
+  model: "Pixel",
+  product: null,
+  platform: "android",
+} as Device
+
+const sample = (): NetSample => ({
+  downloadBytesPerSec: 1024,
+  uploadBytesPerSec: 512,
+  totalRxBytes: 1_000_000,
+  totalTxBytes: 500_000,
+  interfaces: [],
+})
+
+/** Mount, start a recording, and get three samples into it. */
+async function recordingPane() {
+  render(<NetspeedPane device={device} />)
+  await waitFor(() => {
+    expect(watchNetspeed).toHaveBeenCalled()
+  })
+  act(() => {
+    emit({ event: "batch", items: [sample(), sample(), sample()] })
+  })
+  await screen.findByRole("button", { name: /record/iu })
+  act(() => {
+    screen.getByRole("button", { name: /record/iu }).click()
+  })
+  act(() => {
+    emit({ event: "batch", items: [sample(), sample(), sample()] })
+  })
+  await screen.findByRole("button", { name: /stop/iu })
+}
+
+describe("NetspeedPane", () => {
+  beforeEach(() => {
+    watchNetspeed.mockClear()
+    writeRecording.mockClear()
+    show.mockClear()
+  })
+
+  it("keeps the recording after exporting it", async () => {
+    // The regression this guards: a successful export called `discard()`,
+    // which both stopped the recording nobody asked to stop and threw away
+    // the samples. The Mac's `NetworkView.export()` writes and returns.
+    await recordingPane()
+
+    act(() => {
+      screen.getByRole("button", { name: /export/iu }).click()
+    })
+    await waitFor(() => {
+      expect(writeRecording).toHaveBeenCalled()
+    })
+
+    // Still recording, and the samples are still there to export again.
+    expect(screen.getByRole("button", { name: /stop/iu })).toBeDefined()
+    act(() => {
+      screen.getByRole("button", { name: /export/iu }).click()
+    })
+    await waitFor(() => {
+      expect(writeRecording).toHaveBeenCalledTimes(2)
+    })
+    expect(writeRecording.mock.calls[1]?.[0]).toHaveLength(3)
+  })
+
+  it("keeps the samples when stopping without exporting", async () => {
+    // "Stop without exporting" answers "not now", not "throw it away" — the
+    // Export button must still work afterwards.
+    await recordingPane()
+
+    act(() => {
+      screen.getByRole("button", { name: /stop/iu }).click()
+    })
+    act(() => {
+      screen.getByRole("button", { name: "Stop without exporting" }).click()
+    })
+
+    expect(screen.getByRole("button", { name: /record/iu })).toBeDefined()
+    act(() => {
+      screen.getByRole("button", { name: /export/iu }).click()
+    })
+    await waitFor(() => {
+      expect(writeRecording).toHaveBeenCalled()
+    })
+    expect(writeRecording.mock.calls[0]?.[0]).toHaveLength(3)
+  })
+
+  it("stops straight away when there is nothing recorded", async () => {
+    render(<NetspeedPane device={device} />)
+    await waitFor(() => {
+      expect(watchNetspeed).toHaveBeenCalled()
+    })
+    act(() => {
+      screen.getByRole("button", { name: /record/iu }).click()
+    })
+    act(() => {
+      screen.getByRole("button", { name: /stop/iu }).click()
+    })
+
+    // No dialog: there is nothing to lose.
+    expect(screen.queryByText("Export this recording before stopping?")).toBeNull()
+    expect(screen.getByRole("button", { name: /record/iu })).toBeDefined()
+  })
+})

--- a/desktop/src/components/NetspeedPane.tsx
+++ b/desktop/src/components/NetspeedPane.tsx
@@ -29,13 +29,11 @@ export function NetspeedPane({ device }: { device: Device | null }) {
   const totals = sessionTotals(net.live)
   const max = chartMax(net.live)
 
+  // Writes and returns, as the Mac's `NetworkView.export()` does. It must not
+  // touch the recording: exporting is not a way of ending one, and a recording
+  // you have saved once is still there to save again.
   const exportRecording = () => {
-    writeRecording(net.recorded, device.serial).then((result) => {
-      show(result)
-      // Cleared only on a successful write: a failed export must not be the
-      // thing that loses the recording it failed to save.
-      if (result.ok) net.discard()
-    }, ignore)
+    writeRecording(net.recorded, device.serial).then(show, ignore)
   }
 
   return (
@@ -62,10 +60,13 @@ export function NetspeedPane({ device }: { device: Device | null }) {
           onExtra={() => {
             setConfirming(false)
             exportRecording()
+            net.stopRecording()
           }}
           onConfirm={() => {
+            // "not now", not "throw it away" — the samples stay exportable,
+            // which is what `PerformancePane` does with the same dialog.
             setConfirming(false)
-            net.discard()
+            net.stopRecording()
           }}
           onCancel={() => {
             setConfirming(false)

--- a/desktop/src/hooks/useNetspeed.test.ts
+++ b/desktop/src/hooks/useNetspeed.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { NetSample, StreamUpdate } from "@/lib/wire"
+
+const { watchNetspeed, emit } = vi.hoisted(() => {
+  let send: ((update: StreamUpdate<NetSample>) => void) | null = null
+  return {
+    watchNetspeed: vi.fn(
+      (_serial: string, onUpdate: (update: StreamUpdate<NetSample>) => void) => {
+        send = onUpdate
+        return Promise.resolve({ stop: () => Promise.resolve() })
+      },
+    ),
+    emit: (update: StreamUpdate<NetSample>) => {
+      send?.(update)
+    },
+  }
+})
+
+vi.mock("@/lib/daemon", () => ({
+  watchNetspeed,
+  asDaemonError: (thrown: unknown) => ({
+    code: "unknown",
+    message: String(thrown),
+    detail: null,
+  }),
+}))
+
+const { useNetspeed } = await import("@/hooks/useNetspeed")
+
+const sample = (): NetSample => ({
+  downloadBytesPerSec: 1024,
+  uploadBytesPerSec: 512,
+  totalRxBytes: 1_000_000,
+  totalTxBytes: 500_000,
+  interfaces: [],
+})
+
+describe("useNetspeed", () => {
+  beforeEach(() => {
+    watchNetspeed.mockClear()
+  })
+
+  async function recording(count: number) {
+    const rendered = renderHook(() => useNetspeed("abc"))
+    await waitFor(() => {
+      expect(watchNetspeed).toHaveBeenCalled()
+    })
+    act(() => {
+      rendered.result.current.startRecording()
+    })
+    act(() => {
+      emit({ event: "batch", items: Array.from({ length: count }, sample) })
+    })
+    await waitFor(() => {
+      expect(rendered.result.current.recorded).toHaveLength(count)
+    })
+    return rendered
+  }
+
+  it("keeps the samples when the recording stops", async () => {
+    // The Mac's `NetworkView.stopRecording()` only flips the flag; the samples
+    // stay exportable. `stopRecording` must not be `discard` by another name.
+    const { result } = await recording(3)
+
+    act(() => {
+      result.current.stopRecording()
+    })
+
+    expect(result.current.recording).toBe(false)
+    expect(result.current.recorded).toHaveLength(3)
+  })
+
+  it("starts a new recording empty rather than adopting the rolling window", async () => {
+    const { result } = await recording(2)
+
+    act(() => {
+      result.current.startRecording()
+    })
+
+    expect(result.current.recorded).toHaveLength(0)
+    expect(result.current.live.length).toBeGreaterThan(0)
+  })
+})

--- a/desktop/src/hooks/useNetspeed.ts
+++ b/desktop/src/hooks/useNetspeed.ts
@@ -21,7 +21,6 @@ export interface Netspeed {
   dropped: number
   startRecording: () => void
   stopRecording: () => void
-  discard: () => void
 }
 
 /**
@@ -144,15 +143,14 @@ export function useNetspeed(serial: string | null): Netspeed {
       setRecording(true)
     }, []),
 
+    // Only flips the flag; the samples stay exportable, as they do on the Mac.
+    // There is no `discard` here on purpose — nothing in the UI throws a
+    // recording away, and the one that used to (a successful export) was the
+    // bug. The Mac's exit guard offers a real discard; when that lands here,
+    // it comes back with a caller.
     stopRecording: useCallback(() => {
       isRecording.current = false
       setRecording(false)
-    }, []),
-
-    discard: useCallback(() => {
-      isRecording.current = false
-      setRecording(false)
-      setRecorded([])
     }, []),
   }
 }

--- a/desktop/src/hooks/usePerformance.test.ts
+++ b/desktop/src/hooks/usePerformance.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { PerfSample, StreamUpdate } from "@/lib/wire"
+
+const { watchPerformance, emit } = vi.hoisted(() => {
+  let send: ((update: StreamUpdate<PerfSample>) => void) | null = null
+  return {
+    watchPerformance: vi.fn(
+      (_params: unknown, onUpdate: (update: StreamUpdate<PerfSample>) => void) => {
+        send = onUpdate
+        return Promise.resolve({ stop: () => Promise.resolve() })
+      },
+    ),
+    emit: (update: StreamUpdate<PerfSample>) => {
+      send?.(update)
+    },
+  }
+})
+
+vi.mock("@/lib/daemon", () => ({
+  watchPerformance,
+  asDaemonError: (thrown: unknown) => ({
+    code: "unknown",
+    message: String(thrown),
+    detail: null,
+  }),
+}))
+
+const { usePerformance } = await import("@/hooks/usePerformance")
+
+const sample = (cpu: number): PerfSample => ({
+  cores: [{ core: -1, label: "All", usagePercent: cpu }],
+  ramTotalKb: 8_000_000,
+  ramUsedKb: 4_000_000,
+  appFps: null,
+  appJankPercent: null,
+  appPssKb: null,
+  downloadBytesPerSec: null,
+  uploadBytesPerSec: null,
+  processes: [],
+})
+
+/** Record, then feed `count` samples in. */
+async function recordSamples(
+  result: { current: { toggleRecord: () => void; samples: unknown[] } },
+  count: number,
+) {
+  act(() => {
+    result.current.toggleRecord()
+  })
+  await waitFor(() => {
+    expect(watchPerformance).toHaveBeenCalled()
+  })
+  act(() => {
+    emit({ event: "batch", items: Array.from({ length: count }, (_, i) => sample(i)) })
+  })
+  await waitFor(() => {
+    expect(result.current.samples).toHaveLength(count)
+  })
+}
+
+describe("usePerformance", () => {
+  beforeEach(() => {
+    watchPerformance.mockClear()
+  })
+
+  it("keeps the recording when per-process is toggled mid-run", async () => {
+    // The regression this guards: `processes` was in the reset effect's
+    // dependency list, so flipping the toolbar switch emptied `samples` and
+    // dropped the phase to idle — minutes of data gone, with no confirmation
+    // and without going through the "Export before stopping?" guard.
+    const { result, rerender } = renderHook(
+      ({ processes }) => usePerformance({ serial: "abc", packageId: null, processes }),
+      { initialProps: { processes: false } },
+    )
+
+    await recordSamples(result, 3)
+
+    rerender({ processes: true })
+
+    expect(result.current.samples).toHaveLength(3)
+    expect(result.current.phase).toBe("recording")
+  })
+
+  it("re-subscribes with the new per-process flag", async () => {
+    const { result, rerender } = renderHook(
+      ({ processes }) => usePerformance({ serial: "abc", packageId: null, processes }),
+      { initialProps: { processes: false } },
+    )
+
+    await recordSamples(result, 1)
+    expect(watchPerformance.mock.calls[0]?.[0]).toMatchObject({ processes: false })
+
+    rerender({ processes: true })
+
+    await waitFor(() => {
+      expect(watchPerformance).toHaveBeenCalledTimes(2)
+    })
+    expect(watchPerformance.mock.calls[1]?.[0]).toMatchObject({ processes: true })
+  })
+
+  it("still discards the recording when the device changes", async () => {
+    // The other half of the same effect, which is correct and must stay:
+    // splicing two devices' numbers into one chart would be worse than losing
+    // the run.
+    const { result, rerender } = renderHook(
+      ({ serial }) => usePerformance({ serial, packageId: null, processes: false }),
+      { initialProps: { serial: "abc" } },
+    )
+
+    await recordSamples(result, 2)
+
+    rerender({ serial: "xyz" })
+
+    expect(result.current.samples).toHaveLength(0)
+    expect(result.current.phase).toBe("idle")
+  })
+
+  it("still discards the recording when the app bundle changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ packageId }) => usePerformance({ serial: "abc", packageId, processes: false }),
+      { initialProps: { packageId: "com.one" as string | null } },
+    )
+
+    await recordSamples(result, 2)
+
+    rerender({ packageId: "com.two" })
+
+    expect(result.current.samples).toHaveLength(0)
+    expect(result.current.phase).toBe("idle")
+  })
+})

--- a/desktop/src/hooks/usePerformance.ts
+++ b/desktop/src/hooks/usePerformance.ts
@@ -43,11 +43,17 @@ export function usePerformance({
 
   // A recording belongs to one device and one app; changing either ends it
   // rather than splicing two devices' numbers into one chart.
+  //
+  // `processes` is deliberately NOT here: it changes what the *next* sample
+  // carries, not whose numbers these are, so discarding the run over it threw
+  // minutes of data away with no confirmation, bypassing the Stop button's
+  // "Export before stopping?" guard. The subscription effect still re-keys on
+  // it, so the flag takes effect from the next sample on.
   useEffect(() => {
     setSamples([])
     setPhase("idle")
     setDropped(0)
-  }, [serial, packageId, processes])
+  }, [serial, packageId])
 
   useEffect(() => {
     if (phase !== "recording" || serial === null) return

--- a/desktop/src/test/setup.ts
+++ b/desktop/src/test/setup.ts
@@ -1,0 +1,7 @@
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+// Unmount between tests. Testing Library only auto-cleans when vitest runs with
+// `globals: true`, and this project does not — without this, a component from
+// one test stays mounted and the next `render` finds two of everything.
+afterEach(cleanup)

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -36,7 +36,12 @@ export default defineConfig({
     sourcemap: Boolean(process.env["TAURI_ENV_DEBUG"]),
   },
   test: {
-    environment: "node",
-    include: ["src/**/*.test.ts"],
+    // jsdom, not node: the panes and hooks are where the state machines live
+    // (a recording that must survive a toggle, a listing that must not land on
+    // the device you just switched away from), and a node environment cannot
+    // reach any of it. The pure `lib/` tests do not care either way.
+    environment: "jsdom",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: ["./src/test/setup.ts"],
   },
 })


### PR DESCRIPTION
Fixes #283 (data-loss half), fixes #284, fixes #288.

Two ways to lose a recording with no confirmation, plus the test harness that would have caught both. Found in the #264 review.

## Performance — the Per-process switch discarded the run (#283)

`usePerformance.ts` had `processes` in the reset effect's dependency list:

```ts
useEffect(() => {
  setSamples([]); setPhase("idle"); setDropped(0)
}, [serial, packageId, processes])   // ← processes
```

Record for two minutes, flip Per-process to see the table, and the samples were gone — no confirmation, no undo, and the Stop button's "Export this recording before stopping?" guard never ran, because only Stop raises it.

The flag changes what the *next* sample carries, not whose numbers these are, so it does not belong in a dependency list that means "this is a different recording now". The subscription effect still re-keys on it, so the flag takes effect from the next sample.

> The other half of #283 — that the Mac has no such switch at all, collecting per-process automatically on alternate ticks (`PerformanceView.swift:564`) — is left open. Matching it needs the daemon to alternate, which is a wire change, not a UI one.

## Network Speed — export consumed the recording (#284)

```ts
writeRecording(net.recorded, device.serial).then((result) => {
  show(result)
  if (result.ok) net.discard()      // stops recording AND clears the samples
}, ignore)
```

Three things wrong with that: exporting mid-recording silently *stopped* the recording; the samples were thrown away so the Export button greyed out and you could not export twice; and "Stop without exporting" also called `discard()`, so answering "not now" meant "never".

The Mac's `NetworkView.export()` (`NetworkView.swift:397-420`) writes the files and returns; `stopRecording()` (`:342`) only flips the flag. Both now do that — which also makes this screen agree with `PerformancePane`, where the same dialog was already correct.

`discard` has no callers left, so it is deleted rather than left sitting there as an unreachable way to reintroduce the bug. The Mac's exit guard offers a real discard; when that lands here it comes back with a caller.

## The harness (#288)

`vite.config.ts` was `environment: "node"` with `include: ["src/**/*.test.ts"]`, and there was no jsdom and no `@testing-library/react`. Components and hooks were not merely untested — they were untestable, which is exactly where both bugs lived and where every other P1 from the #264 review still lives (#285, #287).

Adds `jsdom@30.0.1` and `@testing-library/react@16.3.2` (+ its `@testing-library/dom` peer), switches the environment, includes `.test.tsx`, and adds a setup file that unmounts between tests — Testing Library only auto-cleans under `globals: true`, which this project does not use.

## Verification

Both new tests fail on the parent commit and pass on this one:

```
FAIL  usePerformance > keeps the recording when per-process is toggled mid-run
      AssertionError: expected [] to have a length of 3 but got +0
FAIL  NetspeedPane > keeps the recording after exporting it
FAIL  NetspeedPane > keeps the samples when stopping without exporting
```

`make desktop-test` green: typecheck, oxlint, **397 vitest tests** (388 before), `cargo fmt --check`, `clippy -D warnings`, 30 Rust tests.

No Swift touched, so the macOS app and the daemon are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)