### PR TITLE
Keep the pairing code out of the Command Log

### DIFF
--- a/ADBKit/Sources/ADBKit/Exec/AdbClient.swift
+++ b/ADBKit/Sources/ADBKit/Exec/AdbClient.swift
@@ -113,7 +113,7 @@ public struct AdbClient: Sendable {
             maxOutputBytes: maxOutputBytes
         )
         await log.record(
-            command: "adb \(args.joined(separator: " "))",
+            command: Self.loggedCommand(args),
             exitCode: output.exitCode,
             duration: clock.now - started,
             stdout: binary ? "<binary, \(output.stdout.count) bytes>" : output.stdoutText,
@@ -126,6 +126,35 @@ public struct AdbClient: Sendable {
 /// Single-quote a value for the *device-side* shell. `adb shell` joins its
 /// arguments with spaces and runs them through `sh` on the device, so any
 /// user-supplied path/URL must be quoted to survive spaces and metacharacters.
+extension AdbClient {
+    /// How a command reads in the Command Log — with `adb pair`'s code masked.
+    ///
+    /// The pairing code is a bearer credential for adb access to a device, and
+    /// it is the *only* secret this app puts in an argument vector: the signing
+    /// paths deliberately route a keystore password through a 0600 file
+    /// instead. The log keeps 200 entries and Settings ▸ Command Log copies
+    /// them out, which is exactly what gets pasted into a bug report.
+    ///
+    /// Masked rather than dropped: "a pair ran here, against this endpoint" is
+    /// the useful half, and a missing argument would read as a malformed
+    /// command to whoever is debugging one.
+    static func loggedCommand(_ args: [String]) -> String {
+        "adb " + redactCredentials(args).joined(separator: " ")
+    }
+
+    /// Pure so the rule is tested rather than eyeballed.
+    static func redactCredentials(_ args: [String]) -> [String] {
+        var masked = args
+        // `-s <serial>` is the only prefix adb takes before the subcommand.
+        let subcommand = (masked.first == "-s" && masked.count > 1) ? 2 : 0
+        guard subcommand < masked.count, masked[subcommand] == "pair",
+              masked.count > subcommand + 2
+        else { return masked }
+        masked[subcommand + 2] = "<pairing code redacted>"
+        return masked
+    }
+}
+
 public func shellQuote(_ value: String) -> String {
     "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
 }

--- a/ADBKit/Tests/ADBKitTests/CommandLogRedactionTests.swift
+++ b/ADBKit/Tests/ADBKitTests/CommandLogRedactionTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import ADBKit
+
+/// The pairing code is the one credential this app puts in an argument
+/// vector, and the Command Log is copied out of Settings into bug reports.
+@Suite struct CommandLogRedactionTests {
+    @Test func thePairingCodeIsMaskedAndTheEndpointIsKept() {
+        // "a pair ran here, against this endpoint" is the useful half.
+        #expect(AdbClient.loggedCommand(["pair", "192.168.1.42:37123", "aaaabbbbcccc"])
+            == "adb pair 192.168.1.42:37123 <pairing code redacted>")
+    }
+
+    @Test func theCodeNeverSurvivesInAnyForm() {
+        let logged = AdbClient.loggedCommand(["pair", "10.0.0.7:41235", "hunter2hunter2"])
+        #expect(!logged.contains("hunter2hunter2"))
+    }
+
+    @Test func aDeviceScopedPairIsStillMasked() {
+        // `-s <serial>` is the only prefix adb takes before the subcommand;
+        // counting from zero would mask the wrong argument.
+        #expect(AdbClient.loggedCommand(["-s", "R58M4", "pair", "10.0.0.7:41235", "secretcode12"])
+            == "adb -s R58M4 pair 10.0.0.7:41235 <pairing code redacted>")
+    }
+
+    @Test func aPairWithNoCodeIsLeftAlone() {
+        // adb prompts for the code interactively — there is nothing to mask,
+        // and inventing an argument would read as a malformed command.
+        #expect(AdbClient.loggedCommand(["pair", "192.168.1.42:37123"])
+            == "adb pair 192.168.1.42:37123")
+    }
+
+    @Test func everyOtherCommandIsUntouched() {
+        #expect(AdbClient.loggedCommand(["connect", "192.168.1.42:40913"])
+            == "adb connect 192.168.1.42:40913")
+        #expect(AdbClient.loggedCommand(["devices", "-l"]) == "adb devices -l")
+        #expect(AdbClient.loggedCommand(["-s", "R58M4", "shell", "getprop"])
+            == "adb -s R58M4 shell getprop")
+        #expect(AdbClient.loggedCommand([]) == "adb ")
+    }
+
+    @Test func theWordPairAsAnArgumentIsNotASubcommand() {
+        // Only the subcommand slot counts — masking on any occurrence would
+        // redact a real argument someone needs to read.
+        #expect(AdbClient.loggedCommand(["shell", "am", "start", "pair", "a", "b"])
+            == "adb shell am start pair a b")
+    }
+
+    @Test func theRealClientLogsTheMaskedForm() async throws {
+        // End to end: what the log actually holds after a pair, not just what
+        // the pure helper returns.
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["pair"], stdout: "Successfully paired to 192.168.1.42:37123")
+        let log = CommandLog()
+        let locator = ToolLocator(runner: runner, environment: [:])
+        await locator.seed(.adb, path: "/fake/adb")
+        let client = AdbClient(locator: locator, runner: runner, log: log)
+
+        _ = try await CommandLog.userInitiated {
+            try await client.run(["pair", "192.168.1.42:37123", "aaaabbbbcccc"])
+        }
+        let entries = await log.snapshot()
+        #expect(entries.contains { $0.command.contains("<pairing code redacted>") })
+        #expect(!entries.contains { $0.command.contains("aaaabbbbcccc") })
+        // The password still reached adb itself — only the log is masked.
+        #expect(runner.invocations.contains {
+            $0.arguments == ["pair", "192.168.1.42:37123", "aaaabbbbcccc"]
+        })
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/QrPairingTests.swift
+++ b/ADBKit/Tests/ADBKitTests/QrPairingTests.swift
@@ -156,6 +156,24 @@ import Testing
         #expect(!runner.invocations.contains { $0.arguments.first == "pair" })
     }
 
