### PR TITLE
Reactotron reverse on restart, emulator relaunch feedback, native notifications, and wide video format support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ on:
 permissions:
   contents: read
 
+# One run per branch. A PR is 12 jobs across four runners plus two container
+# builds and the Linux app smoke, so three pushes in a row otherwise leave
+# three full sets racing for the same answer. Cancelling is only ever right
+# for a PR: a push to main feeds the Pages deploy and a tag run signs and
+# notarizes, so those two must always finish even when another arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: macos-15

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -115,7 +115,7 @@ public actor ReactotronServer {
     ///     (mirrors reactotron-core-server's 30s ping), so a half-dead socket
     ///     surfaces as a transport error instead of lingering "connected".
     public init(
-        port: UInt16 = 9090,
+        port: UInt16 = ReactotronService.defaultPort,
         loopbackOnly: Bool = true,
         pingInterval: Duration = .seconds(30)
     ) {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronService.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronService.swift
@@ -6,6 +6,11 @@ import Foundation
 /// localhost:9090 reaches the Mac, and tears both down on stop. The timeline
 /// view owns one of these, mirroring how `LogcatView` owns a `LogcatStreamer`.
 public actor ReactotronService {
+    /// The port upstream Reactotron's clients dial, and so the only one the
+    /// relay and its `adb reverse` tunnel may use. Named because the number is
+    /// a contract with `reactotron-react-native`, not a preference.
+    public static let defaultPort: UInt16 = 9090
+
     private let client: AdbClient
     private let port: UInt16
     private let server: ReactotronServer
@@ -14,7 +19,7 @@ public actor ReactotronService {
     /// Reactotron app's behavior) also accepts clients from the local network —
     /// required when the app's Metro bundle was served over Wi-Fi/LAN, because
     /// the client dials the bundle's host, not localhost.
-    public init(client: AdbClient, port: UInt16 = 9090, loopbackOnly: Bool = true) {
+    public init(client: AdbClient, port: UInt16 = ReactotronService.defaultPort, loopbackOnly: Bool = true) {
         self.client = client
         self.port = port
         self.server = ReactotronServer(port: port, loopbackOnly: loopbackOnly)

--- a/ADBKit/Sources/ADBKit/Services/VideoEditService.swift
+++ b/ADBKit/Sources/ADBKit/Services/VideoEditService.swift
@@ -53,6 +53,62 @@ public actor VideoEditService {
         return try? Data(contentsOf: out)
     }
 
+    /// An MP4 of `source` that AVFoundation can open, written to a temp file —
+    /// nil when ffmpeg is missing or both conversions fail.
+    ///
+    /// Only for inputs the player has already refused. The editor accepts
+    /// every container ffmpeg demuxes (`VideoInputFormat`), but playback,
+    /// scrubbing and AVKit's trim UI are all AVFoundation, which opens a
+    /// fraction of that list — so an `.mkv` would otherwise load as a black
+    /// pane with the trim button permanently disabled.
+    ///
+    /// A remux is tried first and is nearly free (`-c copy`, a file copy's
+    /// worth of work) — it covers the common case of H.264 in a container
+    /// AVFoundation won't parse. Only if that still won't play does the codec
+    /// itself need converting.
+    ///
+    /// The proxy is for *playing*. Exports always run from the original, so
+    /// nothing here costs the saved file any quality — and trim points chosen
+    /// against the proxy carry over unchanged, since both share one timeline.
+    public func playableProxy(for source: URL, isPlayable: @Sendable (URL) async -> Bool) async -> URL? {
+        guard let ffmpeg = await ffmpegPath() else { return nil }
+        let remuxed = proxyURL(for: source)
+        if await run(ffmpeg, VideoEditing.remuxArguments(input: source.path, output: remuxed.path)),
+           await isPlayable(remuxed) {
+            return remuxed
+        }
+        try? FileManager.default.removeItem(at: remuxed)
+
+        let transcoded = proxyURL(for: source)
+        if await run(ffmpeg, VideoEditing.transcodeArguments(input: source.path, output: transcoded.path)),
+           await isPlayable(transcoded) {
+            return transcoded
+        }
+        try? FileManager.default.removeItem(at: transcoded)
+        return nil
+    }
+
+    /// Always `.mp4` whatever went in — the container AVFoundation is
+    /// certain to parse. The name keeps the source's for the rare case
+    /// someone finds one of these in the temp directory.
+    private func proxyURL(for source: URL) -> URL {
+        let base = source.deletingPathExtension().lastPathComponent
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "droidective-proxy-\(base)-\(UInt32.random(in: 0 ... 0xffff_ffff))")
+            .appendingPathExtension("mp4")
+    }
+
+    /// A transcode of a long recording is minutes of work, so this shares the
+    /// export timeout rather than the thumbnail's.
+    private func run(_ ffmpeg: String, _ arguments: [String]) async -> Bool {
+        let output = await SystemProcessRunner().run(
+            executable: ffmpeg, arguments: arguments,
+            timeout: .seconds(600), maxOutputBytes: 4 * 1024 * 1024
+        )
+        return output.exitCode == 0
+    }
+
     /// Apply `options` to `source` and write `destination`. A no-edit export to
     /// the same container is a lossless file copy; everything else re-encodes.
     public func export(

--- a/ADBKit/Sources/ADBKit/Services/VideoEditing.swift
+++ b/ADBKit/Sources/ADBKit/Services/VideoEditing.swift
@@ -136,6 +136,30 @@ public enum VideoEditing {
         ["-i", input, "-c", "copy", "-movflags", "+faststart", "-y", output]
     }
 
+    /// Re-encode to H.264/AAC in an MP4 — the fallback that makes any input
+    /// the editor accepts playable by AVFoundation.
+    ///
+    /// A remux is tried first and handles the common case (an `.mkv` or `.ts`
+    /// already carrying H.264: repackaging costs a file copy). This is for
+    /// what a remux can't fix — VP9, AV1, Theora, MPEG-4 Part 2, anything
+    /// AVFoundation has no decoder for — where the pixels themselves have to
+    /// be converted.
+    ///
+    /// `-preset veryfast` because this is a proxy the user is waiting on, not
+    /// the export: the exported file is always produced from the original, so
+    /// nothing here reaches the saved result. `-pix_fmt yuv420p` because
+    /// AVFoundation refuses 10-bit and 4:4:4 H.264, which is exactly the kind
+    /// of file that needed a transcode in the first place.
+    public static func transcodeArguments(input: String, output: String) -> [String] {
+        [
+            "-i", input,
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+            "-pix_fmt", "yuv420p",
+            "-c:a", "aac", "-b:a", "128k",
+            "-movflags", "+faststart", "-y", output,
+        ]
+    }
+
     /// Losslessly concatenate same-codec segments (the concat demuxer) — used to
     /// stitch a paused/resumed recording's segments back into one file. `listFile`
     /// is an ffmpeg concat list (`file '<path>'` per line); `-safe 0` allows the

--- a/ADBKit/Sources/ADBKit/Services/VideoInputFormat.swift
+++ b/ADBKit/Sources/ADBKit/Services/VideoInputFormat.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Every container the video editor opens — the single source of truth for the
+/// open panel's filter, the drop filter, and the Finder document types, the way
+/// `AppPackageFormat` is for installable packages. A format added here widens
+/// every entry point at once.
+///
+/// This is the *input* list and is deliberately separate from `VideoFormat`,
+/// which enumerates export targets: the two overlap (mp4/mov/mkv/webm) but
+/// neither contains the other — GIF is an output only, and avi/flv/ts/wmv are
+/// inputs only, because ffmpeg reads far more than the editor should offer to
+/// write.
+///
+/// Membership means "ffmpeg demuxes this reliably", not "AVFoundation plays
+/// it" — most of this list AVFoundation refuses. Playback is handled by
+/// probing the file and building a proxy when it can't be played
+/// (`VideoEditService.playableProxy`), so the list needs no
+/// `isAVFoundationNative` flag and would be wrong to carry one: an `.mp4`
+/// holding AV1 fails the same probe an `.mkv` does.
+public enum VideoInputFormat: String, Sendable, CaseIterable {
+    /// The recorder's own container, and the export default.
+    case mp4
+    case mov
+    case m4v
+    /// Matroska and WebM — what a Chrome or OBS capture usually is. Neither
+    /// conforms to `public.movie`, so both need declared types to be openable.
+    case mkv
+    case webm
+    case avi
+    case flv
+    /// MPEG transport streams, as produced by screen capture boxes and HLS
+    /// segment dumps.
+    case ts
+    case m2ts
+    case mpg
+    case mpeg
+    case wmv
+    case threeGP = "3gp"
+    case ogv
+    /// Animated GIF, which is also an export target — trimming and cropping
+    /// one is the same operation as for any other input.
+    case gif
+
+    /// Every extension the editor opens, lowercased.
+    public static var fileExtensions: [String] { allCases.map(\.rawValue) }
+
+    /// The format of `fileName`, or nil when the extension isn't one we open.
+    /// Case-insensitive by construction — a camera writes `.MOV`, a transport
+    /// stream dump `.TS`.
+    public static func detect(fileName: String) -> VideoInputFormat? {
+        VideoInputFormat(rawValue: URL(fileURLWithPath: fileName).pathExtension.lowercased())
+    }
+
+    public var displayName: String {
+        switch self {
+        case .mp4: return "MP4"
+        case .mov: return "QuickTime"
+        case .m4v: return "M4V"
+        case .mkv: return "Matroska"
+        case .webm: return "WebM"
+        case .avi: return "AVI"
+        case .flv: return "Flash Video"
+        case .ts: return "MPEG Transport Stream"
+        case .m2ts: return "AVCHD"
+        case .mpg, .mpeg: return "MPEG"
+        case .wmv: return "Windows Media"
+        case .threeGP: return "3GP"
+        case .ogv: return "Ogg Video"
+        case .gif: return "GIF"
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/ReactotronServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronServiceTests.swift
@@ -1,0 +1,68 @@
+#if canImport(Network)
+import Testing
+@testable import ADBKit
+
+/// The `adb reverse` half of the relay — the tunnel that lets a device's
+/// localhost:9090 reach the Mac. Arg-vector tests, because the port is a
+/// contract with `reactotron-react-native` and a wrong or missing tunnel is
+/// a client that simply never appears.
+@Suite struct ReactotronServiceTests {
+    @Test func reverseUsesTheClientsAgreedPortOnEachSerial() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = ReactotronService(client: await makeTestClient(runner: runner))
+
+        let results = await service.reverse(serials: ["S1", "S2"])
+
+        #expect(results.map(\.ok) == [true, true])
+        #expect(runner.invocations.map(\.arguments) == [
+            ["-s", "S1", "reverse", "tcp:9090", "tcp:9090"],
+            ["-s", "S2", "reverse", "tcp:9090", "tcp:9090"],
+        ])
+    }
+
+    /// 9090 is upstream's number, not a preference — if this changes, every
+    /// `reactotron-react-native` client in the wild stops connecting.
+    @Test func defaultPortIsUpstreams() {
+        #expect(ReactotronService.defaultPort == 9090)
+    }
+
+    /// A freshly attached or just-booted device rejects the first reverse, so
+    /// giving up on one refusal is the difference between a working tunnel and
+    /// a permanent "waiting for a connection".
+    @Test func aRefusedReverseIsRetried() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stderr: "error: device offline", exitCode: 1)
+        let service = ReactotronService(client: await makeTestClient(runner: runner))
+
+        let results = await service.reverse(serials: ["S1"])
+
+        #expect(results.count == 1)
+        #expect(results[0].ok == false)
+        #expect(results[0].serial == "S1")
+        // The adb reason reaches the UI, which shows it in the tunnel banner.
+        #expect(results[0].detail.contains("device offline"))
+        #expect(runner.invocations.count == 3)
+    }
+
+    @Test func stopRemovesTheTunnelPerSerial() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "")
+        let service = ReactotronService(client: await makeTestClient(runner: runner))
+
+        await service.stop(serials: ["S1", "S2"])
+
+        #expect(runner.invocations.map(\.arguments) == [
+            ["-s", "S1", "reverse", "--remove", "tcp:9090"],
+            ["-s", "S2", "reverse", "--remove", "tcp:9090"],
+        ])
+    }
+
+    /// Shown in the Commands tab so the tunnel can be reproduced by hand.
+    @Test func reverseCommandMatchesWhatIsRun() async {
+        let runner = MockProcessRunner()
+        let service = ReactotronService(client: await makeTestClient(runner: runner))
+        #expect(await service.reverseCommand == "adb reverse tcp:9090 tcp:9090")
+    }
+}
+#endif

