### PR TITLE
Stop comparing createdAt when deciding a request is unsaved

### DIFF
--- a/desktop/src/lib/api/workspace-unsaved.test.ts
+++ b/desktop/src/lib/api/workspace-unsaved.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import { emptyWorkspace, newCollection, newRequest } from "@/lib/api/defaults"
+import type { ApiClientData, SavedRequest } from "@/lib/api/model"
+import { addCollection, hasUnsavedChanges, saveRequest } from "@/lib/api/workspace"
+
+/**
+ * The dirty-check that drives the New Request confirmation. Split out of
+ * `workspace.test.ts` to keep both files inside the 300-line lint cap.
+ */
+function withCollection(): { data: ApiClientData; id: string } {
+  const collection = { ...newCollection("Orders"), id: "c1" }
+  return { data: addCollection(emptyWorkspace(), collection), id: "c1" }
+}
+
+function request(over: Partial<SavedRequest> = {}): SavedRequest {
+  return { ...newRequest(), id: "r1", name: "List", url: "https://example.test", ...over }
+}
+
+describe("hasUnsavedChanges", () => {
+  it("is false for an empty scratch request and true once a URL is typed", () => {
+    expect(hasUnsavedChanges(emptyWorkspace(), { ...newRequest(), url: "" }, null)).toBe(false)
+    expect(hasUnsavedChanges(emptyWorkspace(), request(), null)).toBe(true)
+  })
+
+  it("is false for a request that matches what is stored", () => {
+    const { data, id } = withCollection()
+    const saved = saveRequest(data, request(), id, null)
+    expect(hasUnsavedChanges(saved, request(), id)).toBe(false)
+  })
+
+  /**
+   * `modifiedAt` moves on every save, so comparing it would call a request
+   * dirty the instant it was saved — which is the confirmation firing on every
+   * New Request.
+   */
+  it("ignores the modified timestamp", () => {
+    const { data, id } = withCollection()
+    const saved = saveRequest(data, request({ modifiedAt: 1 }), id, null)
+    expect(hasUnsavedChanges(saved, request({ modifiedAt: 999 }), id)).toBe(false)
+  })
+
+  /**
+   * `createdAt` is stable for one request but not across two constructions of
+   * the same content — `newRequest()` stamps it from the clock — so a request
+   * rebuilt from defaults (an import, a Postman round-trip) reported changes
+   * nobody made.
+   */
+  it("ignores the created timestamp", () => {
+    const { data, id } = withCollection()
+    const saved = saveRequest(data, request({ createdAt: 1, modifiedAt: 2 }), id, null)
+    expect(hasUnsavedChanges(saved, request({ createdAt: 998, modifiedAt: 999 }), id)).toBe(false)
+  })
+
+  /**
+   * The same rule via the clock, which is how it was found: "matches what is
+   * stored" above builds two fixtures back to back and only held while both
+   * landed in the same millisecond, so it failed in CI once a run straddled a
+   * tick. Waiting for a guaranteed tick fails every time before the fix and
+   * passes every time after, rather than once in a while either way.
+   */
+  it("matches a request built a clock tick later", async () => {
+    const { data, id } = withCollection()
+    const saved = saveRequest(data, request(), id, null)
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 2)
+    })
+    expect(hasUnsavedChanges(saved, request(), id)).toBe(false)
+  })
+
+  it("is true once a field actually changes", () => {
+    const { data, id } = withCollection()
+    const saved = saveRequest(data, request(), id, null)
+    expect(hasUnsavedChanges(saved, request({ method: "POST" }), id)).toBe(true)
+  })
+})
+

--- a/desktop/src/lib/api/workspace.test.ts
+++ b/desktop/src/lib/api/workspace.test.ts
@@ -12,7 +12,6 @@ import {
   deleteEnvironment,
   deleteItem,
   duplicateItem,
-  hasUnsavedChanges,
   inheritedAuth,
   mergeImport,
   moveItem,
@@ -239,36 +238,6 @@ describe("mergeImport", () => {
     })
     expect(merged.collections.map((one) => one.name)).toEqual(["Orders", "Imported"])
     expect(merged.environments).toHaveLength(1)
-  })
-})
-
-describe("hasUnsavedChanges", () => {
-  it("is false for an empty scratch request and true once a URL is typed", () => {
-    expect(hasUnsavedChanges(emptyWorkspace(), { ...newRequest(), url: "" }, null)).toBe(false)
-    expect(hasUnsavedChanges(emptyWorkspace(), request(), null)).toBe(true)
-  })
-
-  it("is false for a request that matches what is stored", () => {
-    const { data, id } = withCollection()
-    const saved = saveRequest(data, request(), id, null)
-    expect(hasUnsavedChanges(saved, request(), id)).toBe(false)
-  })
-
-  /**
-   * `modifiedAt` moves on every save, so comparing it would call a request
-   * dirty the instant it was saved — which is the confirmation firing on every
-   * New Request.
-   */
-  it("ignores the modified timestamp", () => {
-    const { data, id } = withCollection()
-    const saved = saveRequest(data, request({ modifiedAt: 1 }), id, null)
-    expect(hasUnsavedChanges(saved, request({ modifiedAt: 999 }), id)).toBe(false)
-  })
-
-  it("is true once a field actually changes", () => {
-    const { data, id } = withCollection()
-    const saved = saveRequest(data, request(), id, null)
-    expect(hasUnsavedChanges(saved, request({ method: "POST" }), id)).toBe(true)
   })
 })
 

