### PR TITLE
Retry the remaining Windows-exposed renames past a sharing violation

### DIFF
--- a/ADBKit/Sources/ADBKit/Persistence/JSONStore.swift
+++ b/ADBKit/Sources/ADBKit/Persistence/JSONStore.swift
@@ -50,7 +50,7 @@ public actor JSONStore<T: Codable & Sendable> {
         return loaded
     }
 
-    public func save(_ value: T) throws {
+    public func save(_ value: T) async throws {
         // Cache only after the write succeeds — a throwing write must not leave
         // the in-memory cache holding a value that never reached disk, or a
         // later load() would return unpersisted data.
@@ -60,24 +60,30 @@ public actor JSONStore<T: Codable & Sendable> {
         try FileManager.default.createDirectory(
             at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true
         )
-        #if canImport(Darwin)
-        let tempURL = fileURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(fileURL.lastPathComponent).tmp-\(UUID().uuidString)")
-        try data.write(to: tempURL)
-        _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
-        #else
-        // corelibs Foundation doesn't implement replaceItemAt; its `.atomic`
-        // write is the same temp-file-then-rename(2) dance.
-        try data.write(to: fileURL, options: .atomic)
-        #endif
+        // Both branches finish by renaming a temp file over `fileURL`, and on
+        // Windows a scanner holding either end fails that rename with a sharing
+        // violation — the same one `FileRetry` was added for. What is lost here
+        // is a user's layout or prefs, so it retries rather than surfacing.
+        try await FileRetry.run {
+            #if canImport(Darwin)
+            let tempURL = fileURL.deletingLastPathComponent()
+                .appendingPathComponent(".\(fileURL.lastPathComponent).tmp-\(UUID().uuidString)")
+            try data.write(to: tempURL)
+            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+            #else
+            // corelibs Foundation doesn't implement replaceItemAt; its `.atomic`
+            // write is the same temp-file-then-rename(2) dance.
+            try data.write(to: fileURL, options: .atomic)
+            #endif
+        }
         cached = value
     }
 
     @discardableResult
-    public func update(_ mutate: @Sendable (inout T) -> Void) throws -> T {
+    public func update(_ mutate: @Sendable (inout T) -> Void) async throws -> T {
         var value = load()
         mutate(&value)
-        try save(value)
+        try await save(value)
         return value
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/AabConvertService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AabConvertService.swift
@@ -113,7 +113,10 @@ public struct AabConvertService: Sendable {
         let name = URL(fileURLWithPath: aabPath).deletingPathExtension().lastPathComponent
         try fm.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
         let destination = Self.availableDestination(in: outputDirectory, baseName: "\(name)-universal")
-        try fm.moveItem(at: universal, to: destination)
+        // `unzip` extracted this file moments ago; on Windows a scanner reading
+        // it in fails the rename with a sharing violation, which would lose a
+        // conversion the user already waited on.
+        try await FileRetry.run { try fm.moveItem(at: universal, to: destination) }
         let size = ((try? fm.attributesOfItem(atPath: destination.path))?[.size] as? NSNumber)?.int64Value ?? 0
         return ConvertedApk(url: destination, sizeBytes: size)
     }

--- a/ADBKit/Sources/ADBKit/Services/AdbKeyboardInstaller.swift
+++ b/ADBKit/Sources/ADBKit/Services/AdbKeyboardInstaller.swift
@@ -24,7 +24,10 @@ public struct AdbKeyboardInstaller: Sendable {
             }
             apkPath = FileManager.default.temporaryDirectory.appendingPathComponent("ADBKeyboard.apk")
             try? FileManager.default.removeItem(at: apkPath)
-            try FileManager.default.moveItem(at: downloaded, to: apkPath)
+            // The same download-then-rename the managed-tool jar move retries:
+            // URLSession wrote this file a moment ago, and a Windows scanner
+            // still holding it fails the move with a sharing violation.
+            try await FileRetry.run { try FileManager.default.moveItem(at: downloaded, to: apkPath) }
         } catch {
             return FeatureResult(ok: false, message: "Couldn't download ADBKeyboard: \(error.localizedDescription)")
         }

--- a/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
+++ b/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
@@ -245,7 +245,7 @@ public actor ManagedToolStore {
         guard let runnablePath = runnable(in: versionDir, spec: spec) else {
             throw StoreError.runnableNotFound(tool)
         }
-        try markCurrent(tool, tag: release.tagName)
+        try await markCurrent(tool, tag: release.tagName)
         return runnablePath
     }
 
@@ -253,7 +253,7 @@ public actor ManagedToolStore {
     /// an equal-or-newer version is already installed. Features get the tool
     /// with no first-use download, while Settings ▸ Tools keeps version
     /// tracking and in-place upgrades over it. Idempotent.
-    public func seed(_ tool: ManagedTool, version: String, from source: URL) throws {
+    public func seed(_ tool: ManagedTool, version: String, from source: URL) async throws {
         if let installed = installedVersion(tool),
            !ManagedToolReleases.isNewer(version, than: installed) { return }
         guard let spec = ManagedToolSpec.catalog[tool] else { throw StoreError.unsupported(tool) }
@@ -261,7 +261,7 @@ public actor ManagedToolStore {
         try recreateDirectory(versionDir)
         try fileManager.copyItem(at: source, to: versionDir.appendingPathComponent(source.lastPathComponent))
         guard runnable(in: versionDir, spec: spec) != nil else { throw StoreError.runnableNotFound(tool) }
-        try markCurrent(tool, tag: version)
+        try await markCurrent(tool, tag: version)
     }
 
     // MARK: - Internals
@@ -369,8 +369,18 @@ public actor ManagedToolStore {
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
     }
 
-    private func markCurrent(_ tool: ManagedTool, tag: String) throws {
+    /// Through `FileRetry` for the same reason the jar move is: `atomically`
+    /// writes a temp file and *renames* it over the marker, and that rename is
+    /// what a Windows scanner turns into a sharing violation. This one runs on
+    /// every install, seeded or downloaded, so it races more often than the
+    /// move does — it is what failed `build-windows` on #300.
+    ///
+    /// Still atomic. A torn marker would leave the store naming a version that
+    /// isn't the one on disk, which outlasts the write it came from; a slow
+    /// write doesn't.
+    private func markCurrent(_ tool: ManagedTool, tag: String) async throws {
         try fileManager.createDirectory(at: toolRoot(tool), withIntermediateDirectories: true)
-        try tag.write(to: toolRoot(tool).appendingPathComponent("current.txt"), atomically: true, encoding: .utf8)
+        let marker = toolRoot(tool).appendingPathComponent("current.txt")
+        try await FileRetry.run { try tag.write(to: marker, atomically: true, encoding: .utf8) }
     }
 }


### PR DESCRIPTION
A Foundation "atomic" write is not in place: it writes a temp file and renames it over the destination. On Windows a scanner still holding either end fails that rename with `ERROR_SHARING_VIOLATION` (Win32 32), surfaced as `NSFileWriteNoPermissionError`. #298 added `FileRetry` for exactly this and wrapped one site — the staged jar move — noting the others "had not been seen to fail." Two since have, and two more are the same shape.

## What changed

| Site | Why it matters |
|---|---|
| `ManagedToolStore.markCurrent` | Writes the `current.txt` version marker. **This is what failed `build-windows` on #300.** It runs on every install, seeded or downloaded, so it races more often than the jar move that follows it. |
| `JSONStore.save` | Every persisted store — layout, prefs, custom commands. A lost write here costs a user's window layout rather than a retryable install. |
| `AdbKeyboardInstaller` | Moves a file `URLSession` just wrote — the download-then-rename #298 named. |
| `AabConvertService` | Moves a file `unzip` just extracted, after a conversion the user already waited on. |

Both writes stay atomic. A torn marker would leave the store naming a version that is not the one on disk, which outlasts the write it came from; a slow write does not.

`markCurrent`, `seed`, `JSONStore.save` and `update` become `async`. That is source-compatible because `ManagedToolStore` and `JSONStore` are **actors** — every caller already awaited them. No call site changed.

## What was deliberately left alone

- **`CacheTrash.setAside`** is sync, returns `nil` on failure by design, and runs on the quit path it was written to unblock (Sentry DROIDECTIVE-MAC-R). Retrying there would reintroduce the hang it fixed.
- **The two `xzBinary` renames** in `ManagedToolStore.place` are unreachable on Windows — one is inside `#if canImport(Darwin)`, the other in the non-Windows `#else`, and Windows throws before both.

## Testing

`FileRetry`'s retry loop is already covered by `FileRetryTests` (which runs on Linux too); this change is the wiring into it, visible in the diff. No new test: distinguishing "retried" from "succeeded" needs either a timing assertion or a production injection hook, and neither earns its keep here.

Green locally:

- ADBKit **1861** tests (macOS) · **1781** (Linux, via `make test-linux`)
- `droidectived` **320** · `ReactotronMCP` **99** · AppTests **105**
- `make build` — **BUILD SUCCEEDED**, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)