### PR TITLE
Drag and drop files onto the mirror, and route every dropped file

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeatureEngine.swift
@@ -57,6 +57,7 @@ public struct FeatureEngine: Sendable {
     public let customCommands: CustomCommandService
     public let adbKeyboard: AdbKeyboardInstaller
     public let fileExplorer: FileExplorerService
+    public let transfer: DeviceTransferService
     public let appsExplorer: AppsExplorerService
     public let appIcons: AppIconService
     public let emulators: EmulatorService
@@ -105,6 +106,7 @@ public struct FeatureEngine: Sendable {
         self.customCommands = CustomCommandService(client: client)
         self.adbKeyboard = AdbKeyboardInstaller(client: client)
         self.fileExplorer = FileExplorerService(client: client)
+        self.transfer = DeviceTransferService(client: client)
         self.appsExplorer = AppsExplorerService(client: client)
         self.appIcons = AppIconService(client: client)
         self.emulators = EmulatorService(client: client, locator: locator)

--- a/ADBKit/Sources/ADBKit/Services/Drop/DeviceTransferService.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/DeviceTransferService.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// The result of copying one batch of files to a device.
+public struct TransferOutcome: Sendable, Equatable {
+    public var copied: Int
+    public var total: Int
+    /// One message per file that didn't land, in the order they were tried.
+    public var failures: [String]
+    public var destination: String
+
+    public init(copied: Int, total: Int, failures: [String], destination: String) {
+        self.copied = copied
+        self.total = total
+        self.failures = failures
+        self.destination = destination
+    }
+
+    public var ok: Bool { failures.isEmpty && copied == total }
+
+    /// The headline for a toast or a chip.
+    public var summary: String {
+        if ok {
+            return total == 1
+                ? "Copied to \(destination)"
+                : "Copied \(copied) files to \(destination)"
+        }
+        if copied == 0 {
+            return failures.first ?? "Nothing was copied"
+        }
+        return "Copied \(copied) of \(total) — \(failures.count) failed"
+    }
+
+    /// The full detail, kept off the toast and handed to the notifications
+    /// panel the way install failures already are.
+    public var detail: String? { failures.isEmpty ? nil : failures.joined(separator: "\n") }
+}
+
+/// Copying host files onto a device: make the destination, push, then ask
+/// MediaStore to index what landed.
+///
+/// `adb push` rides the sync protocol — no device shell, so the local and
+/// remote paths need no quoting. Every *other* step here (`mkdir`, `stat`,
+/// `rm`, the media scan) does cross `adb shell` carrying a file name that came
+/// straight from Finder, so each one quotes.
+public struct DeviceTransferService: Sendable {
+    /// What the copy is doing right now, for the progress chip.
+    public enum Stage: Sendable, Equatable {
+        case preparing
+        case copying(name: String, index: Int, total: Int)
+        case indexing
+    }
+
+    let client: AdbClient
+
+    public init(client: AdbClient) {
+        self.client = client
+    }
+
+    /// The device path a local file lands on.
+    public static func remotePath(forLocal localPath: String, inDir dir: String) -> String {
+        let name = URL(fileURLWithPath: localPath).lastPathComponent
+        let base = dir.hasSuffix("/") ? String(dir.dropLast()) : dir
+        return base + "/" + name
+    }
+
+    public func copyToDevice(
+        paths: [String],
+        toDir dir: String,
+        serial: String,
+        onStage: @Sendable @escaping (Stage) -> Void = { _ in }
+    ) async throws(AdbError) -> TransferOutcome {
+        guard !paths.isEmpty else {
+            return TransferOutcome(copied: 0, total: 0, failures: [], destination: dir)
+        }
+        onStage(.preparing)
+        // A destination that isn't there yet is a silent `adb push` failure,
+        // and /sdcard/Download is missing on a freshly wiped emulator.
+        _ = try await client.run(on: serial, ["shell", "mkdir", "-p", shellQuote(dir)])
+        let sdk = await sdkLevel(serial: serial)
+
+        var copied = 0
+        var failures: [String] = []
+        var landed: [String] = []
+        for (index, path) in paths.enumerated() {
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            onStage(.copying(name: name, index: index + 1, total: paths.count))
+            let remote = Self.remotePath(forLocal: path, inDir: dir)
+            let result = try await client.run(
+                on: serial, ["push", path, remote], timeout: .seconds(600))
+            if result.succeeded {
+                copied += 1
+                landed.append(remote)
+            } else {
+                failures.append("\(name): \(friendlyAdbError(result, fallback: "couldn't be copied"))")
+            }
+        }
+
+        if !landed.isEmpty {
+            onStage(.indexing)
+            for remote in landed {
+                // Best effort by design: an unindexed file is still on the
+                // device, so a scan that fails must not fail the copy.
+                _ = try? await client.run(on: serial, MediaScan.command(sdk: sdk, path: remote))
+            }
+        }
+        return TransferOutcome(
+            copied: copied, total: paths.count, failures: failures, destination: dir)
+    }
+
+    /// Bytes already written on the device, for a real percentage while a push
+    /// runs. The mirror of the pull-progress trick: poll the growing side
+    /// against the size we already know. nil when the file isn't there yet or
+    /// the device's `stat` didn't answer with a number.
+    public func remoteSize(of path: String, serial: String) async -> Int? {
+        guard let result = try? await client.run(
+            on: serial, ["shell", "stat", "-c", "%s", shellQuote(path)], timeout: .seconds(10)
+        ), result.succeeded else { return nil }
+        let text = result.stdout
+            .components(separatedBy: .newlines)
+            .first { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        return text.map { $0.trimmingCharacters(in: .whitespaces) }.flatMap(Int.init)
+    }
+
+    /// Clean up the partial file a cancelled copy left behind. Best effort —
+    /// the copy is already over, and a leftover is a tidiness problem, not a
+    /// correctness one.
+    public func removeRemote(path: String, serial: String) async {
+        _ = try? await client.run(on: serial, ["shell", "rm", "-f", shellQuote(path)])
+    }
+
+    private func sdkLevel(serial: String) async -> Int? {
+        guard let value = try? await DeviceProps.get(
+            client: client, serial: serial, "ro.build.version.sdk"
+        ) else { return nil }
+        return Int(value.trimmingCharacters(in: .whitespaces))
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/Drop/FileDropRouter.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/FileDropRouter.swift
@@ -69,9 +69,13 @@ public struct DeviceDropPlan: Sendable, Equatable {
     public var allPaths: [String] { installs + bundles + copies }
 
     /// True when the drop carries something that could plausibly be *stored*
-    /// rather than installed — which is the only genuine ambiguity a drop on a
-    /// mirror has, and so the only time the overlay offers a second zone.
-    public var hasAlternative: Bool { !installs.isEmpty || !bundles.isEmpty }
+    /// rather than installed — the only genuine ambiguity a drop on a mirror
+    /// has, and so the only time the overlay mentions a second option.
+    ///
+    /// Packages only, not bundles: the alternative is a button on the install
+    /// prompt, and a bundle never raises one (it opens the converter). Saying
+    /// "…or copy" for an `.aab` would promise a choice that isn't offered.
+    public var hasAlternative: Bool { !installs.isEmpty }
 
     /// The same drop, with every package treated as a file to copy. What the
     /// overlay's secondary zone commits to.

--- a/ADBKit/Sources/ADBKit/Services/Drop/FileDropRouter.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/FileDropRouter.swift
@@ -1,0 +1,273 @@
+import Foundation
+
+/// One path handed over by a drag, with the one fact about it that extension
+/// matching can't answer.
+public struct DroppedPath: Sendable, Equatable, Hashable {
+    public let path: String
+    public let isDirectory: Bool
+
+    public init(path: String, isDirectory: Bool = false) {
+        self.path = path
+        self.isDirectory = isDirectory
+    }
+
+    /// The file name, for display and for the device-side destination.
+    public var name: String { URL(fileURLWithPath: path).lastPathComponent }
+}
+
+/// What a dropped path is, decided by extension alone — the same rule the
+/// open panels and the Finder document types use, so a drag and a double-click
+/// can never disagree about a file.
+public enum DroppedFileKind: Sendable, Equatable {
+    /// An installable Android package (`.apk` and the three split containers).
+    case appPackage(AppPackageFormat)
+    /// An Android App Bundle. Not installable — it converts to an APK first.
+    case appBundle
+    /// A container the video editor opens.
+    case video(VideoInputFormat)
+    case folder
+    case other
+}
+
+/// Where a drop goes when the surface under the cursor claims nothing for it.
+///
+/// The cases map one-to-one onto the App's existing Finder-open entry points,
+/// which is the point: a double-clicked file and a dragged one resolve through
+/// the same table instead of two hand-written filters that drift apart.
+public enum DropRoute: Sendable, Equatable {
+    case openPackages([String])
+    case convertBundles([String])
+    case openVideos([String])
+    case copyToDevice([String])
+    /// Nothing can be done with these — no device to copy them to.
+    case unsupported([String])
+}
+
+/// What a drop onto a device surface (the mirror, a wall tile, a pop-out
+/// window) will do. The surface owns one device, so there is no targeting
+/// question to answer: everything here lands on that serial.
+public struct DeviceDropPlan: Sendable, Equatable {
+    /// Packages to install.
+    public var installs: [String]
+    /// App Bundles, which convert to an APK before they can be installed.
+    public var bundles: [String]
+    /// Files (and folders) to copy into `destination`.
+    public var copies: [String]
+    /// The device directory `copies` land in.
+    public var destination: String
+
+    public init(installs: [String] = [], bundles: [String] = [], copies: [String] = [], destination: String) {
+        self.installs = installs
+        self.bundles = bundles
+        self.copies = copies
+        self.destination = destination
+    }
+
+    public var isEmpty: Bool { installs.isEmpty && bundles.isEmpty && copies.isEmpty }
+
+    /// Everything the plan touches, in the order it arrived.
+    public var allPaths: [String] { installs + bundles + copies }
+
+    /// True when the drop carries something that could plausibly be *stored*
+    /// rather than installed — which is the only genuine ambiguity a drop on a
+    /// mirror has, and so the only time the overlay offers a second zone.
+    public var hasAlternative: Bool { !installs.isEmpty || !bundles.isEmpty }
+
+    /// The same drop, with every package treated as a file to copy. What the
+    /// overlay's secondary zone commits to.
+    public var copyingEverything: DeviceDropPlan {
+        DeviceDropPlan(copies: allPaths, destination: destination)
+    }
+}
+
+/// What the drop overlay says while the drag is still in the air. Pure, so the
+/// wording is tested rather than eyeballed — the whole design rests on the
+/// reader believing this sentence before they let go.
+public struct DropAnnouncement: Sendable, Equatable {
+    /// SF Symbol name. ADBKit stays UI-free: this is a string, not an Image.
+    public var symbol: String
+    public var verb: String
+    public var detail: String
+    /// The secondary zone's label, when there is a second choice.
+    public var alternative: String?
+    /// True when the drop can't be honored — the overlay reads as a refusal
+    /// rather than a promise.
+    public var refusal: Bool
+
+    public init(
+        symbol: String, verb: String, detail: String,
+        alternative: String? = nil, refusal: Bool = false
+    ) {
+        self.symbol = symbol
+        self.verb = verb
+        self.detail = detail
+        self.alternative = alternative
+        self.refusal = refusal
+    }
+}
+
+/// The one table that decides what a dropped file does, wherever it lands.
+public enum FileDropRouter {
+    /// Where files copied to a device go. Deliberately one predictable folder
+    /// rather than routing by type into Pictures/Movies/Music: the overlay
+    /// names it before the drop, and a person hunting for what they just sent
+    /// should only ever have one place to look. Matches scrcpy's default, so
+    /// the habit transfers.
+    public static let defaultDestination = "/sdcard/Download"
+
+    public static func kind(of dropped: DroppedPath) -> DroppedFileKind {
+        if dropped.isDirectory { return .folder }
+        if let package = AppPackageFormat.detect(fileName: dropped.name) { return .appPackage(package) }
+        let ext = URL(fileURLWithPath: dropped.name).pathExtension.lowercased()
+        if ext == "aab" { return .appBundle }
+        if let video = VideoInputFormat.detect(fileName: dropped.name) { return .video(video) }
+        return .other
+    }
+
+    // MARK: - A drop on a device surface
+
+    public static func plan(
+        _ dropped: [DroppedPath], destination: String = defaultDestination
+    ) -> DeviceDropPlan {
+        var plan = DeviceDropPlan(destination: destination)
+        for item in dropped {
+            switch kind(of: item) {
+            case .appPackage: plan.installs.append(item.path)
+            case .appBundle: plan.bundles.append(item.path)
+            // A video dropped on a phone is a file being sent to the phone.
+            // Only a surface with nothing to do with it routes it to the editor.
+            case .video, .folder, .other: plan.copies.append(item.path)
+            }
+        }
+        return plan
+    }
+
+    // MARK: - A drop on a surface that claims nothing
+
+    /// Group by kind and hand each group to the feature that owns it, so a
+    /// drop is never silently swallowed. Order is fixed (packages, bundles,
+    /// videos, files) so a mixed drop behaves the same way twice.
+    public static func routes(
+        for dropped: [DroppedPath], hasDevice: Bool, destination: String = defaultDestination
+    ) -> [DropRoute] {
+        var packages: [String] = []
+        var bundles: [String] = []
+        var videos: [String] = []
+        var rest: [String] = []
+        for item in dropped {
+            switch kind(of: item) {
+            case .appPackage: packages.append(item.path)
+            case .appBundle: bundles.append(item.path)
+            case .video: videos.append(item.path)
+            case .folder, .other: rest.append(item.path)
+            }
+        }
+        var routes: [DropRoute] = []
+        if !packages.isEmpty { routes.append(.openPackages(packages)) }
+        if !bundles.isEmpty { routes.append(.convertBundles(bundles)) }
+        if !videos.isEmpty { routes.append(.openVideos(videos)) }
+        if !rest.isEmpty { routes.append(hasDevice ? .copyToDevice(rest) : .unsupported(rest)) }
+        return routes
+    }
+
+    // MARK: - Wording
+
+    public static func announcement(
+        for plan: DeviceDropPlan, deviceName: String, copyingInstead: Bool = false
+    ) -> DropAnnouncement {
+        let effective = copyingInstead ? plan.copyingEverything : plan
+        if effective.isEmpty {
+            return DropAnnouncement(
+                symbol: "xmark.circle", verb: "Nothing to drop here",
+                detail: "The drag carried no files.", refusal: true)
+        }
+        let alternative = (!copyingInstead && plan.hasAlternative)
+            ? "…or copy to \(plan.destination)" : nil
+        var verbs: [String] = []
+        if !effective.installs.isEmpty { verbs.append(installVerb(effective.installs.count)) }
+        if !effective.bundles.isEmpty { verbs.append(bundleVerb(effective.bundles.count)) }
+        if !effective.copies.isEmpty { verbs.append(copyVerb(effective.copies.count)) }
+        // "Copy to Pixel 7" but "Install on Pixel 7" — the preposition follows
+        // the verb, and a mixed drop leads with the install. A bundle names no
+        // device at all: converting happens on the Mac, and promising an
+        // install "on Pixel 7" would overstate what the drop actually starts.
+        let onlyCopies = effective.installs.isEmpty && effective.bundles.isEmpty
+        let namesDevice = !effective.installs.isEmpty || !effective.copies.isEmpty
+        let suffix = namesDevice ? " \(onlyCopies ? "to" : "on") \(deviceName)" : ""
+        return DropAnnouncement(
+            symbol: onlyCopies ? "arrow.down.doc" : "arrow.down.app",
+            verb: verbs.joined(separator: " · ") + suffix,
+            detail: detail(for: effective),
+            alternative: alternative)
+    }
+
+    public static func announcement(for routes: [DropRoute]) -> DropAnnouncement? {
+        guard !routes.isEmpty else { return nil }
+        if routes.count == 1, case let .unsupported(paths) = routes[0] {
+            return DropAnnouncement(
+                symbol: "xmark.circle",
+                verb: paths.count == 1
+                    ? "Droidective can't open \(name(paths[0]))"
+                    : "Droidective can't open these \(paths.count) files",
+                detail: "Connect a device to copy files instead.",
+                refusal: true)
+        }
+        let verbs = routes.map(verb(for:))
+        let counted = routes.reduce(0) { $0 + count(of: $1) }
+        return DropAnnouncement(
+            symbol: "arrow.down.forward.square",
+            verb: verbs.joined(separator: " · "),
+            detail: counted == 1 ? name(firstPath(of: routes[0])) : "\(counted) files")
+    }
+
+    // MARK: - Private wording helpers
+
+    private static func installVerb(_ count: Int) -> String {
+        count == 1 ? "Install" : "Install \(count) apps"
+    }
+
+    private static func bundleVerb(_ count: Int) -> String {
+        count == 1 ? "Convert to APK" : "Convert \(count) bundles to APKs"
+    }
+
+    private static func copyVerb(_ count: Int) -> String {
+        count == 1 ? "Copy" : "Copy \(count) files"
+    }
+
+    private static func detail(for plan: DeviceDropPlan) -> String {
+        let total = plan.allPaths.count
+        if total == 1, plan.copies.isEmpty { return name(plan.allPaths[0]) }
+        if plan.copies.isEmpty { return "\(total) packages" }
+        if total == 1 { return "\(name(plan.copies[0])) → \(plan.destination)" }
+        return "\(plan.copies.count) to \(plan.destination)"
+    }
+
+    private static func verb(for route: DropRoute) -> String {
+        switch route {
+        case let .openPackages(paths):
+            paths.count == 1 ? "Open app package" : "Open \(paths.count) app packages"
+        case .convertBundles:
+            "Convert to APK"
+        case let .openVideos(paths):
+            paths.count == 1 ? "Open in Video Editor" : "Open \(paths.count) videos"
+        case let .copyToDevice(paths):
+            paths.count == 1 ? "Copy to device" : "Copy \(paths.count) files to device"
+        case let .unsupported(paths):
+            paths.count == 1 ? "Can't open this file" : "Can't open these \(paths.count) files"
+        }
+    }
+
+    private static func count(of route: DropRoute) -> Int { paths(of: route).count }
+
+    private static func firstPath(of route: DropRoute) -> String { paths(of: route).first ?? "" }
+
+    private static func paths(of route: DropRoute) -> [String] {
+        switch route {
+        case let .openPackages(paths), let .convertBundles(paths),
+             let .openVideos(paths), let .copyToDevice(paths), let .unsupported(paths):
+            paths
+        }
+    }
+
+    private static func name(_ path: String) -> String { URL(fileURLWithPath: path).lastPathComponent }
+}

--- a/ADBKit/Sources/ADBKit/Services/Drop/InstallPlan.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/InstallPlan.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// The version of a package as the *device* reports it, narrowed to the two
+/// fields the install prompt compares. `AppInfo` carries em-dashes for "not
+/// known", which is why both are optional here rather than defaulted strings.
+public struct InstalledAppVersion: Sendable, Equatable {
+    public var versionName: String?
+    public var versionCode: String?
+
+    public init(versionName: String? = nil, versionCode: String? = nil) {
+        self.versionName = InstalledAppVersion.cleaned(versionName)
+        self.versionCode = InstalledAppVersion.cleaned(versionCode)
+    }
+
+    /// `AppInfo.notInstalled` fills its fields with "—"; dumpsys can also
+    /// report "null". Neither is a version.
+    private static func cleaned(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == "—" || trimmed == "-" || trimmed == "null" { return nil }
+        return trimmed
+    }
+}
+
+/// How the dropped package relates to what is already on the device. This is
+/// the sentence the whole install sheet is built on, so it is decided once,
+/// here, and tested — not inferred in a view.
+public enum InstallRelation: String, Sendable, Equatable, CaseIterable {
+    case notInstalled
+    case reinstall
+    case update
+    case downgrade
+    /// The app is there but the two versions can't be compared — no aapt2 to
+    /// read the APK, or a version code the device didn't report.
+    case unknown
+}
+
+/// What the install prompt offers, and what it must refuse.
+public struct InstallDecision: Sendable, Equatable {
+    public var relation: InstallRelation
+    /// The primary button's label — it names what will actually happen.
+    public var primaryTitle: String
+    /// Whether "keep app data" (a plain `adb install -r`) is on the table.
+    public var canKeepData: Bool
+    /// Why it isn't, when it isn't.
+    public var keepDataNote: String?
+    /// Whether the sheet should preselect Replace (uninstall, then install).
+    public var replaceByDefault: Bool
+    /// Whether the sheet has a choice to make at all. A first install doesn't.
+    public var offersChoice: Bool
+
+    public init(
+        relation: InstallRelation, primaryTitle: String, canKeepData: Bool,
+        keepDataNote: String?, replaceByDefault: Bool, offersChoice: Bool
+    ) {
+        self.relation = relation
+        self.primaryTitle = primaryTitle
+        self.canKeepData = canKeepData
+        self.keepDataNote = keepDataNote
+        self.replaceByDefault = replaceByDefault
+        self.offersChoice = offersChoice
+    }
+}
+
+public enum InstallPlan {
+    /// Compare two Android `versionCode`s.
+    ///
+    /// The code is the authoritative integer and the *name* is only a label —
+    /// "3.0" against "3.0.1" is a string, not an ordering. Returns nil when
+    /// either side is missing or isn't a plain integer, which is the honest
+    /// answer: the sheet then says it can't tell rather than guessing.
+    public static func compareVersionCodes(_ local: String?, _ installed: String?) -> ComparisonResult? {
+        guard let left = integerCode(local), let right = integerCode(installed) else { return nil }
+        if left == right { return .orderedSame }
+        return left > right ? .orderedDescending : .orderedAscending
+    }
+
+    private static func integerCode(_ value: String?) -> UInt64? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, trimmed.allSatisfy(\.isASCII), trimmed.allSatisfy(\.isNumber) else { return nil }
+        return UInt64(trimmed)
+    }
+
+    /// The decision for one package against one device.
+    ///
+    /// A downgrade is the case worth getting right: Android refuses
+    /// `INSTALL_FAILED_VERSION_DOWNGRADE` for an in-place reinstall, so the
+    /// only route is uninstall-then-install — which wipes app data. Saying
+    /// that up front beats discovering it from a failure.
+    public static func decide(local: ApkInfo, installed: InstalledAppVersion?) -> InstallDecision {
+        guard let installed, installed.versionName != nil || installed.versionCode != nil else {
+            return InstallDecision(
+                relation: .notInstalled, primaryTitle: "Install", canKeepData: true,
+                keepDataNote: nil, replaceByDefault: false, offersChoice: false)
+        }
+        switch compareVersionCodes(local.versionCode, installed.versionCode) {
+        case .orderedDescending:
+            return InstallDecision(
+                relation: .update, primaryTitle: "Update", canKeepData: true,
+                keepDataNote: nil, replaceByDefault: false, offersChoice: true)
+        case .orderedSame:
+            return InstallDecision(
+                relation: .reinstall, primaryTitle: "Reinstall", canKeepData: true,
+                keepDataNote: nil, replaceByDefault: false, offersChoice: true)
+        case .orderedAscending:
+            return InstallDecision(
+                relation: .downgrade, primaryTitle: "Downgrade & Replace", canKeepData: false,
+                keepDataNote: "Not possible for a downgrade", replaceByDefault: true,
+                offersChoice: true)
+        case nil:
+            return InstallDecision(
+                relation: .unknown, primaryTitle: "Install", canKeepData: true,
+                keepDataNote: local.versionCode == nil
+                    ? "Version details need the Android SDK build-tools" : nil,
+                replaceByDefault: false, offersChoice: true)
+        }
+    }
+
+    /// A one-line version for the sheet's comparison rows: "3.0.2  (30201)",
+    /// or just one half when the other is missing.
+    public static func versionLabel(name: String?, code: String?) -> String {
+        switch (name, code) {
+        case let (name?, code?): "\(name)  (\(code))"
+        case let (name?, nil): name
+        case let (nil, code?): "(\(code))"
+        case (nil, nil): "Unknown"
+        }
+    }
+
+    /// True when adb's failure text is the kind an uninstall-first retry
+    /// actually fixes — the recovery the failure chip offers. Anything else
+    /// (no storage, wrong ABI, a corrupt APK) is not helped by wiping the app,
+    /// so it must not be offered.
+    public static func isResolvedByReplacing(_ adbOutput: String) -> Bool {
+        let recoverable = [
+            "INSTALL_FAILED_UPDATE_INCOMPATIBLE",
+            "INSTALL_FAILED_VERSION_DOWNGRADE",
+            "INSTALL_FAILED_DUPLICATE_PERMISSION",
+            "INSTALL_FAILED_ALREADY_EXISTS",
+            "signatures do not match",
+        ]
+        return recoverable.contains { adbOutput.localizedCaseInsensitiveContains($0) }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/Drop/InstallPlan.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/InstallPlan.swift
@@ -128,18 +128,28 @@ public enum InstallPlan {
         }
     }
 
-    /// True when adb's failure text is the kind an uninstall-first retry
+    /// True when an install failure is the kind an uninstall-first retry
     /// actually fixes — the recovery the failure chip offers. Anything else
     /// (no storage, wrong ABI, a corrupt APK) is not helped by wiping the app,
     /// so it must not be offered.
-    public static func isResolvedByReplacing(_ adbOutput: String) -> Bool {
+    ///
+    /// Recognises adb's own `INSTALL_FAILED_*` codes *and* the wording
+    /// `AppInstallService.friendlyReason` replaces them with, because by the
+    /// time a failure reaches the UI it may be either: the raw output is kept
+    /// on the job, the friendly one-liner is what the chip shows, and a caller
+    /// reading the wrong one would silently never offer the recovery.
+    /// `theFriendlyWordingOfARecoverableCodeIsAlsoRecognised` pins the pair.
+    public static func isResolvedByReplacing(_ failure: String) -> Bool {
         let recoverable = [
             "INSTALL_FAILED_UPDATE_INCOMPATIBLE",
             "INSTALL_FAILED_VERSION_DOWNGRADE",
             "INSTALL_FAILED_DUPLICATE_PERMISSION",
             "INSTALL_FAILED_ALREADY_EXISTS",
             "signatures do not match",
+            // The friendly halves of the same four.
+            "uninstall it first",
+            "already installed",
         ]
-        return recoverable.contains { adbOutput.localizedCaseInsensitiveContains($0) }
+        return recoverable.contains { failure.localizedCaseInsensitiveContains($0) }
     }
 }

--- a/ADBKit/Sources/ADBKit/Services/Drop/MediaScan.swift
+++ b/ADBKit/Sources/ADBKit/Services/Drop/MediaScan.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Getting a pushed file into MediaStore, so a screenshot dropped on the
+/// mirror actually turns up in the Gallery instead of only in Files.
+///
+/// `adb push` writes the bytes and nothing else — the media database is not
+/// watching the filesystem. Which command performs the scan changed with
+/// Android 10: `MEDIA_SCANNER_SCAN_FILE` is ignored for `file://` URIs from
+/// API 29 on (the same change that took away raw file paths), and the
+/// replacement is a direct provider call. Older devices only know the
+/// broadcast. Pure and static so both arg vectors are asserted in tests
+/// rather than tried on one phone and assumed.
+public enum MediaScan {
+    /// The first API level where the provider call is the working route.
+    public static let providerCallMinimumSDK = 29
+
+    /// The adb argument vector (everything after the serial) that indexes
+    /// `path`. The path crosses `adb shell`, so it is quoted — a dropped file
+    /// name is whatever Finder had, backticks and all.
+    public static func command(sdk: Int?, path: String) -> [String] {
+        // An unknown SDK takes the modern route: it is what every device the
+        // app can still reach a Play-services era build on understands, and a
+        // failed scan is a cosmetic loss, not a lost file.
+        guard let sdk, sdk < providerCallMinimumSDK else {
+            return [
+                "shell", "content", "call",
+                "--uri", "content://media/external/file",
+                "--method", "scan_file",
+                "--arg", shellQuote(path),
+            ]
+        }
+        return [
+            "shell", "am", "broadcast",
+            "-a", "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+            "-d", shellQuote("file://" + path),
+        ]
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/DeviceTransferLiveTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceTransferLiveTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+/// Tier 3: the drop's copy path against a real device.
+///
+/// The mock suite proves the argument vectors. This proves the device actually
+/// accepts them: that `mkdir -p` makes a destination, that a push with a name
+/// full of shell metacharacters lands under that exact name, that `stat -c %s`
+/// answers with a number (the whole basis of the progress readout), and that
+/// the media-scan command for this device's API level isn't rejected. Every
+/// one of those is a device behaviour a mock can only assume.
+///
+/// Disabled by default. Run with
+/// `DEVICE_LIVE_TEST=1 MIRROR_SERIAL=emulator-5554 swift test --filter DeviceTransferLiveTests`.
+@Suite struct DeviceTransferLiveTests {
+    private static var liveEnabled: Bool {
+        ProcessInfo.processInfo.environment["DEVICE_LIVE_TEST"] == "1"
+    }
+
+    private static var serial: String {
+        ProcessInfo.processInfo.environment["MIRROR_SERIAL"] ?? "emulator-5554"
+    }
+
+    private static var adb: AdbClient { AdbClient(locator: ToolLocator()) }
+
+    /// A scratch directory on the device, unique per test and swept afterwards.
+    ///
+    /// Unique per test on purpose: swift-testing runs a suite's cases in
+    /// parallel, and one shared directory means each case's cleanup deletes
+    /// what its siblings are still asserting against.
+    private func makeRemoteRoot() -> String {
+        "/sdcard/Download/droidective-drop-\(UUID().uuidString.prefix(8))"
+    }
+
+    private func makeLocalFile(named name: String, bytes: Int) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("droidective-drop-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try Data(repeating: 0x41, count: bytes).write(to: url)
+        return url
+    }
+
+    private func sweep(_ root: String) async {
+        _ = try? await Self.adb.run(
+            on: Self.serial, ["shell", "rm", "-rf", shellQuote(root)])
+    }
+
+    @Test(.enabled(if: liveEnabled))
+    func aCopyLandsAndTheDeviceReportsItsSize() async throws {
+        let service = DeviceTransferService(client: Self.adb)
+        let local = try makeLocalFile(named: "drop sample.txt", bytes: 4096)
+        defer { try? FileManager.default.removeItem(at: local.deletingLastPathComponent()) }
+        let root = makeRemoteRoot()
+        defer { Task { await sweep(root) } }
+
+        let outcome = try await service.copyToDevice(
+            paths: [local.path], toDir: root, serial: Self.serial)
+        #expect(outcome.ok, "copy failed: \(outcome.failures)")
+
+        // The destination directory did not exist before this call.
+        let remote = DeviceTransferService.remotePath(forLocal: local.path, inDir: root)
+        let size = await service.remoteSize(of: remote, serial: Self.serial)
+        #expect(size == 4096, "stat -c %s is what the progress readout is built on")
+    }
+
+    @Test(.enabled(if: liveEnabled))
+    func aNameFullOfShellMetacharactersSurvivesIntact() async throws {
+        // The name comes from Finder. If any step joins it into a device shell
+        // command unquoted, this either fails or does something else entirely.
+        let service = DeviceTransferService(client: Self.adb)
+        let awkward = "a b'c$d`e;f&g.txt"
+        let local = try makeLocalFile(named: awkward, bytes: 128)
+        defer { try? FileManager.default.removeItem(at: local.deletingLastPathComponent()) }
+        let root = makeRemoteRoot()
+        defer { Task { await sweep(root) } }
+
+        let outcome = try await service.copyToDevice(
+            paths: [local.path], toDir: root, serial: Self.serial)
+        #expect(outcome.ok, "copy failed: \(outcome.failures)")
+
+        let listing = try await Self.adb.run(
+            on: Self.serial, ["shell", "ls", "-a", shellQuote(root)])
+        #expect(listing.stdout.contains(awkward), "landed as something else: \(listing.stdout)")
+
+        let remote = DeviceTransferService.remotePath(forLocal: local.path, inDir: root)
+        #expect(await service.remoteSize(of: remote, serial: Self.serial) == 128)
+
+        // …and the cleanup path can address it again.
+        await service.removeRemote(path: remote, serial: Self.serial)
+        let after = try await Self.adb.run(
+            on: Self.serial, ["shell", "ls", "-a", shellQuote(root)])
+        #expect(!after.stdout.contains(awkward))
+    }
+
+    @Test(.enabled(if: liveEnabled))
+    func theMediaScanCommandIsAcceptedByThisDevice() async throws {
+        // A rejected scan doesn't fail a copy by design, so nothing else would
+        // ever tell us the command is wrong for this API level.
+        let sdk = Int(try await DeviceProps.get(
+            client: Self.adb, serial: Self.serial, "ro.build.version.sdk"
+        ).trimmingCharacters(in: .whitespaces))
+        let service = DeviceTransferService(client: Self.adb)
+        let local = try makeLocalFile(named: "scan-me.png", bytes: 64)
+        defer { try? FileManager.default.removeItem(at: local.deletingLastPathComponent()) }
+        let root = makeRemoteRoot()
+        defer { Task { await sweep(root) } }
+
+        _ = try await service.copyToDevice(
+            paths: [local.path], toDir: root, serial: Self.serial)
+        let remote = DeviceTransferService.remotePath(forLocal: local.path, inDir: root)
+        let scan = try await Self.adb.run(
+            on: Self.serial, MediaScan.command(sdk: sdk, path: remote))
+        #expect(scan.succeeded, "scan rejected: \(scan.stderr)")
+        #expect(!scan.stderr.localizedCaseInsensitiveContains("unknown"), "\(scan.stderr)")
+    }
+
+    @Test(.enabled(if: liveEnabled))
+    func aFolderCopiesWithItsContents() async throws {
+        let service = DeviceTransferService(client: Self.adb)
+        let localRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("droidective-drop-\(UUID().uuidString)")
+        let folder = localRoot.appendingPathComponent("assets")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try Data("one".utf8).write(to: folder.appendingPathComponent("one.txt"))
+        try Data("two".utf8).write(to: folder.appendingPathComponent("two.txt"))
+        defer { try? FileManager.default.removeItem(at: localRoot) }
+        let root = makeRemoteRoot()
+        defer { Task { await sweep(root) } }
+
+        let outcome = try await service.copyToDevice(
+            paths: [folder.path], toDir: root, serial: Self.serial)
+        #expect(outcome.ok, "copy failed: \(outcome.failures)")
+        let listing = try await Self.adb.run(
+            on: Self.serial, ["shell", "ls", shellQuote(root + "/assets")])
+        #expect(listing.stdout.contains("one.txt"))
+        #expect(listing.stdout.contains("two.txt"))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/DeviceTransferServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/DeviceTransferServiceTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+@Suite struct DeviceTransferServiceTests {
+    private func makeService(_ runner: MockProcessRunner) async -> DeviceTransferService {
+        DeviceTransferService(client: await makeTestClient(runner: runner))
+    }
+
+    /// A device that accepts everything and reports Android 14.
+    private func scriptHealthyDevice(_ runner: MockProcessRunner) {
+        runner.script(argsPrefix: ["-s", "S1"], stdout: "")
+        runner.script(argsPrefix: ["-s", "S1", "shell", "getprop", "ro.build.version.sdk"], stdout: "34\n")
+    }
+
+    private func args(_ runner: MockProcessRunner) -> [[String]] {
+        runner.invocations.map(\.arguments)
+    }
+
+    // MARK: - The happy path, as an argument vector
+
+    @Test func aCopyMakesTheFolderPushesThenIndexes() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(
+            paths: ["/Users/me/notes.pdf"], toDir: "/sdcard/Download", serial: "S1")
+
+        #expect(outcome.ok)
+        #expect(outcome.copied == 1)
+        let vectors = args(runner)
+        #expect(vectors.contains(["-s", "S1", "shell", "mkdir", "-p", "'/sdcard/Download'"]))
+        // The push rides the sync protocol: no device shell, so no quoting.
+        #expect(vectors.contains(["-s", "S1", "push", "/Users/me/notes.pdf", "/sdcard/Download/notes.pdf"]))
+        #expect(vectors.contains([
+            "-s", "S1", "shell", "content", "call",
+            "--uri", "content://media/external/file",
+            "--method", "scan_file", "--arg", "'/sdcard/Download/notes.pdf'",
+        ]))
+    }
+
+    @Test func theDestinationIsMadeBeforeAnythingIsPushed() async throws {
+        // /sdcard/Download is missing on a freshly wiped emulator, and an
+        // `adb push` into a directory that isn't there fails obscurely.
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        _ = try await service.copyToDevice(paths: ["/a.txt"], toDir: "/sdcard/Drops", serial: "S1")
+        let vectors = args(runner)
+        let mkdir = try #require(vectors.firstIndex { $0.contains("mkdir") })
+        let push = try #require(vectors.firstIndex { $0.contains("push") })
+        #expect(mkdir < push)
+    }
+
+    @Test func indexingRunsAfterEveryPushNotBetweenThem() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        _ = try await service.copyToDevice(paths: ["/a.png", "/b.png"], toDir: "/sdcard/Download", serial: "S1")
+        let vectors = args(runner)
+        let lastPush = try #require(vectors.lastIndex { $0.contains("push") })
+        let firstScan = try #require(vectors.firstIndex { $0.contains("scan_file") })
+        #expect(lastPush < firstScan)
+    }
+
+    // MARK: - Quoting, which is the security boundary here
+
+    @Test func aHostileFolderNameIsQuotedIntoMkdir() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        let dir = "/sdcard/a'; touch /sdcard/pwned; echo '"
+        _ = try await service.copyToDevice(paths: ["/a.txt"], toDir: dir, serial: "S1")
+        #expect(args(runner).contains(["-s", "S1", "shell", "mkdir", "-p", shellQuote(dir)]))
+    }
+
+    @Test func aHostileFileNameIsQuotedIntoTheScanAndTheCleanup() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        // The name is whatever Finder had. It reaches `adb shell` through the
+        // media scan and through the cancel cleanup; both must quote it.
+        let local = "/Users/me/x'; touch /sdcard/pwned; echo '.png"
+        _ = try await service.copyToDevice(paths: [local], toDir: "/sdcard/Download", serial: "S1")
+        let remote = DeviceTransferService.remotePath(forLocal: local, inDir: "/sdcard/Download")
+        #expect(args(runner).contains { $0.last == shellQuote(remote) })
+
+        await service.removeRemote(path: remote, serial: "S1")
+        #expect(args(runner).contains(["-s", "S1", "shell", "rm", "-f", shellQuote(remote)]))
+    }
+
+    @Test func remoteSizeQuotesTheStatPath() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "stat"], stdout: "40108\n")
+        let service = await makeService(runner)
+        let size = await service.remoteSize(of: "/sdcard/Download/a b.mp4", serial: "S1")
+        #expect(size == 40108)
+        #expect(args(runner).contains([
+            "-s", "S1", "shell", "stat", "-c", "%s", "'/sdcard/Download/a b.mp4'",
+        ]))
+    }
+
+    // MARK: - Destination paths
+
+    @Test func aTrailingSlashDoesNotDoubleUp() {
+        #expect(DeviceTransferService.remotePath(forLocal: "/a/b.txt", inDir: "/sdcard/Download/")
+            == "/sdcard/Download/b.txt")
+        #expect(DeviceTransferService.remotePath(forLocal: "/a/b.txt", inDir: "/sdcard/Download")
+            == "/sdcard/Download/b.txt")
+    }
+
+    @Test func aFolderKeepsItsOwnNameOnTheDevice() {
+        #expect(DeviceTransferService.remotePath(forLocal: "/Users/me/assets", inDir: "/sdcard/Download")
+            == "/sdcard/Download/assets")
+    }
+
+    // MARK: - Failure
+
+    @Test func oneBadFileDoesNotAbandonTheRest() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        runner.script(
+            argsPrefix: ["-s", "S1", "push", "/b.txt"],
+            stderr: "adb: error: failed to copy: No space left on device", exitCode: 1)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(
+            paths: ["/a.txt", "/b.txt", "/c.txt"], toDir: "/sdcard/Download", serial: "S1")
+
+        #expect(outcome.ok == false)
+        #expect(outcome.copied == 2)
+        #expect(outcome.total == 3)
+        #expect(outcome.failures.count == 1)
+        #expect(outcome.failures[0].hasPrefix("b.txt: "))
+        #expect(outcome.summary == "Copied 2 of 3 — 1 failed")
+        // c.txt was still tried.
+        #expect(args(runner).contains { $0.contains("/c.txt") })
+    }
+
+    @Test func aFileThatFailedIsNotHandedToTheMediaScanner() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        runner.script(argsPrefix: ["-s", "S1", "push", "/b.png"], stderr: "failed", exitCode: 1)
+        let service = await makeService(runner)
+        _ = try await service.copyToDevice(paths: ["/a.png", "/b.png"], toDir: "/sdcard/Download", serial: "S1")
+        let scans = args(runner).filter { $0.contains("scan_file") }
+        #expect(scans.count == 1)
+        #expect(scans[0].last == "'/sdcard/Download/a.png'")
+    }
+
+    @Test func everythingFailingReportsTheReasonNotACount() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        runner.script(argsPrefix: ["-s", "S1", "push"], stderr: "adb: error: no space", exitCode: 1)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(paths: ["/a.txt"], toDir: "/sdcard/Download", serial: "S1")
+        #expect(outcome.copied == 0)
+        #expect(outcome.summary.hasPrefix("a.txt: "))
+        #expect(outcome.detail?.isEmpty == false)
+    }
+
+    @Test func aFailedScanNeverFailsTheCopy() async throws {
+        // The bytes are on the device; an unindexed file is a cosmetic loss.
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        runner.script(argsPrefix: ["-s", "S1", "shell", "content"], stderr: "no such provider", exitCode: 1)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(paths: ["/a.png"], toDir: "/sdcard/Download", serial: "S1")
+        #expect(outcome.ok)
+    }
+
+    @Test func nothingDroppedRunsNoCommands() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(paths: [], toDir: "/sdcard/Download", serial: "S1")
+        #expect(outcome.total == 0)
+        #expect(runner.invocations.isEmpty)
+    }
+
+    @Test func anOldDeviceGetsTheBroadcastScan() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1"], stdout: "")
+        runner.script(argsPrefix: ["-s", "S1", "shell", "getprop", "ro.build.version.sdk"], stdout: "26\n")
+        let service = await makeService(runner)
+        _ = try await service.copyToDevice(paths: ["/a.png"], toDir: "/sdcard/Download", serial: "S1")
+        #expect(args(runner).contains { $0.contains("android.intent.action.MEDIA_SCANNER_SCAN_FILE") })
+    }
+
+    @Test func anUnreadableSdkPropStillCopies() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1"], stdout: "")
+        runner.script(argsPrefix: ["-s", "S1", "shell", "getprop"], stderr: "boom", exitCode: 1)
+        let service = await makeService(runner)
+        let outcome = try await service.copyToDevice(paths: ["/a.png"], toDir: "/sdcard/Download", serial: "S1")
+        #expect(outcome.ok)
+        #expect(args(runner).contains { $0.contains("scan_file") })
+    }
+
+    @Test func remoteSizeIsNilWhenTheFileIsNotThereYet() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "stat"], stderr: "No such file", exitCode: 1)
+        let service = await makeService(runner)
+        #expect(await service.remoteSize(of: "/sdcard/Download/a", serial: "S1") == nil)
+    }
+
+    @Test func remoteSizeIsNilWhenStatAnswersWithSomethingElse() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "stat"], stdout: "stat: unknown option\r\n")
+        let service = await makeService(runner)
+        #expect(await service.remoteSize(of: "/sdcard/Download/a", serial: "S1") == nil)
+    }
+
+    @Test func remoteSizeSurvivesCarriageReturns() async throws {
+        // adb hands back CRLF on some devices, and "40108\r" is not an Int.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "stat"], stdout: "40108\r\n")
+        let service = await makeService(runner)
+        #expect(await service.remoteSize(of: "/sdcard/Download/a", serial: "S1") == 40108)
+    }
+
+    // MARK: - Stages
+
+    @Test func stagesNameEachFileAsItGoes() async throws {
+        let runner = MockProcessRunner()
+        scriptHealthyDevice(runner)
+        let service = await makeService(runner)
+        let box = StageBox()
+        _ = try await service.copyToDevice(
+            paths: ["/a.txt", "/b.txt"], toDir: "/sdcard/Download", serial: "S1",
+            onStage: { box.append($0) })
+        #expect(box.stages == [
+            .preparing,
+            .copying(name: "a.txt", index: 1, total: 2),
+            .copying(name: "b.txt", index: 2, total: 2),
+            .indexing,
+        ])
+    }
+}
+
+/// Collects stage callbacks from the transfer's `@Sendable` closure.
+private final class StageBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [DeviceTransferService.Stage] = []
+
+    var stages: [DeviceTransferService.Stage] {
+        lock.lock(); defer { lock.unlock() }
+        return recorded
+    }
+
+    func append(_ stage: DeviceTransferService.Stage) {
+        lock.lock(); recorded.append(stage); lock.unlock()
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/FileDropRouterTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FileDropRouterTests.swift
@@ -53,9 +53,12 @@ import Testing
         #expect(plan.installs.isEmpty)
     }
 