--- a/desktop/src/lib/api/workspace.ts
+++ b/desktop/src/lib/api/workspace.ts
@@ -196,9 +196,20 @@ export function mergeImport(
  * Whether the open request differs from what is stored.
  *
  * Drives the confirmation on New Request, which used to throw away several
- * minutes of typing without a word. `modifiedAt` is zeroed on both sides
- * first: it moves on every save, so comparing it would call an untouched
- * request dirty the moment it was saved.
+ * minutes of typing without a word. Both timestamps are zeroed on either
+ * side first, because neither is part of what the user typed:
+ *
+ * - `modifiedAt` moves on every save, so comparing it would call an
+ *   untouched request dirty the moment it was saved.
+ * - `createdAt` is stable for one request, but not across two constructions
+ *   of the same content: `newRequest()` stamps both from `Date.now() / 1000`,
+ *   so a request rebuilt from defaults — an import, a round-trip through the
+ *   Postman format — differs from its stored copy by whichever millisecond
+ *   each was made in, and reports changes nobody made.
+ *
+ * Leaving `createdAt` in also made this rule's own test nondeterministic:
+ * `workspace.test.ts` builds two fixtures back to back and expects them to
+ * match, which held only while both landed in the same millisecond.
  */
 export function hasUnsavedChanges(
   data: ApiClientData,
@@ -210,7 +221,12 @@ export function hasUnsavedChanges(
   const stored = collection === undefined ? null : findRequest(current.id, collection.items)
   // Never saved: only worth protecting once there is something in it.
   if (stored === null) return current.url.trim() !== ""
-  return JSON.stringify({ ...stored, modifiedAt: 0 }) !== JSON.stringify({ ...current, modifiedAt: 0 })
+  return content(stored) !== content(current)
+}
+
+/** A request stripped of the timestamps, for comparing what it actually holds. */
+function content(request: SavedRequest): string {
+  return JSON.stringify({ ...request, createdAt: 0, modifiedAt: 0 })
 }
 
 /** The collection an open request belongs to, or null for a scratch one. */


### PR DESCRIPTION
Found while chasing a red `desktop-web` on #318, a Swift-only PR. It was a real bug, not a flake.

## The bug

`hasUnsavedChanges` zeroed `modifiedAt` on both sides before comparing — it moves on every save, so comparing it would call a request dirty the instant it was saved — but left `createdAt` in:

```ts
return JSON.stringify({ ...stored, modifiedAt: 0 }) !== JSON.stringify({ ...current, modifiedAt: 0 })
```

`newRequest()` stamps **both** from the clock:

```ts
const stamp = now()          // Date.now() / 1000
return { …, createdAt: stamp, modifiedAt: stamp }
```

So two constructions of the same content differ by whichever millisecond each was made in. In the app, `saveRequest` preserves `createdAt`, so the open request and its stored copy normally agree — the exposure is a request **rebuilt from defaults rather than loaded**: an import, or a round-trip through the Postman format. That reports changes nobody made and raises the New Request confirmation over nothing.

## How it surfaced

`workspace.test.ts` builds two fixtures back to back and expects them to match:

```ts
const saved = saveRequest(data, request(), id, null)
expect(hasUnsavedChanges(saved, request(), id)).toBe(false)   // ← line 254
```

That only held while both landed in the same millisecond. It failed on #318 as `AssertionError: expected true to be false`, on a branch touching only Swift files, once the run straddled a tick. `desktop-native` and `desktop-linux-smoke` both passed on the same commit — they build and launch the same frontend — which is what ruled out a broken tree.

## The change

Both timestamps go through one `content()` helper. Two tests pin the rule: one sets the timestamps explicitly, and one waits for a guaranteed clock tick — that second fails *every* time before this change and passes *every* time after, instead of once in a while either way.

The `hasUnsavedChanges` cases moved to `workspace-unsaved.test.ts`; the additions took `workspace.test.ts` past the 300-line `max-lines` cap (it was 290 and clean on main, so the warning was mine), and the block was self-contained.

## Verification

- `npm run typecheck` clean, `npm run lint` clean — **zero warnings**, which the repo requires.
- 24 tests pass across the two files.
- **Checked by reverting**: putting the old one-line comparison back reddens both new tests (`ignores the created timestamp`, `matches a request built a clock tick later`) and nothing else; restoring it returns 6/6 green.

Local note: `npx vitest` needs `--environment node` on this machine — a stale `html-encoding-sniffer`/jsdom dep in `node_modules` throws `ERR_REQUIRE_ESM` before any test runs. CI does a fresh `npm ci` and is unaffected. These tests are pure logic, so the environment is immaterial to them.

#318 is red on this and will go green once this lands (or on a rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
