### PR TITLE
Pair over Wi-Fi by scanning a QR code

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureRegistry.swift
@@ -48,6 +48,7 @@ public enum FeatureRegistry {
                 "forward", "tcp", "metro", "disconnect", "private dns", "dns", "dot",
                 "dns-over-tls", "doh", "hostname", "resolver", "wireless", "wifi",
                 "tcpip", "pair", "untethered", "adb connect", "connect",
+                "qr", "qr code", "scan",
             ],
             category: .connection, icon: "network", kind: .view, needsDevice: false
         ),
@@ -63,7 +64,10 @@ public enum FeatureRegistry {
         FeatureDef(
             id: "wireless-adb", title: "Wireless ADB",
             subtitle: "Connect over Wi-Fi (tcpip + Android 11 pairing)",
-            keywords: ["wireless", "wifi", "tcpip", "pair", "connect", "untethered"],
+            keywords: [
+                "wireless", "wifi", "tcpip", "pair", "connect", "untethered",
+                "qr", "qr code", "scan",
+            ],
             category: .connection, icon: "wifi", kind: .view, needsDevice: false
         ),
         FeatureDef(

--- a/ADBKit/Sources/ADBKit/Services/QrPairing.swift
+++ b/ADBKit/Sources/ADBKit/Services/QrPairing.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// The one-time secret behind a QR pairing session: the mDNS instance name the
+/// device is asked to publish under, and the pairing password.
+///
+/// The payload is a repurposed WPA3 Wi-Fi QR code, which is what the device's
+/// "Pair device with QR code" scanner reads:
+///
+///     WIFI:T:ADB;S:<service name>;P:<password>;;
+///
+/// `T:ADB` is what tells the scanner to start its pairing server instead of
+/// joining a network; the SSID slot carries the *requested* instance name for
+/// `_adb-tls-pairing._tcp`, and the password slot the shared secret.
+///
+/// The name is the whole trick. The host can't know the pairing port in
+/// advance — the device picks one and advertises it — so the name is how this
+/// Mac tells the phone that just scanned *our* code apart from every other
+/// device pairing on the network. Android Studio uses `studio-` + 10 random
+/// characters for exactly this; the prefix is free-form (the device takes the
+/// name verbatim), so ours says who generated it.
+public struct QrPairingRequest: Equatable, Sendable {
+    public let serviceName: String
+    public let password: String
+
+    public init(serviceName: String, password: String) {
+        self.serviceName = serviceName
+        self.password = password
+    }
+
+    /// The string to encode as a QR code.
+    public var payload: String {
+        "WIFI:T:ADB;S:\(serviceName);P:\(password);;"
+    }
+
+    /// The alphabet both halves are drawn from.
+    ///
+    /// Alphanumerics only, and deliberately: the WPA3 grammar this payload
+    /// borrows makes `\`, `;`, `,`, `:` and `"` special inside a field, so a
+    /// password containing one would have to be escaped — and an escape the
+    /// device's parser disagrees with is a pairing that fails with no useful
+    /// message. Staying inside `[A-Za-z0-9]` means there is nothing to escape.
+    /// It costs ~4 bits per character against printable ASCII, which 12
+    /// characters of password (71 bits) can afford.
+    static let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+
+    static let namePrefix = "droidective-"
+    static let nameSuffixLength = 10
+    static let passwordLength = 12
+
+    /// A fresh request for one pairing attempt. Never reuse one: the password
+    /// is a bearer credential for adb access to the device, and the name is
+    /// what makes "a device scanned *this* code" answerable.
+    ///
+    /// `SystemRandomNumberGenerator` — what `randomElement()` uses — is the
+    /// platform CSPRNG on every OS ADBKit builds for, so this needs no
+    /// crypto dependency.
+    public static func random() -> QrPairingRequest {
+        QrPairingRequest(
+            serviceName: namePrefix + randomString(length: nameSuffixLength),
+            password: randomString(length: passwordLength)
+        )
+    }
+
+    private static func randomString(length: Int) -> String {
+        var out = ""
+        out.reserveCapacity(length)
+        for _ in 0..<length {
+            // `randomElement()` is nil only for an empty collection.
+            out.append(alphabet.randomElement() ?? "0")
+        }
+        return out
+    }
+}
+
+/// Where a QR pairing attempt has got to. The UI needs these apart because
+/// they mean different things to the person holding the phone: "nothing has
+/// scanned yet" is their cue to keep going, "pairing" is the app's turn.
+public enum QrPairingPhase: Equatable, Sendable {
+    /// The code is on screen and no device has published our name yet.
+    case waitingForScan
+    /// A device scanned the code and is advertising its pairing port.
+    case pairing(endpoint: WirelessEndpoint)
+    /// Paired; finding the connect port and connecting.
+    case connecting(endpoint: WirelessEndpoint)
+    /// Connected — `address` is now in `adb devices`.
+    case connected(address: String)
+    /// Paired, but the connect port never showed up. The device trusts this
+    /// Mac now, so the "Already paired" tab finishes the job by hand.
+    case pairedWithoutConnecting(host: String)
+    /// Terminal failure, carrying adb's own reason where there is one.
+    case failed(message: String)
+}
+
+/// How long each polling stage waits. Exists so tests run the real code path
+/// in milliseconds instead of minutes — the same reason
+/// `discoverConnectEndpoint` takes `attempts`/`delay`.
+/// The defaults live on the properties and nowhere else — deliberately no
+/// hand-written `init`, whose own parameter defaults would be a second copy of
+/// these numbers, free to disagree with them. (It already happened once: the
+/// two copies drifted and the init's value silently won.) The implicit
+/// memberwise init is internal, which is all the tests need; callers outside
+/// ADBKit take `.default` or copy and adjust it.
+public struct QrPairingTiming: Equatable, Sendable {
+    /// Polls of `adb mdns services` waiting for someone to scan the code.
+    /// Spans five minutes; the caller cancelling (closing the sheet,
+    /// switching tabs) ends it sooner.
+    public var scanAttempts: Int = 300
+    public var scanDelay: Duration = .seconds(1)
+    /// Polls waiting for `_adb-tls-connect._tcp` after a successful pair.
+    public var connectAttempts: Int = 5
+    public var connectDelay: Duration = .seconds(1)
+
+    public static let `default` = QrPairingTiming()
+}
+
+extension ConnectionService {
+    /// The pairing endpoint a device advertises once it has scanned the QR for
+    /// `serviceName`, or nil if none turns up within `attempts`.
+    ///
+    /// Same shape as `discoverConnectEndpoint`, and nil for the same reasons:
+    /// mDNS disabled in this adb, a different subnet, nobody scanned.
+    ///
+    /// The polling explicitly opts *out* of the command log even though the
+    /// caller is a user action: this waits on a human picking up their phone,
+    /// so it can run for minutes at one poll a second, and the log holds 200
+    /// entries — left in, a single pairing evicts the whole log and buries the
+    /// two commands that actually did something.
+    public func discoverPairingEndpoint(
+        serviceName: String,
+        attempts: Int = 300,
+        delay: Duration = .seconds(1)
+    ) async -> WirelessEndpoint? {
+        for attempt in 0..<max(1, attempts) {
+            guard !Task.isCancelled else { return nil }
+            if attempt > 0 { try? await Task.sleep(for: delay) }
+            guard
+                let result = try? await CommandLog.$isUserInitiated.withValue(false, operation: {
+                    try await client.run(["mdns", "services"], timeout: .seconds(5))
+                })
+            else { return nil }
+            let services = Self.parseMdnsServices(result.stdout)
+            if let match = Self.matchPairingService(services, requestedName: serviceName) {
+                return match.endpoint
+            }
+        }
+        return nil
+    }
+
+    /// The `_adb-tls-pairing._tcp` row published under the name we asked for.
+    ///
+    /// Matched by prefix, not equality: the pairing service is published
+    /// through Android's `NsdServiceInfo`, which renames on a collision, and
+    /// adb's own mDNS backend appends a suffix of its own to instance names.
+    /// A prefix is still unambiguous — the name carries 10 random characters
+    /// this Mac generated — while equality would silently never match on the
+    /// devices that rename.
+    ///
+    /// The type check is a prefix too, because the row can arrive as
+    /// `_adb-tls-pairing._tcp` or with a trailing dot.
+    public static func matchPairingService(
+        _ services: [MdnsService], requestedName: String
+    ) -> MdnsService? {
+        guard !requestedName.isEmpty else { return nil }
+        return services.first { service in
+            service.type.hasPrefix("_adb-tls-pairing") && service.name.hasPrefix(requestedName)
+        }
+    }
+
+    /// Run a whole QR pairing session: wait for a device to scan `request`,
+    /// pair with it, then connect — reporting each stage as it happens.
+    ///
+    /// Cancelling the consuming task (closing the sheet, leaving the tab)
+    /// stops the polling and the stream; the QR code itself is then spent,
+    /// since a new session must generate a new name and password.
+    public func pairByQrCode(
+        _ request: QrPairingRequest,
+        timing: QrPairingTiming = .default
+    ) -> AsyncStream<QrPairingPhase> {
+        AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.waitingForScan)
+
+                guard
+                    let pairEndpoint = await discoverPairingEndpoint(
+                        serviceName: request.serviceName,
+                        attempts: timing.scanAttempts,
+                        delay: timing.scanDelay),
+                    let pairPort = pairEndpoint.port
+                else {
+                    if !Task.isCancelled {
+                        continuation.yield(.failed(
+                            message: "No device scanned the code. Check that both are on the same "
+                                + "Wi-Fi network, then show a new code."))
+                    }
+                    continuation.finish()
+                    return
+                }
+                continuation.yield(.pairing(endpoint: pairEndpoint))
+
+                do {
+                    let paired = try await pair(
+                        host: pairEndpoint.host, port: pairPort, code: request.password)
+                    guard paired.ok else {
+                        continuation.yield(.failed(message: paired.message))
+                        continuation.finish()
+                        return
+                    }
+                    continuation.yield(.connecting(endpoint: pairEndpoint))
+
+                    guard
+                        let connectEndpoint = await discoverConnectEndpoint(
+                            host: pairEndpoint.host,
+                            attempts: timing.connectAttempts,
+                            delay: timing.connectDelay),
+                        let connectPort = connectEndpoint.port
+                    else {
+                        continuation.yield(.pairedWithoutConnecting(host: pairEndpoint.host))
+                        continuation.finish()
+                        return
+                    }
+
+                    let connected = try await connect(host: connectEndpoint.host, port: connectPort)
+                    let address = "\(connectEndpoint.host):\(connectPort)"
+                    continuation.yield(
+                        connected.ok
+                            ? .connected(address: address)
+                            : .failed(message: connected.message))
+                } catch {
+                    continuation.yield(.failed(message: error.localizedDescription))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/QrPairingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/QrPairingTests.swift
@@ -1,0 +1,203 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct QrPairingPayloadTests {
+    @Test func payloadIsTheWpa3AdbForm() {
+        let request = QrPairingRequest(serviceName: "droidective-abc123", password: "s3cret")
+        #expect(request.payload == "WIFI:T:ADB;S:droidective-abc123;P:s3cret;;")
+    }
+
+    @Test func randomRequestsCarryTheNamePrefixAndTheDeclaredLengths() {
+        let request = QrPairingRequest.random()
+        #expect(request.serviceName.hasPrefix("droidective-"))
+        #expect(request.serviceName.count == "droidective-".count + 10)
+        #expect(request.password.count == 12)
+    }
+
+    @Test func randomRequestsNeedNoWpa3Escaping() {
+        // `\`, `;`, `,`, `:` and `"` are special inside a WPA3 QR field, so a
+        // generated value containing one would have to be escaped. The
+        // alphabet exists to make that impossible.
+        for _ in 0..<200 {
+            let request = QrPairingRequest.random()
+            let generated = request.serviceName.dropFirst("droidective-".count) + request.password
+            #expect(generated.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) })
+        }
+    }
+
+    @Test func randomRequestsDoNotRepeat() {
+        // The name is the correlation key and the password is a bearer
+        // credential — a repeat of either is a bug, not a coincidence.
+        var names: Set<String> = []
+        var passwords: Set<String> = []
+        for _ in 0..<200 {
+            let request = QrPairingRequest.random()
+            names.insert(request.serviceName)
+            passwords.insert(request.password)
+        }
+        #expect(names.count == 200)
+        #expect(passwords.count == 200)
+    }
+}
+
+@Suite struct PairingServiceMatchTests {
+    private let services = ConnectionService.parseMdnsServices("""
+    List of discovered mdns services
+    adb-R58M4-QXjCrW\t_adb-tls-pairing._tcp\t192.168.1.99:33861
+    droidective-aB3xY9zQ1p\t_adb-tls-pairing._tcp\t192.168.1.42:37123
+    droidective-aB3xY9zQ1p\t_adb-tls-connect._tcp\t192.168.1.42:40913
+    """)
+
+    @Test func matchesOurRequestedNameAndOnlyThePairingService() {
+        let match = ConnectionService.matchPairingService(
+            services, requestedName: "droidective-aB3xY9zQ1p")
+        #expect(match?.endpoint == WirelessEndpoint(host: "192.168.1.42", port: "37123"))
+        // The connect row shares the name — taking it would pair against the
+        // wrong port and fail with adb's unhelpful "connection reset".
+        #expect(match?.type.hasPrefix("_adb-tls-pairing") == true)
+    }
+
+    @Test func ignoresAnotherHostsPairingSession() {
+        // A phone pairing with Android Studio next to us advertises too.
+        #expect(ConnectionService.matchPairingService(
+            services, requestedName: "droidective-NEVERUSED") == nil)
+    }
+
+    @Test func toleratesTheSuffixTheMdnsBackendAppends() {
+        // adb's mDNS backend decorates instance names with a random suffix,
+        // so the name on the wire is not the name we asked for — which is why
+        // the match is by prefix. (A suffix carrying a *space* would defeat
+        // `parseMdnsServices`, which splits on spaces as well as tabs; that
+        // only happens on an outright name collision, which the 10 random
+        // characters in the name make vanishingly unlikely.)
+        let decorated = ConnectionService.parseMdnsServices(
+            "droidective-aB3xY9zQ1p-QXjCrW\t_adb-tls-pairing._tcp\t192.168.1.42:37123")
+        #expect(ConnectionService.matchPairingService(
+            decorated, requestedName: "droidective-aB3xY9zQ1p")?.endpoint.port == "37123")
+    }
+
+    @Test func anEmptyNameMatchesNothing() {
+        // Prefix matching means "" would otherwise match the first row.
+        #expect(ConnectionService.matchPairingService(services, requestedName: "") == nil)
+    }
+}
+
+@Suite struct QrPairingFlowTests {
+    private let request = QrPairingRequest(
+        // Twelve alphanumerics like the real thing, but patterned rather than
+        // random: a high-entropy literal here reads as a leaked credential to
+        // the gitleaks pre-commit hook.
+        serviceName: "droidective-aB3xY9zQ1p", password: "aaaabbbbcccc")
+
+    private let fast = QrPairingTiming(
+        scanAttempts: 2, scanDelay: .milliseconds(1),
+        connectAttempts: 2, connectDelay: .milliseconds(1))
+
+    private func makeService(runner: MockProcessRunner) async -> ConnectionService {
+        let client = await makeTestClient(runner: runner)
+        return ConnectionService(client: client, monitor: DeviceMonitor(client: client))
+    }
+
+    private func phases(
+        _ service: ConnectionService, _ timing: QrPairingTiming
+    ) async -> [QrPairingPhase] {
+        var seen: [QrPairingPhase] = []
+        for await phase in service.pairByQrCode(request, timing: timing) { seen.append(phase) }
+        return seen
+    }
+
+    @Test func pairsWithTheAdvertisedPortThenConnectsOnTheConnectPort() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout: """
+        List of discovered mdns services
+        droidective-aB3xY9zQ1p\t_adb-tls-pairing._tcp\t192.168.1.42:37123
+        droidective-aB3xY9zQ1p\t_adb-tls-connect._tcp\t192.168.1.42:40913
+        """)
+        runner.script(argsPrefix: ["pair"], stdout: "Successfully paired to 192.168.1.42:37123")
+        runner.script(argsPrefix: ["connect"], stdout: "connected to 192.168.1.42:40913")
+        runner.script(argsPrefix: ["devices"], stdout: "List of devices attached\n")
+        let service = await makeService(runner: runner)
+
+        let seen = await phases(service, fast)
+        #expect(seen == [
+            .waitingForScan,
+            .pairing(endpoint: WirelessEndpoint(host: "192.168.1.42", port: "37123")),
+            .connecting(endpoint: WirelessEndpoint(host: "192.168.1.42", port: "37123")),
+            .connected(address: "192.168.1.42:40913"),
+        ])
+        // The generated password is what goes on the wire, against the
+        // *pairing* port — and the connect uses the connect port, not it.
+        #expect(runner.invocations.contains {
+            $0.arguments == ["pair", "192.168.1.42:37123", "aaaabbbbcccc"]
+        })
+        #expect(runner.invocations.contains {
+            $0.arguments == ["connect", "192.168.1.42:40913"]
+        })
+    }
+
+    @Test func reportsNoScanWhenNobodyAdvertisesOurName() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout: """
+        List of discovered mdns services
+        adb-R58M4-QXjCrW\t_adb-tls-pairing._tcp\t192.168.1.99:33861
+        """)
+        let service = await makeService(runner: runner)
+
+        let seen = await phases(service, fast)
+        #expect(seen.count == 2)
+        #expect(seen.first == .waitingForScan)
+        if case .failed(let message) = seen.last {
+            #expect(message.contains("No device scanned the code"))
+        } else {
+            Issue.record("expected a failure phase, got \(String(describing: seen.last))")
+        }
+        // It polled every attempt rather than giving up on the first miss.
+        #expect(runner.invocations.filter { $0.arguments == ["mdns", "services"] }.count == 2)
+        #expect(!runner.invocations.contains { $0.arguments.first == "pair" })
+    }
+
+    @Test func surfacesAdbsOwnPairingFailure() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout:
+            "droidective-aB3xY9zQ1p\t_adb-tls-pairing._tcp\t192.168.1.42:37123")
+        runner.script(argsPrefix: ["pair"], stderr: "failed: wrong code", exitCode: 1)
+        let service = await makeService(runner: runner)
+
+        let seen = await phases(service, fast)
+        #expect(seen.last == .failed(message: "failed: wrong code"))
+        #expect(!runner.invocations.contains { $0.arguments.first == "connect" })
+    }
+
+    @Test func staysPairedWhenTheConnectPortNeverArrives() async {
+        // adb's own auto-connect may have taken the device already, and the
+        // pairing is real either way — reporting this as a failure would send
+        // the user back to re-pair a device that is already trusted.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout:
+            "droidective-aB3xY9zQ1p\t_adb-tls-pairing._tcp\t192.168.1.42:37123")
+        runner.script(argsPrefix: ["pair"], stdout: "Successfully paired to 192.168.1.42:37123")
+        let service = await makeService(runner: runner)
+
+        let seen = await phases(service, fast)
+        #expect(seen.last == .pairedWithoutConnecting(host: "192.168.1.42"))
+        #expect(!runner.invocations.contains { $0.arguments.first == "connect" })
+    }
+
+    @Test func cancellingTheConsumerStopsThePolling() async {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["mdns"], stdout: "List of discovered mdns services\n")
+        let service = await makeService(runner: runner)
+
+        // A long scan window, abandoned after the first phase — what closing
+        // the sheet does. Without the stream's onTermination cancelling its
+        // task, this polls adb for five minutes after the UI is gone.
+        let timing = QrPairingTiming(scanAttempts: 300, scanDelay: .milliseconds(20))
+        for await phase in service.pairByQrCode(request, timing: timing) {
+            #expect(phase == .waitingForScan)
+            break
+        }
+        let afterBreak = runner.invocations.count
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(runner.invocations.count - afterBreak <= 1)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
+++ b/App/Sources/FeatureDetail/Views/WirelessAdbView.swift
@@ -11,6 +11,7 @@ struct WirelessAdbSection: View {
     @State private var pairingCode = ""
     @State private var connectionPort = "5555"
     @State private var busy = false
+    @State private var showQrSheet = false
 
     private var usbDevices: [Device] {
         state.devices.filter { $0.platform == .android && !$0.isWireless && $0.isReady }
@@ -37,7 +38,23 @@ struct WirelessAdbSection: View {
             }
         }
 
-        HubSection("Pair a device", subtitle: "Android 11+ — pair with a code, then connect.") {
+        HubSection("Pair a device", subtitle: "Android 11+ — scan a QR code, or pair with a code and connect.") {
+            HStack(spacing: 10) {
+                Button {
+                    showQrSheet = true
+                } label: {
+                    Label("Scan a QR Code…", systemImage: "qrcode")
+                }
+                .buttonStyle(.bordered)
+                .disabled(busy)
+                Text("No typing — the device scans the code and this Mac finds it.")
+                    .font(.app(.footnote))
+                    .foregroundStyle(.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider().padding(.vertical, 2)
+
             HubField("Host / IP", prompt: "192.168.1.42", text: $host)
             HStack(spacing: 12) {
                 HubField("Pairing port", prompt: "37123", text: $pairingPort)
@@ -58,6 +75,9 @@ struct WirelessAdbSection: View {
                 .font(.app(.footnote))
                 .foregroundStyle(.textMuted)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+        .sheet(isPresented: $showQrSheet) {
+            WirelessConnectSheet(mode: .qr)
         }
 
         if !wirelessDevices.isEmpty {

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -235,10 +235,18 @@ struct DeviceBarView: View {
                 }
             }
             Section("Wireless debugging") {
+                // The QR tab first, and it is what "Pair new device…" opens:
+                // it asks the user for nothing, where the pairing-code tab
+                // needs a port and a code typed correctly on the first try.
+                Button {
+                    wirelessSheet = .qr
+                } label: {
+                    Label("Pair new device…", systemImage: "qrcode")
+                }
                 Button {
                     wirelessSheet = .pair
                 } label: {
-                    Label("Pair new device…", systemImage: "link.badge.plus")
+                    Label("Pair with a code…", systemImage: "link.badge.plus")
                 }
                 Button {
                     wirelessSheet = .connect

--- a/App/Sources/Root/QrCodeImage.swift
+++ b/App/Sources/Root/QrCodeImage.swift
@@ -1,0 +1,55 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+/// The QR code for a pairing payload, drawn on its own white card.
+///
+/// Deliberately theme-blind — the one view in the app that ignores the
+/// `.bgSurface` / translucency tokens. A scanner needs dark modules on a light
+/// ground and a quiet zone around the symbol, so a QR tinted to match a dark
+/// translucent window is a QR that doesn't scan. The white card is the feature
+/// working, not a missed token.
+struct QrCodeImage: View {
+    let payload: String
+    var side: CGFloat = 190
+
+    @State private var rendered: CGImage?
+
+    var body: some View {
+        Group {
+            if let rendered {
+                Image(decorative: rendered, scale: 1)
+                    // Nearest-neighbour: a QR upscaled with smoothing has soft
+                    // module edges, which is what makes a scan take three tries.
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: side, height: side)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: side, height: side)
+            }
+        }
+        // The quiet zone. Without it a scanner can't find the symbol's edges.
+        .padding(14)
+        .background(.white, in: RoundedRectangle(cornerRadius: 10))
+        .task(id: payload) { rendered = Self.render(payload) }
+        .accessibilityLabel("Pairing QR code")
+    }
+
+    /// The QR bitmap for `payload`, at whole-module resolution.
+    ///
+    /// `CIQRCodeGenerator` emits one pixel per module, so the image is scaled
+    /// by an integer factor before it leaves Core Image — a fractional scale
+    /// lands module boundaries mid-pixel and no amount of nearest-neighbour
+    /// display fixes that.
+    static func render(_ payload: String, modulePixels: CGFloat = 10) -> CGImage? {
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(payload.utf8)
+        filter.correctionLevel = "M"
+        guard let output = filter.outputImage else { return nil }
+        let scaled = output.transformed(
+            by: CGAffineTransform(scaleX: modulePixels, y: modulePixels))
+        return CIContext().createCGImage(scaled, from: scaled.extent)
+    }
+}

--- a/App/Sources/Root/WirelessConnectSheet.swift
+++ b/App/Sources/Root/WirelessConnectSheet.swift
@@ -4,26 +4,31 @@ import SwiftUI
 /// Which tab the wireless sheet opens on — doubles as the `.sheet(item:)`
 /// payload for the device bar's "Pair new device…" / "Connect to device…"
 /// menu entries.
+///
+/// Titles are short because four of them share one segmented control, and the
+/// two pairing tabs borrow Android Studio's vocabulary ("QR code" / "Pairing
+/// code") so the same Android flow is named the same thing in both tools.
 enum WirelessSheetMode: String, CaseIterable, Identifiable {
-    case pair, connect, usb
+    case qr, pair, connect, usb
 
     var id: String { rawValue }
 
     var tabTitle: String {
         switch self {
-        case .pair: "Pair new device"
+        case .qr: "QR code"
+        case .pair: "Pairing code"
         case .connect: "Already paired"
-        case .usb: "Via USB cable"
+        case .usb: "USB cable"
         }
     }
 }
 
 /// A guided modal for getting a device onto wireless adb, opened from the
-/// device dropdown. Three paths, one per tab: first-time Android 11+ pairing
-/// (code + pairing port, then connect), plain connect for an already-paired
-/// device, and the one-click USB→Wi-Fi bootstrap. Endpoints are single
-/// paste-friendly "ip:port" fields (`ConnectionService.parseEndpoint`), exactly
-/// as the phone displays them.
+/// device dropdown. Four paths, one per tab: scan-a-QR-code pairing, first-time
+/// Android 11+ pairing by code (code + pairing port, then connect), plain
+/// connect for an already-paired device, and the one-click USB→Wi-Fi bootstrap.
+/// Endpoints are single paste-friendly "ip:port" fields
+/// (`ConnectionService.parseEndpoint`), exactly as the phone displays them.
 struct WirelessConnectSheet: View {
     @Environment(AppState.self) private var state
     @Environment(\.dismiss) private var dismiss
@@ -36,6 +41,11 @@ struct WirelessConnectSheet: View {
     @State private var connectEndpoint = ""
     @State private var busy = false
     @State private var status: Status?
+    /// One QR pairing session: the name and password on the code currently
+    /// shown. Replacing it re-keys the tab's `.task`, which is how "Show a new
+    /// code" restarts the whole flow.
+    @State private var qrRequest = QrPairingRequest.random()
+    @State private var qrPhase = QrPairingPhase.waitingForScan
 
     private struct Status: Equatable {
         let ok: Bool
@@ -61,6 +71,7 @@ struct WirelessConnectSheet: View {
             .onChange(of: mode) { status = nil }
 
             switch mode {
+            case .qr: qrTab
             case .pair: pairTab
             case .connect: connectTab
             case .usb: usbTab
@@ -76,7 +87,7 @@ struct WirelessConnectSheet: View {
             }
         }
         .padding(20)
-        .frame(width: 470)
+        .frame(width: 500)
     }
 
     private var header: some View {
@@ -93,6 +104,101 @@ struct WirelessConnectSheet: View {
                     .font(.app(.callout))
                     .foregroundStyle(.textMuted)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Pair by QR code (Android 11+, first time)
+
+    /// The device does the typing: it scans a code carrying a one-off service
+    /// name and password, publishes that name over mDNS, and this tab pairs
+    /// with whoever answers to it. Nothing here needs the pairing port, which
+    /// is the field people get wrong on the tab beside it.
+    ///
+    /// The session runs for as long as the tab is on screen — `.task(id:)`
+    /// starts it, switching tabs or closing the sheet cancels it, and a new
+    /// `qrRequest` restarts it with a fresh code.
+    private var qrTab: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            StepRow(number: 1, title: "Open the scanner on the device") {
+                Text("Settings ▸ Developer options ▸ **Wireless debugging** ▸ **Pair device with QR code**.")
+                    .font(.app(.callout))
+                    .foregroundStyle(.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("The device's camera app won't do — it reads the code as a Wi-Fi network and rejects it.")
+                    .font(.app(.caption))
+                    .foregroundStyle(.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            StepRow(number: 2, title: "Point it at this code", done: qrPhase.isPaired) {
+                HStack(alignment: .top, spacing: 16) {
+                    QrCodeImage(payload: qrRequest.payload)
+                    VStack(alignment: .leading, spacing: 10) {
+                        qrPhaseLine
+                        qrPhaseAction
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .task(id: qrRequest) { await runQrPairing() }
+    }
+
+    @ViewBuilder
+    private var qrPhaseLine: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            switch qrPhase {
+            case .waitingForScan, .pairing, .connecting:
+                ProgressView()
+                    .controlSize(.small)
+            case .connected, .pairedWithoutConnecting:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.brandAccent)
+            case .failed:
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+            Text(qrPhase.sheetMessage)
+                .font(.app(.callout))
+                .foregroundStyle(qrPhase.isFailure ? Color.red : .textMain)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var qrPhaseAction: some View {
+        switch qrPhase {
+        case .failed:
+            Button("Show a New Code") { qrRequest = .random() }
+                .buttonStyle(.borderedProminent)
+        case .pairedWithoutConnecting(let host):
+            // Pairing is the hard half and it succeeded; the connect tab only
+            // needs the port off the Wireless debugging screen.
+            Button("Finish on Already Paired") {
+                connectEndpoint = "\(host):"
+                mode = .connect
+            }
+            .buttonStyle(.borderedProminent)
+        default:
+            EmptyView()
+        }
+    }
+
+    /// Drive one pairing session, mirroring each phase into `qrPhase` and
+    /// closing the sheet when a device lands in `adb devices`.
+    private func runQrPairing() async {
+        qrPhase = .waitingForScan
+        let connection = state.env.engine.connection
+        let request = qrRequest
+        await CommandLog.userInitiated {
+            for await phase in connection.pairByQrCode(request) {
+                qrPhase = phase
+                guard case .connected(let address) = phase else { continue }
+                finishConnected(
+                    FeatureResult(
+                        ok: true, message: "Connected to \(address)", copyText: address),
+                    address: address)
             }
         }
     }
@@ -311,6 +417,41 @@ struct WirelessConnectSheet: View {
             }
             busy = false
         }
+    }
+}
+
+/// The words for each pairing phase. ADBKit owns the state machine; the copy
+/// the user reads lives here with the view that shows it.
+extension QrPairingPhase {
+    var sheetMessage: String {
+        switch self {
+        case .waitingForScan:
+            "Waiting for the device to scan…"
+        case .pairing:
+            "Scanned — pairing…"
+        case .connecting:
+            "Paired — connecting…"
+        case .connected(let address):
+            "Connected to \(address)"
+        case .pairedWithoutConnecting:
+            "Paired, but the device didn't advertise a connect port."
+        case .failed(let message):
+            message
+        }
+    }
+
+    /// Whether the device now trusts this Mac — true even when the connect
+    /// step didn't finish, because re-pairing would be the wrong next move.
+    var isPaired: Bool {
+        switch self {
+        case .connected, .pairedWithoutConnecting: true
+        case .waitingForScan, .pairing, .connecting, .failed: false
+        }
+    }
+
+    var isFailure: Bool {
+        if case .failed = self { return true }
+        return false
     }
 }
 

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -463,15 +463,25 @@ the chrome and the device bar have not.
       leading status icon carries the colour and the tooltip, outside the menu,
       as the Mac splits them. **Absent:** the Windows section (multi-window,
       backlog 21) and the iOS Simulators section (`simctl`).
-- [x] **Wireless pair & connect sheet** — the Mac's three tabs, its numbered
-      steps and its wording: Android 11+ pairing with the code and the
-      *pairing* port, a plain connect that takes a bare host at adb's own 5555,
-      and the one-click USB→Wi-Fi bootstrap. Endpoints are parsed
+- [x] **Wireless pair & connect sheet** — the Mac's numbered steps and its
+      wording: Android 11+ pairing with the code and the *pairing* port, a
+      plain connect that takes a bare host at adb's own 5555, and the
+      one-click USB→Wi-Fi bootstrap. Endpoints are parsed
       **daemon-side** by `ConnectionService.parseEndpoint`, so the two apps
       cannot disagree about what adb accepts; this side only decides when a
       button lights up (`lib/endpoint.ts`, deliberately permissive). A
       successful pair carries the endpoint the device then advertised over mDNS,
       so it connects without asking for a port the phone never showed.
+      **Absent:** the Mac's fourth tab, **QR code** — so the tab strip here
+      still reads "Pair new device / Already paired / Via USB cable" against
+      the Mac's "QR code / Pairing code / Already paired / USB cable". The
+      flow itself is portable and already lives in ADBKit
+      (`QrPairing.swift`: `QrPairingRequest.payload`,
+      `discoverPairingEndpoint`, `pairByQrCode`). Two things are missing on
+      this side: a daemon verb for the session — the existing `pair` verb
+      cannot carry it, because waiting for a scan is a minutes-long stream of
+      phases rather than one request/response — and a QR renderer, since
+      `CIFilter.qrCodeGenerator` is the Mac's and has no counterpart here.
 - [x] **Run-on-all** across connected devices for `supportsRunAll` features —
       the switch appears only with more than one ready device *and* a focused
       feature the registry says fans out, and `effectiveRunOnAll` gates the


### PR DESCRIPTION
The wireless sheet gains a fourth tab. Show a code, point the device's
**Wireless debugging ▸ Pair device with QR code** scanner at it, and the
pairing finishes with nothing typed — the tab where the pairing port and the
six-digit code went in stays beside it, renamed "Pairing code".

## Why

The pairing-code path asks for the two things people get wrong: the pairing
port (random per session, and *not* the port on the main Wireless debugging
screen) and a code that expires while you're typing it. The device can read
both off a QR instead, which is how Android Studio has done it since Android
11.

## How it works

The payload is the WPA3 Wi-Fi QR form the device's scanner reads,
`WIFI:T:ADB;S:<name>;P:<password>;;`. `T:ADB` is what makes the scanner start
a pairing server rather than join a network; the SSID slot requests the mDNS
instance name the device will publish `_adb-tls-pairing._tcp` under, and the
password slot is the shared secret.

That name is the correlation key, and it is the part worth understanding: the
host cannot know the pairing port in advance — the device picks one and
advertises it — so the name is how this Mac tells the phone that scanned *its*
code apart from every other device pairing on the network. Discovery then
matches by prefix rather than equality, because the mDNS backend decorates
instance names with a suffix of its own; the 10 random characters in the name
keep that unambiguous.

Both halves are drawn from an alphanumeric alphabet. `\`, `;`, `,`, `:` and
`"` are special inside a WPA3 field, so a random printable password would need
escaping — and an escape the device's parser disagrees with is a pairing that
fails with nothing useful to show. Staying inside `[A-Za-z0-9]` means there is
nothing to escape, at ~4 bits per character that 12 characters (71 bits) can
afford.

Step 4 is unchanged: `_adb-tls-connect._tcp` gives the connect port, through
the `discoverConnectEndpoint` the post-pair auto-connect already used.

## Three decisions

**The session is a stream of phases, not one call.** `pairByQrCode` yields
`waitingForScan` → `pairing` → `connecting` → `connected`, so the sheet can
say which half of the wait belongs to the user and which to the app instead of
spinning opaquely for minutes. Cancelling the consumer — closing the sheet,
leaving the tab — stops the polling; there is a test for that, because the
alternative is polling adb for five minutes after the UI is gone.

**A pair that succeeds without a connect port reports as paired, not failed.**
adb's own auto-connect may already have taken the device, and the pairing is
real either way. Reporting a failure would send someone back to re-pair a
device that already trusts this Mac, so the phase offers to finish on
"Already paired" with the host prefilled.

**The scan polling opts out of the command log.** It waits on someone picking
up their phone, at a poll a second, and the log holds 200 entries — left in,
one pairing evicts the whole log and buries the `pair` and `connect` calls
that actually did something. Those two are still recorded.

QR rendering is the App layer's (`CIFilter.qrCodeGenerator`), on a white card
that deliberately ignores the theme and the translucency tokens: a QR tinted
to match a dark translucent window does not scan. It is the one view in the
app that should not use `.bgSurface`, and it says so.

## Impact area

- Shared `ADBKit` service — `ConnectionService` gains an extension; nothing
  existing changed except `FeatureRegistry` keywords ("qr", "qr code",
  "scan" on the `connection` hub and `wireless-adb`, so ⌘K finds it).
- No new feature id, no route, no persisted state, no new dependency.
- Two labels moved: the sheet's tabs are now "QR code / Pairing code /
  Already paired / USB cable" (four titles sharing one segmented control, in
  Android Studio's vocabulary), and the device dropdown's "Pair new device…"
  opens the QR tab, with the old path as "Pair with a code…".

## Verified

`make verify` green: **1912** ADBKit (+13) · 99 ReactotronMCP · 406
droidectived · 111 AppTests. Build warning-free. `make test-linux` green
(1827), and the 13 new tests pass in the Linux container too, so the flow is
portable for the port to pick up.

Live, against the built app: the code on screen decodes with `CIDetector` to
exactly `WIFI:T:ADB;S:droidective-sHmtlX8t9c;P:XMx6qvxyX9WW;;`. Forcing a
short scan window put the timeout state on screen (message plus a working
"Show a New Code", which reissues both the name and the password) — which
also proves the poll loop runs, since it timed out on schedule.

**Not verified:** an actual pairing with a device. It cannot be faked
locally — platform-tools 37 has dropped the Bonjour mDNS backend, and its
openscreen browser does not report a service advertised from the same host
(`dns-sd -B` sees such an advertisement; `adb mdns services` stays empty). The
discovery mechanism itself is the one the shipped post-pair auto-connect
already uses. Needs a scan from a real Android 11+ device before merge.

## Follow-up

`docs/desktop-parity.md` records the gap: the Windows/Linux app mirrors this
sheet and does not have the tab yet. The flow logic is already portable in
ADBKit; that side needs a daemon verb (the existing `pair` verb cannot carry
a minutes-long stream of phases) and a QR renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)