-    @Test func onlyAPackageDropOffersTheCopyAlternative() {
+    @Test func onlyAnInstallableDropOffersTheCopyAlternative() {
+        // The alternative is a button on the install prompt. A bundle opens
+        // the converter and raises no prompt, so offering it there would
+        // promise a choice nothing goes on to give.
         #expect(FileDropRouter.plan([file("/tmp/app.apk")]).hasAlternative)
-        #expect(FileDropRouter.plan([file("/tmp/app.aab")]).hasAlternative)
+        #expect(!FileDropRouter.plan([file("/tmp/app.aab")]).hasAlternative)
         #expect(!FileDropRouter.plan([file("/tmp/notes.pdf")]).hasAlternative)
     }
 
@@ -157,7 +160,7 @@ import Testing
         let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7")
         #expect(said.verb == "Convert to APK")
         #expect(said.detail == "app.aab")
-        #expect(said.alternative == "…or copy to /sdcard/Download")
+        #expect(said.alternative == nil)
     }
 
     @Test func aBundleBesideAPackageStillNamesTheDevice() {

--- a/ADBKit/Tests/ADBKitTests/FileDropRouterTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FileDropRouterTests.swift
@@ -1,0 +1,204 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct FileDropRouterTests {
+    private func file(_ path: String) -> DroppedPath { DroppedPath(path: path) }
+    private func folder(_ path: String) -> DroppedPath { DroppedPath(path: path, isDirectory: true) }
+
+    // MARK: - Classification
+
+    @Test func everyInstallableFormatIsAPackage() {
+        for format in AppPackageFormat.allCases {
+            #expect(FileDropRouter.kind(of: file("/tmp/app.\(format.rawValue)")) == .appPackage(format))
+        }
+    }
+
+    @Test func extensionMatchIsCaseInsensitive() {
+        #expect(FileDropRouter.kind(of: file("/tmp/APP-RELEASE.APK")) == .appPackage(.apk))
+        #expect(FileDropRouter.kind(of: file("/tmp/CLIP.MP4")) == .video(.mp4))
+    }
+
+    @Test func aabIsABundleNotAPackage() {
+        #expect(FileDropRouter.kind(of: file("/tmp/app.aab")) == .appBundle)
+    }
+
+    @Test func aDirectoryIsAFolderWhateverItsName() {
+        // A folder called "Something.apk" is still a folder — installing it
+        // would fail with a parse error a long way from the drop.
+        #expect(FileDropRouter.kind(of: folder("/tmp/Something.apk")) == .folder)
+    }
+
+    @Test func anythingElseIsJustAFile() {
+        #expect(FileDropRouter.kind(of: file("/tmp/notes.pdf")) == .other)
+        #expect(FileDropRouter.kind(of: file("/tmp/no-extension")) == .other)
+    }
+
+    // MARK: - A drop on a device surface
+
+    @Test func packagesInstallAndEverythingElseCopies() {
+        let plan = FileDropRouter.plan([
+            file("/tmp/app.apk"), file("/tmp/notes.pdf"), file("/tmp/clip.mp4"), folder("/tmp/assets"),
+        ])
+        #expect(plan.installs == ["/tmp/app.apk"])
+        #expect(plan.copies == ["/tmp/notes.pdf", "/tmp/clip.mp4", "/tmp/assets"])
+        #expect(plan.bundles.isEmpty)
+        #expect(plan.destination == "/sdcard/Download")
+    }
+
+    @Test func aVideoOnAMirrorIsAFileNotAnEditorSession() {
+        // The editor is where an *unclaimed* video goes. On a phone screen the
+        // only sensible reading is "put this on the phone".
+        let plan = FileDropRouter.plan([file("/tmp/clip.mkv")])
+        #expect(plan.copies == ["/tmp/clip.mkv"])
+        #expect(plan.installs.isEmpty)
+    }
+
+    @Test func onlyAPackageDropOffersTheCopyAlternative() {
+        #expect(FileDropRouter.plan([file("/tmp/app.apk")]).hasAlternative)
+        #expect(FileDropRouter.plan([file("/tmp/app.aab")]).hasAlternative)
+        #expect(!FileDropRouter.plan([file("/tmp/notes.pdf")]).hasAlternative)
+    }
+
+    @Test func copyingEverythingKeepsTheArrivalOrder() {
+        let plan = FileDropRouter.plan([file("/a.apk"), file("/b.pdf"), file("/c.aab")])
+        #expect(plan.copyingEverything.copies == ["/a.apk", "/c.aab", "/b.pdf"])
+        #expect(plan.copyingEverything.installs.isEmpty)
+        #expect(plan.copyingEverything.hasAlternative == false)
+    }
+
+    @Test func anEmptyDropPlansNothing() {
+        #expect(FileDropRouter.plan([]).isEmpty)
+    }
+
+    // MARK: - A drop on a surface that claims nothing
+
+    @Test func eachKindGoesToTheFeatureThatOwnsIt() {
+        let routes = FileDropRouter.routes(
+            for: [file("/a.apk"), file("/b.aab"), file("/c.mp4"), file("/d.pdf")], hasDevice: true)
+        #expect(routes == [
+            .openPackages(["/a.apk"]),
+            .convertBundles(["/b.aab"]),
+            .openVideos(["/c.mp4"]),
+            .copyToDevice(["/d.pdf"]),
+        ])
+    }
+
+    @Test func groupOrderIsStableForAMixedDrop() {
+        let shuffled = FileDropRouter.routes(
+            for: [file("/d.pdf"), file("/c.mp4"), file("/b.aab"), file("/a.apk")], hasDevice: true)
+        #expect(shuffled.map(routeName) == ["packages", "bundles", "videos", "copy"])
+    }
+
+    @Test func withNoDeviceAPlainFileIsRefusedRatherThanDropped() {
+        let routes = FileDropRouter.routes(for: [file("/d.pdf")], hasDevice: false)
+        #expect(routes == [.unsupported(["/d.pdf"])])
+    }
+
+    @Test func packagesStillRouteWithNoDeviceConnected() {
+        // Opening the package screen doesn't need a device — it is where you
+        // go to pick one.
+        let routes = FileDropRouter.routes(for: [file("/a.apk")], hasDevice: false)
+        #expect(routes == [.openPackages(["/a.apk"])])
+    }
+
+    @Test func nothingDroppedRoutesNowhere() {
+        #expect(FileDropRouter.routes(for: [], hasDevice: true).isEmpty)
+    }
+
+    private func routeName(_ route: DropRoute) -> String {
+        switch route {
+        case .openPackages: "packages"
+        case .convertBundles: "bundles"
+        case .openVideos: "videos"
+        case .copyToDevice: "copy"
+        case .unsupported: "unsupported"
+        }
+    }
+
+    // MARK: - Wording
+
+    @Test func aSinglePackageNamesTheDeviceAndTheFile() {
+        let plan = FileDropRouter.plan([file("/tmp/app-release.apk")])
+        let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7")
+        #expect(said.verb == "Install on Pixel 7")
+        #expect(said.detail == "app-release.apk")
+        #expect(said.alternative == "…or copy to /sdcard/Download")
+        #expect(said.refusal == false)
+    }
+
+    @Test func aFileDropNamesTheDestination() {
+        let plan = FileDropRouter.plan([file("/tmp/notes.pdf")])
+        let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7")
+        #expect(said.verb == "Copy to Pixel 7")
+        #expect(said.detail == "notes.pdf → /sdcard/Download")
+        #expect(said.alternative == nil)
+    }
+
+    @Test func aMixedDropSaysBothHalves() {
+        let plan = FileDropRouter.plan([file("/a.apk"), file("/b.pdf"), file("/c.pdf")])
+        let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7")
+        #expect(said.verb == "Install · Copy 2 files on Pixel 7")
+    }
+
+    @Test func hoveringTheAlternativeCommitsToCopyingEverything() {
+        let plan = FileDropRouter.plan([file("/a.apk")])
+        let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7", copyingInstead: true)
+        #expect(said.verb == "Copy to Pixel 7")
+        #expect(said.detail == "a.apk → /sdcard/Download")
+        // The alternative is where the pointer already is; offering it again
+        // would say the drop has a choice it no longer has.
+        #expect(said.alternative == nil)
+    }
+
+    @Test func aBundleNamesNoDeviceBecauseConvertingHappensOnTheMac() {
+        // Promising "on Pixel 7" would overstate it: the drop opens the
+        // converter with the bundle staged, and the install is a later step.
+        let plan = FileDropRouter.plan([file("/tmp/app.aab")])
+        let said = FileDropRouter.announcement(for: plan, deviceName: "Pixel 7")
+        #expect(said.verb == "Convert to APK")
+        #expect(said.detail == "app.aab")
+        #expect(said.alternative == "…or copy to /sdcard/Download")
+    }
+
+    @Test func aBundleBesideAPackageStillNamesTheDevice() {
+        let plan = FileDropRouter.plan([file("/a.apk"), file("/b.aab")])
+        #expect(FileDropRouter.announcement(for: plan, deviceName: "Pixel 7").verb
+            == "Install · Convert to APK on Pixel 7")
+    }
+
+    @Test func aRoutedDropNamesTheFeatureItIsAboutToOpen() {
+        let routes = FileDropRouter.routes(for: [file("/c.mp4")], hasDevice: false)
+        let said = FileDropRouter.announcement(for: routes)
+        #expect(said?.verb == "Open in Video Editor")
+        #expect(said?.detail == "c.mp4")
+        #expect(said?.refusal == false)
+    }
+
+    @Test func anUnsupportedDropReadsAsARefusalAndSaysWhatWouldHelp() {
+        let routes = FileDropRouter.routes(for: [file("/d.pdf")], hasDevice: false)
+        let said = FileDropRouter.announcement(for: routes)
+        #expect(said?.refusal == true)
+        #expect(said?.verb == "Droidective can't open d.pdf")
+        #expect(said?.detail == "Connect a device to copy files instead.")
+    }
+
+    @Test func nothingDroppedSaysNothing() {
+        #expect(FileDropRouter.announcement(for: []) == nil)
+    }
+
+    @Test func everyPackageFormatAnnouncesAsAnInstall() {
+        // A format added to AppPackageFormat must widen the mirror drop too,
+        // not quietly become a file copy.
+        for format in AppPackageFormat.allCases {
+            let plan = FileDropRouter.plan([file("/tmp/app.\(format.rawValue)")])
+            #expect(plan.installs.count == 1, "\(format.rawValue) should install")
+        }
+    }
+
+    @Test func everyVideoFormatRoutesToTheEditorWhenUnclaimed() {
+        for format in VideoInputFormat.allCases {
+            let routes = FileDropRouter.routes(for: [file("/tmp/clip.\(format.rawValue)")], hasDevice: true)
+            #expect(routes == [.openVideos(["/tmp/clip.\(format.rawValue)"])], "\(format.rawValue)")
+        }
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/InstallPlanTests.swift
+++ b/ADBKit/Tests/ADBKitTests/InstallPlanTests.swift
@@ -131,6 +131,25 @@ import Testing
         #expect(InstallPlan.isResolvedByReplacing("signatures do not match previously installed version"))
     }
 
