### PR TITLE
Fix the bugs that only show up when you open the panes

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -26,10 +26,11 @@ use crate::daemon::wire::{
     DevSettingsWriteRequest, Device, DevicePropsResponse, DnsResponse, DnsWriteRequest,
     EmulatorActionRequest, EmulatorsResponse, FeatureSummary, FileInfoRequest, FileInfoResponse,
     FileOperationRequest, FilePullRequest, FilePullResponse, FilesListRequest, FilesListResponse,
-    ForegroundResponse, InstallRequest, InstallResponse, LaunchResponse, MemInfoResponse,
-    PairResponse, PermissionWriteRequest, PermissionsResponse, ReactotronReverseRequest,
-    ReactotronReverseResponse, RestrictionWriteRequest, RestrictionsResponse, RootStatusResponse,
-    RunRequest, RunResponse, SandboxRequest, SandboxResponse, StreamParams, ToolsResponse,
+    ForegroundResponse, InstallRequest, InstallResponse, LaunchResponse, ManagedTools,
+    MemInfoResponse, PairResponse, PermissionWriteRequest, PermissionsResponse,
+    ReactotronReverseRequest, ReactotronReverseResponse, RestrictionWriteRequest,
+    RestrictionsResponse, RootStatusResponse, RunRequest, RunResponse, SandboxRequest,
+    SandboxResponse, StreamParams, ToolInstallRequest, ToolInstallResponse, ToolsResponse,
     WifiResponse, WifiWriteRequest, WirelessActionRequest,
 };
 use crate::daemon::{DaemonStatus, Supervisor};
@@ -1031,6 +1032,25 @@ pub async fn search_decompiled(
         .client()
         .await?
         .search_decompiled(&DecompileSearchRequest { root, query })
+        .await
+}
+
+/// Which of the downloadable decompilers this machine has.
+#[tauri::command]
+pub async fn managed_tools(supervisor: State<'_, Supervisor>) -> Result<ManagedTools, DaemonError> {
+    supervisor.client().await?.managed_tools().await
+}
+
+/// Downloads one. Slow — tens of megabytes — so the screen says so.
+#[tauri::command]
+pub async fn install_tool(
+    supervisor: State<'_, Supervisor>,
+    tool: DecompileMode,
+) -> Result<ToolInstallResponse, DaemonError> {
+    supervisor
+        .client()
+        .await?
+        .install_tool(&ToolInstallRequest { tool })
         .await
 }
 

--- a/desktop/src-tauri/src/daemon/client.rs
+++ b/desktop/src-tauri/src/daemon/client.rs
@@ -16,11 +16,11 @@ use crate::daemon::wire::{
     EmulatorActionRequest, EmulatorsResponse, ErrorEnvelope, FeatureSummary, FeaturesResponse,
     FileInfoRequest, FileInfoResponse, FileOperationRequest, FilePullRequest, FilePullResponse,
     FilesListRequest, FilesListResponse, ForegroundResponse, InstallFormatsResponse,
-    InstallRequest, InstallResponse, LaunchResponse, MemInfoResponse, PairResponse,
+    InstallRequest, InstallResponse, LaunchResponse, ManagedTools, MemInfoResponse, PairResponse,
     PermissionWriteRequest, PermissionsResponse, ReactotronReverseRequest,
     ReactotronReverseResponse, RestrictionWriteRequest, RestrictionsResponse, RootStatusResponse,
-    RunRequest, RunResponse, SandboxRequest, SandboxResponse, ToolsResponse, WifiResponse,
-    WifiWriteRequest, WirelessActionRequest,
+    RunRequest, RunResponse, SandboxRequest, SandboxResponse, ToolInstallRequest,
+    ToolInstallResponse, ToolsResponse, WifiResponse, WifiWriteRequest, WirelessActionRequest,
 };
 use crate::error::DaemonError;
 
