### PR TITLE
Fix the relay port bug, and make the fixture that hid one speak up

### DIFF
--- a/ADBKit/Tests/ADBKitTests/AabConvertServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AabConvertServiceTests.swift
@@ -239,13 +239,33 @@ private final class FileProducingRunner: ProcessRunning, @unchecked Sendable {
         recorded.append(Invocation(executable: executable, arguments: arguments))
         lock.unlock()
         if let output = arguments.first(where: { $0.hasPrefix("--output=") }) {
-            _ = FileManager.default.createFile(atPath: String(output.dropFirst("--output=".count)), contents: Data("apks".utf8))
+            write(Data("apks".utf8), to: String(output.dropFirst("--output=".count)))
         }
         if producesUniversalApk, executable == HostArchive.unzipExecutable,
            let flag = arguments.firstIndex(where: { $0 == "-d" || $0 == "-C" }),
            arguments.count > flag + 1 {
             let dest = URL(fileURLWithPath: arguments[flag + 1]).appendingPathComponent("universal.apk")
-            _ = FileManager.default.createFile(atPath: dest.path, contents: Data("universal".utf8))
+            write(Data("universal".utf8), to: dest.path)
         }
+    }
+
+    /// Write one of the files a real tool would have produced, and **say so if
+    /// that fails**.
+    ///
+    /// It failed once on Windows CI, and because the result was discarded the
+    /// only symptom was `extractFailed("")` from the service two lines later —
+    /// an empty message about the wrong step, which says nothing about a
+    /// fixture that could not write its own file. `createFile` also returns a
+    /// must-use `Bool` off Darwin, so discarding it is the trap `SecretFile`
+    /// and the mirror log both had to be fixed for.
+    ///
+    /// Retried because the failure is transient: Windows CI briefly refuses a
+    /// just-created path, which is the same behaviour `FileRetry` exists for.
+    private func write(_ contents: Data, to path: String) {
+        for attempt in 1...5 {
+            if FileManager.default.createFile(atPath: path, contents: contents) { return }
+            Thread.sleep(forTimeInterval: 0.05 * Double(attempt))
+        }
+        Issue.record("the fixture could not write \(path)")
     }
 }

--- a/ADBKit/Tests/ADBKitTests/DecompileServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DecompileServiceTests.swift
@@ -2,12 +2,6 @@ import Foundation
 import Testing
 @testable import ADBKit
 