+    @Test func theFriendlyWordingOfARecoverableCodeIsAlsoRecognised() {
+        // The App layer shows `friendlyReason`'s prose, not adb's code, and a
+        // caller that reads a job's message rather than its raw output would
+        // silently never offer the recovery. That is exactly what happened:
+        // the codes matched, the sentence the user was looking at did not.
+        for code in ["INSTALL_FAILED_UPDATE_INCOMPATIBLE", "INSTALL_FAILED_VERSION_DOWNGRADE"] {
+            let friendly = AppInstallService.friendlyReason(code)
+            #expect(
+                InstallPlan.isResolvedByReplacing(friendly),
+                "friendly wording of \(code) is not recognised: \(friendly)")
+        }
+    }
+
+    @Test func theFriendlyWordingOfAnUnrecoverableCodeStaysUnrecoverable() {
+        for code in ["INSTALL_FAILED_INSUFFICIENT_STORAGE", "INSTALL_FAILED_NO_MATCHING_ABIS"] {
+            #expect(!InstallPlan.isResolvedByReplacing(AppInstallService.friendlyReason(code)))
+        }
+    }
+
     @Test func aFailureAnUninstallCannotFixDoesNotOfferIt() {
         // Wiping the app buys nothing here, and offering it would destroy data
         // for no reason.

--- a/ADBKit/Tests/ADBKitTests/InstallPlanTests.swift
+++ b/ADBKit/Tests/ADBKitTests/InstallPlanTests.swift
@@ -1,0 +1,142 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct InstallPlanTests {
+    private func apk(version: String? = "1.0", code: String?) -> ApkInfo {
+        var info = ApkInfo(fileName: "app.apk", fileSizeBytes: 1024)
+        info.packageName = "com.example.app"
+        info.versionName = version
+        info.versionCode = code
+        return info
+    }
+
+    // MARK: - Version codes
+
+    @Test func theCodeIsTheComparisonNotTheName() {
+        #expect(InstallPlan.compareVersionCodes("30500", "30201") == .orderedDescending)
+        #expect(InstallPlan.compareVersionCodes("30201", "30500") == .orderedAscending)
+        #expect(InstallPlan.compareVersionCodes("30500", "30500") == .orderedSame)
+    }
+
+    @Test func aMissingOrNonNumericCodeIsNotAnOrdering() {
+        #expect(InstallPlan.compareVersionCodes(nil, "1") == nil)
+        #expect(InstallPlan.compareVersionCodes("1", nil) == nil)
+        #expect(InstallPlan.compareVersionCodes("1.0", "2") == nil)
+        #expect(InstallPlan.compareVersionCodes("", "2") == nil)
+        #expect(InstallPlan.compareVersionCodes("  ", "2") == nil)
+        #expect(InstallPlan.compareVersionCodes("12a", "2") == nil)
+    }
+
+    @Test func aCodeTooBigForInt32StillCompares() {
+        // Play allows version codes up to 2_100_000_000, and a wrapping parse
+        // would order two real builds backwards.
+        #expect(InstallPlan.compareVersionCodes("2100000000", "2099999999") == .orderedDescending)
+    }
+
+    @Test func surroundingWhitespaceFromDumpsysIsIgnored() {
+        #expect(InstallPlan.compareVersionCodes(" 30500 ", "30201") == .orderedDescending)
+    }
+
+    // MARK: - Sentinels the device reports for "nothing here"
+
+    @Test func theNotInstalledSentinelsAreNotVersions() {
+        // AppInfo.notInstalled fills its fields with em-dashes; dumpsys can
+        // also say "null". Neither may read as a version, or a first install
+        // would present itself as a reinstall.
+        for sentinel in ["\u{2014}", "-", "null", "", "   "] {
+            let version = InstalledAppVersion(versionName: sentinel, versionCode: sentinel)
+            #expect(version.versionName == nil, "name \(sentinel)")
+            #expect(version.versionCode == nil, "code \(sentinel)")
+        }
+    }
+
+    // MARK: - The decision
+
+    @Test func nothingInstalledIsAPlainInstallWithNoChoiceToMake() {
+        let decision = InstallPlan.decide(local: apk(code: "30500"), installed: nil)
+        #expect(decision.relation == .notInstalled)
+        #expect(decision.primaryTitle == "Install")
+        #expect(decision.offersChoice == false)
+        #expect(decision.canKeepData)
+    }
+
+    @Test func aSentinelOnlyRecordCountsAsNothingInstalled() {
+        let decision = InstallPlan.decide(
+            local: apk(code: "30500"),
+            installed: InstalledAppVersion(versionName: "\u{2014}", versionCode: "\u{2014}"))
+        #expect(decision.relation == .notInstalled)
+    }
+
+    @Test func aNewerPackageIsAnUpdateThatKeepsData() {
+        let decision = InstallPlan.decide(
+            local: apk(code: "30500"), installed: InstalledAppVersion(versionCode: "30201"))
+        #expect(decision.relation == .update)
+        #expect(decision.primaryTitle == "Update")
+        #expect(decision.canKeepData)
+        #expect(decision.replaceByDefault == false)
+        #expect(decision.offersChoice)
+    }
+
+    @Test func theSameVersionIsAReinstall() {
+        let decision = InstallPlan.decide(
+            local: apk(code: "30500"), installed: InstalledAppVersion(versionCode: "30500"))
+        #expect(decision.relation == .reinstall)
+        #expect(decision.primaryTitle == "Reinstall")
+    }
+
+    @Test func aDowngradeCannotKeepDataAndSaysSo() {
+        // Android refuses an in-place downgrade, so the only route wipes the
+        // app. The sheet has to say that before the click, not after adb does.
+        let decision = InstallPlan.decide(
+            local: apk(code: "30201"), installed: InstalledAppVersion(versionCode: "30500"))
+        #expect(decision.relation == .downgrade)
+        #expect(decision.primaryTitle == "Downgrade & Replace")
+        #expect(decision.canKeepData == false)
+        #expect(decision.keepDataNote == "Not possible for a downgrade")
+        #expect(decision.replaceByDefault)
+    }
+
+    @Test func anUnreadableApkStillOffersAnInstallAndExplainsTheGap() {
+        // No aapt2 on the machine: the package has no version code, so the
+        // sheet must degrade rather than disappear.
+        let decision = InstallPlan.decide(
+            local: apk(version: nil, code: nil), installed: InstalledAppVersion(versionCode: "30500"))
+        #expect(decision.relation == .unknown)
+        #expect(decision.primaryTitle == "Install")
+        #expect(decision.canKeepData)
+        #expect(decision.keepDataNote == "Version details need the Android SDK build-tools")
+    }
+
+    @Test func aDeviceThatDidNotReportACodeIsUnknownWithoutBlamingTheToolchain() {
+        let decision = InstallPlan.decide(
+            local: apk(code: "30500"), installed: InstalledAppVersion(versionName: "3.0"))
+        #expect(decision.relation == .unknown)
+        #expect(decision.keepDataNote == nil)
+    }
+
+    // MARK: - Labels
+
+    @Test func theVersionLabelPairsNameAndCodeAndSurvivesEitherMissing() {
+        #expect(InstallPlan.versionLabel(name: "3.0.2", code: "30201") == "3.0.2  (30201)")
+        #expect(InstallPlan.versionLabel(name: "3.0.2", code: nil) == "3.0.2")
+        #expect(InstallPlan.versionLabel(name: nil, code: "30201") == "(30201)")
+        #expect(InstallPlan.versionLabel(name: nil, code: nil) == "Unknown")
+    }
+
+    // MARK: - Recovery
+
+    @Test func onlyFailuresAnUninstallActuallyFixesOfferTheRetry() {
+        #expect(InstallPlan.isResolvedByReplacing("Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE]"))
+        #expect(InstallPlan.isResolvedByReplacing("Failure [INSTALL_FAILED_VERSION_DOWNGRADE]"))
+        #expect(InstallPlan.isResolvedByReplacing("signatures do not match previously installed version"))
+    }
+
+    @Test func aFailureAnUninstallCannotFixDoesNotOfferIt() {
+        // Wiping the app buys nothing here, and offering it would destroy data
+        // for no reason.
+        #expect(!InstallPlan.isResolvedByReplacing("Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"))
+        #expect(!InstallPlan.isResolvedByReplacing("Failure [INSTALL_FAILED_NO_MATCHING_ABIS]"))
+        #expect(!InstallPlan.isResolvedByReplacing("Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]"))
+        #expect(!InstallPlan.isResolvedByReplacing(""))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MediaScanTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MediaScanTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import ADBKit
+
+@Suite struct MediaScanTests {
+    @Test func modernDevicesGetTheProviderCall() {
+        #expect(MediaScan.command(sdk: 34, path: "/sdcard/Download/shot.png") == [
+            "shell", "content", "call",
+            "--uri", "content://media/external/file",
+            "--method", "scan_file",
+            "--arg", "'/sdcard/Download/shot.png'",
+        ])
+    }
+
+    @Test func preAndroid10DevicesGetTheBroadcast() {
+        #expect(MediaScan.command(sdk: 28, path: "/sdcard/Download/shot.png") == [
+            "shell", "am", "broadcast",
+            "-a", "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+            "-d", "'file:///sdcard/Download/shot.png'",
+        ])
+    }
+
+    @Test func android10IsTheFirstProviderCallRelease() {
+        #expect(MediaScan.command(sdk: 29, path: "/x")[1] == "content")
+        #expect(MediaScan.command(sdk: 28, path: "/x")[1] == "am")
+    }
+
+    @Test func anUnknownSdkTakesTheModernRoute() {
+        #expect(MediaScan.command(sdk: nil, path: "/x")[1] == "content")
+    }
+
+    @Test func aHostileFileNameIsQuotedForTheDeviceShell() {
+        // The name came from Finder. Unquoted, the `;` ends the command and
+        // whatever follows runs on the device — this is the shellQuote
+        // boundary, and it has to hold on both routes.
+        let nasty = "/sdcard/Download/x'; touch /sdcard/pwned; echo '.png"
+        let modern = MediaScan.command(sdk: 34, path: nasty)
+        #expect(modern.last == shellQuote(nasty))
+        #expect(modern.last?.hasPrefix("'") == true)
+        #expect(modern.last?.contains("pwned") == true)
+        // The embedded quote is escaped, so the payload never leaves the
+        // single-quoted string.
+        #expect(modern.last?.contains("'\\''") == true)
+        let legacy = MediaScan.command(sdk: 24, path: nasty)
+        #expect(legacy.last == shellQuote("file://" + nasty))
+    }
+}

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -508,6 +508,11 @@ struct ADTApp: App {
                 .keyboardShortcut("f", modifiers: [.command, .shift])
             }
 