@@ -284,6 +284,17 @@ impl DaemonClient {
         request: &DecompileSearchRequest,
     ) -> Result<DecompileHits, DaemonError> {
         self.post("/v1/apk/decompile/search", request).await
+    }
+
+    pub async fn managed_tools(&self) -> Result<ManagedTools, DaemonError> {
+        self.post("/v1/apk/tools", &EMPTY).await
+    }
+
+    pub async fn install_tool(
+        &self,
+        request: &ToolInstallRequest,
+    ) -> Result<ToolInstallResponse, DaemonError> {
+        self.post("/v1/apk/tools/install", request).await
     }
 
     pub async fn rebuild_decompiled(

--- a/desktop/src-tauri/src/daemon/wire.rs
+++ b/desktop/src-tauri/src/daemon/wire.rs
@@ -1192,6 +1192,23 @@ pub struct DecompileHits {
     pub capped: bool,
 }
 
+/// Which of the downloadable decompilers are installed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManagedTools {
+    pub jadx: bool,
+    pub apktool: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolInstallRequest {
+    pub tool: DecompileMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolInstallResponse {
+    pub path: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecompileRebuildRequest {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod daemon;
 mod error;
 mod menu;
+mod metro;
 
 use tauri::{Emitter, Manager, RunEvent};
 
@@ -117,6 +118,8 @@ fn handlers() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync +
         commands::pick_folder,
         commands::apk_toolchain,
         commands::decompile_apk,
+        metro::metro_targets,
+        metro::metro_running,
         commands::decompiled_file,
         commands::search_decompiled,
         commands::rebuild_decompiled,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -123,6 +123,8 @@ fn handlers() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync +
         commands::decompiled_file,
         commands::search_decompiled,
         commands::rebuild_decompiled,
+        commands::managed_tools,
+        commands::install_tool,
         commands::inspect_apk,
         commands::sign_apk,
         commands::convert_aab,

--- a/desktop/src-tauri/src/metro.rs
+++ b/desktop/src-tauri/src/metro.rs
@@ -1,0 +1,67 @@
+//! Metro's debugger endpoints, fetched from Rust rather than the webview.
+//!
+//! **Metro serves no `Access-Control-Allow-Origin`.** The webview's origin is
+//! the app's own, so a `fetch` to `http://localhost:8081/json/list` is
+//! cross-origin and the browser refuses it before Metro ever sees it — the
+//! console reported "nothing is answering on port 8081" while `curl` to the
+//! same URL worked. Rust has no same-origin policy, so the target list comes
+//! through here.
+//!
+//! The debugger **WebSocket** stays in the webview: sockets are not subject
+//! to the same-origin policy, and the alternative is a NIO client nobody needs
+//! (see `no-urlsession-websocket-offdarwin`).
+
+use crate::error::DaemonError;
+
+/// How long to wait on Metro before calling it absent.
+///
+/// Short: this is a loopback request to a process that either answers at once
+/// or is not running, and the screen polls it.
+const TIMEOUT_MS: u64 = 4_000;
+
+fn client() -> Result<reqwest::Client, DaemonError> {
+    reqwest::Client::builder()
+        // Loopback must never be handed to a proxy — the same reason the daemon
+        // client sets this. A machine with HTTP_PROXY set would otherwise send
+        // every Metro probe off the box.
+        .no_proxy()
+        .timeout(std::time::Duration::from_millis(TIMEOUT_MS))
+        .build()
+        .map_err(|error| DaemonError::Transport(error.to_string()))
+}
+
+/// Metro's debugger target list, verbatim.
+///
+/// Returned as raw JSON rather than typed here: the shape is Metro's, it
+/// changes between React Native versions, and `lib/metro.ts` already holds the
+/// rules for reading it — the same rules `MetroInspector` uses in the Mac app.
+#[tauri::command]
+pub async fn metro_targets(port: u16) -> Result<serde_json::Value, DaemonError> {
+    let url = format!("http://127.0.0.1:{port}/json/list");
+    let response = client()?
+        .get(&url)
+        .send()
+        .await
+        .map_err(|error| DaemonError::Transport(error.to_string()))?;
+    response
+        .json()
+        .await
+        .map_err(|error| DaemonError::Decode(error.to_string()))
+}
+
+/// Whether a Metro dev server is answering on the port.
+///
+/// `/status` replies `packager-status:running` when it is up. Asked separately
+/// from the target list so the screen can tell "Metro is not running" from
+/// "Metro is running and no app has connected", which need different advice.
+#[tauri::command]
+pub async fn metro_running(port: u16) -> Result<bool, DaemonError> {
+    let url = format!("http://127.0.0.1:{port}/status");
+    let Ok(response) = client()?.get(&url).send().await else {
+        return Ok(false);
+    };
+    let Ok(body) = response.text().await else {
+        return Ok(false);
+    };
+    Ok(body.contains("packager-status:running"))
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* ws://127.0.0.1:*"
     }
   },
   "bundle": {

--- a/desktop/src/components/ApkInspectorPane.tsx
+++ b/desktop/src/components/ApkInspectorPane.tsx
@@ -71,7 +71,7 @@ export function ApkInspectorPane({ apkPath = null }: { apkPath?: string | null }
           </button>
         </HubSection>
       ) : (
-        <ApkDetail report={report} busy={busy} onChoose={choose} />
+        <ApkDetail report={report} busy={busy} onChoose={apkPath === null ? choose : null} />
       )}
     </HubColumn>
   )
@@ -84,7 +84,8 @@ function ApkDetail({
 }: {
   report: ApkReport
   busy: boolean
-  onChoose: () => void
+  /** Null inside APK Studio, which owns the choice itself. */
+  onChoose: (() => void) | null
 }) {
   return (
     <>
@@ -92,14 +93,19 @@ function ApkDetail({
         title={report.label ?? report.fileName}
         subtitle={report.packageName ?? report.fileName}
         accessory={
-          <button
-            type="button"
-            disabled={busy}
-            onClick={onChoose}
-            className="rounded border border-border-subtle px-2 py-1 text-[12px] text-text-primary hover:bg-bg-hover disabled:opacity-40"
-          >
-            Inspect another…
-          </button>
+          // Null inside APK Studio: the studio owns which APK is loaded, and a
+          // second chooser here would change this tab's APK while the others
+          // kept the old one.
+          onChoose === null ? null : (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onChoose}
+              className="rounded border border-border-subtle px-2 py-1 text-[12px] text-text-primary hover:bg-bg-hover disabled:opacity-40"
+            >
+              Inspect another…
+            </button>
+          )
         }
       >
         <HubRowList

--- a/desktop/src/components/ApkSignPane.tsx
+++ b/desktop/src/components/ApkSignPane.tsx
@@ -77,6 +77,7 @@ export function ApkSignPane({ apkPath = null }: { apkPath?: string | null }) {
       <HubSection title="Sign APK" subtitle="Zipalign and sign an APK with your keystore.">
         <SignForm
           apk={apk}
+          embedded={apkPath !== null}
           keystore={keystore}
           busy={busy}
           onPick={(set, label, extensions) =>
@@ -102,6 +103,7 @@ export function ApkSignPane({ apkPath = null }: { apkPath?: string | null }) {
 
 function SignForm({
   apk,
+  embedded,
   keystore,
   busy,
   onPick,
@@ -110,6 +112,8 @@ function SignForm({
   onSign,
 }: {
   apk: string | null
+  /** True when APK Studio handed the APK over and owns the choice. */
+  embedded: boolean
   keystore: Keystore
   busy: boolean
   onPick: (set: (path: string) => void, label: string, extensions: string[]) => void
@@ -123,13 +127,18 @@ function SignForm({
 
   return (
     <>
-      <ApkFileRow
-        label="APK"
-        path={apk}
-        chooseLabel="Choose APK…"
-        changeLabel="Choose a different APK…"
-        onChoose={() => onPick(setApk, "APK", ["apk"])}
-      />
+      {/* Inside APK Studio the studio owns the APK, so this row would be a
+          second way to change it and leave the other tabs behind. The file is
+          still named — just in the studio's own header. */}
+      {embedded ? null : (
+        <ApkFileRow
+          label="APK"
+          path={apk}
+          chooseLabel="Choose APK…"
+          changeLabel="Choose a different APK…"
+          onChoose={() => onPick(setApk, "APK", ["apk"])}
+        />
+      )}
       <ApkFileRow
         label="Keystore"
         path={keystore.path}

--- a/desktop/src/components/ConsoleFeed.tsx
+++ b/desktop/src/components/ConsoleFeed.tsx
@@ -1,7 +1,7 @@
 import { ChevronRight, CircleAlert, TriangleAlert } from "lucide-react"
 import { useEffect, useRef } from "react"
 
-import type { ConsoleRow } from "@/lib/console-feed"
+import { emptyFeedText, type ConsoleRow } from "@/lib/console-feed"
 import { tokensFor, type Token } from "@/lib/console-format"
 
 /**
@@ -16,10 +16,14 @@ export function ConsoleFeed({
   rows,
   empty,
   problem,
+  connection,
+  targetCount,
 }: {
   rows: ConsoleRow[]
   empty: boolean
   problem: string | null
+  connection: string
+  targetCount: number
 }) {
   const scroller = useRef<HTMLDivElement | null>(null)
   const pinned = useRef(true)
@@ -38,11 +42,14 @@ export function ConsoleFeed({
         pinned.current =
           element.scrollHeight - element.scrollTop - element.clientHeight < 24
       }}
-      className="min-h-0 flex-1 overflow-auto font-mono text-[11.5px]"
+      // Never sideways. A feed that can scroll horizontally lets its content
+      // size to max-content, and a long Metro bundle URL then runs off the
+      // pane instead of wrapping. Logcat's feed is y-only for the same reason.
+      className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden font-mono text-[11.5px]"
     >
       {empty ? (
         <p className="p-3 font-sans text-text-tertiary">
-          {problem ?? "Connected. Anything the app logs shows up here."}
+          {emptyFeedText(connection, targetCount, problem)}
         </p>
       ) : (
         rows.map((row) => <Row key={row.id} row={row} />)
@@ -58,29 +65,44 @@ function Row({ row }: { row: ConsoleRow }) {
       : row.level === "warning"
         ? "bg-amber-500/10 text-amber-200"
         : "text-text-primary"
+  // A plain block with inline parts, the way the logcat feed does it — **not** a
+  // flex line. As a flex row inside a scrollable feed the message item was
+  // sized against max-content and collapsed to one character wide: every log
+  // rendered as a vertical column of letters. Found by opening the pane
+  // against a real app, not by reading this.
+  //
+  // `overflow-wrap: anywhere` rather than `break-words`, because the long
+  // token here is a Metro bundle URL with no spaces to break at.
   return (
-    <div className={`flex gap-2 border-b border-border-subtle/40 px-3 py-[3px] ${tone}`}>
-      <span className="shrink-0 select-none text-text-tertiary">
-        {row.level === "error" ? (
-          <CircleAlert size={11} className="mt-[3px]" />
-        ) : row.level === "warning" ? (
-          <TriangleAlert size={11} className="mt-[3px]" />
-        ) : row.local ? (
-          <ChevronRight size={11} className="mt-[3px]" />
-        ) : (
-          <span className="inline-block w-[11px]" />
-        )}
-      </span>
-      <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
-        {row.args.length === 0 ? row.text : <Args row={row} />}
-      </span>
+    <div
+      className={`whitespace-pre-wrap [overflow-wrap:anywhere] border-b border-border-subtle/40 px-3 py-[3px] ${tone}`}
+    >
       {row.source === null ? null : (
-        <span className="shrink-0 select-none text-text-tertiary" title={row.source}>
+        <span
+          className="float-right ml-2 select-none text-text-tertiary"
+          title={row.source}
+        >
           {row.source}
         </span>
       )}
+      <Glyph row={row} />
+      {row.args.length === 0 ? row.text : <Args row={row} />}
     </div>
   )
+}
+
+/** The level's mark, or the width of one so the messages still line up. */
+function Glyph({ row }: { row: ConsoleRow }) {
+  if (row.level === "error") {
+    return <CircleAlert size={11} className="mr-1.5 inline-block align-[-1px] text-red-400" />
+  }
+  if (row.level === "warning") {
+    return <TriangleAlert size={11} className="mr-1.5 inline-block align-[-1px] text-amber-400" />
+  }
+  if (row.local) {
+    return <ChevronRight size={11} className="mr-1.5 inline-block align-[-1px] text-text-tertiary" />
+  }
+  return <span className="mr-1.5 inline-block w-[11px]" />
 }
 
 /**

--- a/desktop/src/components/DecompileBrowser.tsx
+++ b/desktop/src/components/DecompileBrowser.tsx
@@ -113,13 +113,18 @@ function Toolbar({ state }: { state: Decompile }) {
           Rebuild
         </button>
       ) : null}
-      <button
-        type="button"
-        onClick={state.choose}
-        className="rounded border border-border-subtle px-2 py-1 text-text-secondary hover:bg-bg-surface"
-      >
-        Choose APK…
-      </button>
+      {/* Hidden inside APK Studio, which owns which APK is loaded — a second
+          chooser here would change this tab's APK and leave the others on the
+          old one. */}
+      {state.embedded ? null : (
+        <button
+          type="button"
+          onClick={state.choose}
+          className="rounded border border-border-subtle px-2 py-1 text-text-secondary hover:bg-bg-surface"
+        >
+          Choose APK…
+        </button>
+      )}
     </div>
   )
 }

--- a/desktop/src/components/DecompilePane.tsx
+++ b/desktop/src/components/DecompilePane.tsx
@@ -63,14 +63,18 @@ function Chooser({ state }: { state: Decompile }) {
             </span>
           </label>
         ))}
-        <button
-          type="button"
-          disabled={state.busy}
-          onClick={path === null ? state.choose : () => state.run(false)}
-          className="mt-1 self-start rounded bg-accent px-3 py-1 text-white disabled:opacity-40"
-        >
-          {buttonLabel(state.busy, path)}
-        </button>
+        {state.toolReady === false ? (
+          <ToolGate mode={state.mode} installing={state.installing} onInstall={state.install} />
+        ) : (
+          <button
+            type="button"
+            disabled={state.busy}
+            onClick={path === null ? state.choose : () => state.run(false)}
+            className="mt-1 self-start rounded bg-accent px-3 py-1 text-white disabled:opacity-40"
+          >
+            {buttonLabel(state.busy, path)}
+          </button>
+        )}
         {path === null ? null : (
           <p className="truncate text-[11.5px] text-text-tertiary" title={path}>
             {path}
@@ -78,6 +82,41 @@ function Chooser({ state }: { state: Decompile }) {
         )}
       </div>
     </HubSection>
+  )
+}
+
+/**
+ * The decompiler is a download, and this is where that is said.
+ *
+ * Before this the run simply failed with "a tool this needs is not installed"
+ * and nothing to click — a dead end on any machine that had not already fetched
+ * it, which is every fresh one. The size is named because it is tens of
+ * megabytes and the wait is otherwise unexplained.
+ */
+function ToolGate({
+  mode,
+  installing,
+  onInstall,
+}: {
+  mode: string
+  installing: boolean
+  onInstall: () => void
+}) {
+  return (
+    <div className="mt-1 flex flex-col items-start gap-1.5 rounded border border-border-subtle p-2.5">
+      <p className="text-text-primary">{mode} is not downloaded yet.</p>
+      <p className="text-[11.5px] text-text-tertiary">
+        It is fetched once from its GitHub release — tens of megabytes — and kept for next time.
+      </p>
+      <button
+        type="button"
+        disabled={installing}
+        onClick={onInstall}
+        className="mt-0.5 rounded bg-accent px-3 py-1 text-white disabled:opacity-40"
+      >
+        {installing ? `Downloading ${mode}…` : `Download ${mode}`}
+      </button>
+    </div>
   )
 }
 

--- a/desktop/src/components/JsConsolePane.tsx
+++ b/desktop/src/components/JsConsolePane.tsx
@@ -70,7 +70,13 @@ export function JsConsolePane({ device }: { device: Device | null }) {
         onToggle={(level) => setLevels((current) => toggleLevel(current, level))}
         onClear={console.clear}
       />
-      <ConsoleFeed rows={shown} empty={console.rows.length === 0} problem={console.problem} />
+      <ConsoleFeed
+        rows={shown}
+        empty={console.rows.length === 0}
+        problem={console.problem}
+        connection={console.connection}
+        targetCount={console.targets.length}
+      />
       <Prompt
         value={draft}
         enabled={console.connection === "connected"}

--- a/desktop/src/hooks/useDecompile.ts
+++ b/desktop/src/hooks/useDecompile.ts
@@ -1,23 +1,29 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { useNotifications } from "@/hooks/useNotifications"
+import { managedTools } from "@/lib/daemon"
+import { isBinary, toggleExpanded } from "@/lib/decompile"
 import {
-  asDaemonError,
-  decompileApk,
-  decompiledFile,
-  pickFile,
-  pickFolder,
-  rebuildDecompiled,
-  searchDecompiled,
-} from "@/lib/daemon"
-import { ancestors, defaultExpanded, isBinary, toggleExpanded } from "@/lib/decompile"
-import type { ToastInput } from "@/lib/notifications"
+  chooseApk,
+  fetchTool,
+  readFile,
+  runDecompile,
+  runRebuild,
+  runSearch,
+  withAncestors,
+  type Show,
+} from "@/lib/decompile-actions"
 import type { DecompileFileText, DecompileHits, DecompileMode, DecompileTree } from "@/lib/wire"
-
-type Show = (input: ToastInput) => void
 
 export interface Decompile {
   path: string | null
+  /** True when APK Studio handed the APK over and owns the choice. */
+  embedded: boolean
+  /** Whether the chosen decompiler is downloaded. Null until asked. */
+  toolReady: boolean | null
+  /** True while fetching it. */
+  installing: boolean
+  install: () => void
   mode: DecompileMode
   tree: DecompileTree | null
   busy: boolean
@@ -41,25 +47,63 @@ export interface Decompile {
 }
 
 /**
- * A failure as one line.
+ * Whether the chosen decompiler is downloaded.
  *
- * Toasts carry no separate detail field, and the daemon's detail is the half
- * that says *why* — apktool's own words rather than "the tool could not
- * finish", which on its own sends nobody anywhere.
+ * Asked up front rather than discovered by a failed run. jadx is a download,
+ * and the old behaviour was a decompile that failed with "a tool this needs is
+ * not installed" and nothing to click — a dead end on any machine that had not
+ * already fetched it, which is every fresh one.
+ *
+ * Null means *unknown*, not missing: the daemon being unreachable is a
+ * different problem, and one the rest of the screen already reports.
  */
-function withDetail(error: { message: string; detail?: string | null }): string {
-  const detail = error.detail
-  if (detail === null || detail === undefined || detail === "") return error.message
-  return `${error.message} ${detail}`
+function useToolReady(mode: DecompileMode, installing: boolean): boolean | null {
+  const [ready, setReady] = useState<boolean | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void managedTools()
+      .then((tools) => {
+        if (!cancelled) setReady(mode === "jadx" ? tools.jadx : tools.apktool)
+      })
+      .catch(() => {
+        if (!cancelled) setReady(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [mode, installing])
+  return ready
 }
 
 /**
- * Everything APK Decompile does, away from the markup.
+ * Opening one decompiled file.
  *
- * Its own hook because the pane is two screens over one piece of state — a
- * chooser and a browser — and threading eleven values plus their setters
- * between them is what makes a component too big to read.
+ * A binary needs no read at all — the viewer says what it is instead, rather
+ * than showing a screen of replacement characters.
  */
+function useOpenFile(
+  tree: DecompileTree | null,
+  setSelected: (path: string) => void,
+  setSource: (source: DecompileFileText | null) => void,
+  setLoadingFile: (loading: boolean) => void,
+  show: Show,
+): (path: string) => void {
+  return useCallback(
+    (which: string) => {
+      const root = tree?.root
+      if (root === undefined) return
+      setSelected(which)
+      if (isBinary(which)) {
+        setSource(null)
+        return
+      }
+      setLoadingFile(true)
+      void readFile(root, which, setSource, show).finally(() => setLoadingFile(false))
+    },
+    [tree, show, setSelected, setSource, setLoadingFile],
+  )
+}
+
 export function useDecompile(apkPath: string | null): Decompile {
   const { show } = useNotifications()
 
@@ -74,6 +118,8 @@ export function useDecompile(apkPath: string | null): Decompile {
   const [query, setQuery] = useState("")
   const [hits, setHits] = useState<DecompileHits | null>(null)
   const [searching, setSearching] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  const toolReady = useToolReady(mode, installing)
 
   // An APK handed in (APK Studio) should not need choosing a second time.
   useEffect(() => {
@@ -93,26 +139,19 @@ export function useDecompile(apkPath: string | null): Decompile {
     [show],
   )
 
-  const open = useCallback(
-    (which: string) => {
-      const root = tree?.root
-      if (root === undefined) return
-      setSelected(which)
-      // A binary needs no read at all: the viewer says what it is instead.
-      if (isBinary(which)) {
-        setSource(null)
-        return
-      }
-      setLoadingFile(true)
-      void readFile(root, which, setSource, show).finally(() => setLoadingFile(false))
-    },
-    [tree, show],
-  )
+  const open = useOpenFile(tree, setSelected, setSource, setLoadingFile, show)
 
   return {
     path,
+    embedded: apkPath !== null,
     mode,
     tree,
+    toolReady,
+    installing,
+    install: () => {
+      setInstalling(true)
+      void fetchTool(mode, show).finally(() => setInstalling(false))
+    },
     busy,
     expanded,
     selected,
@@ -164,92 +203,3 @@ export function useDecompile(apkPath: string | null): Decompile {
  * Clearing on failure matters: leaving the previous APK's output on screen
  * under a failure toast reads as though the new one decompiled.
  */
-async function runDecompile(
-  path: string,
-  mode: DecompileMode,
-  refresh: boolean,
-  sink: {
-    setTree: (tree: DecompileTree | null) => void
-    setExpanded: (expanded: ReadonlySet<string>) => void
-    show: Show
-  },
-): Promise<void> {
-  try {
-    const answer = await decompileApk(path, mode, refresh)
-    sink.setTree(answer)
-    sink.setExpanded(defaultExpanded(answer.tree))
-  } catch (thrown) {
-    sink.setTree(null)
-    sink.show({ message: withDetail(asDaemonError(thrown)), ok: false })
-  }
-}
-
-/** Pick an APK, then decompile it. A dismissed dialog is a choice, not a failure. */
-async function chooseApk(
-  mode: DecompileMode,
-  setPath: (path: string) => void,
-  start: (path: string, mode: DecompileMode, refresh: boolean) => void,
-  show: Show,
-): Promise<void> {
-  try {
-    const picked = await pickFile("APK", ["apk"])
-    if (picked === null) return
-    setPath(picked)
-    start(picked, mode, false)
-  } catch (thrown) {
-    show({ message: withDetail(asDaemonError(thrown)), ok: false })
-  }
-}
-
-async function readFile(
-  root: string,
-  path: string,
-  setSource: (source: DecompileFileText | null) => void,
-  show: Show,
-): Promise<void> {
-  try {
-    setSource(await decompiledFile(root, path))
-  } catch (thrown) {
-    setSource(null)
-    show({ message: withDetail(asDaemonError(thrown)), ok: false })
-  }
-}
-
-async function runSearch(
-  root: string,
-  query: string,
-  setHits: (hits: DecompileHits) => void,
-  show: Show,
-): Promise<void> {
-  try {
-    setHits(await searchDecompiled(root, query))
-  } catch (thrown) {
-    show({ message: withDetail(asDaemonError(thrown)), ok: false })
-  }
-}
-
-async function runRebuild(root: string, path: string | null, show: Show): Promise<void> {
-  try {
-    const folder = await pickFolder()
-    if (folder === null) return
-    const base = (path ?? "app").split("/").pop() ?? "app"
-    const name = base.replace(/\.apk$/iu, "")
-    const answer = await rebuildDecompiled(root, root, `${folder}/${name}-rebuilt.apk`)
-    // Unsigned by design: apktool's output will not install until it is signed,
-    // and APK Sign is the screen that does that.
-    show({ message: "Rebuilt. Sign it before installing.", revealPath: answer.output, ok: true })
-  } catch (thrown) {
-    show({ message: withDetail(asDaemonError(thrown)), ok: false })
-  }
-}
-
-/** Opening the tree down to a file, so revealing a hit does not leave it hidden. */
-function withAncestors(
-  expanded: ReadonlySet<string>,
-  root: string,
-  path: string,
-): Set<string> {
-  const next = new Set(expanded)
-  for (const directory of ancestors(root, path)) next.add(directory)
-  return next
-}

--- a/desktop/src/hooks/useJsConsole.ts
+++ b/desktop/src/hooks/useJsConsole.ts
@@ -109,22 +109,9 @@ export function useJsConsole(port: number): JsConsole {
     [addRows, send],
   )
 
-  // Keepalive, only while there is something to keep alive.
-  useEffect(() => {
-    if (connection !== "connected") return
-    const timer = setInterval(() => send("Runtime.evaluate", keepaliveParams()), KEEPALIVE_MS)
-    return () => clearInterval(timer)
-  }, [connection, send])
-
-  // Close on unmount, not whenever React feels like it.
-  useEffect(
-    () => () => {
-      detach.current?.abort()
-      socket.current?.close()
-      socket.current = null
-    },
-    [],
-  )
+  useAutoConnect(connection, targets, target, setTarget, wiring)
+  useKeepalive(connection, send)
+  useCloseOnUnmount(socket, detach)
 
   return {
     rows,
@@ -162,3 +149,61 @@ function echoAndRun(
 }
 
 export type { Connection, NamedValue }
+
+/**
+ * Attach on our own when there is exactly one target.
+ *
+ * The Mac's console does this rather than making someone pick out of a list of
+ * one. Only with exactly one: where there are several, which app to attach to
+ * is a real choice, and guessing would attach to the wrong one in silence.
+ */
+function useAutoConnect(
+  connection: Connection,
+  targets: CdpTarget[],
+  target: CdpTarget | null,
+  setTarget: (target: CdpTarget) => void,
+  wiring: Wiring,
+): void {
+  useEffect(() => {
+    if (connection !== "idle" || targets.length !== 1) return
+    const only = targets[0]
+    if (only === undefined || only.id === target?.id) return
+    setTarget(only)
+    openSocket(only, wiring)
+    // `wiring` is refs and stable callbacks; its identity churn means nothing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection, targets, target])
+}
+
+/**
+ * Poke the connection while there is one.
+ *
+ * The React Native debugger proxy drops a socket it decides is idle, and a
+ * console watching a quiet app is exactly that. `void 0` is the cheapest
+ * expression that proves the runtime is still answering.
+ */
+function useKeepalive(
+  connection: Connection,
+  send: (method: string, params: Record<string, unknown>) => number | null,
+): void {
+  useEffect(() => {
+    if (connection !== "connected") return
+    const timer = setInterval(() => send("Runtime.evaluate", keepaliveParams()), KEEPALIVE_MS)
+    return () => clearInterval(timer)
+  }, [connection, send])
+}
+
+/** Close the socket when the pane goes, not whenever React feels like it. */
+function useCloseOnUnmount(
+  socket: React.RefObject<WebSocket | null>,
+  detach: React.RefObject<AbortController | null>,
+): void {
+  useEffect(
+    () => () => {
+      detach.current?.abort()
+      socket.current?.close()
+      socket.current = null
+    },
+    [socket, detach],
+  )
+}

--- a/desktop/src/lib/cdp-session.ts
+++ b/desktop/src/lib/cdp-session.ts
@@ -18,7 +18,8 @@ import {
   type RemoteObject,
 } from "@/lib/cdp"
 import { rowFromCall, rowFromException, type ConsoleRow } from "@/lib/console-feed"
-import { isLocalDebuggerUrl, parseTargets, targetsUrl, type CdpTarget } from "@/lib/metro"
+import { metroRunning, metroTargets } from "@/lib/daemon"
+import { isLocalDebuggerUrl, parseTargets, type CdpTarget } from "@/lib/metro"
 
 export type Connection = "idle" | "searching" | "connecting" | "connected" | "failed"
 
@@ -80,19 +81,28 @@ export async function findTargets(
   const settle = (connection: Connection) => {
     setConnection((current) => (current === "connected" ? current : connection))
   }
+  let found: CdpTarget[]
   try {
-    const response = await fetch(targetsUrl(port))
-    const found = parseTargets(await response.json())
-    setTargets(found)
-    if (found.length === 0) {
-      settle("idle")
-      setProblem("Metro is running, but no app has connected to it yet.")
-    }
+    found = parseTargets(await metroTargets(port))
   } catch {
     setTargets([])
     settle("idle")
     setProblem(`Nothing is answering on port ${String(port)}. Is Metro running?`)
+    return
   }
+  setTargets(found)
+  // Settle either way. Leaving it on "searching" after the answer arrived is a
+  // status that never stops spinning, which reads as a hang.
+  settle("idle")
+  if (found.length > 0) return
+  // Metro answering with an empty list and Metro not being there at all need
+  // different things done about them, so they get different sentences.
+  const running = await metroRunning(port).catch(() => false)
+  setProblem(
+    running
+      ? "Metro is running, but no app has connected to it yet."
+      : `Nothing is answering on port ${String(port)}. Is Metro running?`,
+  )
 }
 
 /** Open a CDP socket to one target and wire its events. */

--- a/desktop/src/lib/console-ansi.test.ts
+++ b/desktop/src/lib/console-ansi.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Escape-sequence stripping, against what React Native's dev server really
+ * sends.
+ *
+ * The console rendered `ESC[48;2;253;247;231m…NOTE: …` verbatim before this
+ * existed — found by opening the pane against a real app. The rules are
+ * ADBKit's `ConsoleANSI`, including the one that matters most: an unterminated
+ * escape is data, not a sequence, and must not swallow the rest of the line.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { stripAnsi } from "@/lib/console-ansi"
+
+const ESC = "\u001B"
+
+describe("stripAnsi", () => {
+  it("leaves text with no escapes exactly alone", () => {
+    expect(stripAnsi("plain text")).toBe("plain text")
+    expect(stripAnsi("")).toBe("")
+  })
+
+  it("removes the SGR colours Metro wraps its notices in", () => {
+    // The real line, shortened: this is what rendered as visible gibberish.
+    const raw =
+      `${ESC}[48;2;253;247;231m${ESC}[30m${ESC}[1mNOTE: ` +
+      `${ESC}[22mYou are using an unsupported debugging client.`
+    expect(stripAnsi(raw)).toBe("NOTE: You are using an unsupported debugging client.")
+  })
+
+  it("removes a reset and a cursor move", () => {
+    expect(stripAnsi(`${ESC}[0mhi${ESC}[2K`)).toBe("hi")
+  })
+
+  it("removes an OSC ending in BEL", () => {
+    expect(stripAnsi(`${ESC}]0;a title\u0007after`)).toBe("after")
+  })
+
+  it("removes an OSC ending in the ST pair", () => {
+    expect(stripAnsi(`${ESC}]8;;http://x${ESC}\\after`)).toBe("after")
+  })
+
+  it("removes the two-byte C1 forms", () => {
+    expect(stripAnsi(`a${ESC}Db`)).toBe("ab")
+  })
+
+  it("keeps an unterminated CSI rather than swallowing the tail", () => {
+    // A lone ESC in real data is data. Eating the rest of the line would hide
+    // the message someone is looking for.
+    expect(stripAnsi(`${ESC}[38;5`)).toBe(`${ESC}[38;5`)
+  })
+
+  it("keeps an unterminated OSC rather than swallowing the tail", () => {
+    expect(stripAnsi(`${ESC}]0;no terminator`)).toBe(`${ESC}]0;no terminator`)
+  })
+
+  it("keeps a trailing lone escape", () => {
+    expect(stripAnsi(`text${ESC}`)).toBe(`text${ESC}`)
+  })
+
+  it("keeps an escape followed by something that is no sequence at all", () => {
+    expect(stripAnsi(`${ESC}~x`)).toBe(`${ESC}~x`)
+  })
+
+  it("survives multi-byte text either side of a sequence", () => {
+    // Byte-wise stripping must not cut a UTF-8 character in half.
+    expect(stripAnsi(`é${ESC}[31mü→`)).toBe("éü→")
+  })
+})

--- a/desktop/src/lib/console-ansi.ts
+++ b/desktop/src/lib/console-ansi.ts
@@ -1,0 +1,88 @@
+/**
+ * Terminal escape sequences, removed — a port of ADBKit's `ConsoleANSI`.
+ *
+ * React Native's dev server writes its notices coloured for a terminal, so they
+ * arrive over CDP with real escape bytes in them. Rendered as-is they read as
+ * `ESC[48;2;…m ESC[1mNOTE: ESC[22mYou are using…`, which is exactly what
+ * the console showed before this existed.
+ *
+ * Byte-wise rather than by regular expression, and matching the Swift exactly:
+ * an *unterminated* escape is left alone rather than swallowing the rest of the
+ * line, because a lone ESC in real data is data.
+ */
+
+const ESCAPE = 0x1b
+const BELL = 0x07
+const OPEN_BRACKET = 0x5b
+const CLOSE_BRACKET = 0x5d
+const BACKSLASH = 0x5c
+
+/** Cheap pre-check: most console lines carry no escapes at all. */
+function containsEscapes(text: string): boolean {
+  return text.includes("\u001B")
+}
+
+/**
+ * The text without its escape sequences: CSI (`ESC [ … final`), OSC
+ * (`ESC ] … BEL` or `ESC ] … ESC \`), and the two-byte C1 forms.
+ */
+export function stripAnsi(text: string): string {
+  if (!containsEscapes(text)) return text
+  const bytes = new TextEncoder().encode(text)
+  const out: number[] = []
+  let index = 0
+  while (index < bytes.length) {
+    const byte = bytes[index] ?? 0
+    if (byte !== ESCAPE || index + 1 >= bytes.length) {
+      out.push(byte)
+      index += 1
+      continue
+    }
+    const next = bytes[index + 1] ?? 0
+    if (next === OPEN_BRACKET) {
+      index = afterCsi(bytes, index, out)
+      continue
+    }
+    if (next === CLOSE_BRACKET) {
+      index = afterOsc(bytes, index, out)
+      continue
+    }
+    if (next >= 0x40 && next <= 0x5f) {
+      // The two-byte C1 forms.
+      index += 2
+      continue
+    }
+    out.push(byte)
+    index += 1
+  }
+  return new TextDecoder().decode(new Uint8Array(out))
+}
+
+/** CSI: parameter bytes, then intermediate bytes, then one final byte. */
+function afterCsi(bytes: Uint8Array, start: number, out: number[]): number {
+  let cursor = start + 2
+  while (cursor < bytes.length && inRange(bytes[cursor], 0x30, 0x3f)) cursor += 1
+  while (cursor < bytes.length && inRange(bytes[cursor], 0x20, 0x2f)) cursor += 1
+  if (cursor < bytes.length && inRange(bytes[cursor], 0x40, 0x7e)) return cursor + 1
+  // Unterminated — keep it rather than swallowing the tail.
+  out.push(bytes[start] ?? 0)
+  return start + 1
+}
+
+/** OSC: runs to BEL, or to the ST pair. */
+function afterOsc(bytes: Uint8Array, start: number, out: number[]): number {
+  let cursor = start + 2
+  while (cursor < bytes.length) {
+    if (bytes[cursor] === BELL) return cursor + 1
+    if (bytes[cursor] === ESCAPE && cursor + 1 < bytes.length && bytes[cursor + 1] === BACKSLASH) {
+      return cursor + 2
+    }
+    cursor += 1
+  }
+  out.push(bytes[start] ?? 0)
+  return start + 1
+}
+
+function inRange(value: number | undefined, low: number, high: number): boolean {
+  return value !== undefined && value >= low && value <= high
+}

--- a/desktop/src/lib/console-feed.test.ts
+++ b/desktop/src/lib/console-feed.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   appended,
+  emptyFeedText,
   filtered,
   levelCounts,
   levelOf,
@@ -223,5 +224,34 @@ describe("rowText", () => {
 
   it("omits the source when there is none", () => {
     expect(rowText(row(1, "info", "hi"))).toBe("00:00:00.000 [info] hi")
+  })
+})
+
+/**
+ * What an empty feed says.
+ *
+ * It used to claim "Connected" whenever there was nothing to report, which was
+ * wrong at the one moment someone reads it for guidance — before a target is
+ * picked. Found by opening the pane, not by reading it.
+ */
+describe("emptyFeedText", () => {
+  it("reports a problem ahead of anything else", () => {
+    expect(emptyFeedText("idle", 0, "Metro is not running.")).toBe("Metro is not running.")
+    expect(emptyFeedText("connected", 1, "Metro is not running.")).toBe("Metro is not running.")
+  })
+
+  it("only claims a connection when there is one", () => {
+    expect(emptyFeedText("connected", 1, null)).toContain("Connected")
+    expect(emptyFeedText("idle", 1, null)).not.toContain("Connected")
+    expect(emptyFeedText("searching", 0, null)).not.toContain("Connected")
+    expect(emptyFeedText("connecting", 1, null)).not.toContain("Connected")
+  })
+
+  it("asks for a pick when targets are waiting", () => {
+    expect(emptyFeedText("idle", 2, null)).toContain("Pick a target")
+  })
+
+  it("says how to get a target when there is none", () => {
+    expect(emptyFeedText("idle", 0, null)).toContain("Metro")
   })
 })

--- a/desktop/src/lib/console-feed.ts
+++ b/desktop/src/lib/console-feed.ts
@@ -171,3 +171,30 @@ export function rowText(row: ConsoleRow): string {
   const where = row.source === null ? "" : ` (${row.source})`
   return `${stamp} [${row.level}] ${row.text}${where}`
 }
+
+/**
+ * What an empty feed should say.
+ *
+ * It used to claim "Connected" whenever there was no problem to report, which
+ * was wrong every time before a target was picked — the one moment someone is
+ * looking at it for guidance.
+ */
+export function emptyFeedText(
+  connection: string,
+  targetCount: number,
+  problem: string | null,
+): string {
+  if (problem !== null) return problem
+  switch (connection) {
+    case "connected":
+      return "Connected. Anything the app logs shows up here."
+    case "connecting":
+      return "Connecting…"
+    case "searching":
+      return "Looking for a debug target…"
+    default:
+      return targetCount > 0
+        ? "Pick a target above to start reading its console."
+        : "No debug target yet. Start Metro and open the app."
+  }
+}

--- a/desktop/src/lib/console-format.ts
+++ b/desktop/src/lib/console-format.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ObjectPreview, PropertyPreview, RemoteObject } from "@/lib/cdp"
+import { stripAnsi } from "@/lib/console-ansi"
 
 /** A colourable span. Semantic, so the markup decides the colour. */
 export type TokenKind =
@@ -99,7 +100,7 @@ function arrayLength(preview: ObjectPreview): number | null {
 function elementToken(property: PropertyPreview): Token {
   switch (property.type) {
     case "string":
-      return token(quoted(property.value ?? ""), "string")
+      return token(quoted(stripAnsi(property.value ?? "")), "string")
     case "number":
     case "bigint":
       return token(property.value ?? "", "number")
@@ -180,7 +181,11 @@ function objectTokens(object: RemoteObject): Token[] {
 export function tokensFor(object: RemoteObject, style: RenderStyle = "value"): Token[] {
   switch (object.type) {
     case "string": {
-      const text = typeof object.value === "string" ? object.value : (object.description ?? "")
+      // Stripped here, as the Swift does. React Native's dev-server notices
+      // arrive coloured for a terminal, and the codes are not text anyone
+      // wants to read.
+      const raw = typeof object.value === "string" ? object.value : (object.description ?? "")
+      const text = stripAnsi(raw)
       return style === "consoleArgument"
         ? [token(text, "plain")]
         : [token(quoted(text), "string")]

--- a/desktop/src/lib/daemon-apk.ts
+++ b/desktop/src/lib/daemon-apk.ts
@@ -18,6 +18,8 @@ import type {
   DecompileRebuildResponse,
   DecompileTree,
   InstallResponse,
+  ManagedTools,
+  ToolInstallResponse,
 } from "@/lib/wire"
 
 /** Which of the APK tools are on this machine. */
@@ -134,4 +136,19 @@ export function metroTargets(port: number): Promise<unknown> {
 /** Whether a Metro dev server is answering, which is a different question. */
 export function metroRunning(port: number): Promise<boolean> {
   return invoke("metro_running", { port })
+}
+
+/**
+ * Which downloadable decompilers this machine has.
+ *
+ * Asked before a run, not after one fails: jadx is a download, and finding that
+ * out from a failed decompile is finding it out at the worst moment.
+ */
+export function managedTools(): Promise<ManagedTools> {
+  return invoke("managed_tools")
+}
+
+/** Downloads jadx or apktool. Tens of megabytes, so the screen says so. */
+export function installTool(tool: DecompileMode): Promise<ToolInstallResponse> {
+  return invoke("install_tool", { tool })
 }

--- a/desktop/src/lib/daemon-apk.ts
+++ b/desktop/src/lib/daemon-apk.ts
@@ -117,3 +117,21 @@ export function rebuildDecompiled(
 ): Promise<DecompileRebuildResponse> {
   return invoke("rebuild_decompiled", { root, sourceDir, output })
 }
+
+/**
+ * Metro's debugger target list, fetched in Rust.
+ *
+ * Not `fetch` from here: Metro serves no `Access-Control-Allow-Origin`, so a
+ * cross-origin request from the webview is refused by the browser before Metro
+ * sees it — the console reported "nothing is answering" while curl to the same
+ * URL worked. Rust has no same-origin policy. The debugger *socket* stays in
+ * the webview, which needs no such help.
+ */
+export function metroTargets(port: number): Promise<unknown> {
+  return invoke("metro_targets", { port })
+}
+
+/** Whether a Metro dev server is answering, which is a different question. */
+export function metroRunning(port: number): Promise<boolean> {
+  return invoke("metro_running", { port })
+}

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -239,6 +239,8 @@ export {
   decompiledFile,
   inspectApk,
   installPath,
+  installTool,
+  managedTools,
   metroRunning,
   metroTargets,
   pickFile,

--- a/desktop/src/lib/daemon.ts
+++ b/desktop/src/lib/daemon.ts
@@ -239,6 +239,8 @@ export {
   decompiledFile,
   inspectApk,
   installPath,
+  metroRunning,
+  metroTargets,
   pickFile,
   pickFolder,
   rebuildDecompiled,

--- a/desktop/src/lib/decompile-actions.ts
+++ b/desktop/src/lib/decompile-actions.ts
@@ -1,0 +1,143 @@
+/**
+ * What APK Decompile *does*, away from React.
+ *
+ * Split out of `useDecompile` because none of it is a hook — it is the daemon
+ * calls and the small decisions around them, and keeping it here lets the hook
+ * stay about state.
+ */
+
+import {
+  asDaemonError,
+  decompileApk,
+  decompiledFile,
+  installTool,
+  pickFile,
+  pickFolder,
+  rebuildDecompiled,
+  searchDecompiled,
+} from "@/lib/daemon"
+import { ancestors, defaultExpanded } from "@/lib/decompile"
+import type { ToastInput } from "@/lib/notifications"
+import type { DecompileFileText, DecompileHits, DecompileMode, DecompileTree } from "@/lib/wire"
+
+export type Show = (input: ToastInput) => void
+
+/**
+ * A failure as one line.
+ *
+ * Toasts carry no separate detail field, and the daemon's detail is the half
+ * that says *why* — apktool's own words rather than "the tool could not
+ * finish", which on its own sends nobody anywhere.
+ */
+export function withDetail(error: { message: string; detail?: string | null }): string {
+  const detail = error.detail
+  if (detail === null || detail === undefined || detail === "") return error.message
+  return `${error.message} ${detail}`
+}
+
+/**
+ * Everything APK Decompile does, away from the markup.
+ *
+ * Its own hook because the pane is two screens over one piece of state — a
+ * chooser and a browser — and threading eleven values plus their setters
+ * between them is what makes a component too big to read.
+ */
+export async function runDecompile(
+  path: string,
+  mode: DecompileMode,
+  refresh: boolean,
+  sink: {
+    setTree: (tree: DecompileTree | null) => void
+    setExpanded: (expanded: ReadonlySet<string>) => void
+    show: Show
+  },
+): Promise<void> {
+  try {
+    const answer = await decompileApk(path, mode, refresh)
+    sink.setTree(answer)
+    sink.setExpanded(defaultExpanded(answer.tree))
+  } catch (thrown) {
+    sink.setTree(null)
+    sink.show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+/** Download one decompiler, saying which when it lands or when it does not. */
+export async function fetchTool(mode: DecompileMode, show: Show): Promise<void> {
+  try {
+    await installTool(mode)
+    show({ message: `${mode} is ready.`, ok: true })
+  } catch (thrown) {
+    show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+/** Pick an APK, then decompile it. A dismissed dialog is a choice, not a failure. */
+export async function chooseApk(
+  mode: DecompileMode,
+  setPath: (path: string) => void,
+  start: (path: string, mode: DecompileMode, refresh: boolean) => void,
+  show: Show,
+): Promise<void> {
+  try {
+    const picked = await pickFile("APK", ["apk"])
+    if (picked === null) return
+    setPath(picked)
+    start(picked, mode, false)
+  } catch (thrown) {
+    show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+export async function readFile(
+  root: string,
+  path: string,
+  setSource: (source: DecompileFileText | null) => void,
+  show: Show,
+): Promise<void> {
+  try {
+    setSource(await decompiledFile(root, path))
+  } catch (thrown) {
+    setSource(null)
+    show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+export async function runSearch(
+  root: string,
+  query: string,
+  setHits: (hits: DecompileHits) => void,
+  show: Show,
+): Promise<void> {
+  try {
+    setHits(await searchDecompiled(root, query))
+  } catch (thrown) {
+    show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+export async function runRebuild(root: string, path: string | null, show: Show): Promise<void> {
+  try {
+    const folder = await pickFolder()
+    if (folder === null) return
+    const base = (path ?? "app").split("/").pop() ?? "app"
+    const name = base.replace(/\.apk$/iu, "")
+    const answer = await rebuildDecompiled(root, root, `${folder}/${name}-rebuilt.apk`)
+    // Unsigned by design: apktool's output will not install until it is signed,
+    // and APK Sign is the screen that does that.
+    show({ message: "Rebuilt. Sign it before installing.", revealPath: answer.output, ok: true })
+  } catch (thrown) {
+    show({ message: withDetail(asDaemonError(thrown)), ok: false })
+  }
+}
+
+/** Opening the tree down to a file, so revealing a hit does not leave it hidden. */
+export function withAncestors(
+  expanded: ReadonlySet<string>,
+  root: string,
+  path: string,
+): Set<string> {
+  const next = new Set(expanded)
+  for (const directory of ancestors(root, path)) next.add(directory)
+  return next
+}

--- a/desktop/src/lib/metro.test.ts
+++ b/desktop/src/lib/metro.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it } from "vitest"
 
-import { isHermes, isLocalDebuggerUrl, parseTargets, statusUrl, targetLabel, targetsUrl, isMetroStatus } from "@/lib/metro"
+import { isHermes, isLocalDebuggerUrl, parseTargets, targetLabel } from "@/lib/metro"
 
 const HERMES = {
   id: "1",
@@ -112,18 +112,6 @@ describe("isLocalDebuggerUrl", () => {
 
   it("is not fooled by a host that merely contains localhost", () => {
     expect(isLocalDebuggerUrl("ws://localhost.evil.com/x")).toBe(false)
-  })
-})
-
-describe("endpoints", () => {
-  it("names Metro's own routes", () => {
-    expect(targetsUrl(8081)).toBe("http://localhost:8081/json/list")
-    expect(statusUrl(8081)).toBe("http://localhost:8081/status")
-  })
-
-  it("reads Metro's status reply", () => {
-    expect(isMetroStatus("packager-status:running")).toBe(true)
-    expect(isMetroStatus("something else")).toBe(false)
   })
 })
 

--- a/desktop/src/lib/metro.ts
+++ b/desktop/src/lib/metro.ts
@@ -5,11 +5,17 @@
  * to pick the same target out of the same list — a console that attached to
  * Metro's placeholder entry would connect and then never receive anything.
  *
- * **The socket lives in the webview, not the daemon.** `URLSessionWebSocketTask`
- * compiles off-Darwin and then fails at runtime ("WebSockets not supported by
- * libcurl"), so the daemon cannot hold a CDP connection without a NIO client
- * written from scratch. Metro runs on this machine, so the webview can reach it
- * directly and both WebKitGTK and WebView2 ship a real WebSocket.
+ * **The socket lives in the webview; the target list does not.**
+ * `URLSessionWebSocketTask` compiles off-Darwin and then fails at runtime
+ * ("WebSockets not supported by libcurl"), so the daemon cannot hold a CDP
+ * connection without a NIO client written from scratch — and it needs none,
+ * because WebKitGTK and WebView2 both ship a real WebSocket and sockets are
+ * not subject to the same-origin policy.
+ *
+ * The *list* is fetched in Rust (`metro_targets`), because Metro serves no
+ * `Access-Control-Allow-Origin` and a cross-origin `fetch` from the page is
+ * refused before Metro ever sees it. So there are no URLs here: Rust builds
+ * them, and this file only reads what comes back.
  */
 
 export interface CdpTarget {
@@ -94,20 +100,6 @@ export function isLocalDebuggerUrl(raw: string): boolean {
   const host = url.hostname.toLowerCase()
   // `new URL` keeps IPv6 hosts in brackets.
   return host === "127.0.0.1" || host === "localhost" || host === "::1" || host === "[::1]"
-}
-
-/** Metro's target-list endpoint for a port. */
-export function targetsUrl(port: number): string {
-  return `http://localhost:${String(port)}/json/list`
-}
-
-/** Metro's status endpoint, which answers `packager-status:running` when up. */
-export function statusUrl(port: number): string {
-  return `http://localhost:${String(port)}/status`
-}
-
-export function isMetroStatus(body: string): boolean {
-  return body.includes("packager-status:running")
 }
 
 /** A one-line label for a target, as the picker shows it. */

--- a/desktop/src/lib/wire-apk.ts
+++ b/desktop/src/lib/wire-apk.ts
@@ -121,3 +121,13 @@ export interface DecompileHits {
 export interface DecompileRebuildResponse {
   output: string
 }
+
+/** Which of the downloadable decompilers are installed. */
+export interface ManagedTools {
+  jadx: boolean
+  apktool: boolean
+}
+
+export interface ToolInstallResponse {
+  path: string
+}

--- a/droidectived/Sources/DaemonCore/DaemonProtocol.swift
+++ b/droidectived/Sources/DaemonCore/DaemonProtocol.swift
@@ -82,6 +82,10 @@ public enum DaemonProtocol {
         case apkDecompileFile = "/v1/apk/decompile/file"
         case apkDecompileSearch = "/v1/apk/decompile/search"
         case apkRebuild = "/v1/apk/rebuild"
+        /// The downloadable half of the APK toolchain. Asked before a run so a
+        /// screen can offer the download rather than failing into it.
+        case apkTools = "/v1/apk/tools"
+        case apkToolInstall = "/v1/apk/tools/install"
         case customCommandsRead = "/v1/customcommands/read"
         case customCommandsWrite = "/v1/customcommands/write"
         case customCommandsRun = "/v1/customcommands/run"

--- a/droidectived/Sources/DaemonCore/DaemonServer.swift
+++ b/droidectived/Sources/DaemonCore/DaemonServer.swift
@@ -163,6 +163,11 @@ public protocol DaemonBackend: Sendable {
     /// throws when apktool or Java is absent, or the build fails.
     func rebuildDecompiled(_ request: DecompileProtocol.RebuildRequest) async throws
         -> DecompileProtocol.RebuildResponse?
+    /// Which of the downloadable decompilers are installed.
+    func managedTools() async -> DecompileProtocol.ManagedTools
+    /// Downloads one. Idempotent — an install that is already current is reused.
+    func installTool(_ tool: DecompileProtocol.Installable) async throws
+        -> DecompileProtocol.InstallResponse
     /// The saved custom commands. Best-effort: a store that will not load
     /// reads as no commands rather than failing the screen.
     func customCommands() async -> [CustomCommand]
@@ -202,6 +207,9 @@ public struct LiveBackend: DaemonBackend {
     /// routes may touch. Its own directory rather than the tools one: this is
     /// throwaway output, regenerable from the APK.
     private let decompileCache: URL
+    /// Where the managed tools live — the same directory `ApkToolchain` reads,
+    /// so a jadx downloaded here is the jadx a decompile then finds.
+    private let managedToolsDirectory: URL
 
     public init(
         monitor: DeviceMonitor, engine: FeatureEngine, client: AdbClient,
@@ -220,6 +228,7 @@ public struct LiveBackend: DaemonBackend {
         apkToolchainValue = ApkToolchain(
             locator: locator, store: ManagedToolStore(rootDirectory: toolsDirectory))
         decompileCache = AppPaths.decompiledCacheDir
+        managedToolsDirectory = toolsDirectory
     }
 
     public func listDevices() async -> [Device] { await monitor.list(force: true) }
@@ -631,6 +640,20 @@ public struct LiveBackend: DaemonBackend {
         try await DecompileService(toolchain: apkToolchainValue).rebuild(
             sourceDir: request.sourceDir, to: request.output)
         return DecompileProtocol.RebuildResponse(output: request.output)
+    }
+
+    public func managedTools() async -> DecompileProtocol.ManagedTools {
+        let store = ManagedToolStore(rootDirectory: managedToolsDirectory)
+        return await DecompileProtocol.ManagedTools(
+            jadx: store.installedVersion(.jadx) != nil,
+            apktool: store.installedVersion(.apktool) != nil)
+    }
+
+    public func installTool(
+        _ tool: DecompileProtocol.Installable
+    ) async throws -> DecompileProtocol.InstallResponse {
+        let store = ManagedToolStore(rootDirectory: managedToolsDirectory)
+        return DecompileProtocol.InstallResponse(path: try await store.install(tool.tool))
     }
 
     /// Both halves of the confinement: the root really is one of ours, and the
@@ -1056,6 +1079,11 @@ private final class RequestHandler: ChannelInboundHandler, RemovableChannelHandl
                 body: Data(body.readableBytesView), backend: backend))
         case .apkDecompileSearch:
             return Self.answer(await DecompileRoutes.search(
+                body: Data(body.readableBytesView), backend: backend))
+        case .apkTools:
+            return Self.answer(await DecompileRoutes.tools(backend: backend))
+        case .apkToolInstall:
+            return Self.answer(await DecompileRoutes.install(
                 body: Data(body.readableBytesView), backend: backend))
         case .apkRebuild:
             return Self.answer(await DecompileRoutes.rebuild(

--- a/droidectived/Sources/DaemonCore/DecompileRoutes.swift
+++ b/droidectived/Sources/DaemonCore/DecompileRoutes.swift
@@ -155,6 +155,47 @@ public enum DecompileProtocol {
     static let maxFileBytes = 4 << 20
     static let maxHits = 500
 
+    /// Which downloadable tools this machine has, so a screen can offer the
+    /// download *before* someone waits on a run that cannot start.
+    ///
+    /// Only the ones the decompiler needs. The store knows about several more,
+    /// and a screen that listed them all would be a tool manager — which is a
+    /// different feature.
+    public struct ManagedTools: Codable, Equatable, Sendable {
+        public let jadx: Bool
+        public let apktool: Bool
+
+        public init(jadx: Bool, apktool: Bool) {
+            self.jadx = jadx
+            self.apktool = apktool
+        }
+    }
+
+    /// Which tool to fetch. A closed set rather than the store's whole
+    /// catalogue: this route exists for the decompiler's two, and a request
+    /// naming anything else is a client bug, not a download.
+    public enum Installable: String, Codable, Sendable, CaseIterable {
+        case jadx
+        case apktool
+
+        var tool: ManagedTool {
+            switch self {
+            case .jadx: .jadx
+            case .apktool: .apktool
+            }
+        }
+    }
+
+    public struct InstallRequest: Codable, Equatable, Sendable {
+        public let tool: Installable
+        public init(tool: Installable) { self.tool = tool }
+    }
+
+    public struct InstallResponse: Codable, Equatable, Sendable {
+        public let path: String
+        public init(path: String) { self.path = path }
+    }
+
     static let badRequest = DaemonProtocol.ErrorBody(
         code: "bad_request", message: "That is not a decompile request.", detail: nil)
 
@@ -235,6 +276,26 @@ enum DecompileRoutes {
             return (403, DaemonProtocol.encoded(DecompileProtocol.outsideRoot))
         }
         return (200, DaemonProtocol.encoded(hits))
+    }
+
+    static func tools(backend: any DaemonBackend) async -> DaemonProtocol.Answer {
+        (200, DaemonProtocol.encoded(await backend.managedTools()))
+    }
+
+    static func install(body: Data, backend: any DaemonBackend) async -> DaemonProtocol.Answer {
+        guard let request = try? JSONDecoder().decode(
+            DecompileProtocol.InstallRequest.self, from: body)
+        else { return (400, DaemonProtocol.encoded(DecompileProtocol.badRequest)) }
+        do {
+            return (200, DaemonProtocol.encoded(try await backend.installTool(request.tool)))
+        } catch {
+            // A download that fails is not a missing tool — it is a network or
+            // a release problem, and saying "not installed" would send someone
+            // to install what they just tried to install.
+            return (422, DaemonProtocol.encoded(DaemonProtocol.ErrorBody(
+                code: "download_failed",
+                message: "That tool could not be downloaded.", detail: "\(error)")))
+        }
     }
 
     static func rebuild(body: Data, backend: any DaemonBackend) async -> DaemonProtocol.Answer {

--- a/droidectived/Tests/DaemonCoreTests/BackendDefaults.swift
+++ b/droidectived/Tests/DaemonCoreTests/BackendDefaults.swift
@@ -97,6 +97,16 @@ extension DaemonBackend {
         DecompileProtocol.RebuildResponse(output: request.output)
     }
 
+    func managedTools() async -> DecompileProtocol.ManagedTools {
+        DecompileProtocol.ManagedTools(jadx: true, apktool: true)
+    }
+
+    func installTool(
+        _ tool: DecompileProtocol.Installable
+    ) async throws -> DecompileProtocol.InstallResponse {
+        DecompileProtocol.InstallResponse(path: "/stub/\(tool.rawValue)")
+    }
+
     func customCommands() async -> [CustomCommand] { [] }
 
     func writeCustomCommands(_ commands: [CustomCommand]) async throws {}


### PR DESCRIPTION
The three screens from #302 had not been opened by hand — the machine locked partway through that session. Opening them found seven bugs. None of them fails a unit test; all of them needed a real Metro, a real app, or a real APK.

## JS Console — the target list never loaded

Metro serves no `Access-Control-Allow-Origin`, so a cross-origin `fetch` from the webview is refused **before Metro sees it**. The pane said "nothing is answering on port 8081" while `curl` to that same URL worked, which is exactly how it hid.

The list now comes through Rust (`metro_targets`), which has no same-origin policy. The debugger *socket* stays in the webview — sockets are not subject to it, and that was the design decision measured in #302. CSP loses the HTTP half again, and `metro.ts` loses its URL builders since Rust owns those now.

## JS Console — every log rendered as a vertical column of letters

One character per line, down the pane. The row was a flex line inside a scrollable feed, so the message item was sized against the content's max-content width and collapsed to a single character. It is now a plain block with inline parts, which is what the logcat feed has always been — and the feed can no longer scroll sideways, so a long Metro bundle URL wraps instead of running off the edge.

## JS Console — escape codes printed literally

`ESC[48;2;253;247;231m ESC[1mNOTE: ESC[22mYou are using…`. React Native's dev server colours its notices for a terminal. `ConsoleANSI` is ported and applied in both places a string reaches the screen, as the Swift does. The rule worth keeping: an *unterminated* escape is data and must not swallow the rest of the line.

## JS Console — the status lied

It never left "searching" once targets were found, and the feed claimed "Connected" before anything was — at the one moment someone reads it for guidance. Both derive from the real state now. Auto-connect is added too, which is what the Mac's console does: with exactly one target there is no choice to make; with several there is, so it does not guess.

## APK Decompile — no way to install the decompiler

Pressing Decompile failed with "a tool this needs is not installed" and nothing to click. jadx and apktool are downloads; the Mac sends people to Settings ▸ Tools, a screen this app does not have. **The feature dead-ended on every fresh machine.**

Two daemon routes over the `ManagedToolStore` the Mac already uses, so a jadx fetched here is the jadx the decompile then finds. Asked *before* a run, not after one fails — finding out that jadx is a 50 MB download from a decompile that just failed is finding out at the worst moment. A failed download gets its own code, because reporting it as `tool_missing` would send someone to install what they just tried to install.

## APK Studio — the tabs could disagree about which APK was loaded

Inspect's "Inspect another…", Decompile's "Choose APK…" and Sign's APK row were each a second way to change the APK, which would have moved one tab and left the other two on the old one with nothing saying so. The studio owns the choice; the embedded panes no longer offer their own.

## The relay port test

`stoppingReleasesThePort` failed twice running on CI, on 49407 and 49412 — both inside the ephemeral range that `port: 0` draws from, which the parallel suites bind throughout. It now uses a port below that range.

**An open bug this uncovered, deliberately not fixed here.** Picking the port with a probe relay — one extra start/stop cycle — made it fail on *every* run, with `Cannot schedule tasks on an EventLoop that has already shut down` just before. That says `ReactotronRelay.stop()` can return before the listener is really gone, and a fresh bind moments later is refused even with `SO_REUSEADDR` set. It does not reproduce on this Mac: 30 direct restarts and 12 full-suite runs are clean. Guessing at a fix for a shipping Mac feature without a reproduction is not something worth shipping, so it is recorded in the flake notes instead.

## Testing

| | |
|---|---|
| ADBKit | **1861** (macOS) · **1781** (Linux) |
| daemon | **340** · ReactotronMCP **99** · AppTests **105** |
| desktop web | **938** (+13) · Rust **42** |
| typecheck · oxlint · clippy · cargo fmt | clean |

Verified live against StreamLab on an emulator: targets found, auto-connected, notices readable, and `1 + 41` evaluated to `42` in the app. APK Studio inspected a real APK — Min SDK 35 populates, confirming #300's parser fix.

**Not verified live:** the decompiler download gate. The machine locked again before I could click it; the routes and the rules are tested, the button is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)