### PR TITLE
Send structured logs, and give Reactotron the diagnostics it lacked

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/LogBudget.swift
+++ b/ADBKit/Sources/ADBKit/Features/LogBudget.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// A per-key rate limit for logs that leave the machine.
+///
+/// Local `os_log` can take everything — it costs nothing when Console isn't
+/// attached. A backend sink cannot: the events worth logging are exactly the
+/// ones that repeat, and the app's own numbers say how badly. One user
+/// produced 1931 hang reports from a single session (DROIDECTIVE-MAC-B), and
+/// the streaming feeds breach their slow-operation threshold many times a
+/// second under load. Unbudgeted, the first pathological session would spend
+/// the whole project's log quota and the next one would arrive to none.
+///
+/// Keyed rather than global so a chatty area can't starve a quiet one: the
+/// Reactotron feed hitting its limit must not hide the one log the updater
+/// emits all day.
+///
+/// The suppressed count rides on the next admitted log, because the magnitude
+/// is the diagnostic. "Flush took 300 ms" is ambiguous; "took 300 ms, 412
+/// suppressed since the last one" is the bug.
+public struct LogBudget: Sendable {
+    public struct Decision: Equatable, Sendable {
+        public let allowed: Bool
+        /// How many were dropped for this key since the last admitted one.
+        /// Always 0 when `allowed` is false — it is reported *to* the log that
+        /// gets through, not to the ones that don't.
+        public let suppressed: Int
+
+        public init(allowed: Bool, suppressed: Int) {
+            self.allowed = allowed
+            self.suppressed = suppressed
+        }
+    }
+
+    private struct Window {
+        var openedAt: Double
+        var admitted: Int
+        var suppressed: Int
+    }
+
+    public let limit: Int
+    public let windowSeconds: Double
+    private var windows: [String: Window] = [:]
+
+    /// - Parameters:
+    ///   - limit: admissions allowed per key per window.
+    ///   - windowSeconds: how long a window lasts before the count resets.
+    public init(limit: Int = 5, windowSeconds: Double = 60) {
+        self.limit = max(1, limit)
+        self.windowSeconds = max(0, windowSeconds)
+    }
+
+    /// Whether a log for `key` may be sent at `seconds` (a monotonic reading).
+    public mutating func admit(_ key: String, at seconds: Double) -> Decision {
+        guard var window = windows[key] else {
+            windows[key] = Window(openedAt: seconds, admitted: 1, suppressed: 0)
+            return Decision(allowed: true, suppressed: 0)
+        }
+        // A window that has run out re-opens and reports what it swallowed.
+        if seconds - window.openedAt >= windowSeconds {
+            let carried = window.suppressed
+            windows[key] = Window(openedAt: seconds, admitted: 1, suppressed: 0)
+            return Decision(allowed: true, suppressed: carried)
+        }
+        guard window.admitted < limit else {
+            window.suppressed += 1
+            windows[key] = window
+            return Decision(allowed: false, suppressed: 0)
+        }
+        let carried = window.suppressed
+        window.admitted += 1
+        window.suppressed = 0
+        windows[key] = window
+        return Decision(allowed: true, suppressed: carried)
+    }
+
+    /// Keys currently tracked — bounded in practice by the number of call
+    /// sites, which is why this needs no eviction.
+    public var trackedKeys: Int { windows.count }
+}