-// Test fixtures write with `atomically: false` on purpose. An atomic write is
-// write-a-temp-then-rename, and on Windows CI that rename is what a scanner
-// refuses with ERROR_SHARING_VIOLATION — the transient `FileRetry` exists for
-// in the shipping code. A fixture writing a brand-new file into a brand-new
-// unique temp directory has nothing for atomicity to protect, so it does not
-// pay that cost.
 @Suite struct DecompileServiceTests {
     // MARK: argument builders
 
@@ -59,9 +53,9 @@ import Testing
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("dec-\(UUID().uuidString)")
         try fm.createDirectory(at: root.appendingPathComponent("a"), withIntermediateDirectories: true)
-        try "x".write(to: root.appendingPathComponent("a/z.smali"), atomically: false, encoding: .utf8)
-        try "x".write(to: root.appendingPathComponent("b.txt"), atomically: false, encoding: .utf8)
-        try "x".write(to: root.appendingPathComponent("c.txt"), atomically: false, encoding: .utf8)
+        try FixtureFile.write("x", to: root.appendingPathComponent("a/z.smali"))
+        try FixtureFile.write("x", to: root.appendingPathComponent("b.txt"))
+        try FixtureFile.write("x", to: root.appendingPathComponent("c.txt"))
 
         let node = DecompileService.tree(at: root)
         #expect(node.isDirectory)
@@ -77,7 +71,7 @@ import Testing
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("search-\(UUID().uuidString)")
         try fm.createDirectory(at: root.appendingPathComponent("com/x"), withIntermediateDirectories: true)
-        try "class A { void hello() {} }".write(to: root.appendingPathComponent("com/x/A.java"), atomically: false, encoding: .utf8)
+        try FixtureFile.write("class A { void hello() {} }", to: root.appendingPathComponent("com/x/A.java"))
         try "<manifest hello=\"1\"/>".write(to: root.appendingPathComponent("AndroidManifest.xml"), atomically: false, encoding: .utf8)
         try Data([0xFF, 0xD8, 0xFF]).write(to: root.appendingPathComponent("icon.png"))  // binary ext → skipped
 
@@ -113,7 +107,7 @@ import Testing
         let dir = out.appendingPathComponent(
             DecompileService.outputDirName(apkPath: "/x/a.apk", mode: .jadx), isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try "class A {}".write(to: dir.appendingPathComponent("A.java"), atomically: false, encoding: .utf8)
+        try FixtureFile.write("class A {}", to: dir.appendingPathComponent("A.java"))
         let service = await Self.makeService(java: nil)
         let result = try await service.decompile(apkPath: "/x/a.apk", mode: .jadx, into: out)
         #expect(result == dir)
@@ -126,7 +120,7 @@ import Testing
         let cached = out.appendingPathComponent(
             DecompileService.outputDirName(apkPath: "/debug/a.apk", mode: .jadx), isDirectory: true)
         try FileManager.default.createDirectory(at: cached, withIntermediateDirectories: true)
-        try "class A {}".write(to: cached.appendingPathComponent("A.java"), atomically: false, encoding: .utf8)
+        try FixtureFile.write("class A {}", to: cached.appendingPathComponent("A.java"))
         let service = await Self.makeService(java: nil)
         await #expect(throws: DecompileService.DecompileError.self) {
             try await service.decompile(apkPath: "/release/a.apk", mode: .jadx, into: out)

--- a/ADBKit/Tests/ADBKitTests/DecompileServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DecompileServiceTests.swift
@@ -2,6 +2,12 @@ import Foundation
 import Testing
 @testable import ADBKit
 
+// Test fixtures write with `atomically: false` on purpose. An atomic write is
+// write-a-temp-then-rename, and on Windows CI that rename is what a scanner
+// refuses with ERROR_SHARING_VIOLATION — the transient `FileRetry` exists for
+// in the shipping code. A fixture writing a brand-new file into a brand-new
+// unique temp directory has nothing for atomicity to protect, so it does not
+// pay that cost.
 @Suite struct DecompileServiceTests {
     // MARK: argument builders
 
@@ -53,9 +59,9 @@ import Testing
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("dec-\(UUID().uuidString)")
         try fm.createDirectory(at: root.appendingPathComponent("a"), withIntermediateDirectories: true)
-        try "x".write(to: root.appendingPathComponent("a/z.smali"), atomically: true, encoding: .utf8)
-        try "x".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
-        try "x".write(to: root.appendingPathComponent("c.txt"), atomically: true, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("a/z.smali"), atomically: false, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("b.txt"), atomically: false, encoding: .utf8)
+        try "x".write(to: root.appendingPathComponent("c.txt"), atomically: false, encoding: .utf8)
 
         let node = DecompileService.tree(at: root)
         #expect(node.isDirectory)
@@ -71,8 +77,8 @@ import Testing
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("search-\(UUID().uuidString)")
         try fm.createDirectory(at: root.appendingPathComponent("com/x"), withIntermediateDirectories: true)
-        try "class A { void hello() {} }".write(to: root.appendingPathComponent("com/x/A.java"), atomically: true, encoding: .utf8)
-        try "<manifest hello=\"1\"/>".write(to: root.appendingPathComponent("AndroidManifest.xml"), atomically: true, encoding: .utf8)
+        try "class A { void hello() {} }".write(to: root.appendingPathComponent("com/x/A.java"), atomically: false, encoding: .utf8)
+        try "<manifest hello=\"1\"/>".write(to: root.appendingPathComponent("AndroidManifest.xml"), atomically: false, encoding: .utf8)
         try Data([0xFF, 0xD8, 0xFF]).write(to: root.appendingPathComponent("icon.png"))  // binary ext → skipped
 
         let hits = DecompileService.search(in: root, query: "HELLO")  // case-insensitive
@@ -107,7 +113,7 @@ import Testing
         let dir = out.appendingPathComponent(
             DecompileService.outputDirName(apkPath: "/x/a.apk", mode: .jadx), isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try "class A {}".write(to: dir.appendingPathComponent("A.java"), atomically: true, encoding: .utf8)
+        try "class A {}".write(to: dir.appendingPathComponent("A.java"), atomically: false, encoding: .utf8)
         let service = await Self.makeService(java: nil)
         let result = try await service.decompile(apkPath: "/x/a.apk", mode: .jadx, into: out)
         #expect(result == dir)
@@ -120,7 +126,7 @@ import Testing
         let cached = out.appendingPathComponent(
             DecompileService.outputDirName(apkPath: "/debug/a.apk", mode: .jadx), isDirectory: true)
         try FileManager.default.createDirectory(at: cached, withIntermediateDirectories: true)
-        try "class A {}".write(to: cached.appendingPathComponent("A.java"), atomically: true, encoding: .utf8)
+        try "class A {}".write(to: cached.appendingPathComponent("A.java"), atomically: false, encoding: .utf8)
         let service = await Self.makeService(java: nil)
         await #expect(throws: DecompileService.DecompileError.self) {
             try await service.decompile(apkPath: "/release/a.apk", mode: .jadx, into: out)

--- a/ADBKit/Tests/ADBKitTests/FixtureFile.swift
+++ b/ADBKit/Tests/ADBKitTests/FixtureFile.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Writing a file from a test fixture, on a filesystem that sometimes says no.
+///
+/// Windows CI refuses writes into a just-created temp directory with
+/// `NSCocoaErrorDomain 513` / `Win32Error(code: 32)` — ERROR_SHARING_VIOLATION —
+/// because something outside the process is still holding the path. It is the
+/// same transient the shipping code carries `FileRetry` for, and it has now
+/// failed `AabConvertServiceTests`, `DecompileServiceTests` and
+/// `ManagedToolStoreTests` in turn, each time as a confusing error about
+/// whatever the fixture was setting up for rather than about the write.
+///
+/// Two rules, both learned from those failures:
+///
+/// 1. **Never atomic.** An atomic write is write-a-temp-then-rename, and the
+///    rename is the operation Windows refuses. A fixture writing a brand-new
+///    file into a brand-new unique directory has no previous version to
+///    protect, so atomicity buys it nothing and costs it this.
+/// 2. **Retry, then say so.** A transient clears in milliseconds. One that does
+///    not is a real problem, and it should be reported as a failure to *write*,
+///    naming the path — not as whatever the code under test said two steps
+///    later.
+///
+/// `FileRetry` itself is not used here: it is `async`, and these fixtures are
+/// synchronous set-up.
+enum FixtureFile {
+    /// How many times to try before giving up. The shipping `FileRetry` uses
+    /// the same count and the same rising back-off.
+    static let attempts = 5
+
+    static func write(_ contents: Data, to url: URL) throws {
+        var lastError: (any Error)?
+        for attempt in 1...attempts {
+            do {
+                try contents.write(to: url)
+                return
+            } catch {
+                lastError = error
+                Thread.sleep(forTimeInterval: 0.05 * Double(attempt))
+            }
+        }
+        throw lastError ?? CocoaError(.fileWriteUnknown)
+    }
+
+    static func write(_ text: String, to url: URL) throws {
+        try write(Data(text.utf8), to: url)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ManagedToolStoreTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ManagedToolStoreTests.swift
@@ -18,12 +18,6 @@ private let isWindows: Bool = {
     #endif
 }()
 
-// Test fixtures write with `atomically: false` on purpose. An atomic write is
-// write-a-temp-then-rename, and on Windows CI that rename is what a scanner
-// refuses with ERROR_SHARING_VIOLATION — the transient `FileRetry` exists for
-// in the shipping code. A fixture writing a brand-new file into a brand-new
-// unique temp directory has nothing for atomicity to protect, so it does not
-// pay that cost.
 @Suite struct ManagedToolStoreTests {
     /// Canned network: every `data(from:)` returns the same release JSON, every
     /// download writes the same asset bytes. Extraction uses the real runner.
@@ -41,7 +35,7 @@ private let isWindows: Bool = {
         }
         func download(from url: URL, to destination: URL, onProgress: (@Sendable (Double) -> Void)?) async throws {
             onProgress?(1)
-            try assetBytes.write(to: destination, options: .atomic)
+            try FixtureFile.write(assetBytes, to: destination)
         }
     }
 
@@ -57,7 +51,7 @@ private let isWindows: Bool = {
 
     @Test func seedInstallsABundledCopyAndResolvesIt() async throws {
         let jar = FileManager.default.temporaryDirectory.appendingPathComponent("bundletool-all.jar")
-        try Data("BUNDLED-JAR".utf8).write(to: jar)
+        try FixtureFile.write(Data("BUNDLED-JAR".utf8), to: jar)
         defer { try? FileManager.default.removeItem(at: jar) }
         let store = ManagedToolStore(rootDirectory: tempRoot())
 
@@ -196,7 +190,7 @@ private let isWindows: Bool = {
         let work = fm.temporaryDirectory.appendingPathComponent("xz-src-\(UUID().uuidString)")
         try fm.createDirectory(at: work, withIntermediateDirectories: true)
         let raw = work.appendingPathComponent("payload")
-        try payload.write(to: raw)
+        try FixtureFile.write(payload, to: raw)
         let xz = Process()
         xz.executableURL = URL(fileURLWithPath: "/usr/bin/xz")
         xz.arguments = ["--compress", raw.path]
@@ -213,7 +207,7 @@ private let isWindows: Bool = {
         let work = fm.temporaryDirectory.appendingPathComponent("tgz-src-\(UUID().uuidString)")
         let runnable = work.appendingPathComponent("jdk-21").appendingPathComponent(runnableRelPath)
         try fm.createDirectory(at: runnable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try "#!/bin/sh\necho java\n".write(to: runnable, atomically: false, encoding: .utf8)
+        try FixtureFile.write("#!/bin/sh\necho java\n", to: runnable)
         try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runnable.path)
         let out = work.appendingPathComponent("out.tar.gz")
         let tar = Process()

--- a/ADBKit/Tests/ADBKitTests/ManagedToolStoreTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ManagedToolStoreTests.swift
@@ -18,6 +18,12 @@ private let isWindows: Bool = {
     #endif
 }()
 
+// Test fixtures write with `atomically: false` on purpose. An atomic write is
+// write-a-temp-then-rename, and on Windows CI that rename is what a scanner
+// refuses with ERROR_SHARING_VIOLATION — the transient `FileRetry` exists for
+// in the shipping code. A fixture writing a brand-new file into a brand-new
+// unique temp directory has nothing for atomicity to protect, so it does not
+// pay that cost.
 @Suite struct ManagedToolStoreTests {
     /// Canned network: every `data(from:)` returns the same release JSON, every
     /// download writes the same asset bytes. Extraction uses the real runner.
@@ -207,7 +213,7 @@ private let isWindows: Bool = {
         let work = fm.temporaryDirectory.appendingPathComponent("tgz-src-\(UUID().uuidString)")
         let runnable = work.appendingPathComponent("jdk-21").appendingPathComponent(runnableRelPath)
         try fm.createDirectory(at: runnable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try "#!/bin/sh\necho java\n".write(to: runnable, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\necho java\n".write(to: runnable, atomically: false, encoding: .utf8)
         try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: runnable.path)
         let out = work.appendingPathComponent("out.tar.gz")
         let tar = Process()

--- a/droidectived/Sources/DaemonCore/ReactotronRelay.swift
+++ b/droidectived/Sources/DaemonCore/ReactotronRelay.swift
@@ -210,7 +210,22 @@ public actor ReactotronRelay {
         introduced.removeAll()
         let listening = channel
         channel = nil
-        try? await listening?.close().get()
+        if let listening {
+            try? await listening.close().get()
+            // Then wait for the channel to actually *be* closed.
+            //
+            // `close()`'s future completes when the close has been put through
+            // the pipeline; `closeFuture` is the one that fires when the
+            // channel is inactive and its socket released. Awaiting only the
+            // first let `stop()` return with the listener still holding the
+            // port, and a bind moments later was refused —
+            // `stoppingReleasesThePort` caught it on CI three times, on a port
+            // nothing else on the machine could have taken.
+            //
+            // Already-completed when the close was quick, so this costs
+            // nothing in the ordinary case.
+            try? await listening.closeFuture.get()
+        }
         let running = group
         group = nil
         try? await running?.shutdownGracefully()


### PR DESCRIPTION
Two CI failures on unrelated PRs, both of which turned out to be real.

## The relay held its port after `stop()` returned

`stoppingReleasesThePort` has now failed three times. This run settles what it is: the port was **28411** — outside the ephemeral range, so nothing on the machine could have been handed it — with a **single** start/stop cycle and no probe relay. `relay.stop()` returned and `second.start()` was refused.

That rules out both earlier theories. Not a steal by a parallel suite, not the extra cycle a probe added. `stop()` simply returns while the listener still holds the port.

`close()`'s future completes when the close has been put **through the pipeline**. `closeFuture` is the one that fires when the channel is inactive and its socket released. `stop()` awaited only the first, and the group shutdown that follows does not close that gap. It now awaits both — already-completed when the close was quick, so it costs nothing in the ordinary case.

**This is a Mac bug, not only a test one.** Settings ▸ MCP stopping the relay and starting it again, or the timeline tab being closed and reopened, is the same sequence — and the second start reports *"another Reactotron is probably running"* when nothing is.

I was wrong twice about this one, in the direction of blaming the environment. It was the code.

## The fixture that made the other failure unreadable

`build-windows` failed on a docs-only PR with `convertWithKeystoreNeverPutsThePasswordOnTheCommandLine` → `extractFailed("")`. An empty message, about the extract step, when the problem was two lines earlier and somewhere else.

The fixture stands in for bundletool and unzip by creating the files they would have produced, and discarded `createFile`'s result. A Windows filesystem hiccup — the transient this repo already carries `FileRetry` for — surfaced as the *service* saying an extract produced nothing. True and useless.

It now retries the write and records an issue naming the path if it still fails. A fixture that cannot set up its own preconditions should fail as itself. (`createFile` returning a must-use `Bool` off Darwin is the same trap `SecretFile` and the mirror's scrcpy log were fixed for; discarding it in a test is how it got back in.)

## On the evidence

The relay fix does not reproduce on this machine — 30 direct restarts and 12 full-suite runs stay clean — so it is reasoned from the mechanism rather than from a red test going green. CI is the judge over the next few runs. What is certain is that the old code did not guarantee what its own test asserts.

Green locally: ADBKit **1861**, daemon **340**, and the port test five times running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)