### PR TITLE
Assert a controlling terminal portably

### DIFF
--- a/droidectived/Tests/DaemonCoreTests/PtyTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/PtyTests.swift
@@ -131,8 +131,14 @@ import Testing
         // the `TIOCSCTTY` in the C shim happened.
         let pty = try shell()
         defer { pty.terminate() }
-        let text = await run("tty", in: pty, until: "/dev/tty")
-        #expect(text.contains("/dev/tty"))
+        // A device path at all is the portable proof, and the absence of `tty`'s
+        // own "not a tty" is the assertion that actually bites. The *name*
+        // is not portable: Darwin calls a pty slave `/dev/ttysNNN` and Linux
+        // calls it `/dev/pts/N`, so matching on `/dev/tty` passed here and hung
+        // for 45 seconds on Linux waiting for a marker that never arrives.
+        let text = await run("tty", in: pty, until: "/dev/")
+        #expect(text.contains("/dev/"))
+        #expect(!text.contains("not a tty"))
     }
 
     @Test func reportsTheSizeItWasGiven() async throws {


### PR DESCRIPTION
`test-linux` is red on the default branch: `PtyTests.theShellHasAControllingTerminal`
waits for `/dev/tty`, and `tty` names a pty slave `/dev/ttysNNN` on Darwin but
`/dev/pts/N` on Linux. The marker never arrives, so the test hangs for 45 seconds
and then fails.

The portable proof is a device path at all, and the assertion that actually bites
is the absence of `tty`'s own "not a tty" — which is what the test was always
about: whether the `TIOCSCTTY` in the C shim happened.

Reproduced and confirmed in the same `swift:6.2-noble` container the job uses:
251 tests pass there, 266 on macOS, the difference being the Darwin-gated relay
socket suite.

This was written a few minutes after #292 merged, which is why it needs its own
PR rather than being part of it.