--- a/ADBKit/Tests/ADBKitTests/LogBudgetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/LogBudgetTests.swift
@@ -1,0 +1,85 @@
+import Testing
+@testable import ADBKit
+
+/// The rate limit standing between a pathological session and the project's
+/// whole log quota. One user produced 1931 hang reports from one session
+/// (DROIDECTIVE-MAC-B); the feeds breach their slow-operation threshold many
+/// times a second under load.
+@Suite struct LogBudgetTests {
+    @Test func admitsUpToTheLimitThenStops() {
+        var budget = LogBudget(limit: 3, windowSeconds: 60)
+        #expect(budget.admit("feed", at: 0).allowed)
+        #expect(budget.admit("feed", at: 1).allowed)
+        #expect(budget.admit("feed", at: 2).allowed)
+        #expect(!budget.admit("feed", at: 3).allowed)
+        #expect(!budget.admit("feed", at: 4).allowed)
+    }
+
+    @Test func reopensAfterTheWindow() {
+        var budget = LogBudget(limit: 1, windowSeconds: 10)
+        #expect(budget.admit("feed", at: 0).allowed)
+        #expect(!budget.admit("feed", at: 9.9).allowed)
+        #expect(budget.admit("feed", at: 10).allowed)
+    }
+
+    /// The magnitude is the diagnostic: "took 300 ms" is ambiguous, "took
+    /// 300 ms, 412 suppressed" is the bug. So the count rides out on the next
+    /// log that gets through, not on the ones that are dropped.
+    @Test func theNextAdmittedLogCarriesWhatWasSwallowed() {
+        var budget = LogBudget(limit: 1, windowSeconds: 10)
+        #expect(budget.admit("feed", at: 0) == .init(allowed: true, suppressed: 0))
+        for _ in 0 ..< 412 {
+            #expect(budget.admit("feed", at: 1) == .init(allowed: false, suppressed: 0))
+        }
+        #expect(budget.admit("feed", at: 10) == .init(allowed: true, suppressed: 412))
+    }
+
+    /// And it resets, so the following log doesn't re-report the same burst.
+    @Test func theSuppressedCountIsReportedOnce() {
+        var budget = LogBudget(limit: 2, windowSeconds: 10)
+        _ = budget.admit("feed", at: 0)
+        _ = budget.admit("feed", at: 0)
+        _ = budget.admit("feed", at: 1)
+        #expect(budget.admit("feed", at: 10).suppressed == 1)
+        #expect(budget.admit("feed", at: 10).suppressed == 0)
+    }
+
+    /// Keyed, so a chatty feed can't hide the one log the updater emits all
+    /// day — the whole reason this isn't a single global counter.
+    @Test func oneKeyRunningOutDoesNotStarveAnother() {
+        var budget = LogBudget(limit: 1, windowSeconds: 60)
+        #expect(budget.admit("reactotron", at: 0).allowed)
+        #expect(!budget.admit("reactotron", at: 1).allowed)
+        #expect(budget.admit("updater", at: 1).allowed)
+    }
+
+    /// A limit of zero would silence the sink entirely, which is never what a
+    /// caller means — it reads as "off" while looking like a number.
+    @Test func aLimitBelowOneIsRaisedRatherThanSilencing() {
+        var budget = LogBudget(limit: 0, windowSeconds: 60)
+        #expect(budget.limit == 1)
+        #expect(budget.admit("feed", at: 0).allowed)
+    }
+
+    /// A zero window degrades to "always allow" rather than dividing by it.
+    @Test func aZeroWindowAdmitsEveryTime() {
+        var budget = LogBudget(limit: 1, windowSeconds: 0)
+        #expect(budget.admit("feed", at: 0).allowed)
+        #expect(budget.admit("feed", at: 0).allowed)
+    }
+
+    /// Time going backwards (a clock reading that regresses) must not admit
+    /// everything by making the elapsed comparison negative.
+    @Test func aBackwardClockDoesNotOpenTheGate() {
+        var budget = LogBudget(limit: 1, windowSeconds: 10)
+        #expect(budget.admit("feed", at: 100).allowed)
+        #expect(!budget.admit("feed", at: 95).allowed)
+    }
+
+    @Test func keysAreTrackedPerCallSiteNotPerEvent() {
+        var budget = LogBudget(limit: 1, windowSeconds: 60)
+        for _ in 0 ..< 50 { _ = budget.admit("feed", at: 0) }
+        _ = budget.admit("updater", at: 0)
+        #expect(budget.trackedKeys == 2)
+    }
+}

