### PR TITLE
Write the desktop bundles where the release looks for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,13 @@ jobs:
   desktop-artifacts:
     if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-')
     strategy:
-      fail-fast: true
+      # Unlike daemon-artifacts, this does NOT fail fast. Each platform is a
+      # separate build with separate failure modes, and cancelling one because
+      # the other broke hides whether it would have worked — which is what
+      # happened on the first beta tag: a path bug failed Linux, Windows was
+      # cancelled nine minutes into its Swift build, and the run proved nothing
+      # about Windows at all. The release job gates on both regardless.
+      fail-fast: false
       matrix:
         include:
           # The image test-linux and desktop-native already use: the daemon is

--- a/scripts/build-desktop-app.sh
+++ b/scripts/build-desktop-app.sh
@@ -31,6 +31,20 @@ PLATFORM="${1:?platform required: linux or windows}"
 CONFIGURATION="${2:-release}"
 OUT_DIR="${3:-$ROOT/desktop/dist-app}"
 
+# Absolute before anything changes directory. This script cds into desktop/ to
+# run npm, so a *relative* out-dir would resolve there rather than against the
+# caller's cwd — which is exactly what the first beta tag did: the bundles were
+# built correctly and written to desktop/dist while the workflow looked for
+# dist/ at the repo root, and the upload failed with "no files were found" on a
+# build that had actually succeeded.
+#
+# The second pattern is for Git Bash on the Windows runner, where an absolute
+# path is `C:/…` and would otherwise be treated as relative.
+case "$OUT_DIR" in
+/* | [A-Za-z]:[/\\]*) ;;
+*) OUT_DIR="$(pwd)/$OUT_DIR" ;;
+esac
+
 case "$PLATFORM" in
 # Deliberately not the config's "targets": "all". On Linux that adds an .rpm
 # nothing publishes and rpmbuild is not installed; on Windows it would try
@@ -62,6 +76,7 @@ done
 PORT_VERSION="$(release_port_version)"
 MSI_VERSION="$(release_msi_version)"
 echo "building the $PLATFORM desktop app, version $PORT_VERSION ($CONFIGURATION)"
+echo "bundles will be written to $OUT_DIR"
 
 # The version reaches Tauri as a config overlay rather than an edit to
 # tauri.conf.json: the committed config would otherwise have to be bumped in


### PR DESCRIPTION
Two fixes from the first `v3.10.0-beta.1` run
([32850030533](https://github.com/Droidective/Droidective/actions/runs/32850030533)).
No release was published, so nothing public came out of that tag.

## The Linux app built. The upload looked in the wrong place.

The run's red was not a build failure. The Linux leg produced both bundles and
renamed them:

```
packaged dist/Droidective-0.0.1-beta.1-linux-x86_64.deb
     from Droidective_0.0.1-beta.1_amd64.deb
packaged dist/Droidective-0.0.1-beta.1-linux-x86_64.AppImage
     from Droidective_0.0.1-beta.1_amd64.AppImage
packaged 2 linux bundle(s) as version 0.0.1-beta.1
```

…and then `upload-artifact` said *No files were found with the provided path:
dist/\**.

`build-desktop-app.sh` cds into `desktop/` to run npm, so the relative `dist`
the workflow passes resolved to `desktop/dist`, not the repo root. My bug, in
the script I added. The out-dir is now made absolute *before* anything changes
directory, and the resolved path is printed — the log gave no way to see where
the bundles had gone, which is most of why this needed a run to find.

The absolute check has a second pattern, `[A-Za-z]:[/\\]*`, for Git Bash on the
Windows runner: there an absolute path is `C:/…`, which a bare `/*` test treats
as relative.

Verified locally by stubbing the toolchain so the script runs past its checks:

```
$ ./scripts/build-desktop-app.sh linux release dist
bundles will be written to /Users/…/Droidective/dist     # was …/Droidective/desktop/dist
$ ./scripts/build-desktop-app.sh linux release /tmp/somewhere
bundles will be written to /tmp/somewhere                # absolute passes through
```

## desktop-artifacts stops failing fast

`fail-fast: true` (copied from `daemon-artifacts`) cancelled the Windows leg
because Linux failed — nine minutes into its Swift sidecar build. So that run
proved nothing at all about Windows, which is the platform with the least
evidence behind it.

Each platform is a separate build with separate failure modes, and the release
job gates on both regardless, so cancelling one buys nothing and costs the
information. Now `fail-fast: false`.

## What the run did establish

Worth recording, because it narrows what is still unproven:

- **Linux end to end**: apt prerequisites, rustup, `npm ci`, the Swift sidecar,
  `tauri build --bundles deb,appimage`, and the canonical rename. All good.
- **`daemon-artifacts` on both platforms**, so the `PORT_VERSION` rename works —
  the archives came out as `droidectived-0.0.1-beta.1-{linux-x86_64,windows-x86_64}`.
- **On Windows**: Swift setup, Node setup, `rustup default stable`, the tool
  checks, and `release-channel.sh port-version` under Git Bash all worked — it
  printed `building the windows desktop app, version 0.0.1-beta.1 (release)` and
  reached `building droidectived (release) for x86_64-pc-windows-msvc`.

Still unproven on Windows, and the next tag is what tests it: the sidecar
install (`cp` + `chmod`, the change made because Git Bash may not carry
`install`), `npm ci`, `tauri build --bundles nsis,msi`, and whether WiX accepts
the derived numeric `0.0.1`.
