### PR TITLE
Ship the Windows and Linux app on the beta channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,14 @@ jobs:
         with:
           branch: swift-6.2.4-release
           tag: 6.2.4-RELEASE
+      # The ports have their own version line: the tag names the Mac release,
+      # PORT_VERSION names everything Windows and Linux get. Asking the
+      # resolver rather than stripping the tag is what keeps the two apart —
+      # see docs/release-channels.md.
       - name: Build and package droidectived
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="$(./scripts/release-channel.sh port-version)"
           (cd droidectived && swift build -c release --product droidectived)
           BIN="droidectived/.build/release/droidectived"
           [[ "${{ matrix.platform }}" == windows-x86_64 ]] && BIN="$BIN.exe"
@@ -257,6 +261,82 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: daemon-${{ matrix.platform }}
+          path: dist/*
+          if-no-files-found: error
+
+  # The Tauri app for Windows and Linux — stage 2 of the port's release plan
+  # (docs/release-channels.md). Beta tags only, on the same hyphen rule
+  # daemon-artifacts uses: the stable channel is macOS-only, and
+  # stage-release-artifacts.sh would refuse an app bundle on a stable release
+  # anyway.
+  #
+  # Tauri does not cross-compile, so each platform builds on its own runner.
+  # Both run scripts/build-desktop-app.sh — the same script
+  # scripts/build-desktop-linux.sh runs in a container locally, so this job can
+  # be reproduced off CI rather than debugged one push at a time.
+  desktop-artifacts:
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-')
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          # The image test-linux and desktop-native already use: the daemon is
+          # the awkward half (it needs Swift), and Rust and Node are easy to add.
+          - os: ubuntu-24.04
+            container: swift:6.2-noble
+            platform: linux
+          - os: windows-2022
+            container: ''
+            platform: windows
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      # webkit2gtk *4.1* is the one that matters: 4.0 is the GTK3/soup2 build
+      # Tauri 1 used, and linking against it fails late and confusingly.
+      - if: matrix.platform == 'linux'
+        name: Install the Linux bundler dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends \
+            build-essential curl wget file pkg-config ca-certificates \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+            librsvg2-dev libssl-dev libxdo-dev patchelf desktop-file-utils \
+            xdg-utils fakeroot
+      # Ubuntu's packaged toolchain is older than Tauri 2 needs, so Rust comes
+      # from rustup. The Windows runner already ships one.
+      - if: matrix.platform == 'linux'
+        name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - if: matrix.platform == 'windows'
+        uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5  # v0.4.0
+        with:
+          branch: swift-6.2.4-release
+          tag: 6.2.4-RELEASE
+      - if: matrix.platform == 'windows'
+        name: Select a Rust toolchain
+        shell: bash
+        run: |
+          rustup default stable
+          rustc -vV
+      # No npm cache: this job builds an artifact that ships, and a poisoned
+      # cache could inject code into it (zizmor: cache-poisoning) — the same
+      # reasoning as desktop-web.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: 22
+          package-manager-cache: false
+      - name: Build and package the app
+        shell: bash
+        run: ./scripts/build-desktop-app.sh "${{ matrix.platform }}" release dist
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: desktop-${{ matrix.platform }}
           path: dist/*
           if-no-files-found: error
 
@@ -272,7 +352,9 @@ jobs:
       && needs.build.result == 'success'
       && (needs['daemon-artifacts'].result == 'success'
       || needs['daemon-artifacts'].result == 'skipped')
-    needs: [test, build, daemon-artifacts]
+      && (needs['desktop-artifacts'].result == 'success'
+      || needs['desktop-artifacts'].result == 'skipped')
+    needs: [test, build, daemon-artifacts, desktop-artifacts]
     runs-on: macos-15
     permissions:
       contents: write
@@ -377,28 +459,50 @@ jobs:
       - name: Build and package droidectived (macOS universal)
         if: contains(github.ref_name, '-')
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="$(./scripts/release-channel.sh port-version)"
           (cd droidectived && swift build -c release --arch arm64 --arch x86_64 \
             --product droidectived)
           ./scripts/package-daemon.sh "$VERSION" macos-universal \
             droidectived/.build/apple/Products/Release/droidectived \
             DerivedData/Build/Products/Release
-      # Only a beta has them — daemon-artifacts doesn't run for a stable tag.
+      # Only a beta has them — neither artifact job runs for a stable tag.
       - if: contains(github.ref_name, '-')
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: daemon-*
           merge-multiple: true
           path: DerivedData/Build/Products/Release
+      - if: contains(github.ref_name, '-')
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: desktop-*
+          merge-multiple: true
+          path: DerivedData/Build/Products/Release
       # Checksums cover exactly what ships, so they are generated after every
       # artifact is in place and before staging asserts the set. SHA256SUMS is
-      # itself a beta artifact, and on a stable tag there are no archives to
-      # sum — the glob would match nothing and shasum would fail the release.
-      - name: Checksum the daemon archives
+      # itself a beta artifact, and on a stable tag there is nothing to sum —
+      # the glob would match nothing and shasum would fail the release.
+      #
+      # Everything unsigned, which is everything but the DMG: the Mac build is
+      # Developer ID-signed and notarized, the Linux tarball and bundles are
+      # not, and Windows is deliberately unsigned for the beta
+      # (docs/release-channels.md — Authenticode is a named deferral). A sum is
+      # the only integrity check those five have.
+      #
+      # find, not a glob: a stage whose artifacts are absent should fail the
+      # staging assertion by name, not fail shasum with "no such file".
+      - name: Checksum the unsigned artifacts
         if: contains(github.ref_name, '-')
         run: |
           cd DerivedData/Build/Products/Release
-          shasum -a 256 droidectived-* > SHA256SUMS
+          : > SHA256SUMS
+          find . -maxdepth 1 -type f \
+            \( -name 'droidectived-*' -o -name 'Droidective-*.deb' \
+            -o -name 'Droidective-*.AppImage' -o -name 'Droidective-*.msi' \
+            -o -name 'Droidective-*-setup.exe' \) \
+            | sed 's|^\./||' | sort | while IFS= read -r artifact; do
+            shasum -a 256 "$artifact" >> SHA256SUMS
+          done
           cat SHA256SUMS
       - name: Stage the artifacts this channel publishes
         run: ./scripts/stage-release-artifacts.sh "$GITHUB_REF_NAME" DerivedData/Build/Products/Release dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -811,7 +811,17 @@ per-channel version touchpoints, and the staged rollout are in
 `docs/release-channels.md`; `scripts/release-channel.sh` is the single
 resolver and `scripts/test-release-channel.sh` (in `make verify-self` and CI)
 keeps it honest — notably that a stable release can never attach a Windows or
-Linux artifact. Notes are picked by tag (`scripts/extract-notes.sh`), not by
+Linux artifact. **Two version lines:** the tag carries the Mac's version, and
+the root `PORT_VERSION` file (semver, hand-bumped like `MARKETING_VERSION`)
+carries the ports' — so one beta tag is `3.10.0-beta.1` on macOS and
+`0.0.1-beta.1` on Windows and Linux. Every cross-platform artifact name must
+come from `release-channel.sh port-version`, never from `${GITHUB_REF_NAME#v}`:
+that expression is right for the DMG and wrong for everything else, and two
+tests exist to catch the crossing. A beta tag builds the Tauri app for Windows
+(NSIS + MSI) and Linux (.deb + .AppImage) in the `desktop-artifacts` job via
+`scripts/build-desktop-app.sh` — the same script `build-desktop-linux.sh` runs
+in a container locally — and `scripts/package-desktop.sh` renames the bundlers'
+output to the one canonical set `release_artifacts_for_tag` promises. Notes are picked by tag (`scripts/extract-notes.sh`), not by
 position in `RELEASE_NOTES.md`.
 
 ## Status

--- a/PORT_VERSION
+++ b/PORT_VERSION
@@ -1,0 +1,12 @@
+# The Windows/Linux version line.
+#
+# The Mac and the ports are versioned separately: the Mac carries the product's
+# own history (3.10.x), the ports start from zero because that is what they are
+# — see docs/release-channels.md. The tag names the Mac version and picks the
+# channel; this file names everything a beta publishes for Windows and Linux,
+# and it is bumped by hand, like MARKETING_VERSION.
+#
+# Must be semver: Tauri rejects anything else, and the MSI installer version is
+# derived from it (WiX wants numeric major.minor.patch, so a pre-release suffix
+# is stripped for that one field). `0.0.1_beta` is NOT valid here.
+0.0.1-beta.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,85 @@
+## Droidective v3.10.0-beta.1
+
+The first Windows and Linux build of the app itself. Until now a beta carried
+only `droidectived`, the headless daemon; this one carries the desktop app that
+runs on top of it — an NSIS installer and an MSI for Windows, a `.deb` and an
+`.AppImage` for Linux. It is an early build and the version says so: Windows and
+Linux start their own version line at `0.0.1-beta.1` rather than inheriting the
+Mac's.
+
+### Windows and Linux
+
+- **The desktop app, for the first time.** 23 screens have a real pane: Terminal,
+  Apps, Logcat, Device Info, File Explorer, Crash Catcher, Bug Report,
+  Performance, Root Status, Developer Settings, System Restrictions, Wi-Fi,
+  Private DNS, Network Speed, Emulators, Install App, App Info, Permissions,
+  Memory Usage, Sandbox Browser, Manage App, Deep Links and Reactotron — plus
+  the catalog and About. Another 19 features run as actions from the palette
+  without a screen of their own.
+- **It is meant to be the same app.** Where a control exists on both, it has the
+  Mac's wording, icon, confirmation shape and gesture. Two deliberate
+  exceptions, and they are the only ones: a shortcut whose modifier has no
+  equivalent here (⌘\ is Ctrl+\, and the split is Ctrl+\ rather than Ctrl+D
+  because Ctrl+D ends input in every Linux shell), and a label that names a
+  platform.
+- **`droidectived` still ships too**, for macOS, Linux and Windows. It is useful
+  on its own — CI, scripting, adb over loopback — and the app talks to it rather
+  than to adb directly.
+
+### What is not there yet
+
+- **17 of the 61 features have not been started**, and the 42 counted as partial
+  are each missing something the Mac version offers. Read the state as *nothing
+  is finished* rather than *most of it is done*; `docs/desktop-parity.md` tracks
+  it feature by feature.
+- **The mirror, screen recording, the video editor, multi-window, Quick Actions,
+  the tour and notifications are not ported.** They are porting jobs with
+  entries in the backlog, not decisions.
+- **`ios-logs` and `push-notification` will not come.** They drive `xcrun
+  simctl` against an iOS Simulator, which is a macOS toolchain rather than
+  anything about a device.
+- **No automatic updates.** The app does not update itself on Windows or Linux;
+  a new beta is a new download.
+
+### Two version lines
+
+- **Windows and Linux are versioned separately from the Mac.** This build is
+  `0.0.1-beta.1` on those platforms and `3.10.0-beta.1` on macOS. The Mac
+  carries the product's own history — 61 features across three major versions —
+  and the ports do not, so numbering a first Windows build in the threes would
+  claim a maturity it has not got. The two lines move independently from here.
+
+### Unsigned, and what that means
+
+- **Windows will warn.** The installer is not Authenticode-signed, so
+  SmartScreen shows "Windows protected your PC" — More info, then Run anyway.
+  Code-signing is a deliberate deferral, not an oversight: an OV certificate is
+  a recurring cost and a multi-week identity check, and reputation accrues per
+  certificate over download volume a beta will not generate.
+- **Linux bundles are unsigned too**, which is normal for the ecosystem.
+- **Every unsigned artifact is checksummed.** `SHA256SUMS` on the release page
+  covers the installers, the bundles and all three daemon archives. The macOS
+  DMG is Developer ID-signed and notarized as always.
+
+### macOS
+
+- **This is a rebuild, not a Mac release.** The Mac app is identical to v3.9.2 —
+  a beta that exists to ship a Windows and Linux build still rebuilds the Mac
+  app, and it is offered only to installs that opted into beta updates in
+  Settings ▸ General. The stable channel is untouched: the download button and
+  `/releases/latest/download/` keep serving v3.9.2.
+
+### Install
+
+**Windows** — download the `-setup.exe` and run it, clicking through the
+SmartScreen warning above. The `.msi` is there for anyone deploying it centrally.
+
+**Linux** — `sudo apt install ./Droidective-0.0.1-beta.1-linux-x86_64.deb`, or
+make the `.AppImage` executable and run it. Both need `adb` on `PATH`; the `.deb`
+declares it as a dependency.
+
+**macOS** — download the DMG and drag Droidective to Applications. Existing
+installs on the beta channel update themselves.
 ## Droidective v3.9.2
 
 Pulling events out of a busy log. Rows in the Reactotron timeline and the JS

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Droidective",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "identifier": "com.rohindh.droidective.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -7,17 +7,15 @@ which.
 | --- | --- | --- |
 | Tag | `vX.Y.Z` | `vX.Y.Z-beta.N` (any pre-release suffix) |
 | GitHub release | normal | prerelease |
+| Version | `X.Y.Z` — the Mac's line | Mac `X.Y.Z-beta.N`, ports `PORT_VERSION` |
 | macOS | ✅ signed, notarized DMG | ✅ same DMG |
-| Windows | ❌ | ✅ `droidectived` (the Tauri app when it exists) |
-| Linux | ❌ | ✅ `droidectived` (the Tauri app when it exists) |
+| Windows | ❌ | ✅ NSIS installer, MSI, and `droidectived` |
+| Linux | ❌ | ✅ `.deb`, `.AppImage`, and `droidectived` |
 | Update feed | `appcast.xml`, untagged item | `appcast.xml` beta item **+** `updates/beta/latest.json` |
 | Who gets it | every install | Settings ▸ General ▸ Updates ▸ *Receive beta updates*, and Windows/Linux users |
 
-The Windows and Linux rows describe what a beta tag carries **once there is
-something to carry** — today that is nothing, because no Windows or Linux
-binary exists yet. See [Where this stands](#where-this-stands); the policy and
-its enforcement are in place now so the artifacts have a home the day they
-build.
+The Windows and Linux rows are what a beta tag carries today. See
+[Where this stands](#where-this-stands) for how it got here.
 
 **The rule, in one sentence:** the stable channel is macOS-only and always will
 be until a non-Apple platform is good enough to graduate; everything
@@ -45,18 +43,55 @@ from it rather than re-deriving the rule. `scripts/test-release-channel.sh`
 unit-tests it (the `test-verify-guards.sh` pattern): the channel policy is a
 test, not review folklore.
 
-## Why one version line
+## Two version lines
 
-The alternative — a separate `xplat-vA.B.C` line for Windows/Linux — was
-rejected. It buys an honest signal that the ports lag in features, and costs
-two changelogs, two version-touchpoint tables, two feed lifecycles, and a
-standing "how does Windows 0.3 relate to Mac 3.9?" question. One line with a
-`-beta.N` suffix carries the same "this is rougher" signal at a fraction of the
-machinery, and it leaves the existing Sparkle beta channel's meaning untouched.
+The Mac and the ports are versioned **separately**, and the tag carries only
+the Mac's.
 
-So a beta is exactly *the next stable's Mac build, plus the cross-platform
-builds*. A beta cut purely to ship a Windows fix still rebuilds the Mac app;
-that is a harmless rebuild, not a Mac release.
+```
+tag                 Mac DMG           Windows + Linux
+v3.9.2              3.9.2             — (stable is macOS-only)
+v3.10.0-beta.1      3.10.0-beta.1     PORT_VERSION, e.g. 0.0.1-beta.1
+v3.10.0-beta.2      3.10.0-beta.2     PORT_VERSION, bumped or not
+```
+
+The Mac carries the product's own history — 61 features across three major
+versions — and the ports do not. Naming a first Windows build `3.10.0` claims a
+maturity it has not got: someone downloading it reads the version as "the tenth
+minor release of a mature app", and what they get is a port with 17 of those 61
+features not started.
+`0.0.1-beta.1` says the true thing without a paragraph of explanation.
+
+**Where each version lives.** The tag names the Mac's, exactly as before.
+`PORT_VERSION` at the repo root names the ports', and is bumped by hand like
+`MARKETING_VERSION`. `release-channel.sh` reads both — `port-version` and
+`msi-version` — so the rule stays in one resolver and
+`test-release-channel.sh` can assert that the two never cross: the Mac's
+version must never name a port artifact, and the ports' must never name the
+DMG. That pair of tests is the whole design.
+
+**It must be semver.** Tauri rejects anything else, and every bundler derives
+its own version from it. `0.0.1_beta` is not semver — an underscore is not a
+pre-release separator — and `release_port_version` refuses it by name rather
+than letting the build fail later with something less obvious. WiX is the one
+exception that needs help: an MSI version must be numeric
+`major.minor.patch[.build]`, so `msi-version` strips the pre-release suffix and
+the build passes it as `bundle.windows.wix.version`.
+
+**What this costs, and it is not nothing.** This reverses the earlier decision
+to keep one version line, which was taken to avoid exactly these costs: two
+things to bump instead of one, two histories a reader has to relate, and the
+standing question of how Windows 0.0.1 relates to Mac 3.10. The answer to that
+question is "it does not, deliberately" — the ports are their own product until
+one of them is good enough to graduate. The mitigation for the rest is that
+neither version is written down twice: the tag is the Mac's only source and
+`PORT_VERSION` is the ports' only source, and a release that gets them
+backwards fails its own test suite rather than shipping.
+
+A beta is still *the next Mac stable's build plus the cross-platform builds*.
+A beta cut purely to ship a Windows fix still rebuilds the Mac app; that is a
+harmless rebuild, not a Mac release, and `PORT_VERSION` may move without the
+tag's minor moving at all.
 
 ## The two feeds
 
@@ -78,10 +113,19 @@ invisible to Sparkle.
 
 ### `site/updates/beta/latest.json` — Windows and Linux
 
-Written on beta tags only, committed to `main` by the release job (the same
-route the appcast takes, so Pages deploys it), and never written by a stable
-tag — a stable release leaves the previous beta feed in place, because the
-newest beta is still the newest thing Windows and Linux have.
+**Not implemented.** This section is the design, not a description of the
+pipeline: nothing in the release job writes this file today, and the website has
+no beta section to read it. Until both exist, the GitHub prerelease page is
+where Windows and Linux downloads live, and the permanent
+`/releases/latest/download/` link keeps serving the newest *stable* Mac build
+throughout a beta cycle because GitHub's `latest` never resolves to a
+prerelease.
+
+The design, for whoever builds it: written on beta tags only, committed to
+`main` by the release job (the same route the appcast takes, so Pages deploys
+it), and never written by a stable tag — a stable release leaves the previous
+beta feed in place, because the newest beta is still the newest thing Windows
+and Linux have.
 
 ```jsonc
 {
@@ -120,6 +164,7 @@ as the current release.
 | --- | --- | --- |
 | `RELEASE_NOTES.md` — new `## Droidective vX.Y.Z` section | ✅ | ✅ (heading carries the full tag, e.g. `v3.9.0-beta.1`) |
 | `project.yml` `MARKETING_VERSION` | ✅ | ❌ — CI passes the tag's version to `xcodebuild`, overriding it; the file tracks the stable line |
+| `PORT_VERSION` | ❌ — a stable publishes nothing it names | ✅ if the Windows/Linux build changed since the last beta |
 | `website/src/lib/content.ts` `APP_VERSION` | ✅ | ❌ — drives the hero badge and JSON-LD `softwareVersion`, both of which mean *current stable* |
 | `website/src/lib/content.ts` `releases` entry | ✅ | ❌ — the public changelog is the stable line |
 | `BETA_VERSION` + beta section copy | ❌ | ✅ |
@@ -169,9 +214,14 @@ before the Tauri UI depends on it.
 
 | stage | payload of a beta tag | status |
 | --- | --- | --- |
-| 0 | Mac DMG only (channel infra in place, no cross-platform artifact) | ← here |
-| 1 | \+ `droidectived` for Windows, Linux, macOS | daemon scaffold landed; protocol unimplemented |
-| 2 | \+ the Tauri app for Windows and Linux, with its signed updater feed | not started |
+| 0 | Mac DMG only (channel infra in place, no cross-platform artifact) | done |
+| 1 | \+ `droidectived` for Windows, Linux, macOS | done — protocol implemented |
+| 2 | \+ the Tauri app for Windows and Linux | ← here, unsigned; no updater feed yet |
+| 3 | \+ a signed Tauri updater feed | not started (see `latest.json` above) |
+
+`CROSS_PLATFORM_STAGE` in `release-channel.sh` is the switch, and every stage
+is a test: the suite asserts what each one publishes and — more importantly —
+that raising it never leaks a port artifact onto the stable channel.
 
 macOS's stable channel is unaffected at every stage. That is the point of the
 split: the port cannot regress the thing people use today, because the thing
@@ -190,12 +240,24 @@ people use today never ships from a beta tag.
   serving the newest stable throughout a beta cycle. Windows and Linux have no
   equivalent permanent URL — they resolve through `latest.json`, which is why
   that file exists.
-- **The daemon package is macOS-gated on the branch it lives on.** On
-  `feat/droidectived-scaffold` (not yet merged), `droidectived/Package.swift`
-  declares `platforms: [.macOS(.v14)]`, and its CI additions run the daemon
-  suite on macOS and Linux but not Windows — the one component whose entire
-  purpose is serving Windows and Linux is not built on Windows. Fix that when
-  landing the scaffold, before stage 1.
+- **The daemon's suite does not run on Windows, only its build does.** The
+  scaffold has landed, and `droidectived/Package.swift` still declares
+  `platforms: [.macOS(.v14)]` — harmless, because that clause sets an Apple
+  deployment target and does not restrict which hosts can build the package.
+  What is real is the coverage gap: the suite runs in `test` (macOS) and
+  `test-linux`, while `build-windows` only compiles the daemon. So the component
+  whose entire purpose is serving Windows is the one nobody tests there, and a
+  Windows-only behaviour difference — a path separator, a socket option, a
+  handle still held at teardown — surfaces in a beta rather than in CI. The two
+  Windows-only failures already on record (`ERROR_SHARING_VIOLATION` in temp-dir
+  teardown, and `AabConvertServiceTests`) are that shape.
+- **The two version lines are one substitution away from crossing.** Every
+  cross-platform artifact name must come from `release-channel.sh port-version`,
+  never from `${GITHUB_REF_NAME#v}` — that expression is right for the DMG and
+  wrong for everything else, and it is the natural thing to type. Two tests
+  exist purely to catch it (`the Mac's version never names a port artifact` and
+  its mirror), because the failure ships a correctly-built binary under a name
+  that claims it is the Mac release.
 - **A beta must not be the newest `## ` section by accident.** With tag-aware
   extraction this is no longer load-bearing, but the file still reads
   top-down for humans; keep stable sections in version order and betas next to

--- a/scripts/build-daemon-sidecar.sh
+++ b/scripts/build-daemon-sidecar.sh
@@ -45,5 +45,10 @@ BUILT="$ROOT/droidectived/.build/$CONFIGURATION/droidectived$SUFFIX"
 }
 
 mkdir -p "$DESTINATION"
-install -m 755 "$BUILT" "$DESTINATION/droidectived-$TRIPLE$SUFFIX"
+# cp then chmod, not `install`: this script runs on the Windows runner too
+# (Git Bash), where the coreutils set is trimmed and a missing `install` would
+# fail the release with "command not found" rather than anything about the
+# sidecar. chmod is a no-op on Windows and load-bearing everywhere else.
+cp "$BUILT" "$DESTINATION/droidectived-$TRIPLE$SUFFIX"
+chmod 755 "$DESTINATION/droidectived-$TRIPLE$SUFFIX"
 echo "installed $DESTINATION/droidectived-$TRIPLE$SUFFIX"

--- a/scripts/build-desktop-app.sh
+++ b/scripts/build-desktop-app.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Build the desktop app for the host platform and leave canonically-named
+# bundles in an output directory.
+#
+# This is the recipe itself, with no opinion about where it runs. Two callers
+# share it, which is the point:
+#
+#   * build-desktop-linux.sh runs it inside a swift:6.2-noble container, so a
+#     Linux bundle can be produced from a macOS host.
+#   * the release workflow's desktop-artifacts job runs it directly — on Linux
+#     inside that same image, and on Windows on the runner.
+#
+# Before this existed the container recipe and the CI recipe were separate
+# copies of the same steps, and only one of them was ever run locally. A build
+# nobody can reproduce off CI is a build debugged one push at a time.
+#
+# Toolchains are the caller's job: installing Swift, Rust and Node differs per
+# environment and does not belong in the recipe. What this owns is the part that
+# must be identical everywhere — which version the bundles carry, which
+# bundlers run, and what the outputs are called.
+#
+# Usage: build-desktop-app.sh <linux|windows> [debug|release] [out-dir]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=release-channel.sh
+source "$ROOT/scripts/release-channel.sh"
+
+PLATFORM="${1:?platform required: linux or windows}"
+CONFIGURATION="${2:-release}"
+OUT_DIR="${3:-$ROOT/desktop/dist-app}"
+
+case "$PLATFORM" in
+# Deliberately not the config's "targets": "all". On Linux that adds an .rpm
+# nothing publishes and rpmbuild is not installed; on Windows it would try
+# every installer format. Naming the bundlers here keeps the release's artifact
+# set and the build's outputs the same list.
+linux) BUNDLES="deb,appimage" ;;
+windows) BUNDLES="nsis,msi" ;;
+*)
+  echo "error: unknown platform '$PLATFORM' (expected linux or windows)" >&2
+  exit 2
+  ;;
+esac
+
+case "$CONFIGURATION" in
+debug | release) ;;
+*)
+  echo "usage: $(basename "$0") <linux|windows> [debug|release] [out-dir]" >&2
+  exit 2
+  ;;
+esac
+
+for tool in rustc cargo node npm swift; do
+  command -v "$tool" >/dev/null || {
+    echo "error: $tool is not on PATH — the caller installs the toolchains" >&2
+    exit 1
+  }
+done
+
+PORT_VERSION="$(release_port_version)"
+MSI_VERSION="$(release_msi_version)"
+echo "building the $PLATFORM desktop app, version $PORT_VERSION ($CONFIGURATION)"
+
+# The version reaches Tauri as a config overlay rather than an edit to
+# tauri.conf.json: the committed config would otherwise have to be bumped in
+# lockstep with PORT_VERSION, and a release that forgot would ship bundles
+# named one version and reporting another.
+#
+# wix.version is set because WiX requires a numeric major.minor.patch and would
+# otherwise derive it from a pre-release string. NSIS has no such field — it
+# takes the semver as-is, which is what we want in the installer's own UI.
+OVERLAY="$ROOT/desktop/src-tauri/tauri.release.json"
+cat >"$OVERLAY" <<JSON
+{
+  "version": "$PORT_VERSION",
+  "bundle": {
+    "windows": {
+      "wix": {
+        "version": "$MSI_VERSION"
+      }
+    }
+  }
+}
+JSON
+trap 'rm -f "$OVERLAY"' EXIT
+
+# Tauri resolves externalBin by appending the host triple, so the daemon has to
+# be built and installed under that name before cargo runs.
+"$ROOT/scripts/build-daemon-sidecar.sh" "$CONFIGURATION"
+
+cd "$ROOT/desktop"
+npm ci
+
+# `npm run tauri --` rather than a global tauri: the CLI is a devDependency, so
+# this uses the pinned version rather than whatever the host happens to have.
+TAURI_ARGS=(build --bundles "$BUNDLES" --config "$OVERLAY")
+[[ "$CONFIGURATION" == debug ]] && TAURI_ARGS+=(--debug)
+npm run tauri -- "${TAURI_ARGS[@]}"
+
+# Where cargo put things. CARGO_TARGET_DIR is honoured because the container
+# wrapper points it at a cache that outlives the container.
+TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/desktop/src-tauri/target}"
+BUNDLE_DIR="$TARGET_DIR/$CONFIGURATION/bundle"
+[[ -d "$BUNDLE_DIR" ]] || {
+  echo "error: tauri build left no bundle directory at $BUNDLE_DIR" >&2
+  exit 1
+}
+
+"$ROOT/scripts/package-desktop.sh" "$BUNDLE_DIR" "$PLATFORM" "$OUT_DIR"

--- a/scripts/build-desktop-linux.sh
+++ b/scripts/build-desktop-linux.sh
@@ -97,24 +97,9 @@ rsync -a --exclude node_modules --exclude .build --exclude target \
   --exclude DerivedData --exclude .git /repo/ /work/
 cd /work
 
-./scripts/build-daemon-sidecar.sh \"\$CONFIGURATION\"
-
-cd desktop
-npm ci
-# Copy whatever exists even when a later bundler fails: the .deb is written
-# before the AppImage, so one broken target must not discard the other.
-STATUS=0
-if [ \"\$CONFIGURATION\" = debug ]; then
-  npm run tauri -- build --debug || STATUS=\$?
-else
-  npm run tauri -- build || STATUS=\$?
-fi
-
-# Whatever the bundler produced — .deb, .rpm, .AppImage — plus the bare
-# executable, which is what a smoke test actually runs.
-find \"\$CARGO_TARGET_DIR\" -path '*/bundle/*' -type f \
-  \\( -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \\) -exec cp -v {} /out/ \\;
-cp -v \"\$CARGO_TARGET_DIR/\$CONFIGURATION/droidective-desktop\" /out/ 2>/dev/null || true
+# The shared recipe: it sets the version from PORT_VERSION, picks the bundlers,
+# and leaves canonically-named bundles straight in /out. No copy step here —
+# package-desktop.sh is what names them, on this path and in CI alike.
+./scripts/build-desktop-app.sh linux \"\$CONFIGURATION\" /out
 ls -la /out
-exit \$STATUS
 "

--- a/scripts/package-desktop.sh
+++ b/scripts/package-desktop.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Rename Tauri's bundle output to the names the release publishes.
+#
+# Tauri names bundles after the product, the version and the bundler's own idea
+# of an architecture: `Droidective_0.0.1-beta.1_amd64.deb` on Linux,
+# `Droidective_0.0.1-beta.1_x64-setup.exe` on Windows. Those names encode the
+# bundler's conventions rather than ours, they differ per target, and they would
+# make `release-channel.sh` describe the artifact set in four dialects.
+#
+# So the bundlers' names stop here. This script copies each bundle to the one
+# canonical name `release_artifacts_for_tag` already promises, which keeps that
+# function the single description of what a release contains — the same reason
+# package-daemon.sh exists for the daemon.
+#
+# Exactly one bundle per extension is expected. Two `.deb`s in the same tree
+# means a stale build is still lying around, and picking either one at random is
+# how a release ships last week's binary.
+#
+# Usage: package-desktop.sh <search-dir> <linux|windows> <out-dir>
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=release-channel.sh
+source "$ROOT/scripts/release-channel.sh"
+
+SEARCH_DIR="${1:?a directory to search for bundles is required}"
+PLATFORM="${2:?platform required: linux or windows}"
+OUT_DIR="${3:?an output directory is required}"
+
+case "$PLATFORM" in
+linux) EXTENSIONS="deb AppImage" ;;
+windows) EXTENSIONS="exe msi" ;;
+*)
+  echo "error: unknown platform '$PLATFORM' (expected linux or windows)" >&2
+  exit 2
+  ;;
+esac
+
+[[ -d "$SEARCH_DIR" ]] || {
+  echo "error: no such directory: $SEARCH_DIR" >&2
+  exit 1
+}
+
+PORT_VERSION="$(release_port_version)"
+mkdir -p "$OUT_DIR"
+
+# The canonical name for one extension. `-setup.exe` rather than `.exe` because
+# NSIS produces an installer, and a bare `Droidective.exe` next to it would read
+# as the application binary.
+canonical_name() {
+  case "$1" in
+  deb) echo "Droidective-${PORT_VERSION}-linux-x86_64.deb" ;;
+  AppImage) echo "Droidective-${PORT_VERSION}-linux-x86_64.AppImage" ;;
+  exe) echo "Droidective-${PORT_VERSION}-windows-x86_64-setup.exe" ;;
+  msi) echo "Droidective-${PORT_VERSION}-windows-x86_64.msi" ;;
+  *)
+    echo "error: no canonical name for a .$1" >&2
+    return 1
+    ;;
+  esac
+}
+
+packaged=0
+for extension in $EXTENSIONS; do
+  # Read into an array the bash-3.2 way: no `mapfile` on macOS or the runner.
+  found=()
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && found+=("$path")
+  done < <(find "$SEARCH_DIR" -type f -name "*.${extension}" | sort)
+
+  if ((${#found[@]} == 0)); then
+    echo "error: no .$extension bundle under $SEARCH_DIR" >&2
+    echo "       the $PLATFORM bundler did not produce one — read the build log" >&2
+    exit 1
+  fi
+  if ((${#found[@]} > 1)); then
+    echo "error: ${#found[@]} .$extension bundles under $SEARCH_DIR:" >&2
+    printf '         %s\n' "${found[@]}" >&2
+    echo "       refusing to guess which one this release should publish" >&2
+    exit 1
+  fi
+
+  name="$(canonical_name "$extension")"
+  cp "${found[0]}" "$OUT_DIR/$name"
+  echo "packaged $OUT_DIR/$name"
+  echo "     from $(basename "${found[0]}")"
+  packaged=$((packaged + 1))
+done
+
+echo "packaged $packaged $PLATFORM bundle(s) as version $PORT_VERSION"

--- a/scripts/release-channel.sh
+++ b/scripts/release-channel.sh
@@ -9,9 +9,11 @@
 # away from publishing Windows builds on the stable macOS channel.
 #
 # Usage (sourced by the tests, executed by CI):
-#   release-channel.sh channel   v3.9.0-beta.1   -> beta
-#   release-channel.sh version   v3.9.0-beta.1   -> 3.9.0-beta.1
-#   release-channel.sh artifacts v3.9.0-beta.1   -> one filename per line
+#   release-channel.sh channel      v3.9.0-beta.1 -> beta
+#   release-channel.sh version      v3.9.0-beta.1 -> 3.9.0-beta.1
+#   release-channel.sh port-version               -> 0.0.1-beta.1
+#   release-channel.sh msi-version                -> 0.0.1
+#   release-channel.sh artifacts    v3.9.0-beta.1 -> one filename per line
 set -euo pipefail
 
 # Which cross-platform artifacts a beta actually carries today.
@@ -20,8 +22,56 @@ set -euo pipefail
 # action dispatch and the log stream, and builds on all three hosts. It is
 # headless — no GUI — so a beta carries it for people driving the daemon
 # directly while the Tauri app is built on top.
-# Stage 2 (the Tauri app) adds its own entries here.
-CROSS_PLATFORM_STAGE="${CROSS_PLATFORM_STAGE:-1}"
+# Stage 2 adds the Tauri app: a .deb and an .AppImage for Linux, an NSIS
+# installer and an MSI for Windows.
+CROSS_PLATFORM_STAGE="${CROSS_PLATFORM_STAGE:-2}"
+
+# The Mac and the ports are two version lines. The tag carries the Mac's and
+# picks the channel; PORT_VERSION carries the ports'. Reading it here rather
+# than in the workflow keeps the "one resolver" property that makes the policy
+# testable — see docs/release-channels.md.
+RELEASE_CHANNEL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT_VERSION_FILE="${PORT_VERSION_FILE:-$RELEASE_CHANNEL_ROOT/PORT_VERSION}"
+
+# Semver, because Tauri rejects anything else and every bundler derives its own
+# version from it. Deliberately strict: a typo here would name every Windows
+# and Linux artifact wrongly, and the mistake would only surface after the
+# build, sign and notarize steps had run.
+readonly PORT_VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'
+
+# The ports' version: the first non-comment, non-blank line of PORT_VERSION.
+release_port_version() {
+  local version=""
+  [[ -f "$PORT_VERSION_FILE" ]] || {
+    echo "error: no PORT_VERSION file at $PORT_VERSION_FILE" >&2
+    return 1
+  }
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    version="$line"
+    break
+  done <"$PORT_VERSION_FILE"
+  [[ -n "$version" ]] || {
+    echo "error: $PORT_VERSION_FILE has no version line" >&2
+    return 1
+  }
+  [[ "$version" =~ $PORT_VERSION_PATTERN ]] || {
+    echo "error: '$version' in $PORT_VERSION_FILE is not semver (an underscore is not a pre-release separator; use -beta.1)" >&2
+    return 1
+  }
+  echo "$version"
+}
+
+# WiX wants a numeric major.minor.patch, so the MSI drops the pre-release
+# suffix. Tauri derives this itself when the field is unset, but it is set
+# explicitly at build time so a pre-release version cannot fail the bundler.
+release_msi_version() {
+  local version
+  version="$(release_port_version)" || return 1
+  echo "${version%%-*}"
+}
 
 # vX.Y.Z, optionally with a pre-release suffix. Anything else is a typo'd tag
 # and must not reach a signing step.
@@ -54,21 +104,42 @@ release_version_for_tag() {
 # else may ship: stage-release-artifacts.sh rejects extras, which is what keeps
 # a stable macOS release free of Windows and Linux builds.
 release_artifacts_for_tag() {
-  local tag="${1-}" channel version
+  local tag="${1-}" channel port
   channel="$(release_channel_for_tag "$tag")" || return 1
-  version="${tag#v}"
 
   # Both channels: the versioned DMG, plus the stable-named copy that backs the
-  # site's permanent /releases/latest/download link.
+  # site's permanent /releases/latest/download link. The Mac's version is the
+  # tag's.
   echo "Droidective-${tag}.dmg"
   echo "Droidective.dmg"
 
   [[ "$channel" == beta ]] || return 0
   ((CROSS_PLATFORM_STAGE >= 1)) || return 0
 
-  echo "droidectived-${version}-macos-universal.tar.gz"
-  echo "droidectived-${version}-linux-x86_64.tar.gz"
-  echo "droidectived-${version}-windows-x86_64.zip"
+  # Everything below is the ports' own version line, not the tag's.
+  port="$(release_port_version)" || return 1
+
+  # The macOS daemon rides the ports' version too: it is the same build of the
+  # same program, and naming one copy of it after the Mac app would imply the
+  # Mac app and the daemon ship together, which they do not.
+  echo "droidectived-${port}-macos-universal.tar.gz"
+  echo "droidectived-${port}-linux-x86_64.tar.gz"
+  echo "droidectived-${port}-windows-x86_64.zip"
+
+  if ((CROSS_PLATFORM_STAGE >= 2)); then
+    # Canonical names, not the bundlers'. Tauri's own output is
+    # `Droidective_0.0.1-beta.1_amd64.deb` on one target and
+    # `Droidective_0.0.1-beta.1_x64-setup.exe` on another; package-desktop.sh
+    # renames them so this list stays the single description of what ships.
+    #
+    # No .rpm: the bundler can make one, but every name here MUST exist or the
+    # release fails, and rpmbuild is a dependency the container does not carry.
+    echo "Droidective-${port}-linux-x86_64.deb"
+    echo "Droidective-${port}-linux-x86_64.AppImage"
+    echo "Droidective-${port}-windows-x86_64-setup.exe"
+    echo "Droidective-${port}-windows-x86_64.msi"
+  fi
+
   echo "SHA256SUMS"
 }
 
@@ -76,9 +147,12 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   case "${1-}" in
   channel) release_channel_for_tag "${2-}" ;;
   version) release_version_for_tag "${2-}" ;;
+  port-version) release_port_version ;;
+  msi-version) release_msi_version ;;
   artifacts) release_artifacts_for_tag "${2-}" ;;
   *)
     echo "usage: $(basename "$0") {channel|version|artifacts} <tag>" >&2
+    echo "       $(basename "$0") {port-version|msi-version}" >&2
     exit 2
     ;;
   esac

--- a/scripts/stage-release-artifacts.sh
+++ b/scripts/stage-release-artifacts.sh
@@ -61,6 +61,11 @@ fi
 # Anything release-shaped that the channel did not ask for is a policy break,
 # not a stray file to ignore. Scoped to the artifact prefixes and extensions we
 # publish so unrelated build output (.app bundles, dSYMs) stays invisible.
+#
+# The app bundles are in that scope too: a Linux .deb or a Windows .msi left
+# behind by a job that forgot its tag gate is exactly the leak this check exists
+# for, and it would be invisible if the patterns only knew about DMGs and daemon
+# tarballs.
 unexpected=()
 while IFS= read -r path; do
   name="$(basename "$path")"
@@ -69,7 +74,10 @@ while IFS= read -r path; do
   done
   unexpected+=("$name")
 done < <(find "$BUILD_DIR" -maxdepth 1 -type f \
-  \( -name 'Droidective*.dmg' -o -name 'droidectived-*' -o -name 'SHA256SUMS' \) | sort)
+  \( -name 'Droidective*.dmg' -o -name 'droidectived-*' -o -name 'SHA256SUMS' \
+  -o -name 'Droidective*.deb' -o -name 'Droidective*.AppImage' \
+  -o -name 'Droidective*.rpm' -o -name 'Droidective*.msi' \
+  -o -name 'Droidective*.exe' \) | sort)
 
 if ((${#unexpected[@]} > 0)); then
   echo "error: $channel release $TAG would publish ${#unexpected[@]} artifact(s) its channel does not allow:" >&2

--- a/scripts/test-release-channel.sh
+++ b/scripts/test-release-channel.sh
@@ -16,6 +16,19 @@ failures=0
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# The ports' version comes from a fixture, not the repo's PORT_VERSION: these
+# assertions name exact filenames, and bumping the real file must not turn this
+# suite red. Reading the fixture at all is itself the proof that the file — and
+# not the tag — is what names a Windows or Linux artifact.
+cat >"$TMP/PORT_VERSION" <<'FIXTURE'
+# a comment, and a blank line, both skipped
+
+1.2.3-beta.4
+FIXTURE
+# Read by the sourced release-channel.sh, which shellcheck cannot see into.
+# shellcheck disable=SC2034
+PORT_VERSION_FILE="$TMP/PORT_VERSION"
+
 pass() { echo "  ok   $1"; }
 fail() {
   echo "  FAIL $1" >&2
@@ -83,9 +96,9 @@ Droidective.dmg" \
   "$(CROSS_PLATFORM_STAGE=0 release_artifacts_for_tag v3.9.0-beta.1)"
 
 stage1_beta="$(CROSS_PLATFORM_STAGE=1 release_artifacts_for_tag v3.9.0-beta.1)"
-for want in droidectived-3.9.0-beta.1-windows-x86_64.zip \
-  droidectived-3.9.0-beta.1-linux-x86_64.tar.gz \
-  droidectived-3.9.0-beta.1-macos-universal.tar.gz \
+for want in droidectived-1.2.3-beta.4-windows-x86_64.zip \
+  droidectived-1.2.3-beta.4-linux-x86_64.tar.gz \
+  droidectived-1.2.3-beta.4-macos-universal.tar.gz \
   SHA256SUMS; do
   if grep -qxF "$want" <<<"$stage1_beta"; then
     pass "a stage-1 beta publishes $want"
@@ -94,13 +107,75 @@ for want in droidectived-3.9.0-beta.1-windows-x86_64.zip \
   fi
 done
 
-# Raising the stage must never leak the ports onto stable.
-stage1_stable="$(CROSS_PLATFORM_STAGE=1 release_artifacts_for_tag v3.8.0)"
-if grep -qiE 'windows|linux|droidectived' <<<"$stage1_stable"; then
-  fail "stage 1 still keeps stable macOS-only" "got: $stage1_stable"
+# Stage 1 is the daemon only: the app bundles must not appear a stage early.
+if grep -qE '\.(deb|AppImage|msi|exe)$' <<<"$stage1_beta"; then
+  fail "a stage-1 beta carries no app bundle" "got: $stage1_beta"
 else
-  pass "stage 1 still keeps stable macOS-only"
+  pass "a stage-1 beta carries no app bundle"
 fi
+
+stage2_beta="$(CROSS_PLATFORM_STAGE=2 release_artifacts_for_tag v3.9.0-beta.1)"
+for want in Droidective-1.2.3-beta.4-linux-x86_64.deb \
+  Droidective-1.2.3-beta.4-linux-x86_64.AppImage \
+  Droidective-1.2.3-beta.4-windows-x86_64-setup.exe \
+  Droidective-1.2.3-beta.4-windows-x86_64.msi \
+  droidectived-1.2.3-beta.4-linux-x86_64.tar.gz \
+  SHA256SUMS; do
+  if grep -qxF "$want" <<<"$stage2_beta"; then
+    pass "a stage-2 beta publishes $want"
+  else
+    fail "a stage-2 beta publishes $want" "got: $stage2_beta"
+  fi
+done
+
+# The two version lines must not cross. The Mac's version belongs to the DMG
+# and nothing else; the ports' version belongs to everything else. A single
+# artifact carrying the wrong one is the whole failure mode of this design.
+if grep -vE '\.dmg$' <<<"$stage2_beta" | grep -q '3\.9\.0-beta\.1'; then
+  fail "the Mac's version never names a port artifact" "got: $stage2_beta"
+else
+  pass "the Mac's version never names a port artifact"
+fi
+if grep -E '\.dmg$' <<<"$stage2_beta" | grep -q '1\.2\.3-beta\.4'; then
+  fail "the ports' version never names the DMG" "got: $stage2_beta"
+else
+  pass "the ports' version never names the DMG"
+fi
+
+# Raising the stage must never leak the ports onto stable.
+for stage in 1 2; do
+  stage_stable="$(CROSS_PLATFORM_STAGE=$stage release_artifacts_for_tag v3.8.0)"
+  if grep -qiE 'windows|linux|droidectived|\.deb|\.msi|AppImage' <<<"$stage_stable"; then
+    fail "stage $stage still keeps stable macOS-only" "got: $stage_stable"
+  else
+    pass "stage $stage still keeps stable macOS-only"
+  fi
+done
+
+echo "── the ports' version line ────────────────────────────────"
+
+eq "the version is the first non-comment line" 1.2.3-beta.4 "$(release_port_version)"
+eq "the MSI version drops the pre-release suffix" 1.2.3 "$(release_msi_version)"
+eq "a plain version needs no stripping" 2.0.0 \
+  "$(printf '2.0.0\n' >"$TMP/plain" && PORT_VERSION_FILE="$TMP/plain" release_msi_version)"
+
+# The exact mistake this file's comment warns about: an underscore is not a
+# semver pre-release separator, and Tauri rejects it.
+printf '0.0.1_beta\n' >"$TMP/underscore"
+rejects "an underscore pre-release is rejected" \
+  env PORT_VERSION_FILE="$TMP/underscore" "$ROOT/scripts/release-channel.sh" port-version
+
+printf '# only a comment\n' >"$TMP/empty"
+rejects "a file with no version line is rejected" \
+  env PORT_VERSION_FILE="$TMP/empty" "$ROOT/scripts/release-channel.sh" port-version
+
+rejects "a missing PORT_VERSION file is rejected" \
+  env PORT_VERSION_FILE="$TMP/does-not-exist" "$ROOT/scripts/release-channel.sh" port-version
+
+# A beta cannot be named at all without a readable version — better to fail
+# here than to publish `droidectived--linux-x86_64.tar.gz`.
+rejects "a beta artifact set needs the ports' version" \
+  env PORT_VERSION_FILE="$TMP/does-not-exist" "$ROOT/scripts/release-channel.sh" artifacts v3.9.0-beta.1
 
 echo "── notes extraction ───────────────────────────────────────"
 
@@ -172,6 +247,18 @@ Droidective.dmg" "$(cd "$TMP/dist" && ls)"
 : >"$build/droidectived-3.8.0-windows-x86_64.zip"
 rejects "an unexpected Windows artifact fails a stable release" stage v3.8.0 "$build" "$TMP/dist"
 rm "$build/droidectived-3.8.0-windows-x86_64.zip"
+
+# Same leak, one stage later: the app bundles are the artifacts a stage-2 job
+# produces, so each of their extensions has to be visible to the check. A
+# pattern list that only knew about DMGs and tarballs would publish these.
+for stray in Droidective-1.2.3-beta.4-linux-x86_64.deb \
+  Droidective-1.2.3-beta.4-linux-x86_64.AppImage \
+  Droidective-1.2.3-beta.4-windows-x86_64.msi \
+  Droidective-1.2.3-beta.4-windows-x86_64-setup.exe; do
+  : >"$build/$stray"
+  rejects "an unexpected ${stray##*.} fails a stable release" stage v3.8.0 "$build" "$TMP/dist"
+  rm "$build/$stray"
+done
 
 rm "$build/Droidective.dmg"
 rejects "a missing artifact fails the release" stage v3.8.0 "$build" "$TMP/dist"


### PR DESCRIPTION
Stage 2 of the port's release plan. A beta tag now builds the Tauri app for
Windows and Linux — an NSIS installer and an MSI, a `.deb` and an `.AppImage` —
alongside the daemon it already carried. The stable channel is untouched and
still macOS-only.

## Two version lines

The Mac and the ports are versioned separately from here. The tag carries the
Mac's; the new root `PORT_VERSION` carries the ports', starting at
`0.0.1-beta.1`. One beta tag therefore publishes `3.10.0-beta.1` on macOS and
`0.0.1-beta.1` on Windows and Linux.

This **reverses** the "Why one version line" decision in
`docs/release-channels.md`, which was taken to avoid exactly the costs this
brings: two things to bump, two histories a reader has to relate, and the
standing "how does Windows 0.0.1 relate to Mac 3.10?" question. That section is
rewritten rather than left to contradict the pipeline, and it records the answer
— the ports are their own product until one is good enough to graduate — along
with what the change costs.

The failure mode is one substitution: `${GITHUB_REF_NAME#v}` is right for the
DMG and wrong for everything else, and it is the natural thing to type. Two
tests exist purely for it — *the Mac's version never names a port artifact* and
its mirror. `PORT_VERSION` must be semver: `0.0.1_beta` is refused by name,
because Tauri rejects non-semver and WiX needs a numeric version, which
`msi-version` derives by stripping the pre-release suffix.

## One recipe, two callers

`scripts/build-desktop-app.sh` is the build. The new `desktop-artifacts` job
runs it on each runner; `build-desktop-linux.sh` runs it in a container from a
macOS host. Those were two copies of the same steps with only one of them ever
run locally — that script's header already claimed "the same recipe is what the
release workflow runs", which was not true and now is.

`scripts/package-desktop.sh` renames the bundlers' output
(`Droidective_0.0.1-beta.1_amd64.deb`, `…_x64-setup.exe`) to the canonical set,
so `release_artifacts_for_tag` stays the single description of what ships. It
refuses to guess when two bundles of one extension are present, because picking
either is how a release ships last week's binary.

## What a beta tag publishes now

```
Droidective-v3.10.0-beta.1.dmg              ← the Mac's version
Droidective.dmg
droidectived-0.0.1-beta.1-macos-universal.tar.gz   ← the ports' version
droidectived-0.0.1-beta.1-linux-x86_64.tar.gz
droidectived-0.0.1-beta.1-windows-x86_64.zip
Droidective-0.0.1-beta.1-linux-x86_64.deb
Droidective-0.0.1-beta.1-linux-x86_64.AppImage
Droidective-0.0.1-beta.1-windows-x86_64-setup.exe
Droidective-0.0.1-beta.1-windows-x86_64.msi
SHA256SUMS
```

`./scripts/release-channel.sh artifacts v3.9.2` still resolves to the DMG pair
and nothing else.

## Also here

- **`SHA256SUMS` covers every unsigned artifact**, not just the daemon archives.
  The installers and bundles ship unsigned — Windows Authenticode is a named
  deferral — so a sum is their only integrity check. Built with `find` so an
  absent stage fails the staging assertion by name rather than failing `shasum`
  with "no such file".
- **`build-daemon-sidecar.sh` uses `cp` + `chmod` instead of `install`.** This
  script has never run on Windows before; Git Bash carries a trimmed coreutils
  set, and a missing `install` would fail the release with "command not found"
  rather than anything about the sidecar.
- **The staging guard's patterns learned the bundle extensions**, so a `.deb` or
  `.msi` left behind by a job that forgot its tag gate fails a stable release
  instead of shipping on it. Four tests cover it, one per extension.
- **`tauri.conf.json`'s version is `0.0.0`**, a dev placeholder — `0.1.0` read as
  *newer* than the `0.0.1-beta.1` a release publishes. The real version arrives
  as a config overlay at build time, so the committed file never has to be
  bumped in lockstep with `PORT_VERSION`.
- **Two stale claims in `docs/release-channels.md` corrected.** The
  `latest.json` section described a file CI does not write — now marked *not
  implemented*, with the design kept for whoever builds it. And a trap still
  referenced `feat/droidectived-scaffold` "not yet merged", worrying about a
  `platforms: [.macOS(.v14)]` clause that is only an Apple deployment target and
  restricts nothing; the real gap it should have named is that the daemon's suite
  runs on macOS and Linux while Windows only *compiles* it.

## Verification

Done here:

- `make verify-self` green; the channel suite went 21 → 45 assertions.
- `actionlint` clean; `zizmor` reports no new findings (one pre-existing
  informational about `action-gh-release`).
- `shellcheck -x` and `shfmt -i 2` clean on every script touched.
- `make desktop-test` green (40 Rust tests, plus typecheck/lint/vitest).
- `package-desktop.sh` exercised against faked bundle trees: the rename, a
  missing bundler output, and two-stale-bundles.
- The Tauri config overlay validated key-by-key against the CLI's **vendored**
  schema — `bundle.windows.wix.version` exists and takes `major.minor.patch`;
  `NsisConfig` has no version field, so NSIS takes the semver as-is.

**Not done, and worth knowing before merging:** neither port build has actually
run. No container runtime is usable on this machine without an interactive kata
kernel install, and Tauri does not cross-compile, so **the first beta tag is the
first real run of both** — and the Windows app has never been built by CI even
once. Expect to iterate on that job. The known unknowns are the Swift sidecar
build on Windows, WebView2, and whether the MSI accepts the derived numeric
version.

Suggest merging this, tagging `v3.10.0-beta.1`, and treating the first run as
the debugging pass. The stable channel cannot be affected by any of it: a stable
tag skips both artifact jobs, and staging refuses a port artifact on one.