--- a/App/Sources/AppLog.swift
+++ b/App/Sources/AppLog.swift
@@ -1,0 +1,98 @@
+import ADBKit
+import Foundation
+import os
+
+/// The app's logging front door: one call writes to the local unified log and,
+/// when it is worth the quota, to the backend as a structured log line.
+///
+/// Watch the local half live while exercising the app:
+///
+///     /usr/bin/log stream --info --predicate 'subsystem BEGINSWITH "com.rohindh.droidective"'
+///
+/// Two sinks, two very different budgets. `os_log` costs nothing when nothing
+/// is attached, so it takes everything. The backend gets only what would help
+/// diagnose a report from someone else's machine, rate-limited per area by
+/// `LogBudget` — the events worth logging are the ones that repeat, and one
+/// session here has produced 1931 of them.
+///
+/// Everything is `.public` and every attribute is a number, a feature id, or a
+/// fixed label. No paths, URLs, device serials, package ids or command
+/// contents, matching Settings ▸ Privacy and the privacy policy. That is a
+/// property of the call sites, so keep it that way: the type accepts a fixed
+/// `Area` and `[String: Int]` rather than free-form strings for exactly this
+/// reason.
+@MainActor
+enum AppLog {
+    enum Level: String, Sendable {
+        case debug, info, warn, error
+    }
+
+    /// The subsystem's areas. Fixed, so a log line can never carry an
+    /// identifier in the place a category goes, and so the backend's rate
+    /// limit has a stable key to count against.
+    enum Area: String, CaseIterable, Sendable {
+        case feed          // the streaming log/console feeds
+        case reactotron
+        case jsConsole = "js-console"
+        case mirror
+        case device
+        case tools
+        case updater
+        case window
+
+        var logger: Logger {
+            Logger(subsystem: "com.rohindh.droidective", category: rawValue)
+        }
+    }
+
+    /// At most five lines per area per minute reach the backend. Five is
+    /// enough to see a pattern and small enough that a pathological session
+    /// can't spend the project's quota; the count of what it swallowed rides
+    /// out on the next line that fits, so the magnitude survives the limit.
+    private static var budget = LogBudget(limit: 5, windowSeconds: 60)
+
+    private static let started = ContinuousClock.now
+
+    private static var nowSeconds: Double {
+        let elapsed = ContinuousClock.now - started
+        return Double(elapsed.components.seconds)
+            + Double(elapsed.components.attoseconds) / 1e18
+    }
+
+    /// Record something worth knowing. Always logged locally; forwarded to the
+    /// backend when `toBackend` is set and the area's budget allows.
+    static func write(
+        _ level: Level,
+        _ area: Area,
+        _ message: String,
+        _ attributes: [String: Int] = [:],
+        toBackend: Bool = false
+    ) {
+        let rendered = attributes.isEmpty
+            ? message
+            : "\(message) " + attributes.sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: " ")
+        local(level, area, rendered)
+
+        guard toBackend else { return }
+        let decision = budget.admit(area.rawValue, at: nowSeconds)
+        guard decision.allowed else { return }
+        var payload: [String: Any] = attributes
+        payload["area"] = area.rawValue
+        // Zero would read as "nothing was dropped" rather than "not
+        // applicable", so the key is simply absent when there is no burst.
+        if decision.suppressed > 0 { payload["suppressed"] = decision.suppressed }
+        Telemetry.shared.log(level, message, payload)
+    }
+
+    private static func local(_ level: Level, _ area: Area, _ rendered: String) {
+        let logger = area.logger
+        switch level {
+        case .debug: logger.debug("\(rendered, privacy: .public)")
+        case .info: logger.info("\(rendered, privacy: .public)")
+        case .warn: logger.warning("\(rendered, privacy: .public)")
+        case .error: logger.error("\(rendered, privacy: .public)")
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -42,6 +42,10 @@ final class ReactotronSession {
     private var peakItemsBytes = 0
     private var peakItemCount = 0
     private var evictedItemCount = 0
+    /// The last published feed shape, so an unchanged bucket doesn't re-cross
+    /// both telemetry SDKs from the ingest path. Never observed — publishing
+    /// diagnostics must not invalidate the timeline that produced them.
+    @ObservationIgnored private var publishedDiagnostics: FeedDiagnostics?
     fileprivate var commands: [RegisteredCommand] = []
     fileprivate var connection: RtConnection = .idle
     fileprivate var connectedApp: String?
@@ -689,6 +693,7 @@ final class ReactotronSession {
         for item in batch { itemsBytes += item.frameBytes }
         peakItemsBytes = max(peakItemsBytes, itemsBytes)
         peakItemCount = max(peakItemCount, items.count)
+        publishDiagnostics(lastBatch: batch.count)
         let drop = ReactotronTimeline.dropCount(
             sizes: items.lazy.map(\.frameBytes), count: items.count, totalBytes: itemsBytes
         )
@@ -699,6 +704,57 @@ final class ReactotronSession {
         itemsBytes -= dropped.reduce(0) { $0 + $1.frameBytes }
         Self.discardInBackground(dropped)
     }
+
+    /// What this feed is holding, attached to every subsequent crash, hang and
+    /// perf incident — the JS Console has published its equivalent since
+    /// v3.7.0 and this feed never did. That asymmetry is why the largest hang
+    /// issue (DROIDECTIVE-MAC-B) arrived with no indication of how much was
+    /// buffered, and why the two high-memory issues (MAC-A0 at 1.47 GB,
+    /// MAC-4B at 1.48 GB) name a feature and a byte count but not a row
+    /// count.
+    ///
+    /// Published from the flush rather than per event, and only when a bucket
+    /// actually changes: every call crosses both telemetry SDKs, and this sits
+    /// on the ingest path.
+    private func publishDiagnostics(lastBatch: Int) {
+        let snapshot = FeedDiagnostics(
+            items: ConsoleRateBucket.decade(Double(items.count)),
+            megabytes: itemsBytes / 1_048_576,
+            clients: clients.count,
+            evicted: ConsoleRateBucket.decade(Double(evictedItemCount))
+        )
+        guard snapshot != publishedDiagnostics else { return }
+        publishedDiagnostics = snapshot
+        Telemetry.shared.setDiagnosticContext("reactotron", [
+            "buffered_items": snapshot.items,
+            "buffer_mb": snapshot.megabytes,
+            "clients": snapshot.clients,
+            "evicted_items": snapshot.evicted,
+        ])
+        // A single flush this large means the feed is being drained in
+        // batches big enough to stall a layout pass, which is the shape of
+        // the hang the pacing change addresses — worth seeing from the field,
+        // not just from a developer's Console.
+        if lastBatch >= Self.largeBatchWarning {
+            AppLog.write(
+                .warn, .reactotron, "large timeline flush",
+                ["batch": lastBatch, "buffered": items.count, "mb": snapshot.megabytes],
+                toBackend: true
+            )
+        }
+    }
+
+    /// The bucketed shape of the feed, so an unchanged bucket costs nothing.
+    struct FeedDiagnostics: Equatable {
+        let items: Int
+        let megabytes: Int
+        let clients: Int
+        let evicted: Int
+    }
+
+    /// Rows in one flush past which the drain itself is the problem. Well
+    /// above a chatty client's per-interval batch at the paced cadence.
+    private static let largeBatchWarning = 500
 
     /// Replace the browsed store tree, releasing the old graph off the main actor.
     private func replaceStoreState(_ state: JSONValue) {

--- a/App/Sources/PerfLog.swift
+++ b/App/Sources/PerfLog.swift
@@ -3,18 +3,32 @@ import os
 /// Performance instrumentation for the streaming log feeds (JS Console,
 /// Reactotron, the shared scroller). Watch it live while exercising the app:
 ///
-///     log stream --info --predicate 'subsystem == "com.rohindh.droidective.perf"'
+///     /usr/bin/log stream --info --predicate 'subsystem == "com.rohindh.droidective.perf"'
 ///
 /// Everything logs `.public` — the payload is sizes and durations, never
 /// content. Cheap when Console isn't attached (os.Logger no-ops early).
+///
+/// A breach past `backendThresholdMs` also reaches the backend through
+/// `AppLog`, because a main-thread operation that long is what a user
+/// experiences as a hang, and until now these warnings existed only on the
+/// developer's own machine: the app's largest hang issue had to be diagnosed
+/// from tag aggregates because nothing said *what* was slow.
 enum PerfLog {
     static let console = Logger(subsystem: "com.rohindh.droidective.perf", category: "js-console")
     static let feed = Logger(subsystem: "com.rohindh.droidective.perf", category: "log-feed")
 
+    /// Local warnings start here — frequent, cheap, useful with Console open.
+    static let localThresholdMs: Double = 4
+
+    /// Backend reports start here. Well past a frame: at 250 ms the user is
+    /// watching the app not repaint, and Sentry's own hang detector fires at
+    /// 2000 ms, so this is the band that explains a hang before it is one.
+    static let backendThresholdMs: Double = 250
+
     /// Run `body`, logging a warning when it exceeds `thresholdMs`.
     @discardableResult
     static func measure<T>(
-        _ logger: Logger, _ label: String, thresholdMs: Double = 4, _ body: () -> T
+        _ logger: Logger, _ label: String, thresholdMs: Double = localThresholdMs, _ body: () -> T
     ) -> T {
         let start = ContinuousClock.now
         let result = body()
@@ -24,6 +38,30 @@ enum PerfLog {
         if ms >= thresholdMs {
             logger.warning("\(label, privacy: .public) took \(ms, format: .fixed(precision: 1), privacy: .public)ms")
         }
+        return result
+    }
+
+    /// `measure` for work on the main actor that is worth reporting from the
+    /// field. `area` keys the backend's rate limit; `label` stays a fixed
+    /// string so no identifier can ride out inside it.
+    @discardableResult
+    @MainActor
+    static func measureReported<T>(
+        _ area: AppLog.Area, _ label: String, _ body: () -> T
+    ) -> T {
+        let start = ContinuousClock.now
+        let result = body()
+        let elapsed = ContinuousClock.now - start
+        let ms = Double(elapsed.components.seconds) * 1000
+            + Double(elapsed.components.attoseconds) / 1e15
+        guard ms >= localThresholdMs else { return result }
+        AppLog.write(
+            ms >= backendThresholdMs ? .warn : .debug,
+            area,
+            "\(label) was slow",
+            ["ms": Int(ms.rounded())],
+            toBackend: ms >= backendThresholdMs
+        )
         return result
     }
 }

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -144,6 +144,24 @@ final class Telemetry {
         SentrySDK.addBreadcrumb(crumb)
     }
 
+    /// Ship one structured log line. Unlike a breadcrumb this stands on its
+    /// own — it arrives whether or not an event ever ships, which is what
+    /// makes a slow operation visible before it becomes a hang report.
+    ///
+    /// Called only by `AppLog`, which owns the rate limit and the local
+    /// `os_log` half. `attributes` carries numbers and feature ids, never
+    /// paths, URLs or content — same promise as every other sink here.
+    func log(_ level: AppLog.Level, _ message: String, _ attributes: [String: Any]) {
+        guard crashReportingEnabled, sentryRunning else { return }
+        let logger = SentrySDK.logger
+        switch level {
+        case .debug: logger.debug(message, attributes: attributes)
+        case .info: logger.info(message, attributes: attributes)
+        case .warn: logger.warn(message, attributes: attributes)
+        case .error: logger.error(message, attributes: attributes)
+        }
+    }
+
     func setCrashReporting(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: Self.crashReportingKey)
         if enabled { startSentry() } else { stopSentry() }
@@ -202,11 +220,22 @@ final class Telemetry {
     /// pair is what attributes an incident correctly.
     func openFeaturesChanged(_ ids: [String]) {
         let joined = ids.isEmpty ? "none" : ids.sorted().joined(separator: ",")
+        // The count as its own tag, because it is the figure that explained
+        // the largest hang issue and the joined list cannot be aggregated on:
+        // grouping DROIDECTIVE-MAC-B by `open_features` produced one row per
+        // distinct tab *combination*, so the finding — that ~4000 of 5087
+        // events were a handful of users with 9 to 18 tabs mounted — had to be
+        // read off six unrelated rows. Every open tab stays mounted, so this
+        // is a direct measure of how much tree each layout pass walks.
+        let count = String(ids.count)
         if crashReportingEnabled, sentryRunning {
-            SentrySDK.configureScope { $0.setTag(value: joined, key: "open_features") }
+            SentrySDK.configureScope {
+                $0.setTag(value: joined, key: "open_features")
+                $0.setTag(value: count, key: "open_feature_count")
+            }
         }
         if analyticsEnabled, postHogReady {
-            PostHogSDK.shared.register(["open_features": joined])
+            PostHogSDK.shared.register(["open_features": joined, "open_feature_count": ids.count])
         }
     }
 
@@ -366,6 +395,14 @@ final class Telemetry {
             // hangs and crashes inherit the `active_feature` scope tag set in
             // `featureBecameActive`, so they group by the feature on screen.
             options.appHangTimeoutInterval = 2
+            // Structured logs. Before this the only diagnostics that left the
+            // machine were tags, breadcrumbs and a stack, so the Sentry logs
+            // view was empty and `PerfLog`'s slow-operation warnings — the
+            // ones that name what actually stalled — reached nobody but a
+            // developer with Console attached. Diagnosing the largest hang
+            // issue (DROIDECTIVE-MAC-B) took five aggregate queries against
+            // tags because of it. See `AppLog`, which is the only writer.
+            options.enableLogs = true
             // Sampled continuous profiling tied to traced spans — function-level
             // "what burned the CPU" for the sampled sessions.
             options.configureProfiling = { profiling in


### PR DESCRIPTION
## The gap

Sentry's **logs view for this project is empty**. Nothing structured has ever left the machine:

- `PerfLog` writes to `os_log` — it reaches a developer with Console attached and nobody else.
- The only field diagnostics were tags, breadcrumbs, and a stack.
- Only the JS Console publishes a diagnostic context. Reactotron never has.

That's why diagnosing DROIDECTIVE-MAC-B (4197 events / 49 users) took five aggregate queries against tags: no event said *what* was slow or *how much* was buffered.

## The change

`options.enableLogs = true`, and `AppLog` as the single writer — one call writes the local unified log and, when it would help diagnose someone else's machine, a structured line to the backend.

It takes a fixed `Area` and `[String: Int]` rather than free-form strings, so a path, URL or serial **cannot** ride out inside one. The privacy promise in `Settings ▸ Privacy` becomes a property of the type rather than of each call site.

### Rate limiting is not optional here

Backend logs go through `LogBudget` (ADBKit, pure, 9 tests): five per area per minute. The events worth logging are exactly the ones that repeat, and one session in this project produced **1931** of them — unbudgeted, the first pathological session spends the whole quota and the next arrives to none.

Two design points the tests pin:

- **Keyed per area**, so a chatty feed can't starve the one line the updater emits all day.
- **The suppressed count rides out on the next admitted line.** "Flush took 300 ms" is ambiguous; "took 300 ms, 412 suppressed since the last one" is the bug. Dropping the magnitude along with the lines would defeat the point of logging at all.

Edge cases covered: a limit below 1 is raised rather than silencing the sink, a zero window degrades to always-allow rather than dividing by it, and a clock reading that regresses doesn't open the gate.

### Reporting threshold

`PerfLog.measureReported` reports a breach past **250 ms** — well past a frame, well under Sentry's 2000 ms hang threshold. That's the band that explains a hang *before* it becomes one.

## Two specific gaps closed

**Reactotron's diagnostic context.** It now publishes what the JS Console has had since v3.7.0: buffered items, buffer megabytes, clients, evictions — bucketed via `ConsoleRateBucket.decade` and published from the flush, only when a bucket changes, because every call crosses both telemetry SDKs and this sits on the ingest path. This is why MAC-B arrived with no indication of how much was buffered, and why MAC-A0 and MAC-4B name 1.47 GB and 1.48 GB without a row count.

**`open_feature_count`.** Joins the existing `open_features` tag. Every open tab stays mounted, so the count is a direct measure of how much tree each layout pass walks — and it's aggregatable, where the joined list is not: grouping MAC-B by `open_features` produced one row per distinct tab *combination*, so the finding that a handful of users with 9–18 tabs accounted for ~4000 of 5087 events had to be read off six unrelated rows.

## Verification

`make verify` green: **1883** ADBKit (+9 for `LogBudget`, +5 net after branch base) · 99 ReactotronMCP · 406 droidectived · 106 AppTests. Build warning-free.

The `SentryLogger` surface (`trace`/`debug`/`info`/`warn`/`error`/`fatal`, `options.enableLogs`, `beforeSendLog`) was read off the pinned 9.18.0 `.swiftinterface` rather than from memory.

**Not verified:** that lines actually arrive in Sentry's logs view. That needs a signed build reporting from a real session — the same limitation as the notification work. The emptiness of the dataset today is the evidence the sink was off; that it's on now is a config change plus a call path, both compile-checked.

Related: DROIDECTIVE-MAC-B, DROIDECTIVE-MAC-A0, DROIDECTIVE-MAC-4B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
