### PR TITLE
Pace the Reactotron feed like the other two

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// How often a streaming feed drains its buffered rows into observable state.
+///
+/// This is the pacing that decides how much SwiftUI work a chatty stream
+/// costs, because each flush re-diffs the whole visible feed: the interval is
+/// a direct multiplier on main-thread layout. A 16 ms cadence is up to 62 full
+/// diffs a second, and every open tab stays mounted (`TabHostView`'s
+/// keep-alive ZStack), so those diffs are paid across *every* mounted feed
+/// rather than only the one on screen.
+///
+/// The JS Console found this first and shipped 250 ms/1 s
+/// (DROIDECTIVE-MAC-2N); logcat shipped a flat 300 ms in v3.6.1. The rule
+/// lives here so the third feed can't miss it — the Reactotron timeline did,
+/// and stayed at 16 ms while being the largest feed of the three
+/// (DROIDECTIVE-MAC-B: 5087 hangs, and its top `open_features` rows are
+/// single users with 9 to 18 tabs mounted at once).
+///
+/// **Inactive is slower, never stopped.** Nobody is reading in real time and a
+/// feed streaming behind an unfocused window used to burn CPU for hours — but
+/// pausing outright is worse than pacing: the buffer grows unbounded, and
+/// reactivation hands SwiftUI one enormous flush, which is the same
+/// mass-mutation stall the pacing exists to avoid.
+public enum FeedFlushCadence {
+    /// The app is frontmost — fast enough to read as live, slow enough that a
+    /// burst becomes one mutation per quarter second instead of per frame.
+    public static let active: Duration = .milliseconds(250)
+
+    /// Another app is frontmost. Four flushes a second down to one.
+    public static let inactive: Duration = .seconds(1)
+
+    public static func interval(appActive: Bool) -> Duration {
+        appActive ? active : inactive
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import ADBKit
+
+/// The pacing shared by the three streaming feeds. Each flush re-diffs a whole
+/// visible feed and every open tab stays mounted, so this interval is a direct
+/// multiplier on main-thread layout across all of them.
+@Suite struct FeedFlushCadenceTests {
+    @Test func inactiveIsSlowerThanActive() {
+        #expect(FeedFlushCadence.interval(appActive: false) > FeedFlushCadence.interval(appActive: true))
+    }
+
+    @Test func picksTheIntervalForEachState() {
+        #expect(FeedFlushCadence.interval(appActive: true) == FeedFlushCadence.active)
+        #expect(FeedFlushCadence.interval(appActive: false) == FeedFlushCadence.inactive)
+    }
+
+    /// The regression this exists for. Reactotron sat at 16 ms — up to 62 full
+    /// re-diffs a second, paid across every mounted tab — while being the
+    /// largest of the three feeds (DROIDECTIVE-MAC-B). Anything at or below a
+    /// frame is that bug back.
+    @Test func activeIsNotPerFrame() {
+        #expect(FeedFlushCadence.active >= .milliseconds(100))
+    }
+
+    /// Never zero and never stopped: pausing a feed outright grows the buffer
+    /// unbounded and hands SwiftUI one enormous flush on reactivation, which
+    /// is the same mass-mutation stall the pacing avoids.
+    @Test func neitherStateStopsTheFeed() {
+        #expect(FeedFlushCadence.active > .zero)
+        #expect(FeedFlushCadence.inactive > .zero)
+        // A cap, so "slower while inactive" can't drift into "effectively off"
+        // — a feed that only flushes every few seconds reads as broken when
+        // the user comes back to it.
+        #expect(FeedFlushCadence.inactive <= .seconds(2))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -1034,11 +1034,13 @@ final class JSConsoleSession {
     /// under a chatty Metro stream — the sustained main-thread churn behind
     /// the js-console hang cluster (Sentry DROIDECTIVE-MAC-2N and the 3.7.0
     /// hang burst; logcat shipped the same 300 ms fix in v3.6.1). Entries
-    /// keep accumulating between flushes; only rendering is paced. While the
-    /// app is inactive nobody is reading in real time, so the feed coasts at
-    /// 1 s — streaming with the window unfocused used to burn CPU for hours.
+    /// keep accumulating between flushes; only rendering is paced.
+    ///
+    /// The intervals moved to `FeedFlushCadence` when the Reactotron timeline
+    /// turned out to have missed this fix entirely — the rule is shared so a
+    /// feed cannot be added without it.
     private var flushInterval: Duration {
-        NSApp.isActive ? .milliseconds(250) : .seconds(1)
+        FeedFlushCadence.interval(appActive: NSApp.isActive)
     }
 
     private func scheduleFlush() {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -658,11 +658,19 @@ final class ReactotronSession {
 
     /// Buffer a timeline event and schedule a coalesced flush, so a burst of
     /// events becomes one `items` mutation instead of one per event.
+    ///
+    /// Paced by `FeedFlushCadence`, which the JS Console and logcat already
+    /// use. This feed was left at 16 ms — up to 62 full re-diffs of the
+    /// timeline a second, whether or not anyone was looking at it, and paid
+    /// across every mounted tab because open tabs all stay in the keep-alive
+    /// ZStack. It is the largest of the three feeds and the one named in the
+    /// app's biggest hang issue (DROIDECTIVE-MAC-B).
     private func enqueue(_ item: RtItem) {
         pendingItems.append(item)
         guard flushTask == nil else { return }
+        let interval = FeedFlushCadence.interval(appActive: NSApp.isActive)
         flushTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(16))
+            try? await Task.sleep(for: interval)
             guard !Task.isCancelled else { return }
             self?.flushPending()
         }


### PR DESCRIPTION
## What the data says

DROIDECTIVE-MAC-B is the app's largest issue — **5087 hangs / 49 users**, and **201 events / 14 users on current releases** (3.9.1, 3.9.2, 3.10.0-beta.5), where every other open issue is a 1–7 event tail.

Both of its headline attributes are misleading. The culprit is `ADTApp.$main`, and Sentry rates it `super_low` actionability. Its top `active_feature` is `react-native` with 1937 events — but `react-native` is a hub of action cards, which cannot produce that stack. Grouping instead by `open_features`, the tag this app added *precisely* because "a hidden tab's stream can be the real workload while `active_feature` names whatever is on screen":

| open_features | events | users |
|---|---|---|
| `home,js-console,react-native,simulate` | 1931 | **1** |
| 10 tabs incl. `performance`, `crash-catcher` | 656 | **1** |
| 9 tabs | 610 | **1** |
| **15 tabs** incl. `js-console`, `logcat`, `reactotron`, `performance` | 362 | **1** |
| **18 tabs** | 49 | **1** |
| `home` only | 28 | 13 |

~4000 of 5087 events are five individual users with many keep-alive tabs mounted. **99% fire with `app_active: false`.** The sample event was using 1.01 GB on an 8 GB Mac mini with 188 MB free. The stack is a display-list teardown — seven nested `updateInheritedView` levels into `Container.removeRemaining` → `removeFromSuperview` → `conformsToProtocol:`.

## The change

Every open tab stays mounted in `TabHostView`'s keep-alive ZStack, so each flush's re-diff is paid across *every* mounted feed, not just the one on screen. That makes a feed's flush interval a direct multiplier on main-thread layout.

Two of the three feeds already knew this. The JS Console shipped 250 ms/1 s for DROIDECTIVE-MAC-2N, with a comment saying the 16 ms cadence was "the sustained main-thread churn behind the js-console hang cluster"; logcat shipped a flat 300 ms in v3.6.1. **The Reactotron timeline missed it and stayed at `.milliseconds(16)`** — up to 62 full re-diffs a second, whether or not anyone was looking — while being the largest of the three feeds.

`FeedFlushCadence` (ADBKit, pure) now holds the intervals for both App-layer feeds, so a third can't be added without them. This is the third instance of the same rule, which is what earns the extraction.

**Inactive is slower, never stopped.** Pausing a feed until reactivation was the tempting version and is worse: the buffer grows unbounded — this app already has MAC-A0 at 1.47 GB and MAC-4B at 1.48 GB — and reactivation hands SwiftUI one enormous flush, which is the same mass-mutation stall the pacing exists to avoid. A test pins that, and pins that the active interval never drops back to a frame.

Logcat keeps its own flat 300 ms, and the comment says why: `LogcatStreamer` is a portable ADBKit actor with no access to app-activation state, and 300 ms is already 18× the interval this changes.

## Verification

`make verify` green: 1878 ADBKit · 99 ReactotronMCP · 406 droidectived · 106 AppTests. Build warning-free.

**This is a pacing change to a hang that cannot be reproduced locally** — it needs 9–18 mounted tabs and a live device streaming into them. What is verified is the mechanism (the `open_features` breakdown above) and that Reactotron was the one feed of three without the fix its siblings shipped for the same issue class. Whether MAC-B's rate actually drops has to be read off the next release.

Related: DROIDECTIVE-MAC-B, DROIDECTIVE-MAC-A0, DROIDECTIVE-MAC-4B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