--- a/ADBKit/Tests/ADBKitTests/VideoEditingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/VideoEditingTests.swift
@@ -31,6 +31,22 @@ import Testing
         ])
     }
 
+    /// The playback-proxy fallback, for an input AVFoundation has no decoder
+    /// for (VP9, AV1, Theora) and a remux therefore can't rescue. Three parts
+    /// are load-bearing: H.264 in MP4, `yuv420p` — AVFoundation refuses
+    /// 10-bit and 4:4:4 H.264, which is exactly the kind of file that gets
+    /// here — and `veryfast`, since this is a proxy someone is waiting on and
+    /// it never reaches the exported file.
+    @Test func transcodeArgumentsProduceAnAVFoundationReadableMp4() {
+        #expect(VideoEditing.transcodeArguments(input: "/tmp/a.mkv", output: "/tmp/p.mp4") == [
+            "-i", "/tmp/a.mkv",
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+            "-pix_fmt", "yuv420p",
+            "-c:a", "aac", "-b:a", "128k",
+            "-movflags", "+faststart", "-y", "/tmp/p.mp4",
+        ])
+    }
+
     // MARK: defaults / identity
 
     @Test func defaultMp4ReencodesWithNoFilters() {

--- a/ADBKit/Tests/ADBKitTests/VideoInputFormatTests.swift
+++ b/ADBKit/Tests/ADBKitTests/VideoInputFormatTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import ADBKit
+
+/// The editor's input list. Same shape and same canary as
+/// `AppPackageFormatTests`, because it plays the same role: every drop
+/// filter, open panel, and Finder document type derives from it, so a case
+/// added without the extension list noticing silently widens nothing.
+@Suite struct VideoInputFormatTests {
+    @Test func detectsEveryContainerCaseInsensitively() {
+        #expect(VideoInputFormat.detect(fileName: "clip.mp4") == .mp4)
+        // A camera writes .MOV; a transport-stream dump .TS.
+        #expect(VideoInputFormat.detect(fileName: "IMG_0042.MOV") == .mov)
+        #expect(VideoInputFormat.detect(fileName: "capture.TS") == .ts)
+        #expect(VideoInputFormat.detect(fileName: "screencast.WebM") == .webm)
+        #expect(VideoInputFormat.detect(fileName: "3gp clip.3gp") == .threeGP)
+        // A path with spaces and dots in the name, not just the extension.
+        #expect(VideoInputFormat.detect(fileName: "My Recording v1.2.mkv") == .mkv)
+        #expect(VideoInputFormat.detect(fileName: "/tmp/a/b/x.m2ts") == .m2ts)
+    }
+
+    @Test func rejectsWhatTheEditorCannotOpen() {
+        #expect(VideoInputFormat.detect(fileName: "app.apk") == nil)
+        #expect(VideoInputFormat.detect(fileName: "notes.txt") == nil)
+        #expect(VideoInputFormat.detect(fileName: "song.mp3") == nil)
+        #expect(VideoInputFormat.detect(fileName: "poster.png") == nil)
+        #expect(VideoInputFormat.detect(fileName: "noextension") == nil)
+        // A directory named like a file — the open panel's own check rejects
+        // directories, this only answers on the extension.
+        #expect(VideoInputFormat.detect(fileName: "/videos/mp4") == nil)
+    }
+
+    /// The canary: every case reaches the list the filters are built from.
+    @Test func extensionsCoverEveryCaseSoDropFiltersStayInSync() {
+        #expect(Set(VideoInputFormat.fileExtensions) == [
+            "mp4", "mov", "m4v", "mkv", "webm", "avi", "flv",
+            "ts", "m2ts", "mpg", "mpeg", "wmv", "3gp", "ogv", "gif",
+        ])
+        // Raw values *are* the extensions, which is what makes the list free.
+        #expect(VideoInputFormat.fileExtensions.allSatisfy { $0 == $0.lowercased() })
+    }
+
+    /// The recorder's own output has to be openable, or Edit from the
+    /// recording-decision sheet lands on a rejected file.
+    @Test func theRecordersContainerIsAccepted() {
+        #expect(VideoInputFormat.detect(fileName: "recording_20260903.mp4") == .mp4)
+    }
+
+    /// Every export target that is also a container must round-trip back in,
+    /// or a file the editor just wrote can't be reopened. GIF included — it
+    /// is both, unlike the input-only and output-only members either side.
+    @Test func everyExportTargetCanBeReopened() {
+        for format in VideoFormat.allCases {
+            #expect(
+                VideoInputFormat(rawValue: format.fileExtension) != nil,
+                "exported .\(format.fileExtension) cannot be reopened"
+            )
+        }
+    }
+
+    @Test func namesAreDistinctEnoughToShow() {
+        let names = VideoInputFormat.allCases.map(\.displayName)
+        #expect(names.allSatisfy { !$0.isEmpty })
+        // mpg and mpeg deliberately share "MPEG"; nothing else may collide.
+        #expect(Set(names).count == VideoInputFormat.allCases.count - 1)
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -112,15 +112,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    /// Clicking an install notification reopens the main window — while
-    /// backgrounded the app is an accessory, so plain activation would land
-    /// on nothing.
+    /// Show notifications while Droidective itself is frontmost. Without
+    /// this the system swallows them silently whenever the app is active,
+    /// which is most of the time — the whole point is that a five-second
+    /// toast is not the only trace an event leaves.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    /// Clicking a notification opens the in-app notification bar on the
+    /// matching row. While backgrounded the app is an accessory, so plain
+    /// activation would land on nothing — `revealNotifications` brings a
+    /// window up first, opening one if every window is closed.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        Task { @MainActor in AppCore.shared.activateAnyWindow() }
+        // Read off the response here: it's a non-Sendable class, so only the
+        // extracted string may cross into the main-actor task.
+        let entry = response.notification.request.content.userInfo[SystemNotifier.entryKey] as? String
+        Task { @MainActor in
+            AppCore.shared.revealNotifications(entry: entry.flatMap(UUID.init(uuidString:)))
+        }
         completionHandler()
     }
 

