### PR TITLE
Stop requiring adb to install, and stop the menu bar being see-through

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/InstallHints.swift
+++ b/ADBKit/Sources/ADBKit/Services/InstallHints.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Where to get a missing tool, worded for the machine that is missing it.
+///
+/// The app never installs a tool itself, on any platform, so the hint *is* the
+/// whole answer — which makes a wrong one worse than none. "Install it via
+/// Android Studio" is the right sentence on a Mac and a poor one on Ubuntu,
+/// where the answer is a single apt command somebody can paste.
+///
+/// Pure and static so the wording is tested rather than eyeballed: the Doctor
+/// and the device bar both read it, and neither can tell a good hint from a
+/// stale one.
+public enum InstallHints {
+    /// The families whose package managers differ enough to change the answer.
+    public enum LinuxFamily: String, Sendable, CaseIterable {
+        case debian
+        case fedora
+        case arch
+        case suse
+        /// A distribution this build has no command for — name the package
+        /// instead of guessing a package manager.
+        case unknown
+    }
+
+    /// The family named by an `/etc/os-release` file.
+    ///
+    /// `ID_LIKE` is consulted after `ID` and matters more than it looks: Mint,
+    /// Pop!_OS, Zorin and elementary all report their own `ID` and lean on
+    /// `ID_LIKE=ubuntu debian`, and every one of them installs adb with apt.
+    public static func linuxFamily(osRelease: String) -> LinuxFamily {
+        let fields = parseOSRelease(osRelease)
+        if let id = fields["ID"], let family = family(matching: [id]) { return family }
+        if let like = fields["ID_LIKE"] {
+            let tokens = like.split(whereSeparator: { $0 == " " || $0 == "," }).map(String.init)
+            if let family = family(matching: tokens) { return family }
+        }
+        return .unknown
+    }
+
+    private static func family(matching tokens: [String]) -> LinuxFamily? {
+        for token in tokens {
+            switch token.lowercased() {
+            case "debian", "ubuntu", "raspbian", "linuxmint", "pop", "elementary", "zorin":
+                return .debian
+            case "fedora", "rhel", "centos", "rocky", "almalinux":
+                return .fedora
+            case "arch", "archlinux", "manjaro", "endeavouros":
+                return .arch
+            case "suse", "opensuse", "opensuse-tumbleweed", "opensuse-leap", "sles":
+                return .suse
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// `KEY=value` and `KEY="value"` lines, comments and blanks skipped.
+    ///
+    /// Split on `.newlines` rather than `"\n"`, as everything in this package
+    /// does — the file is written by a package manager and has been seen with
+    /// CRLF in container images.
+    static func parseOSRelease(_ contents: String) -> [String: String] {
+        var fields: [String: String] = [:]
+        for line in contents.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#"),
+                  let separator = trimmed.firstIndex(of: "=")
+            else { continue }
+            let key = String(trimmed[trimmed.startIndex..<separator])
+            var value = String(trimmed[trimmed.index(after: separator)...])
+            if value.count >= 2, value.hasPrefix("\""), value.hasSuffix("\"") {
+                value = String(value.dropFirst().dropLast())
+            }
+            fields[key] = value
+        }
+        return fields
+    }
+
+    /// The one command that installs adb on this Linux family, or nil when the
+    /// distribution is unknown and a guessed command would be worse than none.
+    public static func adbCommand(for family: LinuxFamily) -> String? {
+        switch family {
+        case .debian: return "sudo apt install android-tools-adb"
+        case .fedora: return "sudo dnf install android-tools"
+        case .arch: return "sudo pacman -S android-tools"
+        case .suse: return "sudo zypper install android-tools"
+        case .unknown: return nil
+        }
+    }
+
+    /// The adb hint for this machine.
+    ///
+    /// `osRelease` is passed in rather than read here so the wording stays
+    /// testable for every distribution without one of them being installed.
+    public static func adb(osRelease: String? = nil) -> String {
+        #if os(Linux)
+        let family = linuxFamily(osRelease: osRelease ?? "")
+        if let command = adbCommand(for: family) {
+            return "adb is missing. Install it with `\(command)`, then re-check."
+        }
+        return "adb is missing. Install your distribution's Android platform-tools "
+            + "package (often called android-tools or android-tools-adb), then re-check."
+        #elseif os(Windows)
+        return "adb is missing. Install it with `winget install Google.PlatformTools`, "
+            + "or unzip developer.android.com/tools/releases/platform-tools and add it "
+            + "to PATH, then re-check."
+        #else
+        return "Install Android platform-tools — via Android Studio, or from "
+            + "developer.android.com/tools/releases/platform-tools — then re-check."
+        #endif
+    }
+
+    /// Read `/etc/os-release` if this machine has one. Nil everywhere else.
+    public static func hostOSRelease() -> String? {
+        #if os(Linux)
+        return try? String(contentsOfFile: "/etc/os-release", encoding: .utf8)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/ToolDetectionService.swift
@@ -19,9 +19,10 @@ public struct ToolStatus: Sendable, Equatable {
 /// Detects whether the external tools are installed, with an install hint
 /// per missing one (shown by the Doctor and the device bar).
 public struct ToolDetectionService: Sendable {
+    /// adb's hint is per-machine (`InstallHints`), so it is not in this table —
+    /// the answer on Ubuntu is an apt command and on a Mac it is Android Studio,
+    /// and one sentence cannot be both.
     static let installHints: [Tool: String] = [
-        .adb: "Install Android platform-tools — via Android Studio, or from "
-            + "developer.android.com/tools/releases/platform-tools — then re-check.",
         .scrcpy: "Install scrcpy from github.com/Genymobile/scrcpy (optional — the app bundles its own mirror server).",
         .ffmpeg: "Install ffmpeg from ffmpeg.org (optional — the app bundles its own for video export).",
         .emulator: "Bundled with the Android SDK — install it via Android Studio → SDK Manager.",
@@ -66,7 +67,9 @@ public struct ToolDetectionService: Sendable {
     }
 
     func detectOne(_ tool: Tool, versionArgs: [String]) async -> ToolStatus {
-        let hint = Self.installHints[tool] ?? ""
+        let hint = tool == .adb
+            ? InstallHints.adb(osRelease: InstallHints.hostOSRelease())
+            : (Self.installHints[tool] ?? "")
         guard let path = await locator.resolve(tool) else {
             return ToolStatus(installed: false, path: nil, version: nil, installHint: hint)
         }

--- a/ADBKit/Tests/ADBKitTests/InstallHintsTests.swift
+++ b/ADBKit/Tests/ADBKitTests/InstallHintsTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+/// The hint *is* the whole answer — the app never installs a tool itself — so a
+/// wrong one is worse than none. These pin the wording and the distribution
+/// detection, neither of which anyone can eyeball on a machine that already has
+/// adb.
+@Suite struct InstallHintsTests {
+    // MARK: - Reading /etc/os-release
+
+    @Test func readsQuotedAndBareValues() {
+        let fields = InstallHints.parseOSRelease(
+            """
+            NAME="Ubuntu"
+            VERSION_ID="24.04"
+            ID=ubuntu
+            ID_LIKE=debian
+            """)
+        #expect(fields["NAME"] == "Ubuntu")
+        #expect(fields["ID"] == "ubuntu")
+        #expect(fields["ID_LIKE"] == "debian")
+    }
+
+    /// Written by a package manager, and seen with CRLF in container images.
+    @Test func survivesCRLFAndCommentsAndBlanks() {
+        let fields = InstallHints.parseOSRelease("# a comment\r\n\r\nID=fedora\r\nVERSION_ID=40\r\n")
+        #expect(fields["ID"] == "fedora")
+        #expect(fields["VERSION_ID"] == "40")
+    }
+
+    @Test func aFileItCannotReadNamesNoFamily() {
+        #expect(InstallHints.linuxFamily(osRelease: "") == .unknown)
+        #expect(InstallHints.linuxFamily(osRelease: "not=a=distro") == .unknown)
+    }
+
+    // MARK: - Which family
+
+    @Test func recognisesTheFourFamiliesByID() {
+        #expect(InstallHints.linuxFamily(osRelease: "ID=debian") == .debian)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=fedora") == .fedora)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=arch") == .arch)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=opensuse-tumbleweed") == .suse)
+    }
+
+    /// The case that matters more than it looks: Mint, Pop!_OS, Zorin and
+    /// elementary all report their own `ID` and lean on `ID_LIKE`, and every one
+    /// of them installs adb with apt.
+    @Test func fallsBackToIDLikeForTheDerivatives() {
+        #expect(InstallHints.linuxFamily(osRelease: "ID=linuxmint\nID_LIKE=ubuntu") == .debian)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=pop\nID_LIKE=\"ubuntu debian\"") == .debian)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=manjaro\nID_LIKE=arch") == .arch)
+        #expect(InstallHints.linuxFamily(osRelease: "ID=rocky\nID_LIKE=\"rhel centos fedora\"") == .fedora)
+    }
+
+    /// `ID` wins over `ID_LIKE` — a distribution that names itself is not
+    /// guessing.
+    @Test func theDistributionsOwnIDBeatsWhatItSaysItIsLike() {
+        #expect(InstallHints.linuxFamily(osRelease: "ID=fedora\nID_LIKE=debian") == .fedora)
+    }
+
+    // MARK: - The command
+
+    @Test func everyKnownFamilyHasACommandAndTheUnknownOneDoesNot() {
+        for family in InstallHints.LinuxFamily.allCases where family != .unknown {
+            let command = InstallHints.adbCommand(for: family)
+            #expect(command != nil, "\(family.rawValue) has no install command")
+            #expect(command?.contains("sudo") == true, "\(family.rawValue) should be a root install")
+        }
+        // Guessing a package manager is worse than naming the package.
+        #expect(InstallHints.adbCommand(for: .unknown) == nil)
+    }
+
+    @Test func theDebianCommandIsTheOneThatWorksOnUbuntu() {
+        #expect(InstallHints.adbCommand(for: .debian) == "sudo apt install android-tools-adb")
+    }
+
+    // MARK: - The sentence
+
+    /// Whatever the platform, the hint has to say what is wrong and what to do
+    /// — a hint that only says "adb is missing" leaves the reader where it
+    /// found them.
+    @Test func theHintIsActionableOnEveryPlatform() {
+        let hint = InstallHints.adb(osRelease: "ID=ubuntu")
+        #expect(!hint.isEmpty)
+        #expect(hint.lowercased().contains("adb") || hint.lowercased().contains("platform-tools"))
+
+        #if os(Linux)
+        #expect(hint.contains("sudo apt install android-tools-adb"))
+        #expect(InstallHints.adb(osRelease: "ID=fedora").contains("dnf"))
+        // An unrecognised distribution names the package rather than inventing
+        // a command that would fail.
+        let unknown = InstallHints.adb(osRelease: "ID=something-new")
+        #expect(!unknown.contains("sudo"))
+        #expect(unknown.contains("android-tools"))
+        #elseif os(Windows)
+        #expect(hint.contains("winget") || hint.contains("PATH"))
+        #else
+        #expect(hint.contains("developer.android.com"))
+        #endif
+    }
+}

--- a/desktop/src-tauri/src/glass.rs
+++ b/desktop/src-tauri/src/glass.rs
@@ -15,6 +15,13 @@
 //! That is why the desktop's Blur is a switch where the Mac's is a slider. The
 //! divergence is forced by the platforms rather than chosen, and it is named
 //! here, in Settings, and in `docs/desktop-parity.md`.
+//!
+//! Linux gives up the *whole* effect, not just the blur, and for a reason that
+//! has nothing to do with compositors: the app draws its own GTK menu bar above
+//! the webview there, and that strip has nothing to paint itself on over a
+//! transparent window — the desktop shows through File, Edit and View.
+//! `tauri.linux.conf.json` turns the window's transparency off, and
+//! `lib/platform.ts` stops the page painting itself translucent to match.
 
 use tauri::utils::config::WindowEffectsConfig;
 use tauri::utils::WindowEffect;
@@ -99,6 +106,44 @@ mod tests {
             window_blur_supported(),
             cfg!(any(target_os = "windows", target_os = "macos"))
         );
+    }
+
+    /// The Linux config exists only to turn the window's transparency off, so
+    /// it has to be identical to the shared one in every other respect. Tauri
+    /// merges the platform config over the base, and whether it merges the
+    /// windows array element-wise or replaces it outright is not something to
+    /// find out from a user's screenshot — so the override carries the whole
+    /// window object, and this fails if the two ever drift.
+    #[test]
+    fn the_linux_window_matches_the_shared_one_apart_from_transparency() {
+        let read = |name: &str| -> serde_json::Value {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(name);
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap_or_default())
+                .unwrap_or(serde_json::Value::Null)
+        };
+        let window = |config: &serde_json::Value| -> serde_json::Map<String, serde_json::Value> {
+            config["app"]["windows"][0]
+                .as_object()
+                .cloned()
+                .unwrap_or_default()
+        };
+
+        let mut shared = window(&read("tauri.conf.json"));
+        let mut linux = window(&read("tauri.linux.conf.json"));
+        assert!(!shared.is_empty(), "the shared config declares no window");
+        assert!(!linux.is_empty(), "the linux config declares no window");
+
+        assert_eq!(
+            shared.remove("transparent"),
+            Some(serde_json::Value::Bool(true)),
+            "the shared window should be transparent — that is the whole feature"
+        );
+        assert_eq!(
+            linux.remove("transparent"),
+            Some(serde_json::Value::Bool(false)),
+            "the linux window must not be transparent — the menu bar cannot paint on it"
+        );
+        assert_eq!(shared, linux, "the two window declarations have drifted");
     }
 
     /// Acrylic on Windows, a vibrancy material elsewhere. Named because

--- a/desktop/src-tauri/src/workspace.rs
+++ b/desktop/src-tauri/src/workspace.rs
@@ -193,7 +193,12 @@ pub fn open_workspace_window(app: AppHandle<Wry>, serial: Option<String>) -> tau
     // As the first window is, so the Appearance sliders reach every window
     // rather than only the one the config declared. At 100% opacity the page
     // paints its background solid, so a transparent surface changes nothing.
-    .transparent(true)
+    //
+    // Never on Linux: the app draws its own GTK menu bar there, and that strip
+    // has nothing to paint itself on when the window is transparent — the
+    // desktop shows through File, Edit and View. `tauri.linux.conf.json` says
+    // the same thing about the first window.
+    .transparent(cfg!(not(target_os = "linux")))
     .focused(true)
     .build()?;
     window.set_focus()?;

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -46,11 +46,11 @@
     "linux": {
       "deb": {
         "depends": [
-          "android-tools-adb",
           "libcurl4",
           "libayatana-appindicator3-1"
         ],
         "recommends": [
+          "android-tools-adb",
           "gstreamer1.0-libav"
         ]
       }

--- a/desktop/src-tauri/tauri.linux.conf.json
+++ b/desktop/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Droidective",
+        "width": 1100,
+        "height": 720,
+        "minWidth": 720,
+        "minHeight": 480,
+        "dragDropEnabled": false,
+        "transparent": false
+      }
+    ]
+  }
+}

--- a/desktop/src/components/AdbWarning.tsx
+++ b/desktop/src/components/AdbWarning.tsx
@@ -1,31 +1,53 @@
-import { TriangleAlert } from "lucide-react"
+import { useState } from "react"
+import { Check, TriangleAlert } from "lucide-react"
+
 import { useToolchain } from "@/hooks/useToolchain"
-import { openUrl } from "@/lib/daemon"
+import { copyText, openUrl } from "@/lib/daemon"
+import { installCommand } from "@/lib/doctor"
 
 /**
  * adb is not on this machine — the Mac's own warning, in its place on the bar.
  *
  * Nothing works without adb, so this is the one tool status worth a permanent
- * spot rather than a Doctor visit. The link opens the download page; neither app
- * ever installs a tool itself. Nothing is shown until adb has actually been
- * looked for, so the bar cannot flash a warning during startup.
+ * spot rather than a Doctor visit. Neither app ever installs a tool itself, so
+ * the hint is the whole answer — and the hint comes from the daemon, which
+ * words it for the machine it is running on: an apt command on Ubuntu, a winget
+ * one on Windows, the download page on a Mac.
+ *
+ * Where there is a command, the button copies it. Somebody reading a tooltip
+ * and retyping `sudo apt install android-tools-adb` is the version of this that
+ * wastes people's time.
  */
 export function AdbWarning() {
-  const { adbMissing } = useToolchain()
+  const { adbMissing, adbHint } = useToolchain()
+  const [copied, setCopied] = useState(false)
   if (adbMissing !== true) return null
+
+  const command = installCommand(adbHint)
+
   return (
-    <span className="flex items-center gap-1.5 pl-1">
+    <span className="flex min-w-0 items-center gap-1.5 pl-1">
       <TriangleAlert size={13} className="shrink-0 text-warn" />
-      <span className="text-warn">adb not found</span>
+      <span className="shrink-0 text-warn">adb not found</span>
       <button
         type="button"
+        title={adbHint}
         onClick={() => {
-          void openUrl("https://developer.android.com/tools/releases/platform-tools")
+          if (command === null) {
+            void openUrl("https://developer.android.com/tools/releases/platform-tools")
+            return
+          }
+          void copyText(command).then(() => {
+            setCopied(true)
+            setTimeout(() => {
+              setCopied(false)
+            }, 2000)
+          })
         }}
-        title="adb ships with Android platform-tools — install it via Android Studio or this download page, then re-check in Settings ▸ Doctor"
-        className="text-[11.5px] text-text-tertiary underline hover:text-text-primary"
+        className="flex shrink-0 items-center gap-1 text-[11.5px] text-text-tertiary underline hover:text-text-primary"
       >
-        How to install
+        {copied ? <Check size={11} className="text-accent" /> : null}
+        {command === null ? "How to install" : copied ? "Copied" : "Copy install command"}
       </button>
     </span>
   )

--- a/desktop/src/components/Controls.tsx
+++ b/desktop/src/components/Controls.tsx
@@ -170,6 +170,7 @@ export function Slider({
   onChange,
   ariaLabel,
   format,
+  disabled = false,
 }: {
   value: number
   min: number
@@ -180,6 +181,7 @@ export function Slider({
   ariaLabel?: string | undefined
   /** How the readout beside it reads — raw, unless a caller says otherwise. */
   format?: ((value: number) => string) | undefined
+  disabled?: boolean
 }) {
   return (
     <div className="flex items-center gap-3">
@@ -190,12 +192,16 @@ export function Slider({
         max={max}
         step={step}
         aria-label={ariaLabel ?? "Slider"}
+        disabled={disabled}
         onChange={(event) => {
           onChange(Number(event.target.value))
         }}
-        className="h-1 flex-1 accent-[var(--color-accent)]"
+        className={cn(
+          "h-1 flex-1 accent-[var(--color-accent)]",
+          disabled && "cursor-not-allowed opacity-40",
+        )}
       />
-      <span className="w-10 text-right tabular-nums text-text-secondary">
+      <span className={cn("w-10 text-right tabular-nums text-text-secondary", disabled && "opacity-40")}>
         {format === undefined ? value : format(value)}
       </span>
     </div>

--- a/desktop/src/components/settings/AppearanceWindow.tsx
+++ b/desktop/src/components/settings/AppearanceWindow.tsx
@@ -2,6 +2,7 @@ import { Slider, Switch } from "@/components/Controls"
 import { Row } from "@/components/settings/SettingsKit"
 import { useAppearance } from "@/hooks/useAppearance"
 import { useWindowBlur } from "@/hooks/useWindowBlur"
+import { TRANSPARENCY_SUPPORTED } from "@/lib/platform"
 import {
   clampedAmount,
   clampedOpacity,
@@ -26,20 +27,19 @@ import {
 export function WindowEffectsSection() {
   const { opacity, blur, grain, setOpacity, setBlur, setGrain } = useAppearance()
   const { supported, failure } = useWindowBlur()
-  const translucent = isTranslucent(opacity)
+  // Both the page's alpha and the window behind it have to be able to do it.
+  const translucent = TRANSPARENCY_SUPPORTED && isTranslucent(opacity)
 
   return (
     <>
-      <Row
-        label="Opacity"
-        detail="Below 100% the window turns to glass — what's behind shows through every pane."
-      >
+      <Row label="Opacity" detail={opacityDetail()}>
         <Slider
-          value={clampedOpacity(opacity)}
+          value={TRANSPARENCY_SUPPORTED ? clampedOpacity(opacity) : 1}
           min={MINIMUM_OPACITY}
           max={1}
           step={0.01}
           onChange={setOpacity}
+          disabled={!TRANSPARENCY_SUPPORTED}
           ariaLabel="Window opacity"
           format={percentLabel}
         />
@@ -70,10 +70,18 @@ export function WindowEffectsSection() {
   )
 }
 
+/** What the slider will do here — or why it will not. */
+function opacityDetail(): string {
+  if (!TRANSPARENCY_SUPPORTED) {
+    return "Not on Linux. Droidective draws its own menu bar there, and that strip has nothing to paint itself on over a transparent window — the desktop would show through File, Edit and View. Grain still works."
+  }
+  return "Below 100% the window turns to glass — what's behind shows through every pane."
+}
+
 /** Why the switch is off, in the order the reasons actually matter. */
 function blurDetail(supported: boolean, translucent: boolean, failure: string | null): string {
   if (!supported) {
-    return "Your desktop compositor decides whether a transparent window is blurred — there is no setting an application can ask for on Linux. KDE's KWin and GNOME extensions can both be told to blur one."
+    return "Windows and macOS each have a window blur an application can ask for; Linux leaves it to the compositor, and Droidective's window is not transparent there anyway."
   }
   if (failure !== null) return failure
   if (!translucent) return "Nothing shows through a fully opaque window. Lower Opacity first."

--- a/desktop/src/hooks/useAppearance.tsx
+++ b/desktop/src/hooks/useAppearance.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/appearance"
 import { backgroundPalette, isLightHex, textPalette } from "@/lib/background"
 import { glassPalette } from "@/lib/glass"
+import { TRANSPARENCY_SUPPORTED } from "@/lib/platform"
 import { clampedAmount, clampedOpacity } from "@/lib/window-effects"
 
 /** A stored colour, or "" for "none chosen" — which a malformed one becomes. */
@@ -203,9 +204,11 @@ function useAppliedPalette(saved: Saved, resolved: "light" | "dark", custom: Pal
     const base = custom ?? palette(resolved)
     const text =
       saved.text === "" ? null : textPalette(saved.text, base["--color-bg-root"] ?? "#1a1a1a")
-    for (const [token, value] of Object.entries(
-      glassPalette({ ...base, ...text }, saved.opacity),
-    )) {
+    // Clamped where the window cannot be transparent: painting the page
+    // translucent there dims the app against its own opaque background instead
+    // of showing the desktop, which reads as a broken theme rather than glass.
+    const opacity = TRANSPARENCY_SUPPORTED ? saved.opacity : 1
+    for (const [token, value] of Object.entries(glassPalette({ ...base, ...text }, opacity))) {
       root.style.setProperty(token, value)
     }
     root.style.setProperty("--color-accent", accentFor(saved.accent, resolved))

--- a/desktop/src/hooks/useToolchain.tsx
+++ b/desktop/src/hooks/useToolchain.tsx
@@ -9,6 +9,8 @@ export interface Toolchain {
   detecting: boolean
   /** Null until adb has actually been looked for. */
   adbMissing: boolean | null
+  /** How to get adb *on this machine* — the daemon words it per platform. */
+  adbHint: string
   redetect: () => Promise<void>
 }
 
@@ -45,7 +47,14 @@ export function ToolchainProvider({ children }: { children: React.ReactNode }) {
   }, [redetect])
 
   const value = useMemo<Toolchain>(
-    () => ({ tools, error, detecting, adbMissing: adbMissing(tools), redetect }),
+    () => ({
+      tools,
+      error,
+      detecting,
+      adbMissing: adbMissing(tools),
+      adbHint: tools.find((tool) => tool.id === "adb")?.installHint ?? "",
+      redetect,
+    }),
     [tools, error, detecting, redetect],
   )
   return <ToolchainContext value={value}>{children}</ToolchainContext>

--- a/desktop/src/lib/doctor.test.ts
+++ b/desktop/src/lib/doctor.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { adbMissing, blocking, CHECKS, checkedTools, verdict } from "@/lib/doctor"
+import {
+  adbMissing,
+  blocking,
+  CHECKS,
+  checkedTools,
+  installCommand,
+  verdict,
+} from "@/lib/doctor"
 import type { ToolReport } from "@/lib/wire"
 
 function tool(id: string, installed: boolean): ToolReport {
@@ -76,5 +83,33 @@ describe("adbMissing", () => {
   it("answers once it has", () => {
     expect(adbMissing([tool("adb", false)])).toBe(true)
     expect(adbMissing([tool("adb", true)])).toBe(false)
+  })
+})
+
+describe("installCommand", () => {
+  /**
+   * The daemon words each hint for the machine it runs on, and this is what
+   * lets the UI offer the useful half rather than making somebody retype it
+   * out of a tooltip.
+   */
+  it("pulls the command out of a hint that names one", () => {
+    expect(
+      installCommand("adb is missing. Install it with `sudo apt install android-tools-adb`, then re-check."),
+    ).toBe("sudo apt install android-tools-adb")
+    expect(installCommand("adb is missing. Install it with `winget install Google.PlatformTools`, or …")).toBe(
+      "winget install Google.PlatformTools",
+    )
+  })
+
+  /** A hint that only points at a web page has no command to copy. */
+  it("is null when the hint names no command", () => {
+    expect(installCommand("Install Android platform-tools — via Android Studio, or from …")).toBeNull()
+    expect(installCommand("")).toBeNull()
+  })
+
+  /** An empty pair of backticks is not a command. */
+  it("refuses an empty quote rather than copying nothing", () => {
+    expect(installCommand("install it with `` then re-check")).toBeNull()
+    expect(installCommand("install it with `   ` then re-check")).toBeNull()
   })
 })

--- a/desktop/src/lib/doctor.ts
+++ b/desktop/src/lib/doctor.ts
@@ -31,6 +31,22 @@ export function checkedTools(
   }))
 }
 
+/**
+ * The shell command inside an install hint, if it names one.
+ *
+ * The daemon words each hint for the machine it is running on, so on Ubuntu it
+ * carries `sudo apt install android-tools-adb` and on a Mac it carries a URL.
+ * Pulling the command out is what lets the UI offer to copy the useful half
+ * rather than making somebody retype it out of a tooltip — and reading it from
+ * the hint keeps one source of truth, rather than this app guessing the
+ * package manager a second time.
+ */
+export function installCommand(hint: string): string | null {
+  const quoted = /`([^`]+)`/u.exec(hint)
+  const command = quoted?.[1]?.trim()
+  return command === undefined || command === "" ? null : command
+}
+
 /** Checked tools that are missing — the ones that actually block something. */
 export function blocking(tools: readonly ToolReport[]): ToolReport[] {
   return checkedTools(tools)

--- a/desktop/src/lib/platform.test.ts
+++ b/desktop/src/lib/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { isMacHost, shortcutLabel } from "@/lib/platform"
+import { isLinuxHost, isMacHost, shortcutLabel } from "@/lib/platform"
 
 describe("shortcutLabel", () => {
   it("uses the accelerator the host actually has", () => {
@@ -18,5 +18,27 @@ describe("isMacHost", () => {
   it("recognises the webviews it ships on", () => {
     expect(isMacHost("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120 Edg/120")).toBe(false)
     expect(isMacHost("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15")).toBe(false)
+  })
+})
+
+describe("isLinuxHost", () => {
+  it("recognises the WebKitGTK user agent the Linux build runs under", () => {
+    expect(
+      isLinuxHost("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"),
+    ).toBe(true)
+  })
+
+  it("is false on the other two platforms", () => {
+    expect(isLinuxHost("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15")).toBe(false)
+    expect(isLinuxHost("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")).toBe(false)
+  })
+
+  /**
+   * The trap this exists to avoid: Android's user agent contains "Linux", and
+   * this app talks *to* Android. A webview that ever reported one would turn
+   * window translucency off for the wrong reason.
+   */
+  it("does not mistake an Android user agent for a Linux desktop", () => {
+    expect(isLinuxHost("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36")).toBe(false)
   })
 })

--- a/desktop/src/lib/platform.ts
+++ b/desktop/src/lib/platform.ts
@@ -17,6 +17,26 @@ export function isMacHost(userAgent: string): boolean {
 
 export const IS_MAC = isMacHost(navigator.userAgent)
 
+export function isLinuxHost(userAgent: string): boolean {
+  // "Android" also contains "Linux", and this app talks *to* Android — so the
+  // string that matters is the one WebKitGTK sends, not the substring.
+  return userAgent.includes("Linux") && !userAgent.includes("Android")
+}
+
+/**
+ * Whether the window itself can be transparent, which is what makes the
+ * Appearance ▸ Opacity slider do anything.
+ *
+ * Not on Linux, and the reason is the menu bar: there the app draws its own
+ * GTK menu bar above the webview, and that strip has nothing to paint itself
+ * on when the window is transparent — File, Edit and View end up with the
+ * desktop showing through them. `tauri.linux.conf.json` turns the window's
+ * transparency off for the same reason, and the two have to agree: this
+ * decides whether the *page* paints itself translucent, that decides whether
+ * there is anything behind it to see.
+ */
+export const TRANSPARENCY_SUPPORTED = !isLinuxHost(navigator.userAgent)
+
 /** The accelerator key for this host — ⌘ on a Mac, Ctrl everywhere else. */
 export function hasModifier(event: { metaKey: boolean; ctrlKey: boolean }): boolean {
   return IS_MAC ? event.metaKey : event.ctrlKey

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -607,13 +607,20 @@ two disagree, so a relabelled item cannot leave a stale accelerator behind.
       the contrast step) and 100% hands the palette back untouched, so an
       untouched window renders exactly as before. Grain is an SVG
       `feTurbulence` film rather than a Metal shader, portalled outside the zoom
-      transform so zoom does not magnify the specks. **Divergence:** Blur is a
-      *switch*, not a slider — no platform exposes a radius (Windows has
-      Acrylic and Mica, both on-or-off; Linux leaves window blur to the
-      compositor entirely), and a slider with two positions would be a worse
-      lie than a switch. `src-tauri/src/glass.rs` picks Acrylic on Windows
-      (Mica is 11-only and tints rather than blurs) and disables the row with
-      the reason on Linux.
+      transform so zoom does not magnify the specks. **Two divergences.** Blur
+      is a *switch*, not a slider — no platform exposes a radius (Windows has
+      Acrylic and Mica, both on-or-off), and a slider with two positions would
+      be a worse lie than a switch; `src-tauri/src/glass.rs` picks Acrylic on
+      Windows, since Mica is 11-only and tints rather than blurs. And **Opacity
+      is unavailable on Linux entirely**: the app draws its own GTK menu bar
+      above the webview there, and that strip has nothing to paint itself on
+      over a transparent window — the desktop shows through File, Edit and
+      View, which is exactly what shipped in beta.4 before a user photographed
+      it. `tauri.linux.conf.json` turns the window transparency off,
+      `lib/platform.ts` stops the page painting itself translucent to match, a
+      Rust test fails if the two configs drift, and the Linux smoke job now
+      counts pure-black pixels inside the window so the next hole of this shape
+      fails CI instead of reaching somebody. Grain still works on Linux.
 - [x] **Light theme** — ported from the asset catalog's own colorset values,
       applied as CSS custom properties on `:root` so every existing token
       follows it.

--- a/docs/manual-verification.md
+++ b/docs/manual-verification.md
@@ -135,7 +135,31 @@ WKWebView. This is a platform limit, not a missing tool — see the
   staging is covered by Rust tests, and which of install/push/refuse a drop
   means is `lib/file-drop.ts`, tested without a drag.
 
-## 5. Sound
+## 5. Installing it the way a stranger would
+
+**Why not automatable here:** the container installs the `.deb` with apt on a
+machine that is a blank slate every time. What it cannot tell you is what
+happens on a *real* desktop that already has opinions — a different package
+manager, an existing Android SDK, a distro whose adb package is named something
+else.
+
+The rule the app is built to: **adb is a `Recommends`, never a `Depends`.**
+Refusing to install because a tool is missing, when the app's own Doctor exists
+to tell you the tool is missing, is a worse first impression than any error
+message. beta.4 got this wrong.
+
+- [ ] **Install on a machine with no adb** and confirm the app installs,
+      launches, and says what to do rather than failing to install at all.
+- [ ] **The device bar's "Copy install command"** copies the command for *that*
+      distribution — apt on Debian and its derivatives, dnf on Fedora, pacman on
+      Arch, zypper on openSUSE — and the pasted command actually works.
+- [ ] **A distribution none of those cover** names the package instead of
+      inventing a command (`InstallHints.adbCommand` returns nil, and the hint
+      says "often called android-tools or android-tools-adb").
+- [ ] **The AppImage**, which declares no dependencies at all, on a machine
+      with no adb.
+
+## 6. Sound
 
 **Why not automatable here:** an agent cannot hear. Whether a file *contains*
 audio can be probed; whether it is the right audio, in sync, at a sane level,
@@ -150,7 +174,7 @@ cannot.
 - [ ] **The level meter** moves when you speak.
 - [ ] **Mute mid-take** leaves the timeline continuous, and unmuting is instant.
 
-## 6. macOS permission prompts
+## 7. macOS permission prompts
 
 **Why not automatable here:** the prompts are system-modal and an agent must
 not click through a security dialog on your behalf.
@@ -159,7 +183,7 @@ not click through a security dialog on your behalf.
       with sensible wording the first time each is needed.
 - [ ] Denying one is reported in the app rather than failing silently.
 
-## 7. How it feels
+## 8. How it feels
 
 **Why not automatable here:** these are perceptual judgements. A screenshot
 cannot tell you a mirror is stuttering or that input lags.
@@ -171,7 +195,7 @@ cannot tell you a mirror is stuttering or that input lags.
 - [ ] **Reduced motion** — with the system setting on, the marketing site's
       scroll reveals and hero demo still work.
 
-## 8. Release mechanics
+## 9. Release mechanics
 
 **Why not automatable here:** signing identities, notarisation, and updating
 *from* a previously installed build.
@@ -186,7 +210,7 @@ cannot tell you a mirror is stuttering or that input lags.
       (`scripts/test-release-channel.sh` asserts this, but confirm the actual
       release page).
 
-## 9. Things needing a real account or endpoint
+## 10. Things needing a real account or endpoint
 
 **Why not automatable here:** no credentials, and an agent should not be
 signing in to your services.

--- a/scripts/smoke-desktop-linux.sh
+++ b/scripts/smoke-desktop-linux.sh
@@ -86,6 +86,7 @@ for _ in $(seq 30); do xdpyinfo -display :99 >/dev/null 2>&1 && break; sleep 1; 
 xdpyinfo -display :99 >/dev/null || { echo "Xvfb never came up"; cat /tmp/xvfb.log; exit 1; }
 
 export DISPLAY=:99
+
 # WebKitGTK has no GPU here, and its sandbox needs kernel features a container
 # does not grant. Neither is a property of the app.
 export WEBKIT_DISABLE_COMPOSITING_MODE=1
@@ -147,6 +148,23 @@ WINDOW="$(xdotool search --name "^Droidective$" | head -1)"
 # a drawn UI is far from it.
 spread() { identify -format "%[fx:standard_deviation*255]" "$1"; }
 
+# How many pixels of pure black show inside the window rectangle.
+#
+# Pure black is the Xvfb root, and Droidective never paints it: the darkest
+# thing in the palette is BgRoot at 1a1a1a. So an exactly-black pixel inside
+# the window is somewhere the app did not paint and the screen behind it showed
+# through — which is what a transparent window did to the GTK menu bar, and it
+# reached a user because this job photographed black on black and called it
+# fine. Exact match, no fuzz: 1a1a1a must not count.
+#
+# Painting the root a louder colour would read better in the screenshots and
+# does not work — xsetroot -solid leaves a bare Xvfb root black, with or
+# without xrefresh, because nothing ever exposes it. Checked, twice.
+leaked() {
+  convert "$1" -crop "$2" +repage -fuzz 0% -fill white -opaque black \
+    -fill black +opaque white -colorspace Gray -format "%[fx:mean*w*h]" info:
+}
+
 # Counts differing pixels between two frames, or fails saying so.
 changed() {
   count="$(compare -metric AE "$1" "$2" null: 2>&1 || true)"
@@ -182,6 +200,20 @@ echo "pixels changed after leaving the role picker: $DISMISSED"
 LAUNCH_SPREAD="$(spread /dist/linux-launch.png)"
 echo "launch pixel spread: $LAUNCH_SPREAD"
 [ "${LAUNCH_SPREAD%%.*}" -ge 3 ] || fail "the app painted nothing (spread $LAUNCH_SPREAD)"
+
+# Everything inside the window rectangle is Droidective to paint. Anything the
+# root window shows through is a hole — the menu bar over a transparent window
+# was exactly that, and it reached a user because nothing here looked for it.
+eval "$(xdotool getwindowgeometry --shell "$WINDOW")"
+GEOMETRY="${WIDTH}x${HEIGHT}+${X}+${Y}"
+echo "window geometry: $GEOMETRY"
+LEAKED="$(leaked /dist/linux-launch.png "$GEOMETRY")"
+LEAKED="${LEAKED%%.*}"
+echo "unpainted pixels inside the window: $LEAKED"
+# A correct build measures exactly 0; the allowance is for antialiasing on a
+# future frame, not for a hole. The menu bar alone is ~26,000 pixels.
+[ "${LEAKED:-999999}" -le 500 ] \
+  || fail "the app is see-through in $LEAKED places — something is not painting its background"
 
 # Drive it far enough to open a screen. There is no window manager here, so
 # focus is set directly rather than by clicking. Ctrl+K is the command


### PR DESCRIPTION
Two things a real Linux install found.

## adb was a hard dependency

Installing the `.deb` on a machine without adb failed at apt rather than at the
app — backwards, since Droidective has a Doctor whose whole job is to say a tool
is missing and where to get it, and it never runs if the package refuses to
install. `android-tools-adb` moves to `Recommends`, so apt still pulls it in by
default and a machine without it still gets the app.

The hint it then shows was macOS-shaped. `InstallHints` reads `/etc/os-release`
and words it per machine — `sudo apt install android-tools-adb`, `dnf`, `pacman`
or `zypper` — and falls back to naming the package rather than guessing a
package manager for a distribution it does not know. `ID_LIKE` carries the
derivatives: Mint, Pop!_OS, Zorin and elementary all report their own `ID` and
all install adb with apt. The device bar's button copies the command.

## The menu bar was see-through

Mine, from beta.4. Linux draws the app's own GTK menu bar above the webview, and
that strip has nothing to paint itself on over a transparent window — a user's
terminal was showing through File, Edit and View.

`tauri.linux.conf.json` turns transparency off there, `lib/platform.ts` stops the
page painting itself translucent to match, and Settings says Opacity is
unavailable on Linux and why. Grain still works. A Rust test fails if the two
configs drift, because Tauri's platform-config merge is not something to learn
about from a screenshot.

## Why it shipped, and what now catches it

The Linux smoke job photographs the app against a black root window, so a hole
in it was black on black. It now counts **pure-black pixels inside the window
rectangle** — the palette's darkest colour is `#1a1a1a`, so an exactly-black
pixel in there is somewhere the app did not paint. The fixed build measures 0;
the menu bar alone would have been ~26,000.

Painting the root a louder colour would read better in the screenshots and does
not work: `xsetroot -solid` leaves a bare Xvfb root black with or without
`xrefresh`. Checked twice, and written down in the script so nobody checks a
third time.

## Verified

On a real `.deb` built from this branch:

- control file — `Depends: libcurl4, libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0`, `Recommends: android-tools-adb, gstreamer1.0-libav`
- smoke run passes with `unpainted pixels inside the window: 0`, and the launch
  screenshot shows an opaque menu bar
- `make test-linux` green at 1794 — the per-distro hints are `#if os(Linux)` and
  only type-check there
- ADBKit 1874, `make desktop-test` clean, 1221 vitest

🤖 Generated with [Claude Code](https://claude.com/claude-code)