+            CommandGroup(after: .windowArrangement) {
+                Divider()
+                MirrorWindowCommands(core: core)
+            }
+
             CommandGroup(after: .toolbar) {
                 Button("Increase Font Size") {
                     appState?.increaseFontSize()

--- a/App/Sources/FeatureDetail/Views/AabConvertView.swift
+++ b/App/Sources/FeatureDetail/Views/AabConvertView.swift
@@ -171,13 +171,14 @@ struct AabConvertView: View {
                 )
                 .padding(20)
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard let aab = urls.first(where: { $0.pathExtension.lowercased() == "aab" }) else { return false }
-            converted = nil
-            convertError = nil
-            aabURL = aab
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(
+            extension: "aab",
+            perform: { aab in
+                converted = nil
+                convertError = nil
+                aabURL = aab
+            },
+            isTargeted: { dropTargeted = $0 })
     }
 
     private var stagedCard: some View {

--- a/App/Sources/FeatureDetail/Views/ApkInspectorView.swift
+++ b/App/Sources/FeatureDetail/Views/ApkInspectorView.swift
@@ -81,11 +81,7 @@ struct ApkInspectorView: View {
                 )
                 .padding(24)
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard let apk = urls.first(where: { $0.pathExtension.lowercased() == "apk" }) else { return false }
-            stage(apk)
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(extension: "apk", perform: { stage($0) }, isTargeted: { dropTargeted = $0 })
     }
 
     // MARK: - Report

--- a/App/Sources/FeatureDetail/Views/ApkOpenView.swift
+++ b/App/Sources/FeatureDetail/Views/ApkOpenView.swift
@@ -135,12 +135,10 @@ struct ApkOpenView: View {
                 )
                 .padding(20)
         }
-        .dropDestination(for: URL.self) { dropped, _ in
-            let packages = InstallablePackage.filter(dropped)
-            guard !packages.isEmpty else { return false }
-            state.apkOpen.urls = packages
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(
+            claims: InstallablePackage.filter,
+            perform: { state.apkOpen.urls = $0 },
+            isTargeted: { dropTargeted = $0 })
     }
 
     // MARK: - Actions

--- a/App/Sources/FeatureDetail/Views/ApkSignView.swift
+++ b/App/Sources/FeatureDetail/Views/ApkSignView.swift
@@ -58,11 +58,7 @@ struct ApkSignView: View {
                 )
                 .padding(24)
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard let apk = urls.first(where: { $0.pathExtension.lowercased() == "apk" }) else { return false }
-            stage(apk)
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(extension: "apk", perform: { stage($0) }, isTargeted: { dropTargeted = $0 })
     }
 
     // MARK: - Form

--- a/App/Sources/FeatureDetail/Views/ApkStudioView.swift
+++ b/App/Sources/FeatureDetail/Views/ApkStudioView.swift
@@ -104,11 +104,7 @@ struct ApkStudioView: View {
                     style: StrokeStyle(lineWidth: dropTargeted ? 2 : 1, dash: [7]))
                 .padding(20)
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard let apk = urls.first(where: { $0.pathExtension.lowercased() == "apk" }) else { return false }
-            open(apk)
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(extension: "apk", perform: { open($0) }, isTargeted: { dropTargeted = $0 })
     }
 
     // MARK: - Actions