--- a/App/Sources/FeatureDetail/Views/EmulatorRelaunchPhase.swift
+++ b/App/Sources/FeatureDetail/Views/EmulatorRelaunchPhase.swift
@@ -1,0 +1,40 @@
+/// The stages a relaunch passes through and what the AVD's row says during
+/// each. Pure, so the wording is testable without an emulator — and worth
+/// separating because a relaunch spends nearly all of its time in
+/// `waitingForShutdown`, which is exactly the stretch that used to render as
+/// nothing at all while the console port was polled for up to 20 seconds.
+enum EmulatorRelaunchPhase: Equatable, Sendable {
+    case stopping
+    case waitingForShutdown(secondsElapsed: Int)
+    case booting
+
+    /// What the row shows beside its spinner.
+    var label: String {
+        switch self {
+        case .stopping:
+            "Stopping…"
+        case let .waitingForShutdown(seconds):
+            // The count only appears once there is something to count: a
+            // bare "0s" on the first tick reads like a stuck timer.
+            seconds < 1
+                ? "Waiting for it to shut down…"
+                : "Waiting for it to shut down… \(seconds)s"
+        case .booting:
+            "Booting…"
+        }
+    }
+
+    /// `adb emu kill` failed, so there is nothing to wait for — and booting
+    /// now would race the still-running emulator into a second serial, which
+    /// is the whole reason the wait exists.
+    static func stopFailed(name: String, reason: String) -> String {
+        "Couldn't stop \(name): \(reason)"
+    }
+
+    /// The console port never freed. Booting anyway produces the second
+    /// serial the wait is there to prevent, so the relaunch stops instead and
+    /// says the emulator is still up.
+    static func shutdownTimedOut(name: String, seconds: Int) -> String {
+        "\(name) didn't shut down within \(seconds)s — it's still running, so it wasn't relaunched"
+    }
+}