+    @Test func aFailingMdnsQueryKeepsPollingRatherThanEndingTheWait() async {
+        // `adb mdns services` exiting non-zero — an adb server restarting
+        // under a five-minute wait — must not read as "nobody scanned". It
+        // doesn't, because `AdbClient.run` only *throws* for a missing adb and
+        // hands back a failed result for everything else; this pins that,
+        // because the loop's `else { return nil }` reads at a glance like it
+        // aborts on any hiccup and it is a long way from where it would show.
+        let runner = MockProcessRunner()
+        runner.script(
+            argsPrefix: ["mdns"], stderr: "adb: failed to check server version", exitCode: 1)
+        let service = await makeService(runner: runner)
+
+        let found = await service.discoverPairingEndpoint(
+            serviceName: "droidective-aB3xY9zQ1p", attempts: 3, delay: .milliseconds(1))
+        #expect(found == nil)
+        #expect(runner.invocations.filter { $0.arguments == ["mdns", "services"] }.count == 3)
+    }
+
     @Test func surfacesAdbsOwnPairingFailure() async {
         let runner = MockProcessRunner()
         runner.script(argsPrefix: ["mdns"], stdout:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,7 +614,17 @@ table) is in `docs/reactotron-mcp-analysis.md`.
 - **The Command Log records only wrapped calls.** A view-feature that runs adb
   directly (logcat, device-info, file-explorer…) must wrap its user-initiated
   calls in `CommandLog.userInitiated {}` or they never reach the Settings ▸
-  Command Log sheet. Keep background polling OUT (don't wrap it).
+  Command Log sheet. Keep background polling OUT (don't wrap it) — and keep
+  *long* polling out even when the user did start it: the QR pairing scan waits
+  on a human picking up their phone at one poll a second, and left in it evicts
+  all 200 entries.
+  - **A credential must never reach the log.** It holds 200 entries and
+    Settings copies them out, which is what gets pasted into a bug report.
+    `adb pair`'s code is the only secret this app puts in an argument vector —
+    the signing paths route a keystore password through a 0600 file instead —
+    and `AdbClient.loggedCommand` masks it (pure, tested in
+    `CommandLogRedactionTests`). A new command that takes a secret in argv
+    extends `redactCredentials`; one that can take a file instead should.
 - **Window translucency is token-driven — never paint an opaque full-pane
   fill.** Settings ▸ Appearance ▸ Window has Opacity (10–100%) / Blur / Grain
   sliders. `.bgRoot` / `.bgSurface` are *environment-resolving ShapeStyles*


### PR DESCRIPTION
Follow-up to the two nits I raised while reviewing #324. One was real; the other turned out to be my misreading, so it becomes a test instead of a change.

## The real one: a credential in the Command Log

`adb pair <endpoint> <code>` was recorded verbatim. The code is a bearer credential for adb access to a device, the log holds 200 entries, and Settings ▸ Command Log copies them out — which is exactly what gets pasted into a bug report.

Both pairing paths go through the one `client.run(["pair", …])`, so masking it once covers the QR tab (#324) and the typed-code tab together:

```
before  adb pair 192.168.1.10:37123 wA8auVYUHJLk
after   adb pair 192.168.1.10:37123 <pairing code redacted>
```

Masked rather than dropped — "a pair ran here, against this endpoint" is the useful half, and a missing argument reads as a malformed command to whoever is debugging one. `AdbClient.redactCredentials` is pure and tested, and is where the next argv-borne secret goes; CLAUDE.md now says so next to the existing Command Log rule.

This is the only secret the app puts in an argument vector. The signing paths already route a keystore password through a 0600 file instead, which stays the better pattern where a command supports it.

## The one I got wrong

I flagged that `discoverPairingEndpoint`'s `else { return nil }` abandons a five-minute wait on any transient `adb mdns services` failure. It doesn't. `AdbClient.run` throws only for a missing adb (`locator.adbPath()`) and hands back a *failed result* for a non-zero exit or a timeout — so an adb server restarting mid-scan just polls again, and the early return fires only when adb genuinely isn't there, which should end the wait.

No code change. But the guard reads at a glance like it aborts on any hiccup, and the reason it doesn't lives in a different file, so `aFailingMdnsQueryKeepsPollingRatherThanEndingTheWait` now pins it.

## Verified

- `make verify` green: **2014** ADBKit · 99 ReactotronMCP · 406 daemon · 118 AppTests. App target builds warning-free.
- 7 new redaction tests, including one that drives the real `AdbClient` + real `CommandLog` and asserts the raw code is absent from what was stored while still reaching adb itself.
- **In the running app**, not only in tests. I decoded the QR the app rendered (`CIDetector` on a screenshot — which incidentally proves #324's code is genuinely scannable), published a matching `_adb-tls-pairing._tcp` service with `dns-sd`, and let the app discover it and attempt a real pair. It surfaced adb's own `protocol fault` correctly, and the Command Log showed the redacted line with no `mdns services` spam — so #324's polling opt-out holds too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)