--- a/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
+++ b/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
@@ -146,11 +146,7 @@ struct DecompileBrowserView: View {
                     style: StrokeStyle(lineWidth: dropTargeted ? 2 : 1, dash: [7]))
                 .padding(20)
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard let apk = urls.first(where: { $0.pathExtension.lowercased() == "apk" }) else { return false }
-            apkURL = apk
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(extension: "apk", perform: { apkURL = $0 }, isTargeted: { dropTargeted = $0 })
     }
 
     private var modePicker: some View {

--- a/App/Sources/FeatureDetail/Views/Drop/DeviceDropTarget.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/DeviceDropTarget.swift
@@ -1,0 +1,113 @@
+import ADBKit
+import SwiftUI
+
+/// A package drop waiting on the install prompt.
+struct PendingInstallDrop: Identifiable, Equatable {
+    let id = UUID()
+    let paths: [String]
+    let serial: String
+    let deviceName: String
+    let destination: String
+}
+
+/// Makes a device surface — the mirror pane, a Mirror Wall tile, a pop-out
+/// window — accept dropped files.
+///
+/// Two rules this modifier exists to keep:
+///
+/// * **The drop region is a child that only exists while the surface is on
+///   screen.** A hidden keep-alive tab keeps its drop regions registered, and
+///   a region deeper than the window-level router wins over it (CLAUDE.md,
+///   drop routing) — so a merely-open mirror tab would swallow drops meant for
+///   whatever is actually showing. Branching an *overlay* rather than the
+///   modifier chain keeps `MirrorVideoView`'s identity, so the display layer
+///   is never orphaned by the branch.
+/// * **The overlay never takes a click.** It draws and nothing else; the drop
+///   region is a `Color.clear` behind it with no gesture, so mouse-to-touch
+///   still reaches the video's AppKit view.
+struct DeviceDropTarget: ViewModifier {
+    @Environment(AppState.self) private var state
+    /// The device this surface owns. Deliberately not `targetSerials`: a wall
+    /// tile and a pop-out each show a device the bar isn't pointed at, and
+    /// run-on-all must never turn one drop into six.
+    let serial: String?
+    let deviceName: String
+    /// Whether the surface is actually on screen.
+    let isActive: Bool
+    /// Insets the dashed frame — a tile is small enough that the full-bleed
+    /// margin the full pane uses eats the caption.
+    var inset: CGFloat = 14
+
+    @State private var pending: PendingInstallDrop?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if isActive, let serial {
+                    DeviceDropZone(
+                        deviceName: deviceName, inset: inset,
+                        onDrop: { dropped in accept(dropped, serial: serial) })
+                }
+            }
+            .sheet(item: $pending) { request in
+                InstallDropSheet(request: request)
+            }
+    }
+
+    /// Copies start straight away; packages stop at the prompt, which is where
+    /// the version comparison and the override live.
+    private func accept(_ dropped: [DroppedPath], serial: String) {
+        let plan = FileDropRouter.plan(dropped)
+        guard !plan.isEmpty else { return }
+        state.startDroppedCopies(plan, serial: serial)
+        guard !plan.installs.isEmpty else { return }
+        pending = PendingInstallDrop(
+            paths: plan.installs, serial: serial,
+            deviceName: deviceName, destination: plan.destination)
+    }
+}
+
+/// The drop region itself, plus the sentence it shows while a drag is over it.
+private struct DeviceDropZone: View {
+    let deviceName: String
+    let inset: CGFloat
+    let onDrop: ([DroppedPath]) -> Void
+
+    @State private var hovering: [DroppedPath] = []
+
+    var body: some View {
+        Color.clear
+            .dropDestination(for: URL.self) { urls, _ in
+                let dropped = DragPasteboard.paths(from: urls)
+                hovering = []
+                guard !dropped.isEmpty else { return false }
+                onDrop(dropped)
+                return true
+            } isTargeted: { targeted in
+                // `isTargeted` says something is over the view, never what —
+                // the drag pasteboard is where the names come from.
+                hovering = targeted ? DragPasteboard.droppedPaths() : []
+            }
+            .overlay {
+                if !hovering.isEmpty {
+                    DropAnnouncementView(announcement: announcement, inset: inset)
+                }
+            }
+            .animation(.easeOut(duration: 0.12), value: hovering.isEmpty)
+    }
+
+    private var announcement: DropAnnouncement {
+        FileDropRouter.announcement(
+            for: FileDropRouter.plan(hovering), deviceName: deviceName)
+    }
+}
+
+extension View {
+    /// See `DeviceDropTarget`.
+    func deviceDropTarget(
+        serial: String?, deviceName: String, isActive: Bool, inset: CGFloat = 14
+    ) -> some View {
+        modifier(DeviceDropTarget(
+            serial: serial, deviceName: deviceName, isActive: isActive, inset: inset))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Drop/DragPasteboard.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/DragPasteboard.swift
@@ -1,0 +1,29 @@
+import ADBKit
+import AppKit
+
+/// Reads the files on the in-flight drag, so the overlay can name them while
+/// the pointer is still down.
+///
+/// `dropDestination(for:)` hands over its items only once the drop happens —
+/// `isTargeted` says *that* something is over the view, never *what*. The
+/// design turns on the overlay stating the consequence before the button comes
+/// up, so the hover text comes from the drag pasteboard, which AppKit keeps
+/// populated for the life of the session. This is display only: the drop
+/// itself still uses the URLs SwiftUI delivers, so an empty read costs a
+/// specific sentence and nothing else.
+enum DragPasteboard {
+    static func droppedPaths() -> [DroppedPath] {
+        let board = NSPasteboard(name: .drag)
+        let urls = (board.readObjects(forClasses: [NSURL.self]) as? [URL]) ?? []
+        return paths(from: urls)
+    }
+
+    /// The same classification for URLs that actually arrived on a drop.
+    static func paths(from urls: [URL]) -> [DroppedPath] {
+        urls.filter(\.isFileURL).map { url in
+            var isDirectory: ObjCBool = false
+            FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            return DroppedPath(path: url.path, isDirectory: isDirectory.boolValue)
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Drop/DropAnnouncementView.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/DropAnnouncementView.swift
@@ -1,0 +1,46 @@
+import ADBKit
+import SwiftUI
+
+/// What the surface says while a drag is over it: the verb, what it applies
+/// to, and — when the drop also has a second option — the line that names it.
+///
+/// Never interactive. The drop region is the view underneath; this only draws,
+/// so it can't take a click away from a mirror the user is tapping.
+struct DropAnnouncementView: View {
+    let announcement: DropAnnouncement
+    /// Insets the dashed frame. The mirror leaves a margin so the video still
+    /// reads underneath; the window-level fallback fills its area.
+    var inset: CGFloat = 14
+
+    private var tint: Color { announcement.refusal ? .orange : .brandAccent }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.7)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(tint, style: StrokeStyle(lineWidth: 2, dash: [8, 5]))
+                .padding(inset)
+            VStack(spacing: 8) {
+                Image(systemName: announcement.symbol)
+                    .font(.app(size: 34))
+                    .foregroundStyle(tint)
+                Text(announcement.verb)
+                    .font(.app(.title3).weight(.semibold))
+                    .foregroundStyle(.white)
+                Text(announcement.detail)
+                    .font(.app(.caption))
+                    .foregroundStyle(.white.opacity(0.75))
+                if let alternative = announcement.alternative {
+                    Text(alternative)
+                        .font(.app(.caption))
+                        .foregroundStyle(.white.opacity(0.6))
+                        .padding(.top, 6)
+                }
+            }
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 24)
+        }
+        .allowsHitTesting(false)
+        .transition(.opacity)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Drop/FeatureFileDrop.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/FeatureFileDrop.swift
@@ -1,0 +1,92 @@
+import ADBKit
+import SwiftUI
+
+/// A feature's own file drop zone, with everything it can't use handed to the
+/// window's router instead of dropped on the floor.
+///
+/// Why every feature zone needs this rather than just returning `false`: a drop
+/// goes to the *deepest* region under the cursor and never falls through to an
+/// ancestor, and a hidden keep-alive tab keeps its drop regions registered. So
+/// a pane that declines a file doesn't give the window-level router a turn — it
+/// swallows the drop, and it does so whether or not that pane is the one on
+/// screen. Before this, a video dragged onto Reactotron went nowhere because
+/// an APK Studio tab happened to be open behind it.
+///
+/// The hover state follows the same split: a file this feature would take
+/// lights its own drop zone, and anything else gets the router's announcement,
+/// so the pane never glows "drop your APK here" at a `.mp4`.
+struct FeatureFileDrop: ViewModifier {
+    @Environment(AppState.self) private var state
+    /// The subset of a drop this feature wants, in the order it arrived.
+    let claims: ([URL]) -> [URL]
+    /// Take the claimed files.
+    let perform: ([URL]) -> Void
+    /// Drives the feature's own drop-zone highlight.
+    var isTargeted: (Bool) -> Void = { _ in }
+
+    @State private var routing: [DroppedPath] = []
+
+    func body(content: Content) -> some View {
+        content
+            .dropDestination(for: URL.self) { urls, _ in
+                routing = []
+                isTargeted(false)
+                let mine = claims(urls)
+                if !mine.isEmpty {
+                    perform(mine)
+                    return true
+                }
+                let dropped = DragPasteboard.paths(from: urls)
+                guard !dropped.isEmpty else { return false }
+                state.routeDrop(dropped)
+                return true
+            } isTargeted: { targeted in
+                guard targeted else {
+                    routing = []
+                    isTargeted(false)
+                    return
+                }
+                let hovering = DragPasteboard.droppedPaths()
+                let mine = claims(hovering.map { URL(fileURLWithPath: $0.path) })
+                routing = mine.isEmpty ? hovering : []
+                isTargeted(!mine.isEmpty)
+            }
+            .overlay {
+                if let announcement = routedAnnouncement {
+                    DropAnnouncementView(announcement: announcement, inset: 18)
+                }
+            }
+    }
+
+    private var routedAnnouncement: DropAnnouncement? {
+        guard !routing.isEmpty else { return nil }
+        return FileDropRouter.announcement(
+            for: FileDropRouter.routes(
+                for: routing, hasDevice: state.targetSerials.first != nil))
+    }
+}
+
+extension View {
+    /// See `FeatureFileDrop`.
+    func featureFileDrop(
+        claims: @escaping ([URL]) -> [URL],
+        perform: @escaping ([URL]) -> Void,
+        isTargeted: @escaping (Bool) -> Void = { _ in }
+    ) -> some View {
+        modifier(FeatureFileDrop(claims: claims, perform: perform, isTargeted: isTargeted))
+    }
+
+    /// The common case: a feature that takes one file of a given extension.
+    func featureFileDrop(
+        extension ext: String,
+        perform: @escaping (URL) -> Void,
+        isTargeted: @escaping (Bool) -> Void = { _ in }
+    ) -> some View {
+        featureFileDrop(
+            claims: { urls in
+                urls.first { $0.pathExtension.lowercased() == ext }.map { [$0] } ?? []
+            },
+            perform: { urls in urls.first.map(perform) },
+            isTargeted: isTargeted)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Drop/InstallDropSheet.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/InstallDropSheet.swift
@@ -1,0 +1,305 @@
+import ADBKit
+import SwiftUI
+
+/// The prompt a package drop stops at.
+///
+/// Installing replaces an app someone may be mid-way through using, and a
+/// downgrade or a signature change can only be done by wiping its data — so
+/// the drop announces, and then this asks. It reads the APK (aapt2, when the
+/// SDK build-tools are there) and the device (dumpsys) and states the version
+/// it is moving *from* and *to*, because that is the fact the decision turns
+/// on. With no build-tools it still appears, thinner: a prompt that vanishes
+/// on some machines is worse than one that occasionally can't show a version.
+struct InstallDropSheet: View {
+    @Environment(AppState.self) private var state
+    @Environment(\.dismiss) private var dismiss
+    let request: PendingInstallDrop
+
+    @State private var infos: [String: ApkInfo] = [:]
+    @State private var installed: [String: InstalledAppVersion] = [:]
+    @State private var loaded = false
+    @State private var replace = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                if request.paths.count == 1 {
+                    versionRows(for: request.paths[0])
+                } else {
+                    packageRows
+                }
+                if loaded, offersChoice { choice }
+            }
+            .padding(20)
+            Divider()
+            footer
+        }
+        .frame(width: 440)
+        .background(.bgSurface)
+        .task { await load() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "arrow.down.app.fill")
+                .font(.app(size: 30))
+                .foregroundStyle(.brandAccent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.app(.title3).weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(subtitle)
+                    .font(.app(.caption))
+                    .foregroundStyle(.textMuted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var title: String {
+        guard request.paths.count == 1 else { return "\(request.paths.count) app packages" }
+        let info = infos[request.paths[0]]
+        return info?.label ?? URL(fileURLWithPath: request.paths[0]).lastPathComponent
+    }
+
+    private var subtitle: String {
+        var parts: [String] = []
+        if request.paths.count == 1, let info = infos[request.paths[0]] {
+            if let package = info.packageName { parts.append(package) }
+            if info.fileSizeBytes > 0 { parts.append(Self.size(info.fileSizeBytes)) }
+        }
+        parts.append(request.deviceName)
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Versions
+
+    @ViewBuilder private func versionRows(for path: String) -> some View {
+        let local = infos[path]
+        let device = installedVersion(for: path)
+        VStack(spacing: 0) {
+            versionRow(
+                label: "On device",
+                value: device.map { InstallPlan.versionLabel(name: $0.versionName, code: $0.versionCode) }
+                    ?? (loaded ? "Not installed" : "…"),
+                flag: nil)
+            Divider()
+            versionRow(
+                label: "Dropped",
+                value: loaded
+                    ? InstallPlan.versionLabel(name: local?.versionName, code: local?.versionCode)
+                    : "…",
+                flag: relationFlag(decision(for: path)))
+        }
+        .background(.bgRoot, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(.borderSubtle, lineWidth: 1)
+        }
+    }
+
+    private func versionRow(label: String, value: String, flag: String?) -> some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.app(.caption))
+                .foregroundStyle(.textMuted)
+                .frame(width: 74, alignment: .leading)
+            Text(value)
+                .font(.app(.callout).monospacedDigit())
+            Spacer(minLength: 0)
+            if let flag {
+                Text(flag)
+                    .font(.app(.caption))
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 9)
+    }
+
+    private func relationFlag(_ decision: InstallDecision) -> String? {
+        switch decision.relation {
+        case .downgrade: "older"
+        case .reinstall: "same version"
+        case .update, .notInstalled, .unknown: nil
+        }
+    }
+
+    private var packageRows: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(request.paths.enumerated()), id: \.offset) { index, path in
+                if index > 0 { Divider() }
+                HStack(spacing: 10) {
+                    Text(URL(fileURLWithPath: path).lastPathComponent)
+                        .font(.app(.callout))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 8)
+                    if loaded {
+                        Text(relationLabel(decision(for: path)))
+                            .font(.app(.caption))
+                            .foregroundStyle(
+                                decision(for: path).relation == .downgrade ? Color.orange : .textMuted)
+                    }
+                }
+                .padding(.horizontal, 13)
+                .padding(.vertical, 9)
+            }
+        }
+        .background(.bgRoot, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(.borderSubtle, lineWidth: 1)
+        }
+    }
+
+    private func relationLabel(_ decision: InstallDecision) -> String {
+        switch decision.relation {
+        case .notInstalled: "New"
+        case .update: "Update"
+        case .reinstall: "Reinstall"
+        case .downgrade: "Downgrade"
+        case .unknown: "Install"
+        }
+    }
+
+    // MARK: - Keep or replace
+
+    private var choice: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            choiceRow(
+                selected: !replace, enabled: canKeepData,
+                title: "Keep app data",
+                note: keepDataNote ?? "Reinstalls over the installed copy") { replace = false }
+            choiceRow(
+                selected: replace, enabled: true,
+                title: "Replace",
+                note: "Uninstalls first · clears app data") { replace = true }
+        }
+    }
+
+    private func choiceRow(
+        selected: Bool, enabled: Bool, title: String, note: String, select: @escaping () -> Void
+    ) -> some View {
+        Button(action: select) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: selected ? "largecircle.fill.circle" : "circle")
+                    .font(.app(.callout))
+                    .foregroundStyle(selected ? AnyShapeStyle(.brandAccent) : AnyShapeStyle(.textMuted))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title).font(.app(.callout))
+                    Text(note).font(.app(.caption)).foregroundStyle(.textMuted)
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.5)
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            // The alternative the drop overlay promised: a build you want to
+            // hand to someone, not run.
+            Button("Copy to \(request.destination)") { copyInstead() }
+            Spacer(minLength: 0)
+            Button("Cancel", role: .cancel) { dismiss() }
+                .keyboardShortcut(.cancelAction)
+            Button(primaryTitle) { install() }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!loaded)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.bgRoot)
+    }
+
+    // MARK: - Decisions
+
+    private func decision(for path: String) -> InstallDecision {
+        InstallPlan.decide(
+            local: infos[path] ?? ApkInfo(
+                fileName: URL(fileURLWithPath: path).lastPathComponent, fileSizeBytes: 0),
+            installed: installedVersion(for: path))
+    }
+
+    private func installedVersion(for path: String) -> InstalledAppVersion? {
+        guard let package = infos[path]?.packageName else { return nil }
+        return installed[package]
+    }
+
+    private var decisions: [InstallDecision] { request.paths.map(decision(for:)) }
+
+    private var canKeepData: Bool { decisions.allSatisfy(\.canKeepData) }
+
+    private var offersChoice: Bool { decisions.contains { $0.offersChoice } }
+
+    private var keepDataNote: String? {
+        if canKeepData { return decisions.compactMap(\.keepDataNote).first }
+        return request.paths.count == 1
+            ? decisions[0].keepDataNote
+            : "One of these is a downgrade"
+    }
+
+    private var primaryTitle: String {
+        guard loaded else { return "Install" }
+        guard request.paths.count == 1 else { return "Install \(request.paths.count) apps" }
+        return decisions[0].primaryTitle
+    }
+
+    // MARK: - Actions
+
+    private func install() {
+        for path in request.paths {
+            state.installDropped(
+                [path], serial: request.serial,
+                packageID: infos[path]?.packageName,
+                replacingFirst: replace)
+        }
+        dismiss()
+    }
+
+    private func copyInstead() {
+        state.copyToDevice(request.paths, toDir: request.destination, serial: request.serial)
+        dismiss()
+    }
+
+    // MARK: - Loading
+
+    private func load() async {
+        let engine = state.env.engine
+        var readInfos: [String: ApkInfo] = [:]
+        for path in request.paths {
+            readInfos[path] = await engine.appInstall.inspect(apkPath: path)
+        }
+        guard !Task.isCancelled else { return }
+        infos = readInfos
+
+        var readInstalled: [String: InstalledAppVersion] = [:]
+        for package in Set(readInfos.values.compactMap(\.packageName)) {
+            guard let info = try? await engine.inspection.getAppInfo(
+                serial: request.serial, packageId: package), info.installed else { continue }
+            readInstalled[package] = InstalledAppVersion(
+                versionName: info.versionName, versionCode: info.versionCode)
+        }
+        guard !Task.isCancelled else { return }
+        installed = readInstalled
+        loaded = true
+        replace = decisions.contains { $0.replaceByDefault }
+    }
+
+    private static func size(_ bytes: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Drop/TransferChipsView.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/TransferChipsView.swift
@@ -19,8 +19,7 @@ struct TransferChipsView: View {
     var showsHint: Bool = false
     var compact: Bool = false
 
-    @AppStorage(mirrorDropHintSeenKey) private var hintSeen = false
-    @State private var hintVisible = false
+    private var hintVisible: Bool { showsHint && state.mirrorDropHintVisible }
 
     private var transfers: [TransferJob] { state.transferJobs(onSerial: serial) }
     private var installs: [InstallJob] { state.installJobs(onSerial: serial) }
@@ -45,7 +44,9 @@ struct TransferChipsView: View {
         }
         .animation(.easeOut(duration: 0.18), value: transfers.map(\.id))
         .animation(.easeOut(duration: 0.18), value: installs.map(\.id))
-        .task(id: showsHint) { await revealHintOnce() }
+        .onChange(of: showsHint, initial: true) {
+            if showsHint { state.showMirrorDropHintOnce() }
+        }
     }
 
     // MARK: - Chips
@@ -55,7 +56,8 @@ struct TransferChipsView: View {
             symbol: symbol(for: job),
             tint: tint(for: job),
             text: job.stage,
-            fraction: job.fraction
+            fraction: job.fraction,
+            wraps: !job.isRunning && !isSucceeded(job)
         ) {
             if job.isRunning {
                 chipButton("xmark", help: "Stop copying") { state.cancelTransfer(job.id) }
@@ -68,7 +70,8 @@ struct TransferChipsView: View {
             symbol: job.isRunning ? "arrow.down.app" : installSymbol(job),
             tint: installTint(job),
             text: installText(job),
-            fraction: nil
+            fraction: nil,
+            wraps: isFailed(job)
         ) {
             // Only the failures an uninstall actually fixes offer it: wiping
             // an app buys nothing against a full disk or a wrong ABI.
@@ -92,17 +95,22 @@ struct TransferChipsView: View {
 
     private func chip(
         symbol: String, tint: Color, text: String, fraction: Double?,
+        // A failure names the reason, and the reason is the whole point of the
+        // chip — it wraps instead of being middle-truncated into "…smatch)".
+        wraps: Bool = false,
         @ViewBuilder trailing: () -> some View
     ) -> some View {
-        HStack(spacing: 9) {
+        HStack(alignment: wraps ? .top : .center, spacing: 9) {
             Image(systemName: symbol)
                 .font(.app(.caption).weight(.semibold))
                 .foregroundStyle(tint)
+                .padding(.top, wraps ? 1 : 0)
             Text(text)
                 .font(.app(.caption))
                 .foregroundStyle(.white)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                .lineLimit(wraps ? 3 : 1)
+                .truncationMode(wraps ? .tail : .middle)
+                .fixedSize(horizontal: false, vertical: wraps)
             if let fraction {
                 Text(Self.percent(fraction))
                     .font(.app(.caption).monospacedDigit())
@@ -113,8 +121,12 @@ struct TransferChipsView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 7)
-        .background(.black.opacity(0.72), in: Capsule())
-        .overlay(Capsule().strokeBorder(.white.opacity(0.14), lineWidth: 1))
+        .background(
+            .black.opacity(0.72),
+            in: RoundedRectangle(cornerRadius: wraps ? 12 : 999, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: wraps ? 12 : 999, style: .continuous)
+                .strokeBorder(.white.opacity(0.14), lineWidth: 1))
         .frame(maxWidth: compact ? 260 : 380, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
     }
@@ -183,17 +195,18 @@ struct TransferChipsView: View {
         }
     }
 
+    private func isSucceeded(_ job: TransferJob) -> Bool {
+        if case .succeeded = job.status { return true }
+        return false
+    }
+
+    private func isFailed(_ job: InstallJob) -> Bool {
+        if case .failed = job.status { return true }
+        return false
+    }
+
     private static func percent(_ fraction: Double) -> String {
         "\(Int((max(0, min(1, fraction)) * 100).rounded()))%"
     }
 
-    /// Show the hint once, briefly, the first time a mirror actually streams —
-    /// and never again on any device.
-    private func revealHintOnce() async {
-        guard showsHint, !hintSeen else { return }
-        hintSeen = true
-        withAnimation(.easeOut(duration: 0.2)) { hintVisible = true }
-        try? await Task.sleep(for: .seconds(6))
-        withAnimation(.easeIn(duration: 0.3)) { hintVisible = false }
-    }
 }

--- a/App/Sources/FeatureDetail/Views/Drop/TransferChipsView.swift
+++ b/App/Sources/FeatureDetail/Views/Drop/TransferChipsView.swift
@@ -1,0 +1,199 @@
+import ADBKit
+import SwiftUI
+
+/// Whether the mirror has already shown its one-time "you can drop files here"
+/// hint. Nobody guesses a drop target; nobody wants to be told twice.
+let mirrorDropHintSeenKey = "mirrorDropHintSeen"
+
+/// The progress chips a mirror shows for its own device.
+///
+/// Deliberately *inside* the mirror rather than a toast: the pop-out window
+/// has neither a toast overlay nor a progress strip (both live in RootView),
+/// and a Mirror Wall drop is several transfers at once, which one toast can
+/// only ever describe the last of. The toast still fires underneath as the
+/// record — this is the local, per-device feedback.
+struct TransferChipsView: View {
+    @Environment(AppState.self) private var state
+    let serial: String
+    /// Shows the one-time drop hint once the mirror is actually streaming.
+    var showsHint: Bool = false
+    var compact: Bool = false
+
+    @AppStorage(mirrorDropHintSeenKey) private var hintSeen = false
+    @State private var hintVisible = false
+
+    private var transfers: [TransferJob] { state.transferJobs(onSerial: serial) }
+    private var installs: [InstallJob] { state.installJobs(onSerial: serial) }
+
+    private var hasContent: Bool {
+        !transfers.isEmpty || !installs.isEmpty || hintVisible
+    }
+
+    var body: some View {
+        // Nothing to show means nothing in the tree: an empty padded stack
+        // over the video is an invisible region sitting on the device's own
+        // top-left corner, and the mirror is something people tap.
+        Group {
+            if hasContent {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(transfers) { job in transferChip(job) }
+                    ForEach(installs) { job in installChip(job) }
+                    if hintVisible, transfers.isEmpty, installs.isEmpty { hintChip }
+                }
+                .padding(compact ? 8 : 12)
+            }
+        }
+        .animation(.easeOut(duration: 0.18), value: transfers.map(\.id))
+        .animation(.easeOut(duration: 0.18), value: installs.map(\.id))
+        .task(id: showsHint) { await revealHintOnce() }
+    }
+
+    // MARK: - Chips
+
+    private func transferChip(_ job: TransferJob) -> some View {
+        chip(
+            symbol: symbol(for: job),
+            tint: tint(for: job),
+            text: job.stage,
+            fraction: job.fraction
+        ) {
+            if job.isRunning {
+                chipButton("xmark", help: "Stop copying") { state.cancelTransfer(job.id) }
+            }
+        }
+    }
+
+    private func installChip(_ job: InstallJob) -> some View {
+        chip(
+            symbol: job.isRunning ? "arrow.down.app" : installSymbol(job),
+            tint: installTint(job),
+            text: installText(job),
+            fraction: nil
+        ) {
+            // Only the failures an uninstall actually fixes offer it: wiping
+            // an app buys nothing against a full disk or a wrong ABI.
+            if AppState.offersReplaceRecovery(job) {
+                Button("Uninstall & Install") { state.retryInstallByReplacing(job) }
+                    .buttonStyle(.plain)
+                    .font(.app(.caption).weight(.medium))
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 2)
+                    .overlay(Capsule().strokeBorder(.white.opacity(0.35), lineWidth: 1))
+            }
+        }
+    }
+
+    private var hintChip: some View {
+        chip(
+            symbol: "arrow.down.circle", tint: .white.opacity(0.8),
+            text: "Drop files here to install or copy", fraction: nil
+        ) { EmptyView() }
+    }
+
+    private func chip(
+        symbol: String, tint: Color, text: String, fraction: Double?,
+        @ViewBuilder trailing: () -> some View
+    ) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: symbol)
+                .font(.app(.caption).weight(.semibold))
+                .foregroundStyle(tint)
+            Text(text)
+                .font(.app(.caption))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if let fraction {
+                Text(Self.percent(fraction))
+                    .font(.app(.caption).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.7))
+                progressBar(fraction)
+            }
+            trailing()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(.black.opacity(0.72), in: Capsule())
+        .overlay(Capsule().strokeBorder(.white.opacity(0.14), lineWidth: 1))
+        .frame(maxWidth: compact ? 260 : 380, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func progressBar(_ fraction: Double) -> some View {
+        Capsule()
+            .fill(.white.opacity(0.18))
+            .frame(width: 54, height: 3)
+            .overlay(alignment: .leading) {
+                Capsule()
+                    .fill(Color.brandAccent)
+                    .frame(width: 54 * max(0, min(1, fraction)), height: 3)
+            }
+    }
+
+    private func chipButton(_ symbol: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.app(.caption2).weight(.bold))
+                .foregroundStyle(.white.opacity(0.75))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    // MARK: - Appearance per state
+
+    private func symbol(for job: TransferJob) -> String {
+        switch job.status {
+        case .running: "arrow.down.doc"
+        case .succeeded: "checkmark.circle.fill"
+        case .failed: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func tint(for job: TransferJob) -> Color {
+        switch job.status {
+        case .running: .white.opacity(0.85)
+        case .succeeded: .brandAccent
+        case .failed: .orange
+        }
+    }
+
+    private func installSymbol(_ job: InstallJob) -> String {
+        switch job.status {
+        case .running: "arrow.down.app"
+        case .succeeded: "checkmark.circle.fill"
+        case .failed: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func installTint(_ job: InstallJob) -> Color {
+        switch job.status {
+        case .running: .white.opacity(0.85)
+        case .succeeded: .brandAccent
+        case .failed: .orange
+        }
+    }
+
+    private func installText(_ job: InstallJob) -> String {
+        switch job.status {
+        case .running: job.stage ?? "Installing \(job.packageName)…"
+        case .succeeded: "Installed \(job.packageName)"
+        case let .failed(message): message
+        }
+    }
+
+    private static func percent(_ fraction: Double) -> String {
+        "\(Int((max(0, min(1, fraction)) * 100).rounded()))%"
+    }
+
+    /// Show the hint once, briefly, the first time a mirror actually streams —
+    /// and never again on any device.
+    private func revealHintOnce() async {
+        guard showsHint, !hintSeen else { return }
+        hintSeen = true
+        withAnimation(.easeOut(duration: 0.2)) { hintVisible = true }
+        try? await Task.sleep(for: .seconds(6))
+        withAnimation(.easeIn(duration: 0.3)) { hintVisible = false }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/InstallAppView.swift
+++ b/App/Sources/FeatureDetail/Views/InstallAppView.swift
@@ -60,12 +60,10 @@ struct InstallAppView: View {
                     style: StrokeStyle(lineWidth: dropTargeted ? 2 : 1, dash: [7])
                 )
         }
-        .dropDestination(for: URL.self) { urls, _ in
-            let packages = InstallablePackage.filter(urls)
-            guard !packages.isEmpty else { return false }
-            install(packages)
-            return true
-        } isTargeted: { dropTargeted = $0 }
+        .featureFileDrop(
+            claims: InstallablePackage.filter,
+            perform: { install($0) },
+            isTargeted: { dropTargeted = $0 })
     }
 
     @ViewBuilder private var targetSummary: some View {

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorWallTile.swift
@@ -29,6 +29,11 @@ struct MirrorWallTile: View {
     }
 
     @Environment(AppState.self) private var state
+    /// A hidden keep-alive tab keeps its drop regions, and a region deeper
+    /// than the window-level router wins over it — so a wall left open behind
+    /// another tab would swallow every file dropped anywhere in the pane and
+    /// quietly copy it to one of its devices. Verified the hard way.
+    @Environment(\.tabIsActive) private var tabIsActive
     let device: Device
     let wall: MirrorWallModel
     let blocked: Blocked?
@@ -64,6 +69,15 @@ struct MirrorWallTile: View {
                 statusOverlay
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // A tile is a device identity, not just a video: a drop lands on
+            // *this* device even when something else is mirroring it, and six
+            // tiles take six independent drops.
+            .deviceDropTarget(
+                serial: device.serial, deviceName: state.deviceDisplayName(device),
+                isActive: tabIsActive, inset: 8)
+            .overlay(alignment: .topLeading) {
+                TransferChipsView(serial: device.serial, compact: true)
+            }
 
             caption
         }

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -251,13 +251,31 @@ struct MirrorWallView: View {
             onPopOut: { popOut(device.serial) },
             onBringBack: { bringBack(device.serial) },
             onOpenFullMirror: { openFullMirror(device.serial) })
-            .onDrop(of: [.mirrorWallTile], delegate: MirrorWallDrop(
-                target: device.serial,
-                dragging: dragging,
-                isLast: selection.last == device.serial,
-                tileWidth: width,
-                setSlot: { dropSlot = $0 },
-                perform: moveTile))
+            .onDrop(of: [.mirrorWallTile], delegate: tileDrop(device: device, width: width))
+            .overlay {
+                // A drop goes to the deepest region under the cursor and never
+                // falls through, so the tile's own file-drop region (on the
+                // video, inside this view) would swallow a *tile* drag and
+                // silently kill reordering. While a tile drag is live, shield
+                // the tile with a topmost target of the drag's own type — the
+                // same move `EditorPane` makes to keep drop-to-split alive over
+                // a feature's full-pane drop zone.
+                if dragging != nil {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onDrop(of: [.mirrorWallTile], delegate: tileDrop(device: device, width: width))
+                }
+            }
+    }
+
+    private func tileDrop(device: Device, width: Double) -> MirrorWallDrop {
+        MirrorWallDrop(
+            target: device.serial,
+            dragging: dragging,
+            isLast: selection.last == device.serial,
+            tileWidth: width,
+            setSlot: { dropSlot = $0 },
+            perform: moveTile)
     }
 
     /// Take a device back into the wall by closing whatever holds it: its

--- a/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWindowView.swift
@@ -85,3 +85,42 @@ private struct MirrorWindowRegistrar: View {
         }
     }
 }
+
+/// Window ▸ Open Mirror in New Window.
+///
+/// A pop-out mirror had exactly one entry point people could find: the last
+/// button on the mirror's control bar, which folds into the `⋯` overflow in a
+/// narrow pane. A menu item is the surface someone actually goes looking in —
+/// and, unlike a button inside the mirror, NSMenu sees its key equivalent
+/// before the mirror's view swallows the event.
+///
+/// A `View` rather than a plain closure because `openWindow` is an environment
+/// action, which only a view can read.
+struct MirrorWindowCommands: View {
+    let core: AppCore
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        // scrcpy can't mirror an iOS Simulator, so those never appear here.
+        let devices = core.readyDevices.filter { $0.platform == .android }
+        if devices.count > 1 {
+            Menu("Open Mirror in New Window") {
+                ForEach(devices) { device in
+                    Button(core.deviceTitle(device)) { open(device.serial) }
+                }
+            }
+        } else {
+            Button("Open Mirror in New Window") {
+                guard let only = devices.first else { return }
+                open(only.serial)
+            }
+            .keyboardShortcut("m", modifiers: [.command, .control])
+            .disabled(devices.isEmpty)
+        }
+    }
+
+    private func open(_ serial: String) {
+        core.frontmost?.prepareMirrorWindow(serial: serial)
+        openWindow(id: MirrorWindow.windowID, value: serial)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -225,8 +225,7 @@ struct ScreenMirrorView: View {
         guard let serial = targetSerial else { return }
         // The windows read their adb client and toasts from whichever workspace
         // popped one out; the device rides in the window's own presented value.
-        state.core.mirrorWindowOwner = state.id
-        state.core.noteMirrorWindowRequested(serial)
+        state.prepareMirrorWindow(serial: serial)
         openWindow(id: MirrorWindow.windowID, value: serial)
         state.closeTab(tabFeatureID)
     }
@@ -271,6 +270,11 @@ struct ScreenMirrorView: View {
 
 private struct MirrorStage: View {
     @Bindable var model: MirrorViewModel
+    @Environment(AppState.self) private var state
+    /// A hidden keep-alive tab keeps its drop regions, and a region deeper
+    /// than the window-level router wins over it — so the mirror only offers
+    /// one while it is the tab on screen. See `DeviceDropTarget`.
+    @Environment(\.tabIsActive) private var tabIsActive
     @AppStorage(mirrorIncludeAudioKey) private var includeAudio = false
     @AppStorage(mirrorShowTouchesKey) private var showTouches = false
     /// The recording-audio sheet: pick the combination, hear the mic, start.
@@ -306,6 +310,11 @@ private struct MirrorStage: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .deviceDropTarget(
+                serial: model.serial, deviceName: deviceName, isActive: tabIsActive)
+            .overlay(alignment: .topLeading) {
+                TransferChipsView(serial: model.serial, showsHint: model.status == .streaming)
+            }
 
             controlBar
         }
@@ -314,6 +323,13 @@ private struct MirrorStage: View {
                 start: { Task { await model.startRecording() } },
                 blockedReason: recordingBlockedReason)
         }
+    }
+
+    /// The device this stage is streaming, named the way the rest of the app
+    /// names it — the drop overlay says it out loud before anything lands.
+    private var deviceName: String {
+        state.devices.first { $0.serial == model.serial }
+            .map(state.deviceDisplayName) ?? model.serial
     }
 
     /// Controls below the mirror: device nav keys, then screenshot + record.

--- a/App/Sources/FeatureDetail/Views/VideoEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorView.swift
@@ -41,21 +41,13 @@ struct VideoEditorView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(20)
-        .dropDestination(for: URL.self) { urls, _ in
-            // Filtered, where this used to take whatever was dropped and hand
-            // an .apk or a .txt to AVFoundation as if it were a video.
-            guard let url = PlayableVideo.filter(urls).first else {
-                if let rejected = urls.first {
-                    state.showToast(Toast(
-                        message: "Not a video Droidective can open: \(rejected.lastPathComponent)",
-                        ok: false
-                    ))
-                }
-                return false
-            }
-            openedURL = url
-            return true
-        }
+        // Filtered, where this used to take whatever was dropped and hand an
+        // .apk or a .txt to AVFoundation as if it were a video. What isn't a
+        // video now goes to the feature that can use it instead of a toast
+        // saying no.
+        .featureFileDrop(
+            claims: { PlayableVideo.filter($0).first.map { [$0] } ?? [] },
+            perform: { openedURL = $0.first })
     }
 
     private func openFile() {

--- a/App/Sources/Root/DeviceBarView.swift
+++ b/App/Sources/Root/DeviceBarView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// trailing actions. The device and app are shown as prominent pills (status
 /// dot + bold name) so the active target is unmistakable.
 struct DeviceBarView: View {
+    @Environment(\.openWindow) private var openWindow
     @Environment(AppState.self) private var state
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(sidebarAutoHideDefaultsKey) private var sidebarAutoHide = false
@@ -208,6 +209,19 @@ struct DeviceBarView: View {
                         Label(
                             "New Window for \(state.deviceDisplayName(device))",
                             systemImage: "macwindow.on.rectangle")
+                    }
+                }
+                // The pop-out mirror's other entry points are inside the
+                // mirror itself, which is no help to someone who hasn't opened
+                // one — this is where people look for what a device can do.
+                if let device = selectedDevice, device.platform == .android {
+                    Button {
+                        state.prepareMirrorWindow(serial: device.serial)
+                        openWindow(id: MirrorWindow.windowID, value: device.serial)
+                    } label: {
+                        Label(
+                            "Mirror \(state.deviceDisplayName(device)) in a New Window",
+                            systemImage: "display")
                     }
                 }
             }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -237,21 +237,11 @@ struct RootView: View {
         // so the AAB converter works offline with no first-use download.
         Task { await BundledTools.seed(into: state.env.engine.managedTools) }
         InstallInbox.shared.onReceive = { urls in
-            // Finder opens land in whichever window is in front.
+            // Finder opens land in whichever window is in front, and go
+            // through the same `FileDropRouter` table a drag does — one
+            // decision, tested once, instead of two filters that drift.
             guard let target = AppCore.shared.frontmost else { return }
-            let packages = InstallablePackage.filter(urls)
-            let aabs = urls.filter { $0.pathExtension.lowercased() == "aab" }
-            let videos = PlayableVideo.filter(urls)
-            let handled = Set(
-                AppPackageFormat.fileExtensions + ["aab"] + VideoInputFormat.fileExtensions
-            )
-            for other in urls where !handled.contains(other.pathExtension.lowercased()) {
-                target.showToast(Toast(
-                    message: "Droidective can't open \(other.lastPathComponent)", ok: false))
-            }
-            if !packages.isEmpty { target.openPackages(packages) }
-            if !aabs.isEmpty { target.openAABs(aabs) }
-            if !videos.isEmpty { target.openVideos(videos) }
+            target.routeDrop(DragPasteboard.paths(from: urls))
         }
         #if !APPSTORE
         // Update toasts ("available" / "ready — relaunch" / "up to date")
@@ -721,6 +711,18 @@ struct TabHostView: View {
                 FeatureDetailView(featureID: id)
                     .frame(width: pinned?.width, height: pinned?.height)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    // Files this feature didn't claim, routed to one that can
+                    // use them. It rides the *visible* tab rather than the pane
+                    // because a hidden tab keeps its own drop regions (the
+                    // Mirror Wall's tile targets cover a whole pane), and a
+                    // region in a deeper view beats one on an ancestor — so a
+                    // fallback on the pane never gets a turn. Gated on being
+                    // the active tab, or every mounted tab would carry one —
+                    // and gated off during a tab drag, since a region on the
+                    // tab is deeper than the pane's own tab target and would
+                    // otherwise swallow drop-to-split.
+                    .modifier(WindowFileDropModifier(
+                        isActive: id == active && state.draggingTabID == nil))
                     .environment(\.tabFeatureID, id)
                     .environment(\.tabIsActive, id == active)
                     .opacity(id == active ? 1 : 0)

--- a/App/Sources/Root/WindowFileDrop.swift
+++ b/App/Sources/Root/WindowFileDrop.swift
@@ -1,0 +1,63 @@
+import ADBKit
+import SwiftUI
+
+/// The catch-all under every feature: a file dropped on a screen that has
+/// nothing to do with it still lands somewhere useful.
+///
+/// An APK on Reactotron opens the package screen; a video opens the editor;
+/// anything else copies to the selected device. Nothing is silently swallowed,
+/// and the overlay says which of those is about to happen before the button
+/// comes up — a file that teleports the user into another tab with no
+/// explanation is worse than one that does nothing.
+///
+/// **Where this goes matters.** Drop targeting has two different rules and
+/// they were learned separately: a region in a deeper *view* (an overlay, a
+/// feature's own zone, a hidden keep-alive tab's) beats one on an ancestor,
+/// but among modifiers stacked on the *same* view the outermost wins. So this
+/// is applied last on the pane content — after the tab-drag target it must
+/// out-rank — while the tab shield stays an overlay, which is a child and
+/// therefore still beats it whenever a tab drag is in flight.
+struct WindowFileDropModifier: ViewModifier {
+    @Environment(AppState.self) private var state
+    /// Only the tab on screen offers the fallback. A hidden keep-alive tab
+    /// keeps every region it registers, and one more full-pane target per
+    /// mounted tab is exactly how a drop ends up somewhere nobody can see.
+    let isActive: Bool
+    @State private var hovering: [DroppedPath] = []
+
+    func body(content: Content) -> some View {
+        if isActive { dropping(content) } else { content }
+    }
+
+    private func dropping(_ content: Content) -> some View {
+        content
+            .dropDestination(for: URL.self) { urls, _ in
+                let dropped = DragPasteboard.paths(from: urls)
+                hovering = []
+                guard !dropped.isEmpty else { return false }
+                state.routeDrop(dropped)
+                return true
+            } isTargeted: { targeted in
+                // `isTargeted` says something is over the view, never what —
+                // the drag pasteboard is where the names come from.
+                hovering = targeted ? DragPasteboard.droppedPaths() : []
+            }
+            .overlay {
+                if let announcement = RoutedDrop.announcement(
+                    for: hovering, hasDevice: state.targetSerials.first != nil) {
+                    DropAnnouncementView(announcement: announcement, inset: 18)
+                }
+            }
+            .animation(.easeOut(duration: 0.12), value: hovering.isEmpty)
+    }
+}
+
+/// The sentence a routed drop shows while it is still in the air.
+enum RoutedDrop {
+    static func announcement(for dropped: [DroppedPath], hasDevice: Bool) -> DropAnnouncement? {
+        guard !dropped.isEmpty else { return nil }
+        return FileDropRouter.announcement(
+            for: FileDropRouter.routes(for: dropped, hasDevice: hasDevice))
+    }
+}
+

--- a/App/Sources/State/AppState+Drop.swift
+++ b/App/Sources/State/AppState+Drop.swift
@@ -282,9 +282,36 @@ extension AppState {
     }
 
     /// Whether a finished install job should offer that recovery.
+    ///
+    /// Reads adb's own output, not the job's friendly one-liner: the codes are
+    /// what separates a signature clash (an uninstall fixes it) from a full
+    /// disk (it doesn't), and `friendlyReason` has already replaced them by
+    /// the time the message reaches `status`.
     static func offersReplaceRecovery(_ job: InstallJob) -> Bool {
-        guard job.packageID != nil, case let .failed(message) = job.status else { return false }
-        return InstallPlan.isResolvedByReplacing(message)
+        guard job.packageID != nil, case .failed = job.status else { return false }
+        return InstallPlan.isResolvedByReplacing(job.failureOutput ?? "")
+    }
+}
+
+// MARK: - The one-time drop hint
+
+extension AppState {
+    /// A mirror is streaming: show the "drop files here" hint, once ever.
+    ///
+    /// Nobody guesses a drop target, and nobody wants to be told twice — so it
+    /// appears the first time a mirror actually streams on this Mac and never
+    /// again. The `seen` flag is written the moment it is shown, so a quit in
+    /// the middle can't replay it.
+    func showMirrorDropHintOnce() {
+        guard !UserDefaults.standard.bool(forKey: mirrorDropHintSeenKey) else { return }
+        UserDefaults.standard.set(true, forKey: mirrorDropHintSeenKey)
+        mirrorDropHintVisible = true
+        mirrorDropHintTask?.cancel()
+        mirrorDropHintTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(6))
+            guard !Task.isCancelled else { return }
+            self?.mirrorDropHintVisible = false
+        }
     }
 }
 

--- a/App/Sources/State/AppState+Drop.swift
+++ b/App/Sources/State/AppState+Drop.swift
@@ -1,0 +1,305 @@
+import ADBKit
+import AppKit
+import SwiftUI
+
+/// One batch of files being copied onto one device by a drop.
+///
+/// Scoped by serial because a Mirror Wall drop is genuinely several transfers
+/// at once, and a single toast can only describe the last one to finish.
+struct TransferJob: Identifiable, Equatable {
+    enum Status: Equatable {
+        case running
+        case succeeded(String)
+        case failed(String)
+    }
+
+    let id = UUID()
+    let serial: String
+    let paths: [String]
+    let destination: String
+    var status: Status = .running
+    /// What the batch is doing right now, for the chip's line of text.
+    var stage: String = "Preparing…"
+    /// Real progress for the file in flight, when its size is known. Folders
+    /// and a device whose `stat` didn't answer stay indeterminate.
+    var fraction: Double?
+    /// The device path currently being written — what a cancel has to clean up.
+    var currentRemotePath: String?
+    /// The detail behind a failure, for the notifications panel.
+    var detail: String?
+
+    var isRunning: Bool { status == .running }
+}
+
+extension AppState {
+    // MARK: - A drop on a device surface
+
+    /// Carry out a drop onto one device: packages go through the install
+    /// prompt (the caller owns that sheet), bundles go to the converter, and
+    /// everything else starts copying immediately.
+    ///
+    /// The serial is the surface's own, never `targetSerials` — a wall tile
+    /// and a pop-out window each mirror a device the bar isn't pointed at, and
+    /// run-on-all must not turn one drop into six.
+    func startDroppedCopies(_ plan: DeviceDropPlan, serial: String) {
+        if !plan.bundles.isEmpty {
+            openAABs(plan.bundles.map { URL(fileURLWithPath: $0) })
+        }
+        if !plan.copies.isEmpty {
+            copyToDevice(plan.copies, toDir: plan.destination, serial: serial)
+        }
+    }
+
+    /// Copy host files onto a device, tracked by a chip on whatever mirror is
+    /// showing that device.
+    func copyToDevice(_ paths: [String], toDir destination: String, serial: String) {
+        guard !paths.isEmpty else { return }
+        SystemNotifier.requestAuthorizationOnce()
+        let job = TransferJob(serial: serial, paths: paths, destination: destination)
+        transferJobs.append(job)
+        trimTransferHistory()
+        transferTasks[job.id] = Task { await runTransfer(job.id) }
+    }
+
+    /// Stop a copy and clean up the half-written file it leaves behind.
+    ///
+    /// Cancelling the task terminates the `adb push` child (SystemProcessRunner
+    /// wraps its body in a cancellation handler), which leaves a partial file
+    /// on the device — a leftover is tidiness, not correctness, so the removal
+    /// is best effort.
+    func cancelTransfer(_ id: UUID) {
+        transferTasks[id]?.cancel()
+        transferTasks[id] = nil
+        guard let index = transferJobs.firstIndex(where: { $0.id == id }) else { return }
+        let job = transferJobs[index]
+        transferJobs[index].status = .failed("Cancelled")
+        transferJobs[index].fraction = nil
+        transferJobs[index].stage = "Cancelled"
+        if let partial = job.currentRemotePath {
+            let transfer = env.engine.transfer
+            Task { await transfer.removeRemote(path: partial, serial: job.serial) }
+        }
+        dismissTransferLater(id, after: 3)
+    }
+
+    /// The chips a mirror of `serial` should be showing.
+    func transferJobs(onSerial serial: String) -> [TransferJob] {
+        transferJobs.filter { $0.serial == serial }
+    }
+
+    func installJobs(onSerial serial: String) -> [InstallJob] {
+        installJobs.filter { $0.serial == serial }
+    }
+
+    // MARK: - A drop nothing claimed
+
+    /// Send each group of a drop to the feature that owns it. The one entry
+    /// point for a drag that landed on a surface with no meaning for the file
+    /// — and, through `FileDropRouter`, the same table a Finder open uses.
+    func routeDrop(_ dropped: [DroppedPath]) {
+        let serial = targetSerials.first
+        for route in FileDropRouter.routes(for: dropped, hasDevice: serial != nil) {
+            switch route {
+            case let .openPackages(paths):
+                openPackages(paths.map { URL(fileURLWithPath: $0) })
+            case let .convertBundles(paths):
+                openAABs(paths.map { URL(fileURLWithPath: $0) })
+            case let .openVideos(paths):
+                openVideos(paths.map { URL(fileURLWithPath: $0) })
+            case let .copyToDevice(paths):
+                guard let serial else { continue }
+                copyToDevice(paths, toDir: FileDropRouter.defaultDestination, serial: serial)
+            case let .unsupported(paths):
+                for path in paths {
+                    showToast(Toast(
+                        message: "Droidective can't open \(URL(fileURLWithPath: path).lastPathComponent)",
+                        ok: false))
+                }
+            }
+        }
+    }
+
+    // MARK: - Running one transfer
+
+    private func runTransfer(_ id: UUID) async {
+        guard let job = transferJobs.first(where: { $0.id == id }) else { return }
+        let transfer = env.engine.transfer
+        let poll = Task { await pollTransferProgress(id) }
+        defer { poll.cancel() }
+
+        let outcome: TransferOutcome?
+        do {
+            outcome = try await CommandLog.userInitiated {
+                try await transfer.copyToDevice(
+                    paths: job.paths, toDir: job.destination, serial: job.serial,
+                    onStage: { stage in
+                        Task { @MainActor [weak self] in self?.applyStage(stage, to: id) }
+                    })
+            }
+        } catch {
+            outcome = nil
+            finishTransfer(id, message: (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription, ok: false, detail: nil)
+        }
+        guard !Task.isCancelled else { return }
+        guard let outcome else { return }
+        finishTransfer(id, message: outcome.summary, ok: outcome.ok, detail: outcome.detail)
+    }
+
+    private func applyStage(_ stage: DeviceTransferService.Stage, to id: UUID) {
+        guard let index = transferJobs.firstIndex(where: { $0.id == id }),
+              transferJobs[index].isRunning else { return }
+        switch stage {
+        case .preparing:
+            transferJobs[index].stage = "Preparing…"
+        case let .copying(name, position, total):
+            transferJobs[index].stage = total == 1
+                ? name
+                : "\(name) — \(position) of \(total)"
+            transferJobs[index].fraction = nil
+            transferJobs[index].currentRemotePath = DeviceTransferService.remotePath(
+                forLocal: transferJobs[index].paths[position - 1],
+                inDir: transferJobs[index].destination)
+        case .indexing:
+            transferJobs[index].stage = "Adding to the device's library…"
+            transferJobs[index].fraction = nil
+            transferJobs[index].currentRemotePath = nil
+        }
+    }
+
+    /// Real percentage for the file in flight: poll what the device has
+    /// written against the size we already know locally. The mirror of the
+    /// pull-progress trick, pointed the other way.
+    private func pollTransferProgress(_ id: UUID) async {
+        let transfer = env.engine.transfer
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(600))
+            guard !Task.isCancelled,
+                  let job = transferJobs.first(where: { $0.id == id }), job.isRunning,
+                  let remote = job.currentRemotePath,
+                  let expected = Self.localFileSize(remote: remote, in: job.paths), expected > 0
+            else { continue }
+            let written = await transfer.remoteSize(of: remote, serial: job.serial)
+            guard !Task.isCancelled,
+                  let written,
+                  let index = transferJobs.firstIndex(where: { $0.id == id }),
+                  transferJobs[index].isRunning,
+                  transferJobs[index].currentRemotePath == remote
+            else { continue }
+            transferJobs[index].fraction = min(1, Double(written) / Double(expected))
+        }
+    }
+
+    /// The local size of whichever dropped path is landing at `remote`. nil for
+    /// a folder (no single total) or an unreadable file, which keeps the chip
+    /// honestly indeterminate rather than inventing a percentage.
+    private static func localFileSize(remote: String, in paths: [String]) -> Int? {
+        let name = URL(fileURLWithPath: remote).lastPathComponent
+        guard let local = paths.first(where: { URL(fileURLWithPath: $0).lastPathComponent == name })
+        else { return nil }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: local, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              let attributes = try? FileManager.default.attributesOfItem(atPath: local)
+        else { return nil }
+        return attributes[.size] as? Int
+    }
+
+    private func finishTransfer(_ id: UUID, message: String, ok: Bool, detail: String?) {
+        transferTasks[id] = nil
+        guard let index = transferJobs.firstIndex(where: { $0.id == id }) else { return }
+        transferJobs[index].status = ok ? .succeeded(message) : .failed(message)
+        transferJobs[index].stage = message
+        transferJobs[index].fraction = nil
+        transferJobs[index].currentRemotePath = nil
+        transferJobs[index].detail = detail
+        showToast(Toast(message: message, ok: ok, copyText: detail))
+        // A success has said its piece after a few seconds. A failure stays
+        // until the next drop replaces it — the reason is the whole point.
+        if ok { dismissTransferLater(id, after: 5) }
+    }
+
+    private func dismissTransferLater(_ id: UUID, after seconds: Double) {
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(seconds))
+            self?.transferJobs.removeAll { $0.id == id }
+        }
+    }
+
+    /// Bounded history: drop the oldest finished entries, never a live one.
+    private func trimTransferHistory() {
+        while transferJobs.count > 40,
+              let oldest = transferJobs.firstIndex(where: { !$0.isRunning }) {
+            transferJobs.remove(at: oldest)
+        }
+    }
+}
+
+// MARK: - Installing a dropped package
+
+extension AppState {
+    /// Install packages dropped on a device surface.
+    ///
+    /// `replacingFirst` is the override the install prompt offers: Android
+    /// refuses an in-place downgrade and refuses a signature change, so the
+    /// only route in those cases is uninstall-then-install — which is exactly
+    /// why the prompt has to say it clears app data before the click, not
+    /// after adb does.
+    func installDropped(
+        _ paths: [String], serial: String, packageID: String?, replacingFirst: Bool
+    ) {
+        guard !paths.isEmpty else { return }
+        let urls = paths.map { URL(fileURLWithPath: $0) }
+        guard replacingFirst, let packageID else {
+            startInstall(urls, onSerials: [serial], packageID: packageID)
+            return
+        }
+        Task { @MainActor in
+            let result = await CommandLog.userInitiated {
+                (try? await env.engine.appControl.control(
+                    serial: serial, packageId: packageID, action: .uninstall))
+                    ?? FeatureResult(ok: false, message: "adb not found")
+            }
+            // A package that isn't there is not a reason to stop: the install
+            // is the point, and "not installed" is the state Replace wanted.
+            if !result.ok, !result.message.localizedCaseInsensitiveContains("not installed") {
+                showToast(Toast(message: "Couldn't remove the installed copy — \(result.message)", ok: false))
+            }
+            startInstall(urls, onSerials: [serial], packageID: packageID)
+        }
+    }
+
+    /// The recovery a failed install chip offers: take the installed copy off
+    /// the device and install again. Only reachable for the failures an
+    /// uninstall actually fixes (`InstallPlan.isResolvedByReplacing`) — wiping
+    /// an app buys nothing against a full disk or a wrong ABI.
+    func retryInstallByReplacing(_ job: InstallJob) {
+        guard let packageID = job.packageID else { return }
+        installJobs.removeAll { $0.id == job.id }
+        installDropped(
+            [job.packageURL.path], serial: job.serial,
+            packageID: packageID, replacingFirst: true)
+    }
+
+    /// Whether a finished install job should offer that recovery.
+    static func offersReplaceRecovery(_ job: InstallJob) -> Bool {
+        guard job.packageID != nil, case let .failed(message) = job.status else { return false }
+        return InstallPlan.isResolvedByReplacing(message)
+    }
+}
+
+// MARK: - Pop-out mirror windows
+
+extension AppState {
+    /// The registry bookkeeping a pop-out mirror needs before `openWindow`.
+    ///
+    /// A `WindowGroup(for:)` persists its presented value and re-presents it at
+    /// the next launch, so a mirror window has to have been *asked for* in this
+    /// session or it comes up as a phantom (see `MirrorWindowHost`). Every
+    /// opener — the control bar, a wall tile, the Window menu, the device bar —
+    /// records the request through here.
+    func prepareMirrorWindow(serial: String) {
+        core.mirrorWindowOwner = id
+        core.noteMirrorWindowRequested(serial)
+    }
+}