--- a/App/Sources/FeatureDetail/Views/EmulatorsView.swift
+++ b/App/Sources/FeatureDetail/Views/EmulatorsView.swift
@@ -14,6 +14,9 @@ struct EmulatorsView: View {
     @State private var reloadToken = 0
     @State private var wipeTarget: Avd?
     @State private var showAllSimulators = false
+    /// AVD name → the relaunch stage in flight, so the row can report it and
+    /// the button can't be pressed twice.
+    @State private var relaunching: [String: EmulatorRelaunchPhase] = [:]
 
     /// The role decides which platforms this screen shows at all: iOS
     /// Developer sees only the simulators section (titled "Simulators"),
@@ -26,6 +29,9 @@ struct EmulatorsView: View {
     private var showsSimulators: Bool { visiblePlatforms.contains(.iosSimulator) }
 
     private static let collapsedSimulatorCount = 5
+    /// How long a relaunch waits for the console port to free before giving
+    /// up. An emulator with a large snapshot takes several seconds to exit.
+    private static let shutdownWaitSeconds = 20
 
     var body: some View {
         Group {
@@ -156,7 +162,14 @@ struct EmulatorsView: View {
             }
             Spacer()
 
-            if let serial = avd.runningSerial {
+            if let phase = relaunching[avd.name] {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text(phase.label)
+                        .font(.app(.footnote))
+                        .foregroundStyle(.textMuted)
+                }
+            } else if let serial = avd.runningSerial {
                 Button("Relaunch") {
                     relaunch(avd, serial: serial)
                 }
@@ -318,17 +331,71 @@ struct EmulatorsView: View {
 
     /// Stop the running emulator, wait for its console port to free (so the
     /// relaunch can't come up as a second serial), then boot the same AVD.
+    ///
+    /// Every stage reports: the row carries a spinner and the phase's label,
+    /// because the shutdown wait alone runs to `shutdownWaitSeconds` and used
+    /// to show nothing at all. A failed stop and a shutdown that never
+    /// finishes both stop here with a reason instead of booting into a
+    /// conflict, and the button is unavailable while one is in flight — it
+    /// was re-clickable, and a second click meant two stops and two boots.
     private func relaunch(_ avd: Avd, serial: String) {
+        guard relaunching[avd.name] == nil else { return }
+        // Remembered before anything stops, so the post-boot focus targets the
+        // process we start rather than another emulator already up.
+        let existing = Set(emulatorApps().map(\.processIdentifier))
+        relaunching[avd.name] = .stopping
         Task {
-            await CommandLog.userInitiated {
-                _ = try? await state.env.engine.emulators.stop(serial: serial)
+            defer { relaunching[avd.name] = nil }
+
+            let stopped = await CommandLog.userInitiated {
+                (try? await state.env.engine.emulators.stop(serial: serial))
+                    ?? FeatureResult(ok: false, message: "adb not found")
             }
-            for _ in 0..<20 {
-                if await state.env.engine.emulators.consolePID(serial: serial) == nil { break }
+            guard stopped.ok else {
+                state.showToast(Toast(
+                    message: EmulatorRelaunchPhase.stopFailed(
+                        name: avd.displayName, reason: stopped.message),
+                    ok: false
+                ))
+                return
+            }
+
+            var freed = false
+            for second in 0..<Self.shutdownWaitSeconds {
+                relaunching[avd.name] = .waitingForShutdown(secondsElapsed: second)
+                if await state.env.engine.emulators.consolePID(serial: serial) == nil {
+                    freed = true
+                    break
+                }
                 try? await Task.sleep(for: .seconds(1))
             }
             state.refreshDevices()
-            launch(avd, options: EmulatorService.LaunchOptions())
+            guard freed else {
+                reloadToken += 1
+                state.showToast(Toast(
+                    message: EmulatorRelaunchPhase.shutdownTimedOut(
+                        name: avd.displayName, seconds: Self.shutdownWaitSeconds),
+                    ok: false
+                ))
+                return
+            }
+
+            relaunching[avd.name] = .booting
+            let ok = await CommandLog.userInitiated {
+                let result = await state.env.engine.emulators.launch(
+                    avd: avd.name, options: EmulatorService.LaunchOptions())
+                state.showToast(Toast(
+                    message: result.ok ? "Relaunching \(avd.displayName)…" : result.message,
+                    ok: result.ok
+                ))
+                return result.ok
+            }
+            reloadToken += 1
+            // Its own task so the row's spinner clears now rather than after
+            // the window-focus poll, which runs for as long as 25s.
+            if ok {
+                Task { await focusNewEmulator(excluding: existing) }
+            }
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -83,6 +83,16 @@ final class ReactotronSession {
     /// The ready-Android serials last seen, so `deviceListChanged` reverses
     /// only serials that (re)appeared — not every device on every flicker.
     private var knownReadySerials: Set<String> = []
+    /// Per-serial count of the "the tunnel may have died under us" retries.
+    /// `deviceListChanged` only reverses serials that *appeared*, so a tunnel
+    /// lost while the device stayed listed (an `adb kill-server`, a USB
+    /// re-enumeration that kept the serial) would never reopen. With nothing
+    /// connected we therefore also re-reverse the serials already known — but
+    /// bounded, because that poll fires every 2s and an unbounded retry would
+    /// be one adb call per device per tick, forever. Reset when a client
+    /// connects, so a later disconnect re-arms the net.
+    @ObservationIgnored private var reverseRefreshAttempts: [String: Int] = [:]
+    @ObservationIgnored private let reverseRefreshLimit = 3
 
     /// True once the server is up — stays true after leaving the view when the
     /// user chose to keep the connection alive.
@@ -209,14 +219,38 @@ final class ReactotronSession {
     func deviceListChanged() {
         let current = Set(readyAndroidSerials)
         tunnelIssues = tunnelIssues.filter { current.contains($0.key) }
+        reverseRefreshAttempts = reverseRefreshAttempts.filter { current.contains($0.key) }
         guard isRunning else {
             knownReadySerials = current
             return
         }
         let added = current.subtracting(knownReadySerials)
         knownReadySerials = current
-        guard !added.isEmpty else { return }
-        Task { await applyReverse(serials: Array(added)) }
+        var serials = added
+        // Nothing connected — the tunnel may have died with the device still
+        // listed, so reopen the known ones too (bounded; see the field).
+        if clients.isEmpty {
+            for serial in current.subtracting(added)
+            where reverseRefreshAttempts[serial, default: 0] < reverseRefreshLimit {
+                reverseRefreshAttempts[serial, default: 0] += 1
+                serials.insert(serial)
+            }
+        }
+        guard !serials.isEmpty else { return }
+        Task { await applyReverse(serials: Array(serials)) }
+    }
+
+    /// Re-open every tunnel, ignoring the "only new serials" rule — what
+    /// restarting the app being debugged needs. The fresh process dials
+    /// localhost:9090 the moment it boots, so the tunnel has to be known-good
+    /// before it gets there, and the serial hasn't changed, so nothing in
+    /// `deviceListChanged` would have touched it.
+    func reapplyReverse() async {
+        guard isRunning else { return }
+        let serials = readyAndroidSerials
+        guard !serials.isEmpty else { return }
+        reverseRefreshAttempts.removeAll()
+        await applyReverse(serials: serials)
     }
 
     /// The Settings LAN toggle flipped: restart the socket layer with the new
@@ -508,6 +542,9 @@ final class ReactotronSession {
             }
             clients.removeAll { $0.id == connectionId }
             clients.append(ClientInfo(id: connectionId, name: name, platform: platform))
+            // An app got through, so the tunnels are good: re-arm the
+            // "reopen a silently dead tunnel" budget for the next disconnect.
+            reverseRefreshAttempts.removeAll()
             refreshConnectionState()
             // Straight to the new client, not the picker's current target —
             // otherwise an app (re)connecting while another is selected never
@@ -3611,6 +3648,11 @@ private struct RestartAppMenu: View {
                 cleared = false
             }
             _ = try? await service.control(serial: serial, packageId: package, action: .stop)
+            // Between the stop and the relaunch, because the fresh process
+            // dials localhost:9090 as it boots and a tunnel it finds missing
+            // is a client that never appears. Cheap and idempotent when the
+            // tunnel is already up, which is the common case.
+            await state.reactotronSession.reapplyReverse()
             let result = try? await service.control(serial: serial, packageId: package, action: .open)
             return (result?.ok == true, cleared)
         }

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -105,6 +105,15 @@ struct VideoEditorPane: View {
     @State private var videoSize: CGSize?
     @State private var assetDuration: Double = 0
 
+    /// An MP4 stand-in for a source AVFoundation refuses, built by ffmpeg and
+    /// used for playback only — the export always reads `source.url`, so a
+    /// proxy costs the saved file nothing. Deleted when the editor closes.
+    @State private var proxyURL: URL?
+    @State private var preparingProxy = false
+    /// Neither a remux nor a transcode produced something playable: the file
+    /// can't be edited here, and saying so beats a black pane.
+    @State private var proxyFailed = false
+
     /// Identifies this view's leave guard so a stale clear can't wipe another's.
     @State private var exitGuardID = UUID()
     /// The edit state at the last successful export; edits matching it count as
@@ -153,6 +162,12 @@ struct VideoEditorPane: View {
         .onDisappear {
             player.pause()
             state.clearExitGuard(exitGuardID)
+            // The proxy is scratch: nothing refers to it once the editor is
+            // gone, and a transcoded recording is the size of the original.
+            if let proxyURL {
+                try? FileManager.default.removeItem(at: proxyURL)
+                self.proxyURL = nil
+            }
         }
     }
 
@@ -188,9 +203,58 @@ struct VideoEditorPane: View {
             }
             .frame(width: geo.size.width, height: geo.size.height)
             .clipped()
+            .overlay {
+                if preparingProxy {
+                    conversionOverlay
+                } else if proxyFailed {
+                    unreadableOverlay
+                }
+            }
         }
         .frame(maxWidth: .infinity, minHeight: 260, maxHeight: .infinity)
         .background(Color.black)
+    }
+
+    /// ffmpeg is building a playable copy. Over the (black) player rather than
+    /// replacing the pane, so the header and its Close button stay reachable
+    /// — a transcode of a long recording is minutes, not a moment.
+    private var conversionOverlay: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Preparing \(sourceFormatName) for playback…")
+                .font(.app(.callout))
+                .foregroundStyle(.white)
+            Text("macOS can't play this format directly, so it's being converted.\nYour export still comes from the original file.")
+                .font(.app(.footnote))
+                .foregroundStyle(.white.opacity(0.65))
+                .multilineTextAlignment(.center)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(0.72))
+    }
+
+    private var unreadableOverlay: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.app(size: 30))
+                .foregroundStyle(.orange)
+            Text("Can't read this video")
+                .font(.app(.headline))
+                .foregroundStyle(.white)
+            Text("ffmpeg couldn't decode \(source.url.lastPathComponent). The file may be truncated or use a codec it wasn't built with.")
+                .font(.app(.footnote))
+                .foregroundStyle(.white.opacity(0.65))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black.opacity(0.85))
+    }
+
+    private var sourceFormatName: String {
+        VideoInputFormat.detect(fileName: source.url.lastPathComponent)?.displayName ?? "this video"
     }
 
     /// Player frame: the full container normally — AVKit's floating controls
@@ -496,7 +560,9 @@ struct VideoEditorPane: View {
     // MARK: loading + export
 
     private func loadAsset() async {
-        let size = await Self.naturalVideoSize(at: source.url)
+        proxyFailed = false
+        guard let playable = await resolvePlayableURL() else { return }
+        let size = await Self.naturalVideoSize(at: playable)
         let loaded = try? await asset.load(.duration)
         // Both probes complete before anything is published, so a re-keyed task
         // (a different video) writes none of this one's metadata.
@@ -504,6 +570,57 @@ struct VideoEditorPane: View {
         if let size { videoSize = size }
         if let loaded { assetDuration = loaded.seconds }
         player.isMuted = edit.mute
+    }
+
+    /// The URL to *play*: the source itself when AVFoundation can open it,
+    /// otherwise an ffmpeg-built MP4 proxy.
+    ///
+    /// The editor accepts every container ffmpeg demuxes, but playback,
+    /// scrubbing and AVKit's trim UI are all AVFoundation, which reads a
+    /// fraction of that list — so an `.mkv` used to load as a black pane with
+    /// Trim permanently disabled. The file is asked rather than its extension,
+    /// because the extension doesn't predict the answer: an `.mp4` carrying
+    /// AV1 fails the same probe an `.mkv` does, and a `.mkv` carrying H.264
+    /// passes after nothing more than a remux.
+    ///
+    /// Returns nil when no proxy could be produced, leaving `proxyFailed` set.
+    private func resolvePlayableURL() async -> URL? {
+        if await Self.isPlayable(source.url) { return source.url }
+        if let proxyURL { return proxyURL }
+
+        preparingProxy = true
+        let built = await VideoEditService(
+            locator: state.env.client.locator, bundledPath: BundledTools.ffmpegPath()
+        ).playableProxy(for: source.url, isPlayable: Self.isPlayable)
+        guard !Task.isCancelled else {
+            // The view is going away; don't leave the temp file behind.
+            if let built { try? FileManager.default.removeItem(at: built) }
+            return nil
+        }
+        preparingProxy = false
+        guard let built else {
+            proxyFailed = true
+            return nil
+        }
+        proxyURL = built
+        // A fresh AVPlayer, not `replaceCurrentItem`: a player that already
+        // failed on the original is permanently `.failed` and can't be
+        // recovered by handing it a new item.
+        let swapped = AVURLAsset(url: built)
+        asset = swapped
+        player = AVPlayer(playerItem: AVPlayerItem(asset: swapped))
+        return built
+    }
+
+    /// Whether AVFoundation can actually play `url` — playable *and* carrying a
+    /// video track, since an audio-only or header-only file reports playable
+    /// and then renders nothing. Off the main actor so the non-Sendable asset
+    /// never crosses isolation.
+    private nonisolated static func isPlayable(_ url: URL) async -> Bool {
+        let asset = AVURLAsset(url: url)
+        guard let playable = try? await asset.load(.isPlayable), playable else { return false }
+        guard let tracks = try? await asset.loadTracks(withMediaType: .video) else { return false }
+        return !tracks.isEmpty
     }
 
     /// Resolve the video's oriented size off the main actor so the non-Sendable

--- a/App/Sources/FeatureDetail/Views/VideoEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorView.swift
@@ -1,14 +1,13 @@
+import ADBKit
 import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// The Video Editor feature: open (or drop) any video and edit it. Fresh
-/// recordings open the same editor automatically from Screen Record.
+/// recordings open the same editor automatically from Screen Record, and a
+/// video opened from Finder arrives through `AppState.pendingVideo`.
 struct VideoEditorView: View {
     @Environment(AppState.self) private var state
     @State private var openedURL: URL?
-
-    private static let videoTypes: [UTType] = [.movie, .video, .mpeg4Movie, .quickTimeMovie]
 
     var body: some View {
         Group {
@@ -18,6 +17,12 @@ struct VideoEditorView: View {
             } else {
                 emptyState
             }
+        }
+        // A Finder open (or a second one while the editor is already up)
+        // routes the feature here and leaves the URL waiting. Claimed rather
+        // than read, so returning to the tab later doesn't reopen it.
+        .task(id: state.pendingVideo) {
+            if let url = state.claimPendingVideo() { openedURL = url }
         }
     }
 
@@ -37,7 +42,17 @@ struct VideoEditorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(20)
         .dropDestination(for: URL.self) { urls, _ in
-            guard let url = urls.first else { return false }
+            // Filtered, where this used to take whatever was dropped and hand
+            // an .apk or a .txt to AVFoundation as if it were a video.
+            guard let url = PlayableVideo.filter(urls).first else {
+                if let rejected = urls.first {
+                    state.showToast(Toast(
+                        message: "Not a video Droidective can open: \(rejected.lastPathComponent)",
+                        ok: false
+                    ))
+                }
+                return false
+            }
             openedURL = url
             return true
         }
@@ -45,7 +60,7 @@ struct VideoEditorView: View {
 
     private func openFile() {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = Self.videoTypes
+        panel.allowedContentTypes = PlayableVideo.contentTypes
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         if panel.runModal() == .OK, let url = panel.url { openedURL = url }

--- a/App/Sources/Root/NotificationPanelView.swift
+++ b/App/Sources/Root/NotificationPanelView.swift
@@ -14,12 +14,26 @@ struct NotificationPanelView: View {
             if state.notifications.isEmpty {
                 emptyState
             } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(state.notifications) { note in
-                            NotificationRow(note: note)
-                            Divider().padding(.leading, 44)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(state.notifications) { note in
+                                NotificationRow(note: note, focused: state.focusedNotification == note.id)
+                                    .id(note.id)
+                                Divider().padding(.leading, 44)
+                            }
                         }
+                    }
+                    // A clicked macOS notification names its row; scroll to it
+                    // and let the row flash. Cleared once handled so it can't
+                    // re-flash on a later render, and so a reopened panel
+                    // doesn't jump to a row nobody asked about.
+                    .task(id: state.focusedNotification) {
+                        guard let focused = state.focusedNotification else { return }
+                        withAnimation { proxy.scrollTo(focused, anchor: .center) }
+                        try? await Task.sleep(for: .seconds(2))
+                        guard !Task.isCancelled, state.focusedNotification == focused else { return }
+                        state.focusedNotification = nil
                     }
                 }
             }
@@ -67,6 +81,9 @@ struct NotificationPanelView: View {
 private struct NotificationRow: View {
     @Environment(AppState.self) private var state
     let note: AppNotification
+    /// This is the row a macOS notification click asked for — tinted so the
+    /// eye lands on it after the panel scrolls.
+    let focused: Bool
     @State private var hovering = false
 
     var body: some View {
@@ -119,8 +136,18 @@ private struct NotificationRow: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
-        .background(hovering ? AnyShapeStyle(.brandAccent.opacity(0.08)) : AnyShapeStyle(.clear))
+        .background(rowBackground)
+        .animation(.easeOut(duration: 0.25), value: focused)
         .onHover { hovering = $0 }
+    }
+
+    /// Focus outranks hover — the flash is a one-off answer to a click that
+    /// came from outside the app, and the cursor is usually sitting on the
+    /// row by then anyway.
+    private var rowBackground: AnyShapeStyle {
+        if focused { return AnyShapeStyle(.brandAccent.opacity(0.22)) }
+        if hovering { return AnyShapeStyle(.brandAccent.opacity(0.08)) }
+        return AnyShapeStyle(.clear)
     }
 }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -241,13 +241,17 @@ struct RootView: View {
             guard let target = AppCore.shared.frontmost else { return }
             let packages = InstallablePackage.filter(urls)
             let aabs = urls.filter { $0.pathExtension.lowercased() == "aab" }
-            let handled = Set(AppPackageFormat.fileExtensions + ["aab"])
+            let videos = PlayableVideo.filter(urls)
+            let handled = Set(
+                AppPackageFormat.fileExtensions + ["aab"] + VideoInputFormat.fileExtensions
+            )
             for other in urls where !handled.contains(other.pathExtension.lowercased()) {
                 target.showToast(Toast(
-                    message: "Not an installable package: \(other.lastPathComponent)", ok: false))
+                    message: "Droidective can't open \(other.lastPathComponent)", ok: false))
             }
             if !packages.isEmpty { target.openPackages(packages) }
             if !aabs.isEmpty { target.openAABs(aabs) }
+            if !videos.isEmpty { target.openVideos(videos) }
         }
         #if !APPSTORE
         // Update toasts ("available" / "ready — relaunch" / "up to date")

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -642,6 +642,32 @@ final class AppCore {
         }
     }
 
+    /// A macOS notification was clicked: bring a window up and open its
+    /// notification bar on the row the notification came from.
+    ///
+    /// The panel can't be opened inline in every case — with no workspace at
+    /// all, `activateAnyWindow` has only just *asked* for a window, and the
+    /// accessory path inside `activateMainWindow` hops a runloop turn before
+    /// the window is front. So the common case (a window already exists)
+    /// runs straight through, and the cold case waits for a workspace to bind
+    /// rather than guessing a delay.
+    func revealNotifications(entry: UUID?) {
+        activateAnyWindow()
+        if let target = frontmost {
+            target.openNotifications(focusing: entry)
+            return
+        }
+        Task { @MainActor in
+            for _ in 0 ..< 20 {
+                try? await Task.sleep(for: .milliseconds(100))
+                if let target = frontmost {
+                    target.openNotifications(focusing: entry)
+                    return
+                }
+            }
+        }
+    }
+
     /// Mirror a window's device into the registry so the conflict rules see it.
     func noteSelection(_ serial: String?, in id: WorkspaceID) {
         registry.setDevice(serial: serial, for: id)

--- a/App/Sources/State/AppState+Install.swift
+++ b/App/Sources/State/AppState+Install.swift
@@ -69,6 +69,32 @@ extension AppState {
         requestFeature("aab-convert")
     }
 
+    /// Route a Finder-opened video to the Video Editor. Unlike `apk-open`,
+    /// this needs no tab of its own: `video-editor` is already a registry
+    /// feature with a route, so the file is staged and the feature requested —
+    /// which also means it inherits the route tests instead of the string
+    /// branch `apk-open` has to live with.
+    ///
+    /// One at a time, because the editor edits one video: extras say so
+    /// rather than being dropped silently, matching `openAABs`.
+    func openVideos(_ urls: [URL]) {
+        guard let first = urls.first else { return }
+        pendingVideo = first
+        for extra in urls.dropFirst() {
+            showToast(Toast(
+                message: "Editing one video at a time — reopen \(extra.lastPathComponent) after this one",
+                ok: false))
+        }
+        activateMainWindow()
+        requestFeature("video-editor")
+    }
+
+    /// Take the staged Finder-opened video, clearing it so it opens once.
+    func claimPendingVideo() -> URL? {
+        defer { pendingVideo = nil }
+        return pendingVideo
+    }
+
     /// Fire-and-forget install: the work runs in an unstructured task owned by
     /// the app — not the calling view or panel — so navigating away, closing
     /// the panel, or closing the main window never kills an `adb install`

--- a/App/Sources/State/AppState+Install.swift
+++ b/App/Sources/State/AppState+Install.swift
@@ -200,11 +200,11 @@ extension AppState {
     private static func installToast(
         name: String, ok: Int, total: Int, failures: [(serial: String, result: FeatureResult)]
     ) -> Toast {
-        // notifiesWhenBackgrounded is off: the batch posts one summary
+        // postsSystemNotification is off: the batch posts one summary
         // notification instead of one per APK.
         if failures.isEmpty {
             let message = total == 1 ? "Installed \(name)" : "Installed \(name) on \(total) devices"
-            return Toast(message: message, ok: true, notifiesWhenBackgrounded: false)
+            return Toast(message: message, ok: true, postsSystemNotification: false)
         }
         let message = total == 1
             ? "Couldn't install \(name) — \(failures[0].result.message)"
@@ -217,6 +217,6 @@ extension AppState {
             .joined(separator: "\n\n")
         return Toast(
             message: message, ok: false, copyText: detail.isEmpty ? nil : detail,
-            notifiesWhenBackgrounded: false)
+            postsSystemNotification: false)
     }
 }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -357,6 +357,10 @@ final class AppState {
     /// An `.aab` opened from Finder (double-click / Open With), staged for the
     /// AAB to APK feature. The view consumes (clears) it once shown.
     var pendingConvertAAB: URL?
+    /// A video opened from Finder ("Open With ▸ Droidective"), staged for the
+    /// Video Editor. Consumed by `claimPendingVideo` once the editor has it,
+    /// so returning to the tab later doesn't reopen the same file.
+    var pendingVideo: URL?
     /// The real app delegate (the adaptor instance, wired in `ADTApp.body`) —
     /// `NSApp.delegate` is SwiftUI's wrapper on macOS, so casting it fails.
     weak var appDelegate: AppDelegate?

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -43,10 +43,12 @@ struct Toast: Identifiable, Equatable {
     /// always are; a success only when it produced an artifact (a reveal
     /// path) — routine confirmations like "Copied" are dropped.
     let important: Bool
-    /// Whether this mirrors to a macOS notification when the app is
-    /// backgrounded. Defaults to `important`; install per-APK toasts opt out
-    /// because the batch posts one summary instead.
-    let notifiesWhenBackgrounded: Bool
+    /// Whether this also becomes a macOS notification. Defaults to
+    /// `important`, so what the notification bar keeps, Notification Center
+    /// keeps too — foreground included, since a 5s overlay is missable and
+    /// nothing else outlives it. Install per-APK toasts opt out because the
+    /// batch posts one summary instead.
+    let postsSystemNotification: Bool
 
     init(
         message: String,
@@ -56,7 +58,7 @@ struct Toast: Identifiable, Equatable {
         revealPath: String? = nil,
         action: NotificationAction? = nil,
         important: Bool? = nil,
-        notifiesWhenBackgrounded: Bool? = nil
+        postsSystemNotification: Bool? = nil
     ) {
         self.message = message
         self.ok = ok
@@ -68,7 +70,7 @@ struct Toast: Identifiable, Equatable {
         let resolvedImportant = important
             ?? (resolved == .error || resolved == .warning || revealPath != nil)
         self.important = resolvedImportant
-        self.notifiesWhenBackgrounded = notifiesWhenBackgrounded ?? resolvedImportant
+        self.postsSystemNotification = postsSystemNotification ?? resolvedImportant
     }
 }
 
@@ -166,6 +168,10 @@ final class AppState {
     var showNotifications = false
     /// Important notifications arrived since the panel was last opened.
     var unreadNotifications = 0
+    /// The row a clicked macOS notification asked for: scrolled to and
+    /// flashed once, then cleared by the panel so it doesn't re-flash on
+    /// every later render.
+    var focusedNotification: UUID?
     var isRunningFeature = false
 
     // Layout toggle: ⌘B (sidebar).
@@ -1305,8 +1311,10 @@ final class AppState {
 
     func showToast(_ toast: Toast) {
         toasts.append(toast)
-        if toast.notifiesWhenBackgrounded {
-            SystemNotifier.postToastIfBackgrounded(toast)
+        if toast.postsSystemNotification {
+            // The bar entry reuses the toast's id, so the notification can
+            // carry it and a click can open the bar on that exact row.
+            SystemNotifier.postToast(toast, entry: toast.id)
         }
         if toast.important {
             notifications.insert(
@@ -1335,6 +1343,19 @@ final class AppState {
     func toggleNotifications() {
         showNotifications.toggle()
         if showNotifications { unreadNotifications = 0 }
+        if !showNotifications { focusedNotification = nil }
+    }
+
+    /// Open the panel — the route a clicked macOS notification takes, so it
+    /// must not close an already-open one the way `toggleNotifications` would.
+    /// `entry` is the row to scroll to and flash; it is dropped when this
+    /// window's history doesn't hold it, which happens when the notification
+    /// was posted by a different window (the history is per window, the
+    /// notification is per app).
+    func openNotifications(focusing entry: UUID? = nil) {
+        focusedNotification = notifications.contains { $0.id == entry } ? entry : nil
+        showNotifications = true
+        unreadNotifications = 0
     }
 
     func clearNotifications() {

--- a/App/Sources/State/PlayableVideo.swift
+++ b/App/Sources/State/PlayableVideo.swift
@@ -1,0 +1,26 @@
+import ADBKit
+import UniformTypeIdentifiers
+
+/// The App-layer view of `VideoInputFormat`, which is ADBKit's single source
+/// of truth for the containers the video editor opens — a format added there
+/// widens the open panel, the drop filter and the Finder router at once. The
+/// mirror of `InstallablePackage`, and separate for the same reason:
+/// `UniformTypeIdentifiers` is Apple-only and ADBKit stays portable.
+enum PlayableVideo {
+    /// The types the open panel offers. Derived from the extensions rather
+    /// than a hand-written list of system UTTypes, which is what the panel
+    /// used to carry: `.movie`/`.video` are AVFoundation's idea of a video,
+    /// so `.mkv` and `.webm` were greyed out even though ffmpeg reads both.
+    ///
+    /// The extensions resolve to declared types because `project.yml`
+    /// declares the ones macOS lacks (`UTImportedTypeDeclarations`) — without
+    /// that, `UTType(filenameExtension:)` returns nil for `.mkv` and the
+    /// format silently drops out of the panel.
+    static var contentTypes: [UTType] {
+        VideoInputFormat.fileExtensions.compactMap { UTType(filenameExtension: $0) }
+    }
+
+    static func filter(_ urls: [URL]) -> [URL] {
+        urls.filter { VideoInputFormat.detect(fileName: $0.lastPathComponent) != nil }
+    }
+}

--- a/App/Sources/State/SystemNotifier.swift
+++ b/App/Sources/State/SystemNotifier.swift
@@ -1,14 +1,26 @@
 import AppKit
 import UserNotifications
 
-/// Posts a macOS notification when a task finishes and nobody would see the
-/// in-app toast — the main window is closed (background mode) or another app
-/// is frontmost. Every important toast routes through here from `showToast`
-/// (installs, pulls, file operations, conversions, captures…); install
-/// batches post one summary instead of per-APK noise. Clicking a
-/// notification reopens the main window (see `AppDelegate.didReceive`).
+/// Mirrors the app's own notifications into Notification Center. Everything
+/// that reaches the in-app notification bar is posted here too — installs,
+/// pulls, file operations, conversions, captures, crashes, updates — so an
+/// event is never visible only in a toast that disappears after five
+/// seconds. Foreground included: a 5s overlay in the corner of one window is
+/// missable whether or not that window is frontmost, and Notification Center
+/// is the only record that survives it. Whoever wants less says so in System
+/// Settings ▸ Notifications ▸ Droidective, which is where a Mac user looks.
+///
+/// Clicking one lands on the matching row in the in-app notification bar (see
+/// `AppDelegate.didReceive` → `AppCore.revealNotifications`). Install batches
+/// still post one summary instead of one notification per APK.
 @MainActor
 enum SystemNotifier {
+    /// `userInfo` key carrying the `AppNotification.id` a notification came
+    /// from, so a click can open the bar on that row. `nonisolated` because
+    /// the delegate reads it off the response before hopping to the main
+    /// actor — the value crossing is an immutable String.
+    nonisolated static let entryKey = "droidective.notification"
+
     private static var authorizationRequested = false
 
     /// Ask for notification permission once per launch, at the moment it
@@ -26,32 +38,43 @@ enum SystemNotifier {
         }
     }
 
-    /// True when an in-app toast can't be seen: background mode (accessory,
-    /// no windows) or another app frontmost.
+    /// True when an in-app toast can't be seen at all: background mode
+    /// (accessory, no windows) or another app frontmost. Only the install
+    /// batch summary uses this — it has no in-app counterpart to compete
+    /// with, so posting it while the user is watching the install progress
+    /// would be telling them what is already on screen.
     private static var isBackgrounded: Bool {
         NSApp.activationPolicy() == .accessory || !NSApp.isActive
     }
 
-    /// Mirror an important toast as a native notification when backgrounded.
-    static func postToastIfBackgrounded(_ toast: Toast) {
-        guard isBackgrounded else { return }
-        post(title: title(for: toast.level), body: toast.message, sound: toast.level == .error)
+    /// Mirror a toast that reached the notification bar. `entry` is the
+    /// `AppNotification.id` it was filed under, so a click can open the bar
+    /// on that row.
+    static func postToast(_ toast: Toast, entry: UUID) {
+        post(
+            title: title(for: toast.level), body: toast.message,
+            sound: toast.level == .error, entry: entry
+        )
     }
 
     static func postIfBackgrounded(title: String, body: String, sound: Bool = false) {
         guard isBackgrounded else { return }
-        post(title: title, body: body, sound: sound)
+        post(title: title, body: body, sound: sound, entry: nil)
     }
 
+    /// The app's name leads, because a notification is identified by its icon
+    /// and first line — "Task failed" alone says nothing about which app
+    /// failed once it's sitting in Notification Center with fifty others.
     private static func title(for level: Toast.Level) -> String {
         switch level {
-        case .success: return "Task finished"
-        case .info, .warning: return "Droidective"
-        case .error: return "Task failed"
+        case .success: return "Droidective"
+        case .info: return "Droidective"
+        case .warning: return "Droidective — warning"
+        case .error: return "Droidective — failed"
         }
     }
 
-    private static func post(title: String, body: String, sound: Bool) {
+    private static func post(title: String, body: String, sound: Bool, entry: UUID?) {
         // First post of the launch with no prior in-context prompt: ask,
         // then deliver after the grant so this notification isn't lost.
         let needsAuthorization = !authorizationRequested
@@ -66,8 +89,14 @@ enum SystemNotifier {
             content.title = title
             content.body = body
             if sound { content.sound = .default }
-            try? await center.add(
-                UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil))
+            if let entry { content.userInfo = [entryKey: entry.uuidString] }
+            // The bar entry's id doubles as the request identifier, so the
+            // same event re-posted replaces its notification instead of
+            // stacking a second copy.
+            try? await center.add(UNNotificationRequest(
+                identifier: entry?.uuidString ?? UUID().uuidString,
+                content: content, trigger: nil
+            ))
         }
     }
 }

--- a/App/Tests/EmulatorRelaunchPhaseTests.swift
+++ b/App/Tests/EmulatorRelaunchPhaseTests.swift
@@ -1,0 +1,55 @@
+import Testing
+
+/// Relaunching an emulator reported nothing at all: the stop result was
+/// discarded, the console-port poll ran for up to 20 seconds with the row
+/// unchanged, and the only toast was "Launching…" long after the click. These
+/// lock the wording each stage now shows, including the two ways it can end
+/// without booting.
+@Suite struct EmulatorRelaunchPhaseTests {
+    @Test func eachStageSaysWhatItIsDoing() {
+        #expect(EmulatorRelaunchPhase.stopping.label == "Stopping…")
+        #expect(EmulatorRelaunchPhase.booting.label == "Booting…")
+    }
+
+    /// The wait is the long one, so it counts up — but not from "0s", which
+    /// reads like a timer that never started.
+    @Test func theShutdownWaitCountsUpOnceThereIsSomethingToCount() {
+        #expect(
+            EmulatorRelaunchPhase.waitingForShutdown(secondsElapsed: 0).label
+                == "Waiting for it to shut down…"
+        )
+        #expect(
+            EmulatorRelaunchPhase.waitingForShutdown(secondsElapsed: 1).label
+                == "Waiting for it to shut down… 1s"
+        )
+        #expect(
+            EmulatorRelaunchPhase.waitingForShutdown(secondsElapsed: 17).label
+                == "Waiting for it to shut down… 17s"
+        )
+    }
+
+    /// A failed `adb emu kill` used to be swallowed by `_ = try?`, and the
+    /// relaunch waited 20s and booted anyway. The reason has to reach the user.
+    @Test func aFailedStopCarriesAdbsReason() {
+        #expect(
+            EmulatorRelaunchPhase.stopFailed(name: "Pixel_7", reason: "device offline")
+                == "Couldn't stop Pixel_7: device offline"
+        )
+    }
+
+    /// Booting while the old process still holds the console port is what
+    /// produces a second serial, so the timeout says it did not relaunch.
+    @Test func aShutdownThatNeverFinishesSaysTheEmulatorIsStillUp() {
+        let message = EmulatorRelaunchPhase.shutdownTimedOut(name: "Pixel_7", seconds: 20)
+        #expect(message.contains("didn't shut down within 20s"))
+        #expect(message.contains("wasn't relaunched"))
+    }
+
+    @Test func phasesAreDistinguishable() {
+        #expect(EmulatorRelaunchPhase.stopping != .booting)
+        #expect(
+            EmulatorRelaunchPhase.waitingForShutdown(secondsElapsed: 1)
+                != .waitingForShutdown(secondsElapsed: 2)
+        )
+    }
+}

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -259,10 +259,23 @@ before adding to it.
    protocol as a level filter and had never been read by anything.
 5. ~~**Notifications** (backlog 18).~~ **Landed** — and smaller than it looked,
    because the Mac does not decide per event: `SystemNotifier` mirrors the
-   toasts already marked important whenever the window is not the one being
-   looked at, so an install finishing and a watched crash landing both arrive
-   without either screen knowing a tray exists. No Settings switch: the Mac has
-   none (see the Look section).
+   toasts already marked important, so an install finishing and a watched crash
+   landing both arrive without either screen knowing a tray exists. No Settings
+   switch: the Mac has none (see the Look section).
+
+   **The Mac has since dropped the backgrounded condition**, so this is a
+   difference to close. Every important toast now posts, foreground included: a
+   5s overlay in the corner of one window is missable whether or not that
+   window is frontmost, and Notification Center is the only record that
+   outlives it. Drop the `isFocused()` gate, and mirror the two things that
+   came with the change — a click opens the in-app notification bar on the row
+   the notification came from (`AppCore.revealNotifications`, keyed by the
+   `AppNotification.id` carried in `userInfo`), and that id doubles as the
+   request identifier so a re-post replaces its notification instead of
+   stacking a second copy. Note the trap the Mac hit: macOS suppresses a
+   notification while the posting app is frontmost unless the delegate's
+   `willPresent` says otherwise, so check whether the tray has an equivalent
+   before concluding the posts are not firing.
 6. ~~**Background mode and the tray** (20), then **Quick Actions** (19).~~
    **Landed**, in that order and for the stated reason. Closing the window hides
    the app, stops the work that was only running because a window was open, and
@@ -638,14 +651,13 @@ two disagree, so a relabelled item cannot leave a stale accelerator behind.
       the text size move on its own.
 - [x] **Empty states per feature** ("connect a device") — the Mac's
       `NoDeviceView` shape, with its per-feature copy table ported.
-- [x] **Native notifications** — an important result that lands while you are
-      in another app posts one, which is `SystemNotifier`'s rule rather than a
-      list of events: `postToastIfBackgrounded` mirrors the toasts already
-      marked important, so a crash caught while watching and a finished install
-      arrive without either screen knowing about the tray. The titles are its
-      titles ("Task finished" / "Task failed" / "Droidective"), a failure
-      carries the sound, and a batch can opt its members out and post one
-      summary — which the install does, with the Mac's own two titles.
+- [x] **Native notifications** — an important result posts one, which is
+      `SystemNotifier`'s rule rather than a list of events: `postToast`
+      mirrors the toasts already marked important, so a crash caught while
+      watching and a finished install arrive without either screen knowing
+      about the tray. The titles are its titles (all four now lead with the
+      app name), a failure carries the sound, and a batch can opt its members
+      out and post one summary — which the install does.
 
       **There is no Settings switch, because the Mac has none.** This entry
       used to promise one; reading `SettingsView.swift` rather than trusting
@@ -653,6 +665,12 @@ two disagree, so a relabelled item cannot leave a stale accelerator behind.
       per-app notification settings. Adding one here only would be a
       difference to relearn, and the rule says a better idea goes in the Mac
       app first.
+
+      **Open difference:** the Mac no longer waits for the window to be
+      unfocused, and a click on one opens the in-app notification bar on the
+      matching row. See item 5 of the landed list above for what closing this
+      involves — the gate, the click route, the request identifier, and the
+      `willPresent` trap that hides foreground posts.
 
       Two things it does not read from the DOM, both because the DOM answers a
       different question. Backgrounded is the window manager's `isFocused()`,

--- a/project.yml
+++ b/project.yml
@@ -215,6 +215,9 @@ targets:
       # The persisted recording-audio choice, incl. the pre-microphone
       # single-switch migration.
       - App/Sources/FeatureDetail/Views/Record/RecordAudioPreference.swift
+      # What an AVD's row says at each stage of a relaunch — the shutdown
+      # wait runs for up to 20s, so its wording is the whole feedback.
+      - App/Sources/FeatureDetail/Views/EmulatorRelaunchPhase.swift
       - App/Sources/FeatureDetail/Views/TourPaging.swift
       - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
       - App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift

--- a/project.yml
+++ b/project.yml
@@ -133,6 +133,48 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - apkm
+          # The video containers macOS has no type for. The rest of
+          # VideoInputFormat resolves to an Apple identifier (public.mpeg-4,
+          # com.apple.quicktime-movie, public.avi, public.mpeg,
+          # public.mpeg-2-transport-stream, public.avchd-mpeg-2-transport-stream,
+          # public.3gpp, com.microsoft.windows-media-wmv, com.compuserve.gif)
+          # and needs nothing here.
+          #
+          # These four are only ever declared by whichever media player happens
+          # to be installed — on a Mac with IINA, `.mkv` resolves to
+          # `io.iina.mkv` — so relying on the system's answer means the format
+          # silently vanishes from the open panel on a Mac without that app.
+          # Declared as *imported* (the formats are theirs, not ours) with the
+          # conventional identifiers, conforming to public.movie so they read as
+          # video everywhere rather than as opaque data.
+          - UTTypeIdentifier: org.matroska.mkv
+            UTTypeDescription: Matroska Video
+            UTTypeConformsTo:
+              - public.movie
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - mkv
+          - UTTypeIdentifier: org.webmproject.webm
+            UTTypeDescription: WebM Video
+            UTTypeConformsTo:
+              - public.movie
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - webm
+          - UTTypeIdentifier: com.adobe.flash.video
+            UTTypeDescription: Flash Video
+            UTTypeConformsTo:
+              - public.movie
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - flv
+          - UTTypeIdentifier: org.xiph.ogv
+            UTTypeDescription: Ogg Video
+            UTTypeConformsTo:
+              - public.movie
+            UTTypeTagSpecification:
+              public.filename-extension:
+                - ogv
         # The app's private drag types (DragTypes.swift). macOS only writes a
         # custom UTI to the drag pasteboard when the app declares it, so an
         # undeclared type makes every .onDrag with it die silently — no drop
@@ -168,6 +210,62 @@ targets:
               - com.android.apks
               - com.apkpure.xapk
               - com.apkmirror.apkm
+          # Every container the Video Editor opens (VideoInputFormat), so a
+          # video can be sent here from Finder.
+          #
+          # Rank is **Alternate**, not Owner: Droidective joins the "Open With"
+          # menu without taking .mp4 and .mov away from QuickTime. Owner here
+          # would make a debugging tool the default video player on the machine.
+          #
+          - CFBundleTypeName: Video
+            CFBundleTypeRole: Editor
+            LSHandlerRank: Alternate
+            LSItemContentTypes:
+              - public.mpeg-4
+              - com.apple.quicktime-movie
+              - com.apple.m4v-video
+              - org.matroska.mkv
+              - org.webmproject.webm
+              - public.avi
+              - com.adobe.flash.video
+              - public.mpeg-2-transport-stream
+              - public.avchd-mpeg-2-transport-stream
+              - public.mpeg
+              - com.microsoft.windows-media-wmv
+              - public.3gpp
+              - org.xiph.ogv
+              - com.compuserve.gif
+          # The same containers again, matched by extension instead of by
+          # type — and it has to be a separate entry, because Launch Services
+          # ignores CFBundleTypeExtensions in an entry that also carries
+          # LSItemContentTypes.
+          #
+          # This is what covers a format whose extension another app owns.
+          # Verified, not assumed: with IINA installed, `.mkv` resolves to
+          # `io.iina.mkv`, so the `org.matroska.mkv` entry above never matches
+          # and Droidective was missing from Open With for the second most
+          # important format on the list. Check with
+          # LSCopyApplicationURLsForURL after `lsregister -f`, not by reading
+          # the plist.
+          - CFBundleTypeName: Video (by extension)
+            CFBundleTypeRole: Editor
+            LSHandlerRank: Alternate
+            CFBundleTypeExtensions:
+              - mp4
+              - mov
+              - m4v
+              - mkv
+              - webm
+              - avi
+              - flv
+              - ts
+              - m2ts
+              - mpg
+              - mpeg
+              - wmv
+              - 3gp
+              - ogv
+              - gif
     settings:
       base:
         PRODUCT_NAME: Droidective


### PR DESCRIPTION
Five independent changes, one commit each.

### Re-apply the Reactotron `adb reverse` on restart

Opening Reactotron already opened `adb reverse tcp:9090 tcp:9090` on every ready Android device. Two paths were uncovered:

- **Restarting the app being debugged** went force-stop → open without touching the tunnel. The serial doesn't change across a restart, so nothing in `deviceListChanged` reopens it, and the fresh process dials `localhost:9090` as it boots. `reapplyReverse()` now runs between the stop and the relaunch.
- **A tunnel lost while the device stayed listed** (`adb kill-server`, a USB re-enumeration that kept the serial) was never reopened. While the relay is up with nothing connected, each device-list tick now also reverses the serials already known — bounded to three attempts per serial, so an idle relay isn't one adb call per device per 2s poll forever. A client getting through re-arms the budget.

Names the port `ReactotronService.defaultPort`, since 9090 is a contract with `reactotron-react-native`.

### Cancel superseded CI runs on pull requests

A PR run is 12 jobs across four runners plus two container builds and the Linux app smoke. Nothing cancelled a superseded run, so three pushes left three full sets racing. The condition keeps `cancel-in-progress` off for `main` and tags, so a Pages deploy or a signing/notarizing release run always finishes.

### Report progress while relaunching an emulator

Relaunch reported nothing until the boot toast, up to 20 seconds after the click. The stop result was discarded by `_ = try?`, the console-port poll ran silently, the row still read `Running — emulator-5554`, `reloadToken` was never bumped, and the button stayed clickable — a second click meant two stops and two boots.

The row now carries a spinner and the stage: stopping → waiting for it to shut down (counting up) → booting, and the button is unavailable while one is in flight. Both failure paths report instead of pressing on: a failed `adb emu kill` gives adb's reason and stops, and a console port that never frees says the emulator is still running and wasn't relaunched, where it used to fall out of the loop and boot anyway. The wording is `EmulatorRelaunchPhase`, pure and in the AppTests bundle.

### Mirror the in-app notification bar to macOS notifications

`SystemNotifier` only posted when the window was closed or another app was frontmost, so anything that happened while Droidective was in front left no trace but a toast that vanishes after five seconds.

Every toast the notification bar keeps now posts. Foreground included, which needs the delegate's `willPresent` — macOS silently suppresses a notification while the posting app is active. Clicking one lands on the row it came from: the bar entry's id rides in `userInfo` and doubles as the request identifier, so a re-post replaces its notification rather than stacking a copy, and `didReceive` routes through `AppCore.revealNotifications` (bring a window up, opening one if every window is closed, then open its panel, scroll to the row and flash it). The history is per window and the notification is per app, so an id this window never filed is dropped and the panel just opens.

`Toast.notifiesWhenBackgrounded` becomes `postsSystemNotification`, since backgrounded is no longer what it means. Its two opt-outs stand — the install posts one batch summary instead of one notification per APK. No Settings switch, matching what the app does elsewhere; `docs/desktop-parity.md` records the difference this opens for the port, including the `willPresent` trap.

### Accept every video format ffmpeg reads, and open videos from Finder

The open panel filtered on `.movie`/`.video`/`.mpeg4Movie`/`.quickTimeMovie` — AVFoundation's idea of a video — so `.mkv` and `.webm` were greyed out even though the export path is ffmpeg and reads both. The drop zone had the opposite problem: no filter at all, so an `.apk` went straight to AVFoundation as if it were a video.

`VideoInputFormat` (ADBKit) is now the one list, shaped like `AppPackageFormat`: fifteen containers whose `fileExtensions` and `detect(fileName:)` drive the open panel, the drop filter and the Finder document types together. `PlayableVideo` is the App-layer UTType/filter bridge, matching `InstallablePackage`.

Playback is where AVFoundation still constrains things — player, scrubber and AVKit's trim UI are all AVFoundation, so an `.mkv` loaded as a black pane with Trim permanently disabled. The **file** is probed rather than its extension, because the extension doesn't predict the answer: an `.mp4` holding AV1 fails the same probe an `.mkv` does. On failure `VideoEditService.playableProxy` builds an MP4 to play instead — a remux first (a file copy's work, and enough for H.264 in a container AVFoundation won't parse), then a transcode when the codec itself needs converting. Exports always read the original, so a proxy costs the saved file nothing, and trim points carry over because both share one timeline.

Finder can now send a video here at `LSHandlerRank: Alternate`, so Droidective joins "Open With" without taking `.mp4`/`.mov` from QuickTime. Four containers get imported type declarations because macOS has no type for them, and a second document-type entry matches by extension — which is what actually covers a format whose extension another app owns. Unlike `apk-open` this needs no tab of its own: `video-editor` is already a registry feature with a route, so the URL is staged on `AppState.pendingVideo` and the feature requested.

## Verification

`make verify` green: 1886 ADBKit · 99 ReactotronMCP · 406 droidectived · 111 AppTests. Build warning-free.

Checked by hand, not just compiled:

- **Both proxy branches against real files.** H.264 in Matroska: AVFoundation refuses → remux yields a playable MP4. VP9 in WebM: refuses → remux still unplayable → transcode yields a playable MP4.
- **The Finder-open path**, end to end: `open -a Droidective clip.mkv` routes to a Video Editor tab, the video renders, and **Trim is enabled** — the control that was permanently disabled for a non-AVFoundation format.
- **Open With for all fifteen extensions**, via `LSCopyApplicationURLsForURL` after `lsregister -f`. This is what caught the one real bug in the first attempt: with IINA installed a `.mkv` resolves to `io.iina.mkv`, so the type-based entry never matched and the app was missing from Open With for it. Now all fifteen are offered and no existing default changed (IINA keeps mp4/mov/mkv, Preview keeps gif).
- **The notification posts, is authorized, is stored, and dedups.** From the unified log: `Adding notification to storage: com.rohindh.droidective:…`, `hasAuthorizations: true`, and a second post `updating existing notification` rather than stacking one — the request-identifier dedup working live.

One thing not verifiable from a dev build: the **banner drawing** and therefore the **click → panel** route. An ad-hoc-signed app run from `DerivedData` gets code-level authorization but no System Settings ▸ Notifications entry, so the OS reports `notificationsAllowed: false` and suppresses display. Worth a look on a signed build before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)