### PR TITLE
Add the per-release list of what a human has to check

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,6 +19,13 @@ setup, secrets, and the mechanics.
 `scripts/update-bundled-tools.sh`, and `scripts/package-dmg.sh` refuses to
 package an app whose main executable or ffmpeg is missing a slice.
 
+**Before tagging, walk
+[`docs/manual-verification.md`](docs/manual-verification.md).** It is the short
+list of things no agent can check — real hardware, sound, drag and drop,
+notarisation, and whether the app runs on Windows and Linux at all. Everything
+that *can* be automated already is, so what is left there genuinely needs a
+person.
+
 ## One-time setup
 
 Do these once. Steps 1–3 are required before the first auto-updating release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,14 @@ or reviewing a non-trivial change.
 | [review/IMPACT_ANALYSIS.md](review/IMPACT_ANALYSIS.md) | Reasoning about blast radius: persistence, registry, shared services, releases |
 | [review/SECURITY.md](review/SECURITY.md) | Secrets, on-device shell input, file operations, the public-repo rule |
 
+## Shipping a change
+
+- **[manual-verification.md](manual-verification.md)** — the per-release list of
+  what a human has to check, because no agent can: real hardware, sound, drag
+  and drop, notarisation, and whether the app runs on Windows and Linux at all.
+  Anything an agent *can* verify is automated or driven instead, so this list
+  stays short on purpose. Walk it before tagging.
+
 ## A note on these docs
 
 They describe the project as it is, not an aspirational process. If a standard

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -1,0 +1,171 @@
+# Manual verification — what a human has to check
+
+A per-release checklist of the things **an agent cannot verify**, so they get
+checked deliberately rather than assumed. Walk it before tagging a release.
+
+## The bar for being on this list
+
+Only things that are *impossible* for an agent on this machine — not things
+that are slow, awkward, or merely untried. If an agent can drive it against the
+emulator, read the result, and tell whether it worked, it does not belong here
+and should be automated or driven instead.
+
+That bar matters: a list that collects "would be nice to double-check" stops
+being read, and then the genuinely impossible items get missed with it.
+
+**What an agent already does, so you do not have to:** all six test suites; the
+Linux suite in a container; launching the desktop app and driving it against a
+booted emulator through the command palette; screenshotting and reading the
+result; calling daemon routes directly with a token; installing managed tools;
+decompiling a real APK; connecting the JS console to a real Metro and
+evaluating expressions in a running React Native app.
+
+Add an item here only with a one-line reason it cannot be automated. Delete one
+the moment it can be.
+
+---
+
+## 1. Windows and Linux, actually running
+
+**Why not automatable here:** there is no Windows or Linux machine. CI compiles
+both and runs the unit suites; it has never *launched the app*.
+
+This is the largest gap in the project. Everything else on this list is a
+detail by comparison.
+
+- [ ] **Windows: the app launches** and shows a window with the device bar,
+      sidebar and tab strip.
+- [ ] **Linux: the same** (the deb, on a stock GNOME or KDE).
+- [ ] **The mirror decodes.** Open Mirror Screen with a device attached. A
+      WebKitGTK container measured H.264 support in `scripts/probe-webkit-webcodecs.sh`,
+      but no one has watched a real window paint frames. On Linux this needs
+      `gstreamer1.0-libav`; without it the pane should *say so* rather than
+      showing a black rectangle.
+- [ ] **Native file dialogs open** — Install App, APK Studio's Choose APK,
+      and the save-location pickers. These are Rust-side and per-platform.
+- [ ] **Fonts and DPI look right** at 100% and at a scaled display.
+- [ ] **The menu bar** appears where that OS puts it, and its accelerators fire
+      (Ctrl, not ⌘).
+
+## 2. A physical Android device
+
+**Why not automatable here:** only an emulator is attached, and the emulator
+cannot be unplugged, cannot pair over Wi-Fi, and does not behave like an OEM
+build.
+
+- [ ] **USB connect and disconnect** while the app is open — the device bar
+      picks it up and lets it go without a stale selection.
+- [ ] **Wireless pairing** (Android 11+): the pairing-code flow in the device
+      dropdown, then that the paired device is auto-connected.
+- [ ] **USB → Wi-Fi bootstrap** (`adb tcpip`), then unplug and keep working.
+- [ ] **An OEM device**, not a Pixel image — Samsung/Xiaomi skins report
+      `getprop`, permissions and app lists differently, and that is where
+      parsers break.
+- [ ] **A rooted device** for Root Status and the Wi-Fi password read.
+
+## 3. More than one device at once
+
+**Why not automatable here:** one emulator. A second one is possible but does
+not exercise real per-device timing, and six is not.
+
+- [ ] **Mirror Wall with 2+ devices** — tiles stay independent, quality steps
+      down as tiles are added, and dragging a tile's caption strip reorders.
+- [ ] **Run on all devices** for a fan-out action, from the device bar.
+- [ ] **Take Over / Focus banner** when two windows want the same device.
+
+## 4. Drag and drop
+
+**Why not automatable here:** synthetic drags never fire `dragstart` in a
+WKWebView. This is a platform limit, not a missing tool — see the
+`webview-drag-not-scriptable` note.
+
+- [ ] **Sidebar reorder** — drag a feature within its group; drag a category
+      header to move the whole group. The insertion guideline shows.
+- [ ] **Tab drag to split**, and dragging a tab out.
+- [ ] **Drop a file** on File Explorer to push it, and an APK on the window to
+      install it (once backlog 17 lands — until then, confirm it is refused
+      cleanly rather than silently doing nothing).
+
+## 5. Sound
+
+**Why not automatable here:** an agent cannot hear. Whether a file *contains*
+audio can be probed; whether it is the right audio, in sync, at a sane level,
+cannot.
+
+- [ ] **Record with device audio** — play something on the device, record, then
+      listen back.
+- [ ] **Record with the Mac microphone** — speak while recording; narration is
+      audible and roughly in sync with the picture over a long take.
+- [ ] **Both at once** land in *one* track (open the file in QuickTime — a
+      second track would be silently dropped by most players).
+- [ ] **The level meter** moves when you speak.
+- [ ] **Mute mid-take** leaves the timeline continuous, and unmuting is instant.
+
+## 6. macOS permission prompts
+
+**Why not automatable here:** the prompts are system-modal and an agent must
+not click through a security dialog on your behalf.
+
+- [ ] **Screen recording**, **microphone**, and **accessibility** prompts appear
+      with sensible wording the first time each is needed.
+- [ ] Denying one is reported in the app rather than failing silently.
+
+## 7. How it feels
+
+**Why not automatable here:** these are perceptual judgements. A screenshot
+cannot tell you a mirror is stuttering or that input lags.
+
+- [ ] **Mirror smoothness and input latency** — tap, swipe and type into a
+      mirrored device; it should feel direct.
+- [ ] **Light and dark** both read well, including the custom accent and the
+      window translucency sliders.
+- [ ] **Reduced motion** — with the system setting on, the marketing site's
+      scroll reveals and hero demo still work.
+
+## 8. Release mechanics
+
+**Why not automatable here:** signing identities, notarisation, and updating
+*from* a previously installed build.
+
+- [ ] **Developer ID signing and notarisation** succeed, and the DMG opens on a
+      machine that has never seen the app (Gatekeeper).
+- [ ] **The universal binary** really has both slices (`lipo -info`).
+- [ ] **Sparkle updates** from the previous release: the pill appears, the
+      update stages, and relaunching installs it.
+- [ ] **The appcast** points at the artifact that was actually uploaded.
+- [ ] A **stable** tag attaches no Windows or Linux artifact
+      (`scripts/test-release-channel.sh` asserts this, but confirm the actual
+      release page).
+
+## 9. Things needing a real account or endpoint
+
+**Why not automatable here:** no credentials, and an agent should not be
+signing in to your services.
+
+- [ ] **API Testing** against a real endpoint that needs auth, and a Postman
+      collection exported from a real workspace.
+- [ ] **Frida** against a real target — needs a rooted device or a debuggable
+      build on hardware.
+
+---
+
+## Known open issues that need an environment I do not have
+
+Not checklist items — findings recorded so they are not rediscovered.
+
+- **`ReactotronRelay.stop()` can return before the listener is released.**
+  Surfaced by giving the port test an extra start/stop cycle: it then failed on
+  *every* CI run with `Cannot schedule tasks on an EventLoop that has already
+  shut down`, and a fresh bind was refused even with `SO_REUSEADDR` set. It does
+  not reproduce on this Mac — 30 direct restarts and 12 full-suite runs are
+  clean — so it appears to need CI's slower, loaded runner. The port test itself
+  was fixed by moving off the ephemeral range; the underlying timing question is
+  open. Do not "fix" it without a reproduction: it is a shipping Mac feature.
+
+## A constraint worth knowing
+
+An agent can only drive the GUI while **you are logged in and the display is
+awake**. Behind the lock screen Tauri creates no window at all and
+`screencapture` fails, so GUI verification stops dead — twice during the work
+that produced this file. If you want a session to include hands-on checks,
+leave the machine unlocked.