--- a/App/Sources/State/AppState+Install.swift
+++ b/App/Sources/State/AppState+Install.swift
@@ -36,6 +36,10 @@ struct InstallJob: Identifiable, Equatable {
     /// What a split-bundle install is doing right now (unpacking, copying an
     /// expansion file…). Nil for a plain APK, which has only one step.
     var stage: String?
+    /// The package this APK installs, when it was read before the install (the
+    /// drop prompt reads it). It is what an "Uninstall & Install" recovery
+    /// removes, so a failure without it can't offer that button.
+    var packageID: String?
 
     var packageName: String { packageURL.lastPathComponent }
     var isRunning: Bool { status == .running }
@@ -100,8 +104,8 @@ extension AppState {
     /// the panel, or closing the main window never kills an `adb install`
     /// mid-flight. Feedback arrives via `installJobs`, toasts, and a macOS
     /// notification when the batch finishes in the background.
-    func startInstall(_ urls: [URL], onSerials serials: [String]) {
-        Task { await self.installAPKs(urls, onSerials: serials) }
+    func startInstall(_ urls: [URL], onSerials serials: [String], packageID: String? = nil) {
+        Task { await self.installAPKs(urls, onSerials: serials, packageID: packageID) }
     }
 
     /// Install one or more packages on the given device serials, one toast per
@@ -113,7 +117,9 @@ extension AppState {
     /// unpacked and narrowed to this device's splits first — see
     /// `AppBundleInstallService`.
     @discardableResult
-    func installAPKs(_ urls: [URL], onSerials serials: [String]) async -> (report: String, ok: Bool) {
+    func installAPKs(
+        _ urls: [URL], onSerials serials: [String], packageID: String? = nil
+    ) async -> (report: String, ok: Bool) {
         guard !urls.isEmpty, !serials.isEmpty else { return ("", false) }
         SystemNotifier.requestAuthorizationOnce()
         var report: [String] = []
@@ -124,7 +130,7 @@ extension AppState {
                 var ok = 0
                 var failures: [(serial: String, result: FeatureResult)] = []
                 for serial in serials {
-                    let jobID = beginInstallJob(url: url, serial: serial)
+                    let jobID = beginInstallJob(url: url, serial: serial, packageID: packageID)
                     let result = await install(url, on: serial, jobID: jobID)
                     if result.ok { ok += 1 } else { failures.append((serial, result)) }
                     finishInstallJob(jobID, result: result)
@@ -188,10 +194,11 @@ extension AppState {
         return OperationStatus(label: label)
     }
 
-    private func beginInstallJob(url: URL, serial: String) -> UUID {
-        let job = InstallJob(
+    private func beginInstallJob(url: URL, serial: String, packageID: String? = nil) -> UUID {
+        var job = InstallJob(
             packageURL: url, serial: serial,
             deviceLabel: devices.first { $0.serial == serial }?.label ?? serial)
+        job.packageID = packageID
         installJobs.append(job)
         // Bounded history: drop the oldest finished entries, never a live one.
         while installJobs.count > 60, let oldest = installJobs.firstIndex(where: { !$0.isRunning }) {

--- a/App/Sources/State/AppState+Install.swift
+++ b/App/Sources/State/AppState+Install.swift
@@ -40,6 +40,10 @@ struct InstallJob: Identifiable, Equatable {
     /// drop prompt reads it). It is what an "Uninstall & Install" recovery
     /// removes, so a failure without it can't offer that button.
     var packageID: String?
+    /// adb's own output for a failure, kept because `status` carries the
+    /// friendly one-liner and the recovery check needs the `INSTALL_FAILED_*`
+    /// code to tell a signature clash from a full disk.
+    var failureOutput: String?
 
     var packageName: String { packageURL.lastPathComponent }
     var isRunning: Bool { status == .running }
@@ -215,6 +219,7 @@ extension AppState {
     private func finishInstallJob(_ id: UUID, result: FeatureResult) {
         guard let index = installJobs.firstIndex(where: { $0.id == id }) else { return }
         installJobs[index].status = result.ok ? .succeeded : .failed(result.message)
+        installJobs[index].failureOutput = result.ok ? nil : (result.copyText ?? result.message)
         installJobs[index].stage = nil
         // A success row has said its piece after a few seconds — drop it so
         // the install screens don't carry a stale green check forever.

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -397,6 +397,13 @@ final class AppState {
     /// churns on every batch.
     @ObservationIgnored var transferTasks: [UUID: Task<Void, Never>] = [:]
 
+    /// Whether the one-time "drop files here" hint is on screen. Owned by the
+    /// workspace, not the mirror view: that view is rebuilt as its session
+    /// changes, and a hint held in its `@State` flashed for a second and was
+    /// missed rather than lasting its window.
+    var mirrorDropHintVisible = false
+    @ObservationIgnored var mirrorDropHintTask: Task<Void, Never>?
+
     /// Wrap a slow operation so the UI shows what's happening (spinner).
     func withOperation<T: Sendable>(_ label: String, _ work: () async throws -> T) async rethrows -> T {
         // A long task is starting — the in-context moment to ask for

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -387,6 +387,16 @@ final class AppState {
     /// mirrors the running ones via `installOperation` (AppState+Install).
     var installJobs: [InstallJob] = []
 
+    /// Files being copied onto a device by a drop — one entry per batch per
+    /// device, so a Mirror Wall drop shows six independent chips rather than
+    /// one toast that can only describe the last one.
+    var transferJobs: [TransferJob] = []
+
+    /// The task behind each running transfer, so its chip's ✕ can cancel it.
+    /// Ignored by observation: nothing renders a Task, and the dictionary
+    /// churns on every batch.
+    @ObservationIgnored var transferTasks: [UUID: Task<Void, Never>] = [:]
+
     /// Wrap a slow operation so the UI shows what's happening (spinner).
     func withOperation<T: Sendable>(_ label: String, _ work: () async throws -> T) async rethrows -> T {
         // A long task is starting — the in-context moment to ask for

--- a/App/Tests/DragPasteboardTests.swift
+++ b/App/Tests/DragPasteboardTests.swift
@@ -1,0 +1,55 @@
+import ADBKit
+import Foundation
+import Testing
+
+@Suite struct DragPasteboardTests {
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appending(path: "droidective-drop-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func aDirectoryIsReportedAsOneEvenWhenItsNameLooksInstallable() throws {
+        // The router trusts `isDirectory` over the extension, so this is where
+        // the fact has to be right: a folder called "Build.apk" handed to
+        // `adb install` fails with a parse error a long way from the drop.
+        let dir = try makeTempDir()
+        let disguised = dir.appending(path: "Build.apk")
+        try FileManager.default.createDirectory(at: disguised, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let dropped = DragPasteboard.paths(from: [disguised])
+        #expect(dropped.count == 1)
+        #expect(dropped[0].isDirectory)
+        #expect(FileDropRouter.kind(of: dropped[0]) == .folder)
+        #expect(FileDropRouter.plan(dropped).installs.isEmpty)
+    }
+
+    @Test func aRealFileIsNotADirectory() throws {
+        let dir = try makeTempDir()
+        let file = dir.appending(path: "app.apk")
+        try Data("not really an apk".utf8).write(to: file)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let dropped = DragPasteboard.paths(from: [file])
+        #expect(dropped[0].isDirectory == false)
+        #expect(FileDropRouter.plan(dropped).installs == [file.path])
+    }
+
+    @Test func nonFileURLsAreDropped() {
+        // `dropDestination(for: URL.self)` accepts any URL, a dragged web link
+        // included. Pushing one to a device is not a thing.
+        let mixed = [URL(string: "https://example.com/a.apk")!, URL(fileURLWithPath: "/tmp/b.txt")]
+        #expect(DragPasteboard.paths(from: mixed).map(\.path) == ["/tmp/b.txt"])
+    }
+
+    @Test func aPathThatNoLongerExistsIsStillCarriedAsAFile() {
+        // Deleted between the drag starting and the drop: `fileExists` says
+        // no, and the honest answer is "a file", so the copy reports adb's
+        // own error rather than the drop silently doing nothing.
+        let dropped = DragPasteboard.paths(from: [URL(fileURLWithPath: "/tmp/definitely-gone-\(UUID()).txt")])
+        #expect(dropped.count == 1)
+        #expect(dropped[0].isDirectory == false)
+    }
+}

--- a/App/Tests/DropRoutingContractTests.swift
+++ b/App/Tests/DropRoutingContractTests.swift
@@ -1,0 +1,79 @@
+import ADBKit
+import Foundation
+import Testing
+
+/// The drop router and the app's Finder document types have to agree.
+///
+/// A format declared openable from Finder but with no route is a file that
+/// double-clicks into the app and then does nothing — which is the exact
+/// failure this whole feature exists to remove. The two lists live in
+/// different files (`project.yml` and `FileDropRouter`), so a test holds them
+/// together rather than review folklore.
+@Suite struct DropRoutingContractTests {
+    /// The repo root, from this file's own compile-time path.
+    private static var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // App/Tests
+            .deletingLastPathComponent()  // App
+            .deletingLastPathComponent()  // repo
+    }
+
+    /// Every file extension the app tells Launch Services it can be handed.
+    ///
+    /// Two places declare them and both count: `CFBundleTypeExtensions` on a
+    /// document type, and `public.filename-extension` on a declared UTI (which
+    /// is how the Android formats arrive — macOS has no type for any of them).
+    private static func declaredExtensions() throws -> Set<String> {
+        let yaml = try String(contentsOf: repoRoot.appending(path: "project.yml"), encoding: .utf8)
+        var found: Set<String> = []
+        var collecting = false
+        for line in yaml.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("CFBundleTypeExtensions:")
+                || trimmed.hasPrefix("public.filename-extension:") {
+                collecting = true
+                continue
+            }
+            guard collecting else { continue }
+            guard trimmed.hasPrefix("- ") else {
+                if !trimmed.isEmpty, !trimmed.hasPrefix("#") { collecting = false }
+                continue
+            }
+            let item = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+            // The next block opens with `- UTTypeIdentifier: …`, which is also
+            // a `- ` line: a scalar list item never carries a colon.
+            guard !item.contains(":") else { collecting = false; continue }
+            found.insert(item.lowercased())
+        }
+        return found
+    }
+
+    @Test func projectYmlActuallyDeclaresExtensions() throws {
+        // Guards the parser above: a silent empty set would make every other
+        // assertion here vacuously true.
+        #expect(try Self.declaredExtensions().count >= 10)
+    }
+
+    @Test func everyFinderOpenableExtensionHasARoute() throws {
+        for ext in try Self.declaredExtensions() {
+            let dropped = [DroppedPath(path: "/tmp/sample.\(ext)")]
+            let routes = FileDropRouter.routes(for: dropped, hasDevice: false)
+            #expect(routes.count == 1, "\(ext) should resolve to exactly one route")
+            if case .unsupported = routes.first {
+                Issue.record("\(ext) is declared in project.yml but the router can't place it")
+            }
+            if case .copyToDevice = routes.first {
+                Issue.record("\(ext) is Finder-openable but the router only copies it to a device")
+            }
+        }
+    }
+
+    @Test func everyRoutableFormatIsAlsoFinderOpenable() throws {
+        // The other direction: a format the router knows about but Finder
+        // can't hand over is a half-wired format.
+        let declared = try Self.declaredExtensions()
+        for ext in AppPackageFormat.fileExtensions + ["aab"] + VideoInputFormat.fileExtensions {
+            #expect(declared.contains(ext), "\(ext) has a route but no CFBundleTypeExtensions entry")
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,17 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   and `SidebarDrop` draws the insertion guideline between rows for features and
   only at group boundaries for groups. Persisted as
   `LayoutState.sidebarOrder`/`categoryOrder`/`collapsedCategories`.
+- `Drop/` (Services): the drag-and-drop model — `FileDropRouter` (the one table
+  deciding what a dropped file does: packages install, `.aab` converts, videos
+  open in the editor, everything else copies to `/sdcard/Download`, plus the
+  sentence the overlay says before the button comes up), `InstallPlan` (version
+  relation → the primary button's label, and whether "keep app data" is even
+  possible — a downgrade can only be done by uninstalling), `MediaScan` (the
+  SDK-branching command that gets a pushed file into MediaStore, or a dropped
+  screenshot never shows up in the Gallery), and `DeviceTransferService`
+  (`mkdir -p` → push → scan, with `remoteSize` polling behind the progress
+  readout). Finder opens and drags go through the same router, so a
+  double-click and a drag can't drift apart.
 - `Services/`: one per domain — TextInput, AppControl, AppInspection (perms/
   info/meminfo/sandbox), AppsExplorer, FileExplorer, Overrides, ScreenCapture,
   ScreenRecorder (records through a headless `MirrorSession` on the bundled
@@ -543,6 +554,26 @@ table) is in `docs/reactotron-mcp-analysis.md`.
   In-app drags ride private UTIs (`DragTypes.swift`) that must be declared in
   `UTExportedTypeDeclarations` (project.yml) — macOS won't put an undeclared
   UTI on the drag pasteboard, which kills the drag *silently*.
+  - **"Deepest" means the view tree, and a *mounted* tab counts.** A fallback
+    drop region on the pane never gets a turn: the Mirror Wall's per-tile
+    reorder targets cover a whole pane and keep working from a hidden tab, so
+    they eat every file dropped anywhere in it. The file-drop fallback
+    therefore rides the **active tab** (`TabHostView`'s `ForEach`, gated on
+    `id == active`) rather than the pane — and is gated off while
+    `draggingTabID != nil`, because a region on the tab is deeper than the
+    pane's own tab target and would otherwise swallow drop-to-split. Every
+    step of that was found by instrumenting a real drag, not by reading the
+    layering; when a drop "does nothing", log `isTargeted` before theorising.
+  - **A feature that declines a file must route it, not return `false`.**
+    Returning false is a dead drop, and (per the rule above) it is a dead drop
+    even when that feature is not the tab on screen. `featureFileDrop` takes
+    the subset a feature claims and hands the rest to `FileDropRouter`; every
+    full-pane URL zone (APK Studio, Install App, the package screen, AAB, the
+    video editor, inspector, signer, decompiler) goes through it.
+  - **`isTargeted` says *that* something is over the view, never *what*.** The
+    hover announcement reads the in-flight drag pasteboard
+    (`DragPasteboard.droppedPaths()`), which AppKit keeps populated for the
+    life of the session; the drop itself still uses the URLs SwiftUI delivers.
 - **Empty states under a toolbar must `.frame(maxWidth/maxHeight: .infinity)`** —
   otherwise the whole VStack centers and the toolbar floats mid-window.
 - **`scrollPosition(id:)` read-back can't drive a follow/freeze decision under

--- a/project.yml
+++ b/project.yml
@@ -317,6 +317,10 @@ targets:
       # wait runs for up to 20s, so its wording is the whole feedback.
       - App/Sources/FeatureDetail/Views/EmulatorRelaunchPhase.swift
       - App/Sources/FeatureDetail/Views/TourPaging.swift
+      # Classifying what a drag actually carried. A folder named
+      # "Something.apk" is a folder, and installing it would fail a long way
+      # from the drop.
+      - App/Sources/FeatureDetail/Views/Drop/DragPasteboard.swift
       - App/Sources/FeatureDetail/Views/ConsoleLinkSpanMemo.swift
       - App/Sources/FeatureDetail/Views/ConsoleRateBucket.swift
       # Which log row a click's y lands on — the rule behind ⌘-click and

--- a/scripts/emulator-harness.sh
+++ b/scripts/emulator-harness.sh
@@ -142,7 +142,7 @@ if ((${#FILTERS[@]} == 0)); then
   if ((RECORD == 1)); then
     FILTERS=(FixtureRecordingTests)
   else
-    FILTERS=(DeviceLiveTests AppBundleInstallLiveTests)
+    FILTERS=(DeviceLiveTests AppBundleInstallLiveTests DeviceTransferLiveTests)
   fi
 fi
 


### PR DESCRIPTION
Closes #321.

The issue asked for two things. One already shipped, so this is really one feature plus a discoverability fix — and then a third thing the work uncovered.

## Drop files onto a mirror

Dropping an app package on the mirror installs it on that device; anything else copies to `/sdcard/Download` and is handed to MediaStore, so a dropped screenshot actually turns up in the Gallery. Works in the `scrcpy` tab, in a pop-out window, and on each Mirror Wall tile.

The surface owns one device, so a drop targets **the device you dropped on** — never the device bar's run-on-all. Verified on two emulators: a file dropped on the second wall tile landed on that tile's device while the bar was pointed at the other one.

Four moments, each on the surface that can carry it:

| | where | why |
|---|---|---|
| Announce | overlay on the video | says the consequence before the button comes up |
| Decide | install sheet | version comparison + the override |
| Progress | chip inside the mirror | works in a pop-out, and one per tile |
| Record | toast + Notification Center | history and background alert |

The sheet and chip exist because the pop-out mirror has neither a toast overlay nor a progress strip — both live in `RootView` — and a wall drop is several transfers at once, which one toast can only describe the last of.

## The install prompt

Reads the APK (aapt2) and the device (dumpsys) and states the version it is moving from and to. The primary button says what will happen: **Install** / **Update** / **Reinstall** / **Downgrade & Replace**. Comparison is on `versionCode`, not `versionName`. A downgrade reports that keeping app data isn't possible, because Android refuses an in-place downgrade and the only route wipes the app.

With no SDK build-tools the sheet still appears, thinner — a prompt that vanishes on some machines is worse than one that occasionally can't show a version. Signatures aren't pre-checked (apksigner plus a cert pull for a rare case); instead a failure an uninstall actually fixes carries an **Uninstall & Install** button. A full disk or a wrong ABI does not.

## Never a dead drop

Every full-pane drop zone used to return `false` for what it didn't want, and a drop never falls through to an ancestor — so an APK dropped on Reactotron did nothing at all. Each zone now hands what it can't use to `FileDropRouter`, which also replaces the hand-written filter in the Finder-open path, so a double-click and a drag stop being two different decisions.

| Dropped | Mirror · tile · pop-out | File Explorer | Install · Package · Studio · Video · AAB | Everywhere else |
|---|---|---|---|---|
| `.apk` `.apks` `.xapk` `.apkm` | Install | push here | own behaviour | → package screen |
| `.aab` | Convert to APK | push here | own behaviour | → AAB to APK |
| video ×15 | copy to device | push here | own behaviour | → Video Editor |
| any other file | copy to `/sdcard/Download` | push here | → router | copy to device |
| a folder | copy recursively | push recursively | → router | copy to device |

**Behaviour change worth naming:** an unsupported file handed to the app now copies to the selected device instead of raising "Droidective can't open that", and only says that when no device is connected.

## The pop-out mirror was already there

Issue #321's first ask shipped in v2.9.2 and was rebuilt per-serial in v3.9.0. Its only entry point was the last button on the control bar, which folds into the overflow in a narrow pane, and the Window-menu entry went away when the pop-out became a per-serial `WindowGroup`. Added **Window ▸ Open Mirror in New Window** (⌃⌘M) and a row in the device bar's Windows section.

## Three drop-region traps this hit

Recorded in CLAUDE.md, because each cost real time:

- A tile's file region is deeper than the tile's own reorder target and ate every tile drag. Fixed with the shield `EditorPane` already uses; verified by dragging one tile onto another and watching them swap.
- "Deepest" means the view tree, and a **mounted** tab counts. A hidden Mirror Wall's tile targets cover a whole pane and silently absorbed a file meant for Reactotron — copying it to a device nobody was looking at. The fallback therefore rides the *visible* tab, gated off during a tab drag so drop-to-split still works.
- `isTargeted` says *that* something is over the view, never *what*. The hover text reads the in-flight drag pasteboard; the drop uses the URLs SwiftUI delivers.

## Verification

- `make verify` green: **1968** ADBKit (+69), 99 ReactotronMCP, 406 daemon, **118** AppTests (+7). Zero warnings.
- `DeviceTransferLiveTests` against a real emulator: the destination is created, a name full of shell metacharacters lands intact and can be addressed again, `stat -c %s` returns a real size, folders recurse, and the media-scan command for that API level is accepted.
- Driven live with synthetic drags from Finder: the overlay, the copy, the install sheet against a real 216 MB APK (version comparison correct, cancelled without installing), per-tile targeting across two emulators, the progress chip, routing a video from Reactotron into the Video Editor, tile reordering, and drop-to-split — all confirmed. Tapping the mirror still reaches the device with the drop layer mounted.

No new `FeatureDef`, no `implementedIDs` change, no route. `docs/desktop-parity.md` needs a row for the port — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)