### PR TITLE
Pace streaming feeds by visibility and main-thread load

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeedAudience.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeedAudience.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Who can currently see a streaming feed.
+///
+/// Visibility decides a feed's flush pacing (`FeedFlushCadence.hidden`), and it
+/// cannot be a flag: one feed can be on screen in several places at once. The
+/// Reactotron timeline is app-wide (`AppCore.reactotronSession`), so two
+/// windows can show it side by side; the JS Console is per window but a split
+/// puts it in both panes. A flag written by whichever view reported last would
+/// let a hidden tab in one window pace the feed someone is reading in another.
+///
+/// Membership is keyed by view identity rather than counted, because the
+/// reports come from SwiftUI lifecycle hooks: an `onAppear` without its
+/// matching `onDisappear` (a pane move, a window closing mid-update) would
+/// leak a count that never comes back down, and the same view reporting twice
+/// would double it. Re-reporting the same identity is idempotent here.
+///
+/// A leaked identity — a view torn down without its `onDisappear` — prices the
+/// feed as *watched*, which is the safe direction: it pays for layout nobody
+/// is reading rather than pausing a feed someone is looking at.
+public struct FeedAudience: Sendable, Equatable {
+    private var watching: Set<UUID> = []
+
+    public init() {}
+
+    /// Whether any mounted view can see the feed right now.
+    public var isWatched: Bool { !watching.isEmpty }
+
+    /// Record one view's visibility.
+    ///
+    /// - Returns: whether `isWatched` changed, so a caller can skip the work a
+    ///   transition triggers (the eager flush on becoming visible) when
+    ///   nothing actually changed. Views report on every appearance and tab
+    ///   switch, so most calls change nothing.
+    @discardableResult
+    public mutating func update(view id: UUID, visible: Bool) -> Bool {
+        let was = isWatched
+        if visible {
+            watching.insert(id)
+        } else {
+            watching.remove(id)
+        }
+        return was != isWatched
+    }
+
+    /// Forget every viewer — teardown, where the views are going away without
+    /// necessarily reporting it (a window close, a role reset).
+    @discardableResult
+    public mutating func removeAll() -> Bool {
+        let was = isWatched
+        watching.removeAll()
+        return was != isWatched
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
@@ -10,7 +10,8 @@ import Foundation
 /// rather than only the one on screen.
 ///
 /// The JS Console found this first and shipped 250 ms/1 s
-/// (DROIDECTIVE-MAC-2N); logcat shipped a flat 300 ms in v3.6.1. The rule
+/// (DROIDECTIVE-MAC-2N); logcat shipped a flat 300 ms in v3.6.1, which is the
+/// value the shared rule settled on. The rule
 /// lives here so the third feed can't miss it — the Reactotron timeline did,
 /// and stayed at 16 ms while being the largest feed of the three
 /// (DROIDECTIVE-MAC-B: 5087 hangs, and its top `open_features` rows are
@@ -21,15 +22,88 @@ import Foundation
 /// pausing outright is worse than pacing: the buffer grows unbounded, and
 /// reactivation hands SwiftUI one enormous flush, which is the same
 /// mass-mutation stall the pacing exists to avoid.
+///
+/// Two things the fixed active/inactive pair could not express, both of which
+/// the hang data asked for (5261 hangs in 30 days, 75:1 of them with the app
+/// not frontmost, every culprit a feed row — `coloredTokenText`,
+/// `ResolvedTextFilter`, `ConsoleFlowLayout`, `JSEntryRow.body`, `RtItem`):
+///
+/// - **A feed nobody can see costs the same as one on screen.** Hidden tabs
+///   stay mounted, so a hidden feed's flush lays its rows out exactly like a
+///   visible one. `hidden` prices that in — but it stays a *pace*, not a
+///   pause, for the reason above, and a feed becoming visible must flush
+///   eagerly rather than wait out the long interval.
+/// - **Cost was never in the loop.** A fixed interval asks for the main thread
+///   just as often when a flush costs 5 ms as when it costs 900 ms, so a big
+///   enough feed can saturate the thread and never catch up — the app is then
+///   alive but permanently behind, which is what "it went unresponsive and
+///   clicking the Dock did nothing" is. `lateness` closes the loop: a flush
+///   that had to wait for a busy main thread reports how late it ran, and the
+///   next interval widens by that much, so the feed's share of the thread
+///   falls as the thread gets busier and snaps back when it clears.
 public enum FeedFlushCadence {
-    /// The app is frontmost — fast enough to read as live, slow enough that a
-    /// burst becomes one mutation per quarter second instead of per frame.
-    public static let active: Duration = .milliseconds(250)
+    /// The app is frontmost and the feed is on screen — fast enough to read as
+    /// live, slow enough that a burst becomes one mutation per ~third of a
+    /// second instead of per frame.
+    ///
+    /// 300 ms rather than the JS Console's original 250 ms because logcat has
+    /// shipped 300 since v3.6.1, and unifying downward measurably cost the one
+    /// state the user is actually watching: a logcat streaming ~300 lines/s
+    /// went 14.2% CPU to 15.3% purely from the extra flushes. Every feed is
+    /// cheaper at 300 and none of them reads differently — the fix that
+    /// mattered was leaving 16 ms, not the 50 ms between these two.
+    public static let active: Duration = .milliseconds(300)
 
-    /// Another app is frontmost. Four flushes a second down to one.
+    /// On screen, but another app is frontmost. Four flushes a second down to
+    /// one.
     public static let inactive: Duration = .seconds(1)
 
-    public static func interval(appActive: Bool) -> Duration {
-        appActive ? active : inactive
+    /// Mounted but not on screen — a tab behind another tab, in either pane of
+    /// any window. Nothing is being read, so this only has to keep the buffer
+    /// draining into the feed's own ring; the eager flush on becoming visible
+    /// is what the user actually sees.
+    public static let hidden: Duration = .seconds(5)
+
+    /// Ceiling for the `lateness` widening. Past this the feed has backed off
+    /// as far as it usefully can, and a longer wait only delays recovery —
+    /// including after a system sleep, where lateness is the length of the
+    /// sleep and means nothing about load.
+    public static let maxInterval: Duration = .seconds(8)
+
+    /// The unloaded interval for a feed in this state, before any widening.
+    public static func base(appActive: Bool, watched: Bool) -> Duration {
+        guard watched else { return hidden }
+        return appActive ? active : inactive
+    }
+
+    /// How late a wait of `requested` actually was, given it took `elapsed`.
+    ///
+    /// The reading belongs to the *thread*, not to a feed: it is taken by one
+    /// app-wide sampler whose own scheduled wake-ups measure how far behind
+    /// the main thread is, and every feed then paces against the same number.
+    /// A feed measuring only its own flushes would under-observe exactly when
+    /// it matters — the feed that is starved reports nothing, and the load it
+    /// is waiting behind belongs to the other eight mounted tabs.
+    ///
+    /// Never negative: a clock reading early, or a wake-up that beat its
+    /// deadline, is not evidence of load.
+    public static func lateness(elapsed: Duration, requested: Duration) -> Duration {
+        max(.zero, elapsed - requested)
+    }
+
+    /// How long to wait before the next flush.
+    ///
+    /// - Parameters:
+    ///   - appActive: whether this app is frontmost.
+    ///   - watched: whether any mounted view can currently see this feed
+    ///     (`FeedAudience`), which is not the same as the feed having a view —
+    ///     a hidden tab keeps its view mounted.
+    ///   - lateness: how far past its requested interval the last scheduled
+    ///     flush actually ran. Zero when the main thread kept up; negative
+    ///     values (a clock reading early) are treated as zero.
+    public static func interval(appActive: Bool, watched: Bool, lateness: Duration) -> Duration {
+        let base = base(appActive: appActive, watched: watched)
+        guard lateness > .zero else { return base }
+        return min(maxInterval, max(base, base + lateness))
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -115,8 +115,14 @@ public enum LogcatLineParser {
 /// yields debounced batches. One session per streamer; restarting stops the
 /// previous process.
 public actor LogcatStreamer {
-    static let flushInterval: Duration = .milliseconds(300)
     static let maxBatch = 500
+
+    /// Flush pacing. The App layer sets this from `FeedFlushCadence` — this
+    /// actor is portable and can see neither app activation nor whether the
+    /// tab is on screen, and a mounted hidden tab lays out every row it is
+    /// handed. Defaults to the pace a visible feed in a frontmost app gets, so
+    /// a caller that never sets it behaves as before.
+    private var flushInterval = FeedFlushCadence.base(appActive: true, watched: true)
 
     private let client: AdbClient
     private var process: Process?
@@ -213,11 +219,25 @@ public actor LogcatStreamer {
         }
         flusherTask = Task {
             while !Task.isCancelled {
-                try? await Task.sleep(for: Self.flushInterval)
+                try? await Task.sleep(for: self.flushInterval)
                 self.flush(epoch: sessionEpoch)
             }
         }
         return stream
+    }
+
+    /// Re-pace the flusher. Takes effect on the flusher's next turn, so a
+    /// caller can call it as often as visibility or load changes.
+    public func setFlushInterval(_ interval: Duration) {
+        flushInterval = interval
+    }
+
+    /// Yield whatever is buffered right now. The App layer calls this when a
+    /// hidden feed becomes visible: the hidden pace is several seconds, and
+    /// waiting it out would show the user a feed that looks stalled at the
+    /// moment they switched to it.
+    public func flushNow() {
+        flush(epoch: epoch)
     }
 
     public func stop() {

--- a/ADBKit/Sources/ADBKit/Services/SimulatorLogStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/SimulatorLogStream.swift
@@ -205,8 +205,14 @@ public enum SimulatorLogFilter {
 /// previous session (whose EOF arrives after a restart) can't tear down the
 /// new one.
 public actor SimulatorLogStreamer {
-    static let flushInterval: Duration = .milliseconds(300)
     static let maxBatch = 500
+
+    /// Flush pacing. The App layer sets this from `FeedFlushCadence` — this
+    /// actor is portable and can see neither app activation nor whether the
+    /// tab is on screen, and a mounted hidden tab lays out every row it is
+    /// handed. Defaults to the pace a visible feed in a frontmost app gets, so
+    /// a caller that never sets it behaves as before.
+    private var flushInterval = FeedFlushCadence.base(appActive: true, watched: true)
 
     private let xcrunPath: String
     private var process: Process?
@@ -285,11 +291,25 @@ public actor SimulatorLogStreamer {
         }
         flusherTask = Task {
             while !Task.isCancelled {
-                try? await Task.sleep(for: Self.flushInterval)
+                try? await Task.sleep(for: self.flushInterval)
                 self.flush(epoch: sessionEpoch)
             }
         }
         return stream
+    }
+
+    /// Re-pace the flusher. Takes effect on the flusher's next turn, so a
+    /// caller can call it as often as visibility or load changes.
+    public func setFlushInterval(_ interval: Duration) {
+        flushInterval = interval
+    }
+
+    /// Yield whatever is buffered right now. The App layer calls this when a
+    /// hidden feed becomes visible: the hidden pace is several seconds, and
+    /// waiting it out would show the user a feed that looks stalled at the
+    /// moment they switched to it.
+    public func flushNow() {
+        flush(epoch: epoch)
     }
 
     public func stop() {

--- a/ADBKit/Tests/ADBKitTests/FeedAudienceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeedAudienceTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// Feed visibility, which decides pacing (`FeedFlushCadence.hidden`). The part
+/// that goes wrong is never one view reporting — it is two views disagreeing,
+/// or a view that never reports its exit.
+///
+/// `update` is `mutating`, and the `#expect` macro cannot host a mutating call
+/// (it captures the expression to report it), so every result lands in a local
+/// first.
+@Suite struct FeedAudienceTests {
+    @Test func startsUnwatched() {
+        let audience = FeedAudience()
+        #expect(!audience.isWatched)
+    }
+
+    @Test func oneVisibleViewIsWatched() {
+        var audience = FeedAudience()
+        let changed = audience.update(view: UUID(), visible: true)
+        #expect(changed)
+        #expect(audience.isWatched)
+    }
+
+    /// The reason this isn't a flag: an app-wide feed shown in two windows,
+    /// where one of them switches to another tab. The window still reading it
+    /// must keep the visible pace.
+    @Test func aHiddenViewDoesNotUnwatchAFeedAnotherViewIsShowing() {
+        var audience = FeedAudience()
+        let reading = UUID()
+        let switchedAway = UUID()
+        audience.update(view: reading, visible: true)
+        audience.update(view: switchedAway, visible: true)
+        audience.update(view: switchedAway, visible: false)
+        #expect(audience.isWatched)
+        audience.update(view: reading, visible: false)
+        #expect(!audience.isWatched)
+    }
+
+    /// The reason this isn't a count: views report on every appearance and tab
+    /// switch, so the same identity arrives repeatedly.
+    @Test func repeatedReportsFromOneViewAreIdempotent() {
+        var audience = FeedAudience()
+        let view = UUID()
+        audience.update(view: view, visible: true)
+        audience.update(view: view, visible: true)
+        audience.update(view: view, visible: true)
+        // One `false` from that same view must be enough to end it: a counted
+        // audience would still be at three and stay "watched" forever.
+        audience.update(view: view, visible: false)
+        #expect(!audience.isWatched)
+    }
+
+    @Test func leavingTwiceDoesNotGoNegative() {
+        var audience = FeedAudience()
+        let view = UUID()
+        audience.update(view: view, visible: true)
+        audience.update(view: view, visible: false)
+        audience.update(view: view, visible: false)
+        #expect(!audience.isWatched)
+        // ...and the view coming back is still enough to be watched again — a
+        // count driven negative would need two arrivals to recover.
+        audience.update(view: view, visible: true)
+        #expect(audience.isWatched)
+    }
+
+    @Test func leavingAViewThatNeverArrivedChangesNothing() {
+        var audience = FeedAudience()
+        let changed = audience.update(view: UUID(), visible: false)
+        #expect(!changed)
+        #expect(!audience.isWatched)
+    }
+
+    /// Only the transitions report `true`, so a caller can hang the eager
+    /// reveal flush off this without flushing on every tab switch elsewhere.
+    @Test func onlyTheWatchedTransitionsReportAChange() {
+        var audience = FeedAudience()
+        let first = UUID()
+        let second = UUID()
+        let becameWatched = audience.update(view: first, visible: true)
+        let secondArrived = audience.update(view: second, visible: true)
+        let firstLeft = audience.update(view: first, visible: false)
+        let becameUnwatched = audience.update(view: second, visible: false)
+        #expect(becameWatched)      // unwatched -> watched
+        #expect(!secondArrived)     // still watched
+        #expect(!firstLeft)         // still watched
+        #expect(becameUnwatched)    // watched -> unwatched
+    }
+
+    @Test func removeAllForgetsEveryViewer() {
+        var audience = FeedAudience()
+        audience.update(view: UUID(), visible: true)
+        audience.update(view: UUID(), visible: true)
+        let cleared = audience.removeAll()
+        #expect(cleared)
+        #expect(!audience.isWatched)
+        // Idempotent: a second teardown reports no change.
+        let again = audience.removeAll()
+        #expect(!again)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
@@ -6,12 +6,18 @@ import Testing
 /// multiplier on main-thread layout across all of them.
 @Suite struct FeedFlushCadenceTests {
     @Test func inactiveIsSlowerThanActive() {
-        #expect(FeedFlushCadence.interval(appActive: false) > FeedFlushCadence.interval(appActive: true))
+        #expect(
+            FeedFlushCadence.interval(appActive: false, watched: true, lateness: .zero)
+                > FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero))
     }
 
     @Test func picksTheIntervalForEachState() {
-        #expect(FeedFlushCadence.interval(appActive: true) == FeedFlushCadence.active)
-        #expect(FeedFlushCadence.interval(appActive: false) == FeedFlushCadence.inactive)
+        #expect(
+            FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero)
+                == FeedFlushCadence.active)
+        #expect(
+            FeedFlushCadence.interval(appActive: false, watched: true, lateness: .zero)
+                == FeedFlushCadence.inactive)
     }
 
     /// The regression this exists for. Reactotron sat at 16 ms — up to 62 full
@@ -28,9 +34,143 @@ import Testing
     @Test func neitherStateStopsTheFeed() {
         #expect(FeedFlushCadence.active > .zero)
         #expect(FeedFlushCadence.inactive > .zero)
+        #expect(FeedFlushCadence.hidden > .zero)
         // A cap, so "slower while inactive" can't drift into "effectively off"
         // — a feed that only flushes every few seconds reads as broken when
         // the user comes back to it.
         #expect(FeedFlushCadence.inactive <= .seconds(2))
+    }
+
+    // MARK: Visibility
+
+    /// A mounted-but-hidden tab lays its rows out exactly like a visible one,
+    /// so the feed nobody can see must be the cheapest of the three states —
+    /// including when the app itself is frontmost, which says nothing about
+    /// whether *this* tab is the one on screen.
+    @Test func hiddenIsTheSlowestState() {
+        let hidden = FeedFlushCadence.interval(appActive: true, watched: false, lateness: .zero)
+        #expect(hidden == FeedFlushCadence.hidden)
+        #expect(hidden > FeedFlushCadence.inactive)
+        #expect(hidden > FeedFlushCadence.active)
+    }
+
+    /// App activation is irrelevant while nothing can see the feed: the cost
+    /// being paced away is this tab's layout, and a hidden tab is hidden
+    /// whether or not the window is frontmost.
+    @Test func activationDoesNotChangeAHiddenFeed() {
+        #expect(
+            FeedFlushCadence.interval(appActive: true, watched: false, lateness: .zero)
+                == FeedFlushCadence.interval(appActive: false, watched: false, lateness: .zero))
+    }
+
+    /// Hidden is a pace, not a pause — but it must stay short enough that the
+    /// buffer keeps draining into the feed's own ring between reveals.
+    @Test func hiddenStaysBounded() {
+        #expect(FeedFlushCadence.hidden <= .seconds(10))
+    }
+
+    // MARK: Backpressure
+
+    @Test func aMainThreadThatKeptUpDoesNotWiden() {
+        #expect(
+            FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero)
+                == FeedFlushCadence.active)
+    }
+
+    /// The wedge this exists for: a fixed interval asks for the main thread as
+    /// often when a flush costs 900 ms as when it costs 5 ms, so a big enough
+    /// feed saturates the thread and never catches up. Lateness has to widen
+    /// the next wait by at least what the thread was already behind.
+    @Test func latenessWidensTheNextInterval() {
+        let late = FeedFlushCadence.interval(
+            appActive: true, watched: true, lateness: .milliseconds(900))
+        #expect(late >= FeedFlushCadence.active + .milliseconds(900))
+        #expect(late > FeedFlushCadence.active)
+    }
+
+    @Test func wideningIsMonotonicInLateness() {
+        var previous = FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero)
+        for milliseconds in [50, 200, 800, 1500, 3000] {
+            let next = FeedFlushCadence.interval(
+                appActive: true, watched: true, lateness: .milliseconds(milliseconds))
+            #expect(next >= previous)
+            previous = next
+        }
+    }
+
+    /// A system sleep makes lateness the length of the sleep, which says
+    /// nothing about load — the ceiling is what keeps that from parking the
+    /// feed for an hour. It also bounds how long recovery takes once a real
+    /// overload clears.
+    @Test func hugeLatenessClampsToTheCeiling() {
+        let slept = FeedFlushCadence.interval(
+            appActive: true, watched: true, lateness: .seconds(3600))
+        #expect(slept == FeedFlushCadence.maxInterval)
+    }
+
+    /// Backing off must never overtake the ceiling from any starting state,
+    /// hidden included — the ceiling is the promise that a feed always comes
+    /// back.
+    @Test func noStateExceedsTheCeiling() {
+        for appActive in [true, false] {
+            for watched in [true, false] {
+                for seconds in [0, 1, 10, 600] {
+                    let interval = FeedFlushCadence.interval(
+                        appActive: appActive, watched: watched, lateness: .seconds(seconds))
+                    #expect(interval <= FeedFlushCadence.maxInterval)
+                }
+            }
+        }
+    }
+
+    /// A clock that reads early must not shorten the interval below its base —
+    /// that would be the per-frame flush back under another name.
+    @Test func negativeLatenessIsIgnored() {
+        #expect(
+            FeedFlushCadence.interval(appActive: true, watched: true, lateness: .milliseconds(-500))
+                == FeedFlushCadence.active)
+    }
+
+    /// The ceiling has to leave room above the slowest base, or the widening
+    /// it bounds could never happen for a hidden feed.
+    @Test func theCeilingLeavesRoomAboveEveryBase() {
+        #expect(FeedFlushCadence.maxInterval > FeedFlushCadence.hidden)
+    }
+
+    @Test func baseIgnoresLatenessEntirely() {
+        #expect(FeedFlushCadence.base(appActive: true, watched: true) == FeedFlushCadence.active)
+        #expect(FeedFlushCadence.base(appActive: false, watched: true) == FeedFlushCadence.inactive)
+        #expect(FeedFlushCadence.base(appActive: false, watched: false) == FeedFlushCadence.hidden)
+    }
+
+    // MARK: Lateness readings
+
+    @Test func latenessIsHowFarPastTheRequestedWait() {
+        #expect(
+            FeedFlushCadence.lateness(elapsed: .milliseconds(1200), requested: .seconds(1))
+                == .milliseconds(200))
+    }
+
+    /// A wake-up that beat its deadline, or a clock reading early, is not
+    /// evidence of load — and a negative lateness would *shorten* the next
+    /// interval, which is the per-frame flush back under another name.
+    @Test func aWaitThatFinishedEarlyReadsAsNoLoad() {
+        #expect(FeedFlushCadence.lateness(elapsed: .milliseconds(900), requested: .seconds(1)) == .zero)
+        #expect(FeedFlushCadence.lateness(elapsed: .zero, requested: .seconds(1)) == .zero)
+    }
+
+    @Test func anExactWaitReadsAsNoLoad() {
+        #expect(FeedFlushCadence.lateness(elapsed: .seconds(1), requested: .seconds(1)) == .zero)
+    }
+
+    /// The sampler's reading feeds straight back into the interval, so the
+    /// round trip has to hold: a thread half a second behind buys the feed at
+    /// least that much more room.
+    @Test func aSamplersReadingWidensTheNextInterval() {
+        let observed = FeedFlushCadence.lateness(
+            elapsed: .milliseconds(1500), requested: .seconds(1))
+        let widened = FeedFlushCadence.interval(appActive: true, watched: true, lateness: observed)
+        #expect(observed == .milliseconds(500))
+        #expect(widened == FeedFlushCadence.active + .milliseconds(500))
     }
 }

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -227,6 +227,12 @@ final class JSConsoleSession {
     /// observed `buffer`), so a replay burst doesn't render.
     @ObservationIgnored private var pendingEntries: [JSEntry] = []
     @ObservationIgnored private var flushTask: Task<Void, Never>?
+    /// Which mounted views can see the feed — per window, but a split shows it
+    /// in both panes, so this is an audience rather than a flag
+    /// (`FeedAudience`). Distinct from `attachedViews`, which is about keeping
+    /// the *connection* alive: a hidden tab stays attached and streaming, it
+    /// just stops paying for layout nobody is reading.
+    @ObservationIgnored private var audience = FeedAudience()
     @ObservationIgnored private var welcomeTask: Task<Void, Never>?
     /// The discovery/connection loop, owned by the session so tab close and
     /// window close can stop it without going through a view update.
@@ -339,6 +345,11 @@ final class JSConsoleSession {
     func stop() {
         discoveryTask?.cancel()
         discoveryTask = nil
+        // The session outlives its views (AppState parks the workspace on a
+        // background-mode close), so forget the audience with it — a viewer
+        // left behind here would price the feed as watched for the rest of the
+        // session. Views re-report on their next appearance.
+        audience.removeAll()
     }
 
     // MARK: View attach/detach
@@ -1040,7 +1051,13 @@ final class JSConsoleSession {
     /// turned out to have missed this fix entirely — the rule is shared so a
     /// feed cannot be added without it.
     private var flushInterval: Duration {
-        FeedFlushCadence.interval(appActive: NSApp.isActive)
+        // Visibility and main-thread load both feed the pace: a hidden tab
+        // still lays out every row it flushes, and a thread already behind
+        // must not be asked for a turn as often (`MainThreadLoad`).
+        FeedFlushCadence.interval(
+            appActive: NSApp.isActive,
+            watched: audience.isWatched,
+            lateness: MainThreadLoad.shared.lateness)
     }
 
     private func scheduleFlush() {
@@ -1051,6 +1068,14 @@ final class JSConsoleSession {
             guard let self, !Task.isCancelled else { return }
             self.flushPending()
         }
+    }
+
+    /// One view reported whether it can see the feed. Becoming visible flushes
+    /// at once — the hidden pace is several seconds, and waiting it out would
+    /// show a feed that looks stalled at the moment the user switched to it.
+    func noteVisibility(view id: UUID, visible: Bool) {
+        guard audience.update(view: id, visible: visible), visible else { return }
+        flushPending()
     }
 
     private func flushPending() {
@@ -1206,6 +1231,10 @@ struct JSConsoleView: View {
         // the session keep the connection alive through that). AppState also
         // stops the session on tab/window close; every path is idempotent.
         .onDisappear { session.viewDisappeared() }
+        // Separate from the attach count above: that keeps the *connection*
+        // alive across a pane move, this only says whether anyone can see the
+        // feed. A hidden tab keeps streaming and stops paying for layout.
+        .reportsFeedVisibility { session.noteVisibility(view: $0, visible: $1) }
         .onChange(of: state.targetSerials) { _, serials in session.updateSerials(serials) }
         .onAppear { portText = String(session.port) }
         .onChange(of: session.port) { _, newPort in portText = String(newPort) }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import AppKit
 import SwiftUI
 
 /// Live logcat stream with level/app/text filters, a ⌘F Find bar, pause, and
@@ -34,6 +35,20 @@ struct LogcatView: View {
     @State private var streamingPid: Int?
     /// pid → process name (a periodic `ps` snapshot) for the process column.
     @State private var processNames: [String: String] = [:]
+    /// The live streamer, held so visibility changes can re-pace its flushing
+    /// without restarting the stream (a restart would clear the feed).
+    @State private var streamer: LogcatStreamer?
+    /// Whether this tab is the one on screen. The stream keeps running while
+    /// it isn't — only the flushing slows down (`FeedFlushCadence`), because a
+    /// mounted hidden tab lays out every row it is handed.
+    @Environment(\.tabIsActive) private var tabIsActive
+    /// The same answer, in `@State` so the streaming loop can read it *live*.
+    /// `.task` captures the view value it started with, and an `@Environment`
+    /// read through that capture keeps returning the value from then — so the
+    /// loop would re-pace itself back to the visible interval on the next
+    /// batch and undo the tab switch. `@State` is reference-backed and reads
+    /// current.
+    @State private var feedVisible = true
     /// One-shot: the App filter is seeded from the device bar's chosen bundle
     /// the first time the view appears, then left to the user.
     @State private var seededPackageFilter = false
@@ -84,9 +99,21 @@ struct LogcatView: View {
             logList(visible: visible)
         }
         .task(id: taskKey) { await streamLoop() }
+        // Re-pace on a tab switch rather than re-keying the stream: a restart
+        // would clear the feed. Becoming visible also flushes at once, so the
+        // reveal doesn't wait out the hidden interval.
+        .onChange(of: tabIsActive) { _, visible in
+            feedVisible = visible
+            let interval = pacedFlushInterval
+            Task { @MainActor in
+                await streamer?.setFlushInterval(interval)
+                if visible { await streamer?.flushNow() }
+            }
+        }
         // Open pre-filtered to the bundle chosen in the device bar (changeable
         // from the App picker), and follow when that choice changes later.
         .onAppear {
+            feedVisible = tabIsActive
             guard !seededPackageFilter else { return }
             seededPackageFilter = true
             if let bundle = state.selectedBundle { packageFilter = bundle.packageId }
@@ -479,6 +506,18 @@ struct LogcatView: View {
 
     // MARK: - Streaming
 
+    /// How often the streamer should hand this view a batch: the shared feed
+    /// rule, given whether anyone can see the tab and how far behind the main
+    /// thread already is. Logcat used to run a flat 300 ms in every state —
+    /// the streamer is a portable actor that can see neither, so the App layer
+    /// has to tell it (`LogcatStreamer.setFlushInterval`).
+    private var pacedFlushInterval: Duration {
+        FeedFlushCadence.interval(
+            appActive: NSApp.isActive,
+            watched: feedVisible,
+            lateness: MainThreadLoad.shared.lateness)
+    }
+
     /// Owned by `.task(id:)`: cancelled and restarted whenever the device,
     /// level, or app filter changes. Outer loop survives app restarts (pid
     /// changes) and transient stream deaths.
@@ -489,6 +528,11 @@ struct LogcatView: View {
         guard let serial = state.targetSerials.first else { return }
 
         let streamer = LogcatStreamer(client: state.env.client)
+        self.streamer = streamer
+        // Every exit from this loop drops the reference, so a tab switch can't
+        // re-pace a streamer that has already stopped.
+        defer { self.streamer = nil }
+        await streamer.setFlushInterval(pacedFlushInterval)
         // The process-name column: a ps snapshot up front so the initial tail
         // is named, then refreshed on a slow cadence for processes that spawn
         // mid-stream. Background polling — deliberately not CommandLog-wrapped.
@@ -560,6 +604,11 @@ struct LogcatView: View {
             }
 
             for await batch in stream {
+                if Task.isCancelled { break }
+                // Re-paced per batch, which is the same cadence the other
+                // feeds re-evaluate at — visibility and main-thread load both
+                // move while a stream is running.
+                await streamer.setFlushInterval(pacedFlushInterval)
                 if Task.isCancelled { break }
                 if paused { continue }
                 // Stamp each line's process name at ingest — rendered rows are

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -36,7 +36,13 @@ final class ReactotronSession {
     /// thus one SwiftUI invalidation — per frame, not one per event. Never
     /// observed, so appending to it doesn't re-render.
     @ObservationIgnored private var pendingItems: [RtItem] = []
+    /// Wire bytes waiting in `pendingItems`, for the early-flush bound.
+    @ObservationIgnored private var pendingBytes = 0
     @ObservationIgnored private var flushTask: Task<Void, Never>?
+    /// Which mounted views can see the timeline. App-wide feed, so this spans
+    /// windows as well as panes — see `FeedAudience`. Never observed: pacing
+    /// state must not invalidate the feed it paces.
+    @ObservationIgnored private var audience = FeedAudience()
     // Anonymous usage stats (numbers only, no payload contents) reported per
     // session so the timeline caps can be sized against real workloads.
     private var peakItemsBytes = 0
@@ -310,6 +316,7 @@ final class ReactotronSession {
         flushTask?.cancel()
         flushTask = nil
         pendingItems.removeAll()
+        pendingBytes = 0
         // The timeline/store graphs can be huge (gigabytes of nested JSON
         // payloads); hand them to a background task instead of freeing them
         // inline, which hangs the main thread for the whole release cascade.
@@ -484,6 +491,7 @@ final class ReactotronSession {
         flushTask?.cancel()
         flushTask = nil
         pendingItems.removeAll()
+        pendingBytes = 0
         let cleared = items
         items = []
         itemsBytes = 0
@@ -708,13 +716,39 @@ final class ReactotronSession {
     /// app's biggest hang issue (DROIDECTIVE-MAC-B).
     private func enqueue(_ item: RtItem) {
         pendingItems.append(item)
+        pendingBytes += item.frameBytes
+        // Pending memory has to be bounded by bytes, not by the cadence: a
+        // hidden feed waits seconds between flushes, and a client streaming
+        // huge payloads would otherwise hold all of them unflushed. The JS
+        // Console bounds its own buffer at a quarter of its byte budget for
+        // exactly this reason; the ring trims to the full budget on append
+        // either way.
+        if pendingBytes >= ReactotronTimeline.maxTotalBytes / 4 {
+            flushPending()
+            return
+        }
         guard flushTask == nil else { return }
-        let interval = FeedFlushCadence.interval(appActive: NSApp.isActive)
+        // Hidden tabs stay mounted and lay their rows out like visible ones,
+        // and a main thread that is already behind must not be asked for a
+        // turn as often — `MainThreadLoad` is the app-wide reading of that.
+        let interval = FeedFlushCadence.interval(
+            appActive: NSApp.isActive,
+            watched: audience.isWatched,
+            lateness: MainThreadLoad.shared.lateness)
         flushTask = Task { [weak self] in
             try? await Task.sleep(for: interval)
             guard !Task.isCancelled else { return }
             self?.flushPending()
         }
+    }
+
+    /// One view reported whether it can see the timeline. Becoming visible
+    /// flushes at once: the hidden pace is several seconds, and waiting it out
+    /// would show the user a feed that looks stalled at the moment they
+    /// switched to it.
+    func noteVisibility(view id: UUID, visible: Bool) {
+        guard audience.update(view: id, visible: visible), visible else { return }
+        flushPending()
     }
 
     /// Drain the pending buffer into the timeline in a single append. Called by
@@ -726,6 +760,7 @@ final class ReactotronSession {
         guard !pendingItems.isEmpty else { return }
         let batch = pendingItems
         pendingItems.removeAll(keepingCapacity: true)
+        pendingBytes = 0
         appendBatch(batch)
     }
 
@@ -907,6 +942,11 @@ struct ReactotronView: View {
         // Devices appearing later are handled by AppState → deviceListChanged,
         // which also covers the view being closed (kept-alive sessions).
         .task { await session.start(serials: readySerials) }
+        // The timeline keeps streaming while this tab is hidden — it just
+        // flushes into the view far less often, because a mounted hidden tab
+        // lays its rows out exactly like a visible one and this is the largest
+        // of the three feeds (DROIDECTIVE-MAC-B).
+        .reportsFeedVisibility { session.noteVisibility(view: $0, visible: $1) }
         // Closing the split resets the right pane's clear — that pane is
         // gone, so reopening the split repopulates it with every buffered
         // event (an accidental clear is recoverable). The left pane lives on

--- a/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
@@ -1,4 +1,5 @@
 import ADBKit
+import AppKit
 import SwiftUI
 
 /// Live unified-log stream for the booted iOS Simulator, built around how
@@ -31,6 +32,17 @@ struct SimulatorLogsView: View {
     /// Free-text filter, debounced from `searchInput` into `search`.
     @State private var searchInput = ""
     @State private var search = ""
+    /// Whether this tab is the one on screen. The stream keeps running while
+    /// it isn't — only the flushing slows down (`FeedFlushCadence`), because a
+    /// mounted hidden tab lays out every row it is handed.
+    @Environment(\.tabIsActive) private var tabIsActive
+    /// The same answer, in `@State` so the streaming loop can read it *live*:
+    /// `.task` captures the view value it started with, and an `@Environment`
+    /// read through that capture is frozen at that moment (see `LogcatView`).
+    @State private var feedVisible = true
+    /// The live streamer, held so visibility changes can re-pace its flushing
+    /// without restarting the stream (a restart would clear the feed).
+    @State private var streamer: SimulatorLogStreamer?
     /// Xcode's console Metadata toggle: the time · process · subsystem line
     /// under each message.
     @AppStorage("iosLogsShowMetadata") private var showMetadata = true
@@ -97,6 +109,18 @@ struct SimulatorLogsView: View {
             }
         }
         .task(id: taskKey) { await streamLoop() }
+        // Re-pace on a tab switch rather than re-keying the stream: a restart
+        // would clear the feed. Becoming visible also flushes at once, so the
+        // reveal doesn't wait out the hidden interval.
+        .onChange(of: tabIsActive) { _, visible in
+            feedVisible = visible
+            let interval = pacedFlushInterval
+            Task { @MainActor in
+                await streamer?.setFlushInterval(interval)
+                if visible { await streamer?.flushNow() }
+            }
+        }
+        .onAppear { feedVisible = tabIsActive }
         // A changed filter re-tails the feed — the frozen position loses its
         // meaning when the row set changes.
         .onChange(of: "\(shownLevels.hashValue)|\(processFilter ?? "")|\(search)") { _, _ in
@@ -536,6 +560,16 @@ struct SimulatorLogsView: View {
     /// Owned by `.task(id:)`: cancelled and restarted whenever the simulator,
     /// scope, or emission level changes. The outer loop survives transient
     /// stream deaths.
+    /// How often the streamer should hand this view a batch: the shared feed
+    /// rule, given whether anyone can see the tab and how far behind the main
+    /// thread already is (`SimulatorLogStreamer.setFlushInterval`).
+    private var pacedFlushInterval: Duration {
+        FeedFlushCadence.interval(
+            appActive: NSApp.isActive,
+            watched: feedVisible,
+            lateness: MainThreadLoad.shared.lateness)
+    }
+
     private func streamLoop() async {
         lines.removeAll()
         pending.removeAll()
@@ -544,7 +578,12 @@ struct SimulatorLogsView: View {
         guard let udid = simulatorUdid else { return }
 
         let streamer = SimulatorLogStreamer()
-        defer { Task { await streamer.stop() } }
+        self.streamer = streamer
+        await streamer.setFlushInterval(pacedFlushInterval)
+        defer {
+            self.streamer = nil
+            Task { await streamer.stop() }
+        }
 
         let scope = scope
         let emit = emitLevel
@@ -569,6 +608,11 @@ struct SimulatorLogsView: View {
             }
 
             for await batch in stream {
+                if Task.isCancelled { break }
+                // Re-paced per batch, which is the same cadence the other
+                // feeds re-evaluate at — visibility and main-thread load both
+                // move while a stream is running.
+                await streamer.setFlushInterval(pacedFlushInterval)
                 if Task.isCancelled { break }
                 if paused { continue }
                 absorb(batch)

--- a/App/Sources/Root/MainThreadLoad.swift
+++ b/App/Sources/Root/MainThreadLoad.swift
@@ -1,0 +1,58 @@
+import ADBKit
+import Foundation
+
+/// How far behind the main thread is, sampled by asking it for a turn on a
+/// fixed schedule and measuring how late that turn arrives.
+///
+/// The streaming feeds pace themselves against this (`FeedFlushCadence`).
+/// One app-wide sampler rather than a measurement per feed, for two reasons:
+///
+/// - **Load is a property of the thread, not of a feed.** A user with nine
+///   mounted tabs has three feeds, a mirror session and every hidden tab's
+///   layout sharing one thread. A feed that measured only its own flushes
+///   would under-observe precisely when it matters — the starved feed is the
+///   one that isn't getting turns, so it has nothing to measure.
+/// - **Timing a flush measures the wrong thing.** The expensive part is the
+///   SwiftUI layout the flush *causes*, which happens after the mutation
+///   returns, in a later runloop pass. Waiting for a turn on this thread
+///   prices that in; a stopwatch around the mutation does not.
+///
+/// Deliberately not `@Observable`: this changes twice a second for the life of
+/// the app, and anything observing it would re-render on every sample — the
+/// exact cost it exists to bound. Feeds read it when they schedule a flush.
+@MainActor
+final class MainThreadLoad {
+    static let shared = MainThreadLoad()
+
+    /// Sampling period. Frequent enough that a feed scheduling a flush reads a
+    /// current number, rare enough to be free (two wake-ups a second, no
+    /// allocation, no observation).
+    private static let period: Duration = .milliseconds(500)
+
+    /// How late the last sample's turn arrived — zero when the thread kept up.
+    /// Self-clearing: a saturated thread reports a large value, and the next
+    /// sample after it clears reports zero again, so no decay is needed.
+    private(set) var lateness: Duration = .zero
+
+    private var sampler: Task<Void, Never>?
+
+    private init() {}
+
+    /// Begin sampling. Idempotent — every window's launch setup may call it.
+    func start() {
+        guard sampler == nil else { return }
+        sampler = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let started = ContinuousClock.now
+                try? await Task.sleep(for: Self.period)
+                guard let self, !Task.isCancelled else { return }
+                // A system sleep lands here as an enormous reading; it means
+                // nothing about load, and `FeedFlushCadence.maxInterval` is
+                // what keeps it from parking the feeds. Clamping it here
+                // instead would need a "was the Mac asleep?" guess.
+                self.lateness = FeedFlushCadence.lateness(
+                    elapsed: ContinuousClock.now - started, requested: Self.period)
+            }
+        }
+    }
+}

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -228,6 +228,10 @@ struct RootView: View {
         applyStoredTheme()
         // Anything below is app-wide and must run once, not once per window.
         guard state.core.claimLaunchSetup() else { return }
+        // The reading every streaming feed paces against. App-wide and started
+        // once, because main-thread load belongs to the thread rather than to
+        // any one feed.
+        MainThreadLoad.shared.start()
         // A double-clicked APK — or a split bundle (.apks/.xapk/.apkm) — opens
         // the in-window opened-package screen (install with live status / APK
         // Studio); a double-clicked AAB opens the AAB to APK converter with the

--- a/App/Sources/Root/TabEnvironment.swift
+++ b/App/Sources/Root/TabEnvironment.swift
@@ -16,8 +16,11 @@ extension EnvironmentValues {
     /// True when this view's tab is the foreground (visible) one. Backgrounded
     /// tabs stay mounted, so device-heavy *live* views (network/CPU polling, the
     /// screen mirror) read this to pause while hidden. Recordings and log streams
-    /// deliberately ignore it and keep running. Defaults to true for views shown
-    /// outside the tab host (Settings, sheets), which must never pause.
+    /// deliberately ignore it and keep *running* — but they pace their flushing
+    /// by it (`reportsFeedVisibility`, `FeedFlushCadence.hidden`), because a
+    /// mounted hidden tab lays its rows out exactly like a visible one.
+    /// Defaults to true for views shown outside the tab host (Settings,
+    /// sheets), which must never pause.
     var tabIsActive: Bool {
         get { self[TabIsActiveKey.self] }
         set { self[TabIsActiveKey.self] = newValue }
@@ -30,5 +33,43 @@ extension EnvironmentValues {
     var tabFeatureID: String {
         get { self[TabFeatureIDKey.self] }
         set { self[TabFeatureIDKey.self] = newValue }
+    }
+}
+
+/// Reports to a streaming feed whether this view can currently see it, so the
+/// feed can pace its flushes (`FeedFlushCadence`, `FeedAudience`).
+///
+/// One modifier rather than three hooks per feed: all three feeds — the
+/// Reactotron timeline, the JS Console and logcat — need the identical
+/// appear/switch/disappear triple, and the pacing rule is only as good as its
+/// least careful call site.
+///
+/// The report is keyed by a per-view `UUID` because one feed can be on screen
+/// in several places at once (an app-wide feed in two windows, a per-window
+/// feed in both panes of a split), and because SwiftUI lifecycle hooks are not
+/// reliably balanced — see `FeedAudience`.
+private struct FeedVisibilityReporter: ViewModifier {
+    @Environment(\.tabIsActive) private var tabIsActive
+    /// Identity for this view instance, stable for as long as it is mounted.
+    @State private var viewID = UUID()
+    let report: (UUID, Bool) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            // Reported from lifecycle hooks, never from `body`: these writes
+            // land on state a feed view reads, and writing observable state
+            // during an update is an endless update loop, not a wasted pass.
+            .onAppear { report(viewID, tabIsActive) }
+            .onChange(of: tabIsActive) { _, visible in report(viewID, visible) }
+            .onDisappear { report(viewID, false) }
+    }
+}
+
+extension View {
+    /// Tell a feed when this view can see it. `report` takes the view's
+    /// identity and whether it is visible — pass it straight to the session's
+    /// `noteVisibility(view:visible:)`.
+    func reportsFeedVisibility(to report: @escaping (UUID, Bool) -> Void) -> some View {
+        modifier(FeedVisibilityReporter(report: report))
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,33 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     releases its device, the still-mounted wall starts a session on it, and that
     session outlives the process — the leak this feature was caught doing once.
 
+- **A streaming feed is paced by who can see it and how busy the main thread
+  is** — never by a bare timer. All four feeds (Reactotron, JS Console, logcat,
+  iOS logs) go through `FeedFlushCadence`, and adding a fifth means passing all
+  three inputs: `appActive`, `watched`, `lateness`. Traps worth knowing:
+  - **Visibility is an audience, not a flag** (`FeedAudience`). One feed can be
+    on screen twice — an app-wide feed in two windows, a per-window feed in
+    both panes of a split — and SwiftUI lifecycle hooks are not reliably
+    balanced (a pane move fires the new pane's `onAppear` before the old one's
+    `onDisappear`), so membership is keyed by view identity. A count leaks; a
+    flag lets a hidden tab in one window pace the feed someone is reading in
+    another. `reportsFeedVisibility` is the one modifier that reports it.
+  - **`@Environment` read inside a long-running `.task` is frozen.** `.task`
+    captures the view value it started with, so `tabIsActive` read from the
+    stream loop keeps returning the value from when the loop started — the loop
+    re-paces itself back to the visible interval on the next batch and undoes
+    the tab switch. Mirror it into `@State` (reference-backed, reads current)
+    and read that; the two log views both do.
+  - **Load belongs to the thread, not the feed.** `MainThreadLoad` is one
+    app-wide sampler: a starved feed has nothing to measure (it isn't getting
+    turns), and the load it is waiting behind belongs to the other mounted
+    tabs. It is deliberately not `@Observable` — it changes twice a second, and
+    anything observing it would re-render on every sample.
+  - **Timing the flush measures the wrong thing.** The expensive part is the
+    SwiftUI layout the mutation *causes*, in a later runloop pass. Waiting for a
+    turn on the main thread prices that in; a stopwatch around the mutation
+    does not.
+
 - **Process runner must never block a cooperative thread.** `SystemProcessRunner`
   uses `terminationHandler` + `readabilityHandler`, not `waitUntilExit`. A
   blocking design starved the async pool and froze the whole app. There's a
@@ -856,11 +883,21 @@ every 16 ms — up to 62 full re-diffs a second, paid across *every* mounted tab
 because the keep-alive ZStack mounts them all — and was the single largest
 contributor to DROIDECTIVE-MAC-B (4197 hangs / 49 users, whose top
 `open_features` rows are individual users with 9–18 tabs open). `FeedFlushCadence`
-(ADBKit) now holds 250 ms active / 1 s inactive for both App-layer feeds; logcat
-keeps its own flat 300 ms because `LogcatStreamer` is a portable actor with no
-access to app-activation state. Inactive is slower, never stopped — pausing
-grows the buffer unbounded and hands SwiftUI one enormous flush on reactivation,
-which is the same mass-mutation stall. **Telemetry**: `enableCaptureFailedRequests`
+(ADBKit) now holds 300 ms active / 1 s inactive / 5 s hidden for all four feeds —
+the Reactotron timeline, the JS Console, logcat and iOS logs. Inactive is slower,
+never stopped — pausing grows the buffer unbounded and hands SwiftUI one enormous
+flush on reactivation, which is the same mass-mutation stall — but *hidden* is
+priced separately because a mounted hidden tab lays its rows out exactly like a
+visible one, and a feed becoming visible flushes eagerly so the long interval is
+never what the user waits on. The two log streamers are portable actors that can
+see neither app activation nor tab visibility, so the App layer sets their pace
+(`setFlushInterval`/`flushNow`) the way it already sets `DeviceMonitor`'s poll
+rate; they no longer keep a private flat 300 ms. Cost is in the loop too:
+`MainThreadLoad` (App) samples how late its own scheduled turn on the main
+thread arrives, and every feed widens its next interval by that much
+(`FeedFlushCadence.lateness`, capped at `maxInterval`) — a fixed interval asks
+for the thread just as often whether a flush costs 5 ms or 900 ms, which is how
+"slow" became the wedged-but-alive app behind the reopen reports. **Telemetry**: `enableCaptureFailedRequests`
 is off (Sentry filed Metro's routine `/symbolicate` 500s as app errors, and
 would have shipped API Testing's user-authored URLs, against the no-URLs
 promise), and `enableLogs` is on with `AppLog` as the only writer — a fixed


### PR DESCRIPTION
Streaming feeds now pace themselves by whether anyone can see them and by how busy the main thread is, instead of on a fixed timer.

## The problem

Every open tab stays mounted in `TabHostView`'s keep-alive ZStack, so a hidden feed lays its rows out exactly like a visible one, and the flush cadence was the same whether a flush cost 5 ms or 900 ms. A chatty stream could saturate the main thread and stay behind it — the app alive but never catching up, which is what the "app went unresponsive, clicking the Dock did nothing" reports are.

In 30 days of telemetry, 5261 of 5331 app-hang events fired while the app was **not** frontmost, and the culprits are feed rows throughout: `coloredTokenText`, `ResolvedTextFilter`, `ConsoleFlowLayout`, `JSEntryRow.body`, `RtItem`, `SelectableLogView.scrollToBottom`.

## What changed

`FeedFlushCadence` takes visibility and observed lateness alongside app activation: **300 ms** visible and frontmost, **1 s** visible in the background, **5 s** hidden, each widened by however far behind the main thread already is and capped at 8 s. Hidden is a pace, not a pause — the buffer keeps draining into each feed's own ring — and becoming visible flushes at once, so the long interval is never what the user waits on.

- **`FeedAudience`** (new, ADBKit) keys visibility by view identity. One feed can be on screen twice — an app-wide feed in two windows, a per-window feed in both panes — and SwiftUI fires a pane move's `onAppear` before the old pane's `onDisappear`, so neither a flag nor a count holds up.
- **`MainThreadLoad`** (new, App) is one app-wide sampler measuring how late its own scheduled turn arrives. Per-feed timing measures the wrong thing twice over: a starved feed is the one not getting turns, and the cost is the layout a flush causes a runloop pass later, not the mutation itself.
- **Logcat and iOS logs join the rule.** Their streamers are portable actors that can see neither activation nor visibility, so the App layer sets their pace through `setFlushInterval`/`flushNow`, as it already does for `DeviceMonitor`'s poll rate. Both drop their private flat 300 ms.
- **Reactotron bounds its pending buffer by bytes**, so the longer hidden interval cannot become a memory regression.

## Measurements

Against v3.10.0, both Release builds, logcat streaming ~300 lines/s into a full 5000-line buffer, CPU averaged over 30 s windows:

| state | 3.10.0 | this branch |
| --- | --- | --- |
| visible, frontmost | 14.2% | 13.4% |
| visible, app inactive | 17.7% | 11.8% |
| hidden, frontmost | 14.5% | 9.0% |
| hidden, app inactive | 17.7% | 8.7% |

The reported scenario — a feed tab open while the user works elsewhere — halves. v3.10.0 never got cheaper when nobody was looking, which is the defect.

Reveal was checked under load: after ~35 s hidden, switching back at `11:36:05` showed a tail stamped `11:36:05.572`.

The shared visible interval is 300 ms rather than the JS Console's 250 ms because unifying downward cost 1.1 points in the one state the user is watching (14.2% → 15.3%, reproducible). 300 ms is what logcat has shipped since v3.6.1, and no feed reads differently for it.

## Tests

27 tests across `FeedFlushCadenceTests` and `FeedAudienceTests` cover the interval for each state, monotonic widening under lateness, the ceiling (a system sleep makes lateness meaningless), negative lateness, and the audience's two-viewer / repeated-report / unbalanced-report cases.

`make verify` green: 1922 ADBKit · 99 ReactotronMCP · 406 droidectived · 111 AppTests, warnings-as-errors clean.

Not exercised live: Reactotron and JS Console under real traffic, which need an RN app and Metro. Their pacing path is the same one logcat's live test covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
