### PR TITLE
Stop stoppingReleasesThePort failing on a port it does not own

### DIFF
--- a/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
@@ -308,38 +308,57 @@ import Testing
         })
     }
 
-    /// A port the OS will never hand out by itself.
+    /// Ports the OS will never hand out by itself, tried in turn.
     ///
     /// `port: 0` draws from the ephemeral range (49152–65535 on macOS), and the
     /// other *suites* — this one is `.serialized`, they are not — bind that way
     /// throughout. The test below is shaped "release a port, then take it
     /// again", so with an ephemeral port one of them can be handed it in the
-    /// gap between: it failed twice running on CI, on 49407 and then 49412,
-    /// with `SO_REUSEADDR` already set on the bind. Nothing is auto-assigned
-    /// down here, so the gap stops mattering.
+    /// gap between: it failed twice on CI, on 49407 and then 49412, with
+    /// `SO_REUSEADDR` already set on the bind. Nothing down here is
+    /// auto-assigned, which is why these numbers.
     ///
-    /// Exactly one start/stop pair either side, deliberately: an extra cycle to
-    /// pick the port turned this red every run, which says `stop()` can return
-    /// before the listener is really gone. That is worth chasing on its own,
-    /// and it is not what this test is about.
-    private static let reservedPort = 28_411
+    /// Reserving *one* number was still the fragility. 28411 came back
+    /// "already in use" twice more on 2026-09-04, on two unrelated commits —
+    /// one of them the appcast commit, which changes a single XML file — while
+    /// `test-linux` passed both times and a bare re-run went green. Nothing in
+    /// this target binds it, so the holder is outside the test process and
+    /// unidentified; the standing counter-argument, that 28411 sits below the
+    /// ephemeral range, rests on the *runner's* `net.inet.ip.portrange`, which
+    /// nobody has checked.
+    ///
+    /// So the test no longer depends on any single port being free. What it
+    /// must never tolerate is the *second* bind failing — see below.
+    private static let candidatePorts = [28_411, 29_617, 30_853]
 
     @Test func stoppingReleasesThePort() async throws {
-        let port = Self.reservedPort
-        let relay = ReactotronRelay(port: port)
-        try await relay.start()
-        #expect(await relay.boundPort == port)
-        await relay.stop()
-        #expect(await relay.isRunning == false)
+        for (index, port) in Self.candidatePorts.enumerated() {
+            let relay = ReactotronRelay(port: port)
+            do {
+                try await relay.start()
+            } catch ReactotronRelay.RelayError.portInUse {
+                // Somebody else's socket, which is not what this test is
+                // about. Try the next number instead of failing the suite.
+                if index == Self.candidatePorts.count - 1 {
+                    Issue.record("none of \(Self.candidatePorts) could be bound at all")
+                }
+                continue
+            }
+            #expect(await relay.boundPort == port)
+            await relay.stop()
+            #expect(await relay.isRunning == false)
 
-        // The failure this catches is a relay that closed its channel but kept
-        // its event-loop group, so the next start reports the port in use — and
-        // the feature simply refuses to come back. Still caught: a leak makes
-        // the port unavailable to *anyone*, so this start throws.
-        let second = ReactotronRelay(port: port)
-        try await second.start()
-        #expect(await second.boundPort == port)
-        await second.stop()
+            // The assertion, and the reason the test exists: a relay that
+            // closed its channel but kept its event-loop group reports the
+            // port in use here, and the feature simply refuses to come back.
+            // This bind is never allowed to fail — a foreign holder cannot
+            // explain it, because the bind moments earlier just succeeded.
+            let second = ReactotronRelay(port: port)
+            try await second.start()
+            #expect(await second.boundPort == port)
+            await second.stop()
+            return
+        }
     }
 
     @Test func aStartAndAStopThatRaceLeaveAConsistentRelay() async throws {


### PR DESCRIPTION
`stoppingReleasesThePort` failed twice on 2026-09-04, on unrelated commits — one of them **`Publish appcast for v3.10.0`, which changes a single XML file**. It reddened `main` immediately after the v3.10.0 release.

```
✘ stoppingReleasesThePort() — ReactotronRelayTests.swift:327
   Caught error: Port 28411 is already in use — another Reactotron is probably running.
```

Both times `test-linux` passed on the same commit and a bare re-run of the macOS job went green with no code change.

## Why it wasn't the relay

Nothing in `DaemonCoreTests` binds 28411 — every other test in the file uses `port: 0`, and no other suite in the target binds a fixed port at all. So the holder is outside the test process and unidentified.

The standing counter-argument in the test's own comment is that 28411 sits below the ephemeral range, so no concurrent `port: 0` bind could be handed it. That rests on the **runner's** `net.inet.ip.portrange`, which nobody has checked — the range is configurable and GitHub's macOS image is not stock. I'm not asserting that's the cause; I'm removing the dependency on it being false.

## The change

Reserving *one* number was the fragility. The test now tries three candidates:

- A refused **first** bind is somebody else's socket, not this relay failing to release one → move to the next candidate. Only if none of the three can be bound at all does it record an issue.
- A refused **second** bind is never tolerated. That's the assertion the test exists for — a relay that closed its channel but kept its event-loop group reports the port in use there — and a foreign holder can't explain it when the bind moments earlier just succeeded.

So the false-positive mode goes away and the real assertion gets strictly no weaker.

## Verification

**Verified:** holding 28411 with an external Python socket, the test falls through to 29617 and passes. That's the CI scenario, made deterministic. Full daemon suite green (406) and `make verify` green.

**Not verified, and worth stating plainly:** that it still catches the underlying `stop()` bug. I broke `stop()` both ways — dropped the `closeFuture` await *and* the `shutdownGracefully()` — and the test stayed green locally. That matches the note left when the bug was first fixed: *"Never reproduced locally — 30 direct restarts and 12 full-suite runs stay clean. It needs CI's slower runner."* This change doesn't touch that path: the second bind is still an unguarded `try await`.

The separate suspicion the old comment raised is still open and not addressed here: an extra start/stop cycle "turned this red every run, which says `stop()` can return before the listener is really gone."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
