### PR TITLE
Build the macOS daemon universal without the Xcode build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,8 +456,8 @@ jobs:
       # behind by an ungated job fails the stable release instead of shipping on
       # it — and the publish step can glob `dist/*` without
       # fail_on_unmatched_files breaking on the set that varies.
-      # Universal, like the app: the daemon is a sidecar next to it, and an
-      # arm64-only binary would break Intel Macs that the app itself supports.
+      # Universal, like the app — build-daemon-universal.sh says why that is two
+      # single-arch builds and a lipo rather than one multi-arch swift build.
       # Beta only — release-channel.sh lists the macOS daemon tarball and
       # SHA256SUMS alongside the Linux and Windows ones, so a stable tag
       # publishes neither and building them for one is ten minutes nothing
@@ -466,10 +466,9 @@ jobs:
         if: contains(github.ref_name, '-')
         run: |
           VERSION="$(./scripts/release-channel.sh port-version)"
-          (cd droidectived && swift build -c release --arch arm64 --arch x86_64 \
-            --product droidectived)
+          ./scripts/build-daemon-universal.sh
           ./scripts/package-daemon.sh "$VERSION" macos-universal \
-            droidectived/.build/apple/Products/Release/droidectived \
+            droidectived/.build/universal/droidectived \
             DerivedData/Build/Products/Release
       # Only a beta has them — neither artifact job runs for a stable tag.
       - if: contains(github.ref_name, '-')

--- a/scripts/build-daemon-universal.sh
+++ b/scripts/build-daemon-universal.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Build droidectived as a universal (arm64 + x86_64) macOS binary, at
+# droidectived/.build/universal/droidectived. Universal like the app: the daemon
+# is a sidecar next to it, and an arm64-only binary would break the Intel Macs
+# the app itself supports.
+#
+# Two single-arch builds and a `lipo`, deliberately not one
+# `swift build --arch arm64 --arch x86_64`. The multi-arch flag switches SwiftPM
+# onto the Xcode build system, and on the release runner's Xcode 16.4 that
+# backend cannot read this package's Swift 6 language mode — it calls every
+# target's language version unsupported ("given: [6], supported: []"), then
+# fails with an empty SWIFT_VERSION and duplicate output files. It happens to
+# work on Xcode 26, so a local build gave no warning and the first beta tag was
+# the first thing to see it. Each slice here is built by the same native build
+# system the Linux and Windows legs use, and `lipo` is already how the bundled
+# ffmpeg is made universal.
+#
+# A script rather than inline YAML so this can be run locally instead of only on
+# a tag — which is how it went unnoticed in the first place. The output path is
+# fixed rather than printed for the caller to capture: `swift build` logs to
+# stdout, so a path on stdout arrives with the whole build log wrapped around
+# it. package-daemon.sh fails loudly on a missing binary, so the workflow naming
+# the same path cannot silently ship nothing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE="$ROOT/droidectived"
+OUT="$PACKAGE/.build/universal/droidectived"
+
+slices=()
+for triple in arm64-apple-macosx x86_64-apple-macosx; do
+  echo "building droidectived for $triple"
+  (cd "$PACKAGE" && swift build -c release --product droidectived --triple "$triple")
+  slice="$PACKAGE/.build/$triple/release/droidectived"
+  [[ -f "$slice" ]] || {
+    echo "error: swift build left no $triple binary at $slice" >&2
+    exit 1
+  }
+  slices+=("$slice")
+done
+
+mkdir -p "$(dirname "$OUT")"
+lipo -create -output "$OUT" "${slices[@]}"
+
+# Assert both slices are actually in there. `lipo -create` of a single input
+# succeeds and writes a *thin* binary, which would ship named "universal" and
+# run on nothing but the runner's own architecture.
+ARCHS="$(lipo -archs "$OUT")"
+for arch in arm64 x86_64; do
+  case " $ARCHS " in
+  *" $arch "*) ;;
+  *)
+    echo "error: $OUT has architectures '$ARCHS' — no $arch slice" >&2
+    exit 1
+    ;;
+  esac
+done
+
+echo "built $OUT ($ARCHS)"


### PR DESCRIPTION
The v3.10.0-beta.1 release built, signed, and notarized the Mac app and then
failed on the step after it. `swift build --arch arm64 --arch x86_64` cannot
build droidectived on the release runner: the multi-arch flag switches SwiftPM
onto the Xcode build system, and Xcode 16.4's version of that backend does not
understand the package's Swift 6 language mode. It calls every target's language
version unsupported (`given: [6], supported: []`), then fails the build plan
with an empty `SWIFT_VERSION` and a page of duplicate output files.

It builds on Xcode 26, so a local run gave no warning. The step had also never
run before — it was added for the beta channel, and this was that channel's
first tag.

`scripts/build-daemon-universal.sh` builds each slice with the native build
system, the same one the Linux and Windows daemon legs use, and lipo's them
together the way the bundled ffmpeg already is. It asserts both slices are
present afterwards, because `lipo -create` of a single input succeeds and
writes a thin binary that would ship named "universal".

A script rather than inline YAML so it can be run locally instead of only on a
tag. The output path is fixed rather than printed for the caller to capture:
`swift build` logs to stdout, so a path returned that way arrives with the whole
build log wrapped around it.

## Verification

Ran on this branch, at the toolchain the release job will use it from:

- `scripts/build-daemon-universal.sh` → `x86_64 arm64`, both slices `minos 14.0`
- the full step as CI runs it, then `package-daemon.sh` → an archive holding
  `droidectived` + `LICENSE`, named as `release-channel.sh artifacts` expects
- the extracted binary is a Mach-O universal binary with 2 architectures, and
  it executes
- `shellcheck`, `shfmt -i 2`, `actionlint` clean

## Not covered

The macOS universal daemon build still only runs on a beta tag, so nothing
catches a regression in it before a release. No existing job builds the daemon
for macOS in release, so adding a guard means adding build time to a job that
runs on every PR — worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)