### PR DESCRIPTION
You asked for a list of what you need to test because I cannot — kept in the repo, walked each release.

`docs/manual-verification.md`, linked from `RELEASING.md` (before the tagging steps) and the docs index.

## The bar, written into the doc

Only things that are **impossible** for an agent here — not slow, awkward, or merely untried. The doc says so, and lists what an agent already does instead, so it does not drift into a dumping ground of "would be nice to double-check". A list nobody reads is worse than no list, because the genuinely impossible items go missing along with it.

To hold that bar honestly, I closed everything I could before writing it. In this session that meant verifying the decompiler end to end against a live daemon rather than listing it for you:

- jadx **downloaded and installed** through the new route (v1.5.6, 58s)
- a real APK **decompiled** with it (3.4s, real tree)
- a decompiled Java file **read back**
- **search** returns 500 hits and reports itself capped
- and the security boundary refused all three attacks: `../` traversal, an absolute path outside the root, and a bogus root claiming its own path — the circularity guard

Only the download *button* is unverified, because webview clicks are intermittent; the route beneath it is proven. That did not earn a place on your list.

## What is on it

Nine groups, each with a one-line reason it cannot be automated:

1. **Windows and Linux actually running** — no such machine here. CI compiles both and runs the unit suites; nobody has launched the app. This is the largest gap in the project; everything else is a detail beside it.
2. **A physical Android device** — USB connect/disconnect, Android 11+ wireless pairing, an OEM skin, a rooted device.
3. **More than one device** — Mirror Wall with several, run-on-all, the Take Over banner.
4. **Drag and drop** — synthetic drags never fire `dragstart` in a WKWebView. A platform limit, not a missing tool.
5. **Sound** — an agent cannot hear. Whether a file contains audio is checkable; whether it is the right audio, in sync, at a sane level, is not.
6. **macOS permission prompts** — system-modal, and I should not click through a security dialog for you.
7. **How it feels** — mirror smoothness and input latency, light/dark, reduced motion.
8. **Release mechanics** — signing, notarisation, Gatekeeper, and updating *from* an installed build.
9. **Real accounts or endpoints** — API Testing against something authenticated, Frida against real hardware.

Plus two things recorded that are not checklist items: the open `ReactotronRelay.stop()` timing bug (reproduces only on CI's slower runner — do not "fix" it without a reproduction, it is a shipping Mac feature), and the constraint that GUI verification only works while the machine is unlocked, which stopped the work twice.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)