### PR TITLE
Stop reporting HTTP failures as Droidective errors

### DIFF
--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -366,6 +366,30 @@ final class Telemetry {
             // hangs and crashes inherit the `active_feature` scope tag set in
             // `featureBecameActive`, so they group by the feature on screen.
             options.appHangTimeoutInterval = 2
+            // Sentry captures every 5xx a URLSession sees by default. That is
+            // wrong for this app twice over.
+            //
+            // It is noise: every HTTP client here talks either to a dev server
+            // on the user's own Mac — Metro on 8081, whose `/symbolicate`
+            // answers 500 for any frame it can't map, a routine outcome
+            // `MetroSymbolicator` already handles and circuit-breaks — or to a
+            // server the *user* chose in API Testing. Neither is a Droidective
+            // bug. Metro alone produced 40 events across 9 users
+            // (DROIDECTIVE-MAC-6D) reported as `-[SentryStacktraceBuilder
+            // buildStacktraceForCurrentThread]`, which names the reporter
+            // rather than anything in this app.
+            //
+            // And it leaks: a captured request carries its URL, so a user
+            // testing their own API against a 5xx would ship that URL here.
+            // Settings ▸ Privacy and the privacy policy both promise no URLs
+            // or paths are ever sent, and `sendDefaultPii = false` does not
+            // cover this.
+            //
+            // Nothing is lost by turning it off: the only remote HTTP the app
+            // makes on its own account is managed-tool downloads and the
+            // Sparkle appcast, and both already surface their failure to the
+            // user with the real error.
+            options.enableCaptureFailedRequests = false
             // Sampled continuous profiling tied to traced spans — function-level
             // "what burned the CPU" for the sampled sessions.
             options.configureProfiling = { profiling in


### PR DESCRIPTION
Sentry captures every 5xx a `URLSession` sees by default (`enableCaptureFailedRequests`, on unless set). That's wrong for this app twice over.

**It's noise.** Every HTTP client here talks either to a dev server on the user's own Mac — Metro on 8081, whose `/symbolicate` answers 500 for any frame it can't map, a routine outcome `MetroSymbolicator` already handles and circuit-breaks — or to a server the *user* chose in API Testing. Neither is a Droidective bug. Metro alone accounted for **40 events across 9 users** (DROIDECTIVE-MAC-6D), filed under `-[SentryStacktraceBuilder buildStacktraceForCurrentThread]` — a culprit naming the reporter rather than anything in this app. Grouped by URL, all 40 are loopback:

| url | count |
|---|---|
| `http://127.0.0.1:8081/symbolicate` | 39 |
| `http://127.0.0.1:8082/symbolicate` | 1 |

**It also leaks.** A captured request carries its URL, so a user testing their own API against a 5xx would ship that URL to Sentry. `Settings ▸ Privacy` and the privacy policy both promise no URLs or paths are ever sent, and `sendDefaultPii = false` does not cover the request URL of a captured HTTP error. No such event has been recorded yet — all 40 are Metro — so this closes the hole before it fires rather than after.

**Nothing is lost.** The only remote HTTP the app makes on its own account is managed-tool downloads and the Sparkle appcast, and both already surface their failure to the user with the real error, in the UI.

Considered and rejected: `failedRequestTargets` with a negative-lookahead regex to exclude loopback only. It keeps capture for API Testing, which is the half with the privacy problem, and makes the behaviour depend on how the SDK stringifies a URL.

## Verification

Build clean, zero warnings. No unit test: this is one SDK option, and asserting it would mean linking Sentry into the AppTests logic bundle to inspect `SentryOptions`. The option's presence and type were confirmed against the pinned 9.18.0 `.swiftinterface` rather than from memory.

Fixes DROIDECTIVE-MAC-6D

🤖 Generated with [Claude Code](https://claude.com/claude-code)
