### PR TITLE
Rebuild the marketing site for the app it ships today

### DIFF
--- a/site/for-android-developers.html
+++ b/site/for-android-developers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-ios-developers.html
+++ b/site/for-ios-developers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="/for-android-developers.html">For Android developers →</a>
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-qa-and-testers.html
+++ b/site/for-qa-and-testers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-android-developers.html">For Android developers →</a>
         <a href="/for-support-teams.html">For support teams →</a>
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-security-testers.html
+++ b/site/for-security-testers.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-android-developers.html">For Android developers →</a>
         <a href="/react-native-debugger.html">React Native debugger →</a>
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
       </div>
     </div>
   </main>

--- a/site/for-support-teams.html
+++ b/site/for-support-teams.html
@@ -131,7 +131,7 @@
       <div class="related">
         <a href="/for-qa-and-testers.html">For QA &amp; testers →</a>
         <a href="/for-android-developers.html">For Android developers →</a>
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
       </div>
     </div>
   </main>

--- a/site/react-native-debugger.html
+++ b/site/react-native-debugger.html
@@ -127,7 +127,7 @@
       <h2>Debug React Native without the terminal</h2>
       <a class="btn btn-primary" data-dl="rn" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
       <div class="related">
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
         <a href="/scrcpy-gui-mac.html">scrcpy GUI for Mac →</a>
         <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
       </div>

--- a/site/scrcpy-gui-mac.html
+++ b/site/scrcpy-gui-mac.html
@@ -127,7 +127,7 @@
       <h2>Mirror and record Android on your Mac</h2>
       <a class="btn btn-primary" data-dl="scrcpy" href="https://github.com/Droidective/Droidective/releases/latest">Download for macOS</a>
       <div class="related">
-        <a href="/">All 60 tools →</a>
+        <a href="/">All 61 tools →</a>
         <a href="/react-native-debugger.html">React Native debugger →</a>
         <a href="https://github.com/Droidective/Droidective">Star on GitHub →</a>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Droidective — All-in-One Android &amp; React Native Debugging Tool for macOS</title>
-  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 60 tools in all, no terminal required." />
+  <meta name="description" content="Droidective is a free, open-source macOS app: a Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse device files, monitor performance, and debug React Native with built-in Reactotron — 61 tools in all, no terminal required. Windows and Linux builds ship on the beta channel." />
   <meta name="keywords" content="adb tool, android debugging tool, all in one android dev tool, react native debugger, scrcpy gui mac, android developer tool macos, logcat viewer mac, adb gui, mobile dev tool, android emulator manager, react native debugging" />
   <meta name="author" content="Rohindh R" />
   <meta name="robots" content="index, follow" />
@@ -20,19 +20,17 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Droidective" />
   <meta property="og:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance — 60 tools, one keystroke away." />
+  <meta property="og:description" content="A Raycast-style command palette for Android & React Native debugging over adb. Mirror screens, tail logcat, browse files, monitor performance. 61 tools, one keystroke away." />
   <meta property="og:url" content="https://droidective.com/" />
   <meta property="og:image" content="https://droidective.com/assets/screenshot-home.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Droidective — All-in-One Android & React Native Debugging Tool for macOS" />
-  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 60 tools, one keystroke away. Free & open source." />
+  <meta name="twitter:description" content="A Raycast-style command palette for Android & React Native debugging over adb. 61 tools, one keystroke away. Free and open source." />
   <meta name="twitter:image" content="https://droidective.com/assets/screenshot-home.png" />
 
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet" />
+  <!-- Fonts are bundled (see src/index.css); no third-party stylesheet to block render. -->
 
   <script type="application/ld+json">
   {
@@ -40,11 +38,11 @@
     "@type": "SoftwareApplication",
     "name": "Droidective",
     "applicationCategory": "DeveloperApplication",
-    "operatingSystem": "macOS 14.0 or later",
-    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management — 60 tools in all.",
+    "operatingSystem": "macOS 14.0 or later; Windows and Linux in beta",
+    "description": "A free, open-source macOS command palette for Android & React Native debugging over adb: screen mirroring, logcat, file explorer, performance monitoring, app management. 61 tools in all.",
     "url": "https://droidective.com/",
     "downloadUrl": "https://github.com/Droidective/Droidective/releases/latest",
-    "softwareVersion": "3.0.0",
+    "softwareVersion": "3.11.0",
     "screenshot": "https://droidective.com/assets/screenshot-home.png",
     "license": "https://github.com/Droidective/Droidective/blob/main/LICENSE",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,8 @@
       "name": "website",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/geist": "5.3.0",
+        "@fontsource-variable/geist-mono": "5.3.0",
         "@tailwindcss/vite": "^4.3.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -867,6 +869,24 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.3.0.tgz",
+      "integrity": "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.3.0.tgz",
+      "integrity": "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "5.3.0",
+    "@fontsource-variable/geist-mono": "5.3.0",
     "@tailwindcss/vite": "^4.3.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -13,6 +13,7 @@ import { Hero } from "@/components/site/Hero"
 import { HowItWorks } from "@/components/site/HowItWorks"
 import { McpSpotlight } from "@/components/site/McpSpotlight"
 import { Nav } from "@/components/site/Nav"
+import { Platforms } from "@/components/site/Platforms"
 import { TrustStrip } from "@/components/site/TrustStrip"
 import { UseCaseMoments } from "@/components/site/UseCaseMoments"
 import { WorkflowTabs } from "@/components/site/WorkflowTabs"
@@ -36,6 +37,7 @@ export default function App() {
         <Hero />
         <TrustStrip />
         <WorkflowTabs />
+        <Platforms />
         <McpSpotlight />
         <DemoMoment />
         <Comparison />

--- a/website/src/components/FadeContent.tsx
+++ b/website/src/components/FadeContent.tsx
@@ -9,6 +9,8 @@ interface FadeContentProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   container?: Element | string | null;
   blur?: boolean;
+  /** Vertical offset the reveal travels, in px. Composited, unlike `blur`. */
+  y?: number;
   duration?: number;
   ease?: string;
   delay?: number;
@@ -25,6 +27,7 @@ const FadeContent: React.FC<FadeContentProps> = ({
   children,
   container,
   blur = false,
+  y = 0,
   duration = 1000,
   ease = 'power2.out',
   delay = 0,
@@ -53,10 +56,15 @@ const FadeContent: React.FC<FadeContentProps> = ({
     const startPct = (1 - threshold) * 100;
     const getSeconds = (val: number) => (val > 10 ? val / 1000 : val);
 
+    // `filter` is only ever set when a caller actually asks for blur. Listing it
+    // in `will-change` unconditionally promotes a filter layer for every
+    // revealed section, which costs GPU memory for an effect most of them do
+    // not use.
     gsap.set(el, {
       autoAlpha: initialOpacity,
-      filter: blur ? 'blur(10px)' : 'blur(0px)',
-      willChange: 'opacity, filter, transform'
+      y,
+      ...(blur ? { filter: 'blur(10px)' } : {}),
+      willChange: blur ? 'opacity, filter, transform' : 'opacity, transform'
     });
 
     const tl = gsap.timeline({
@@ -67,7 +75,8 @@ const FadeContent: React.FC<FadeContentProps> = ({
         if (disappearAfter > 0) {
           gsap.to(el, {
             autoAlpha: initialOpacity,
-            filter: blur ? 'blur(10px)' : 'blur(0px)',
+            y,
+            ...(blur ? { filter: 'blur(10px)' } : {}),
             delay: getSeconds(disappearAfter),
             duration: getSeconds(disappearDuration),
             ease: disappearEase,
@@ -79,12 +88,13 @@ const FadeContent: React.FC<FadeContentProps> = ({
 
     tl.to(el, {
       autoAlpha: 1,
-      filter: 'blur(0px)',
+      y: 0,
+      ...(blur ? { filter: 'blur(0px)' } : {}),
       duration: getSeconds(duration),
       ease: ease,
       // Release the compositor layer once revealed — a permanent will-change
       // on every section adds up to real GPU memory on mobile.
-      clearProps: disappearAfter > 0 ? '' : 'willChange,filter'
+      clearProps: disappearAfter > 0 ? '' : 'willChange,filter,transform'
     });
 
     const st = ScrollTrigger.create({

--- a/website/src/components/site/About.tsx
+++ b/website/src/components/site/About.tsx
@@ -34,7 +34,7 @@ export function About() {
   const reducedMotion = usePrefersReducedMotion()
 
   return (
-    <section id="about" className="mx-auto max-w-[1120px] px-6 pb-28 max-[620px]:pb-20">
+    <section id="about" className="section-contained mx-auto max-w-[1120px] px-6 pb-28 max-[620px]:pb-20">
       <SectionHead center title="About me." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>

--- a/website/src/components/site/About.tsx
+++ b/website/src/components/site/About.tsx
@@ -35,7 +35,7 @@ export function About() {
 
   return (
     <section id="about" className="mx-auto max-w-[1120px] px-6 pb-28 max-[620px]:pb-20">
-      <SectionHead center eyebrow="whoami" title="About me." />
+      <SectionHead center title="About me." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>
           <MagicCard className="h-full">
@@ -45,12 +45,12 @@ export function About() {
                 mobile engineer · React Native / Android / iOS / Swift
               </p>
               <p className="mb-4 text-[14.5px] leading-relaxed text-muted/90">
-                I build and ship production mobile apps for a living — taking them from first commit through app-store
+                I build and ship production mobile apps for a living, taking them from first commit through app-store
                 review, over-the-air updates, and the crash reports that follow. Along the way I developed a particular
                 interest in mobile security: hardening apps, and understanding how they break.
               </p>
               <p className="mb-4 text-[14.5px] leading-relaxed text-muted/90">
-                Droidective grew out of my own daily debugging loop — the adb incantations, the log tails, the device
+                Droidective grew out of my own daily debugging loop: the adb incantations, the log tails, the device
                 state I kept faking by hand. I wanted all of it one keystroke away, so I built it.
               </p>
               <p className="mb-6 text-[14.5px] leading-relaxed text-muted/90">

--- a/website/src/components/site/Blog.tsx
+++ b/website/src/components/site/Blog.tsx
@@ -8,8 +8,8 @@ export function Blog() {
   const latest = posts.slice(0, 3)
   return (
     <section id="blog" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
-      <SectionHead center eyebrow="blog" title="Guides &amp; deep dives.">
-        Role-by-role workflows for debugging Android &amp; React Native on a Mac — written in-house, no terminal
+      <SectionHead center title="Guides &amp; deep dives.">
+        Role-by-role workflows for debugging Android &amp; React Native on a Mac, written in-house. No terminal
         required.
       </SectionHead>
       <div className="grid grid-cols-3 gap-5 max-[940px]:grid-cols-2 max-[620px]:grid-cols-1">

--- a/website/src/components/site/Blog.tsx
+++ b/website/src/components/site/Blog.tsx
@@ -7,7 +7,7 @@ import { posts } from "@/lib/blogPosts"
 export function Blog() {
   const latest = posts.slice(0, 3)
   return (
-    <section id="blog" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="blog" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center title="Guides &amp; deep dives.">
         Role-by-role workflows for debugging Android &amp; React Native on a Mac, written in-house. No terminal
         required.

--- a/website/src/components/site/BlogArticle.tsx
+++ b/website/src/components/site/BlogArticle.tsx
@@ -11,7 +11,7 @@ export function BlogArticle({ blocks }: { blocks: Block[] }) {
             return (
               <h2
                 key={idx}
-                className="mt-14 mb-4 scroll-mt-24 text-[clamp(22px,3vw,29px)] leading-[1.15] font-extrabold tracking-[-0.025em] text-text first:mt-0"
+                className="display mt-14 mb-4 scroll-mt-24 text-[clamp(22px,3vw,29px)] leading-[1.15]  text-text first:mt-0"
               >
                 <Inline text={block.text} />
               </h2>

--- a/website/src/components/site/BlogIndexPage.tsx
+++ b/website/src/components/site/BlogIndexPage.tsx
@@ -29,11 +29,11 @@ export function BlogIndexPage() {
               <span className="mr-2 text-green-dim">&gt;_</span>
               blog
             </span>
-            <h1 className="mt-3.5 mb-4 text-[clamp(32px,5vw,52px)] leading-[1.03] font-extrabold tracking-[-0.035em]">
+            <h1 className="display mt-3.5 mb-4 text-[clamp(32px,5vw,52px)] leading-[1.03]">
               The Droidective blog
             </h1>
             <p className="text-[clamp(17px,2vw,20px)] text-muted">
-              Guides, deep dives, and role-by-role workflows for debugging Android &amp; React Native on a Mac — no
+              Guides, deep dives, and role-by-role workflows for debugging Android &amp; React Native on a Mac. No
               terminal required.
             </p>
           </Reveal>
@@ -79,7 +79,7 @@ export function BlogIndexPage() {
                       {featured.readMinutes} min read
                     </span>
                   </div>
-                  <h2 className="mb-3 text-[clamp(23px,3vw,32px)] leading-[1.1] font-extrabold tracking-[-0.025em] transition-colors duration-150 group-hover:text-green-bright">
+                  <h2 className="display mb-3 text-[clamp(23px,3vw,32px)] leading-[1.1]  transition-colors duration-150 group-hover:text-green-bright">
                     {featured.title}
                   </h2>
                   <p className="mb-5 text-[16px] leading-[1.6] text-muted">{featured.subtitle}</p>

--- a/website/src/components/site/BlogPostPage.tsx
+++ b/website/src/components/site/BlogPostPage.tsx
@@ -50,7 +50,7 @@ export function BlogPostPage({ slug }: { slug: string }) {
       <>
         <BlogHeader />
         <main className="mx-auto max-w-[720px] px-6 py-32 text-center">
-          <h1 className="mb-4 text-3xl font-extrabold tracking-[-0.02em]">Post not found</h1>
+          <h1 className="display mb-4 text-3xl">Post not found</h1>
           <p className="mb-8 text-muted">That article doesn’t exist (or moved).</p>
           <a href="/blog/" className="font-mono text-sm text-green hover:text-green-bright">
             ← all posts
@@ -86,7 +86,7 @@ export function BlogPostPage({ slug }: { slug: string }) {
                 {post.readMinutes} min read
               </span>
             </div>
-            <h1 className="mb-5 text-[clamp(30px,5vw,46px)] leading-[1.06] font-extrabold tracking-[-0.035em]">
+            <h1 className="display mb-5 text-[clamp(30px,5vw,46px)] leading-[1.06]">
               {post.title}
             </h1>
             <p className="mb-2 text-[clamp(18px,2.2vw,21px)] leading-[1.5] text-muted">{post.subtitle}</p>
@@ -103,7 +103,7 @@ export function BlogPostPage({ slug }: { slug: string }) {
             ref={endRef}
             className="mx-auto max-w-[720px] rounded-2xl border border-border bg-linear-to-b from-green/6 to-white/0 p-8 text-center max-[620px]:p-6"
           >
-            <h2 className="mb-2.5 text-2xl font-extrabold tracking-[-0.02em]">Try Droidective</h2>
+            <h2 className="display mb-2.5 text-2xl">Try Droidective</h2>
             <p className="mx-auto mb-6 max-w-[46ch] text-[15.5px] text-muted">
               Free, open source, and native to macOS. 56 Android &amp; React Native debugging tools, one keystroke
               away.

--- a/website/src/components/site/Changelog.tsx
+++ b/website/src/components/site/Changelog.tsx
@@ -5,7 +5,7 @@ import { releases } from "@/lib/content"
 
 export function Changelog() {
   return (
-    <section id="changelog" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="changelog" className="section-contained-tall mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center title="Shipped, and still moving.">
         The latest releases. Automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.
       </SectionHead>

--- a/website/src/components/site/Changelog.tsx
+++ b/website/src/components/site/Changelog.tsx
@@ -6,8 +6,8 @@ import { releases } from "@/lib/content"
 export function Changelog() {
   return (
     <section id="changelog" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
-      <SectionHead center eyebrow="changelog" title="Shipped, and still moving.">
-        The latest releases — automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.
+      <SectionHead center title="Shipped, and still moving.">
+        The latest releases. Automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.
       </SectionHead>
       <ReleaseTimeline items={releases.slice(0, 3)} />
       <div className="mt-12 text-center">

--- a/website/src/components/site/ChangelogPage.tsx
+++ b/website/src/components/site/ChangelogPage.tsx
@@ -24,8 +24,8 @@ export function ChangelogPage() {
         </div>
       </header>
       <main className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-12">
-        <SectionHead center eyebrow="changelog" title="Every release.">
-          {releases.length} releases since the first public build — automatic in-app updates since v2.1.0, and
+        <SectionHead center title="Every release.">
+          {releases.length} releases since the first public build. Automatic in-app updates since v2.1.0, and
           Apple-notarized builds since v2.4.0.
         </SectionHead>
         <ReleaseTimeline items={releases} />

--- a/website/src/components/site/Comparison.tsx
+++ b/website/src/components/site/Comparison.tsx
@@ -15,11 +15,11 @@ export function Comparison() {
           <span className="mr-2 text-green-dim/60">&gt;_</span>
           why droidective
         </span>
-        <h2 className="mt-4 mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04] font-extrabold tracking-[-0.035em]">
+        <h2 className="display mt-4 mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04]">
           The better alternative to tool-hopping.
         </h2>
         <p className="text-lg leading-relaxed text-muted">
-          Every one of these tools is good at its job. The cost isn't any single one — it's the seven
+          Every one of these tools is good at its job. The cost isn't any single one. It's the seven
           windows, the lost context, and the command you look up for the hundredth time.
         </p>
       </Reveal>
@@ -27,7 +27,7 @@ export function Comparison() {
       {/* The two stacks, side by side */}
       <Reveal className="mb-6">
         <div className="grid grid-cols-[1fr_auto_1fr] items-stretch gap-5 max-[940px]:grid-cols-1">
-          <div className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-6">
+          <div className="shell h-full"><div className="core h-full p-6">
             <p className="mb-4 font-mono text-[11px] tracking-[0.08em] text-faint/70 uppercase">the old workflow</p>
             <div className="mb-5 flex flex-wrap gap-2">
               {oldStack.map((t) => (
@@ -40,7 +40,7 @@ export function Comparison() {
               ))}
             </div>
             <p className="font-mono text-[13px] text-muted/50">7 windows open.</p>
-          </div>
+          </div></div>
 
           <div aria-hidden className="grid place-items-center max-[940px]:py-1">
             <span className="grid size-9 place-items-center rounded-full border border-green/20 bg-green/[0.07] text-green max-[940px]:rotate-90">
@@ -48,21 +48,21 @@ export function Comparison() {
             </span>
           </div>
 
-          <div className="rounded-2xl border border-green/15 bg-green/[0.03] p-6">
+          <div className="shell h-full" style={{ borderColor: "rgba(105,161,6,0.16)" }}><div className="core h-full bg-green/[0.04] p-6">
             <p className="mb-4 font-mono text-[11px] tracking-[0.08em] text-green/70 uppercase">droidective</p>
             <div className="mb-5 flex flex-wrap gap-2">
               <span className="rounded-lg border border-green/20 bg-green/[0.08] px-2.5 py-1 font-mono text-[11.5px] text-green/90">
-                One native macOS workspace
+                One native workspace
               </span>
             </div>
             <p className="font-mono text-[13px] text-green/60">1 app open.</p>
-          </div>
+          </div></div>
         </div>
       </Reveal>
 
       {/* Row-by-row breakdown */}
       <Reveal>
-        <div className="overflow-hidden rounded-2xl border border-white/[0.06]">
+        <div className="shell"><div className="core overflow-hidden">
           <div className="grid grid-cols-[1fr_1.2fr_1.2fr] border-b border-white/[0.06] bg-white/[0.02] max-[620px]:hidden">
             {["Workflow", "Traditional setup", "Droidective"].map((h, i) => (
               <div
@@ -93,7 +93,7 @@ export function Comparison() {
               </div>
             </div>
           ))}
-        </div>
+        </div></div>
       </Reveal>
     </section>
   )

--- a/website/src/components/site/Contribute.tsx
+++ b/website/src/components/site/Contribute.tsx
@@ -14,7 +14,7 @@ function GithubMark() {
 
 export function Contribute() {
   return (
-    <section id="contribute" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="contribute" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center title="Built in the open. Yours to shape." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>

--- a/website/src/components/site/Contribute.tsx
+++ b/website/src/components/site/Contribute.tsx
@@ -15,7 +15,7 @@ function GithubMark() {
 export function Contribute() {
   return (
     <section id="contribute" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
-      <SectionHead center eyebrow="open source" title="Built in the open. Yours to shape." />
+      <SectionHead center title="Built in the open. Yours to shape." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>
           <MagicCard className="h-full">
@@ -28,7 +28,7 @@ export function Contribute() {
               </p>
               <pre className="m-0 max-w-full rounded-[10px] border border-white/[0.06] bg-ink-900/60 px-3.5 py-3 font-mono text-[12px] break-words whitespace-pre-wrap text-[#cdd5cb]">
                 <span className="text-green">$</span> brew install xcodegen{"\n"}
-                <span className="text-green">$</span> make test    <span className="text-faint/60"># ADBKit unit tests — no device needed</span>
+                <span className="text-green">$</span> make test    <span className="text-faint/60"># ADBKit unit tests, no device needed</span>
                 {"\n"}
                 <span className="text-green">$</span> make run     <span className="text-faint/60"># build &amp; launch</span>
               </pre>
@@ -59,14 +59,14 @@ export function Contribute() {
                 <li className="flex items-start gap-3 py-3 text-[14px] text-muted/90">
                   <span className="mt-0.5 size-4 shrink-0 rounded-[5px] border border-white/[0.08]" />
                   <span>
-                    <b className="font-semibold text-text">Resizable Apps divider</b> — drag the list / detail split in
+                    <b className="font-semibold text-text">Resizable Apps divider</b>: drag the list / detail split in
                     the Apps explorer.
                   </span>
                 </li>
                 <li className="flex items-start gap-3 border-t border-white/[0.04] py-3 text-[14px] text-muted/90">
                   <span className="mt-0.5 size-4 shrink-0 rounded-[5px] border border-white/[0.08]" />
                   <span>
-                    <b className="font-semibold text-text">Your idea here</b> — open an issue and let's talk.
+                    <b className="font-semibold text-text">Your idea here</b>: open an issue and let's talk.
                   </span>
                 </li>
               </ul>

--- a/website/src/components/site/DemoMoment.tsx
+++ b/website/src/components/site/DemoMoment.tsx
@@ -13,15 +13,11 @@ export function DemoMoment() {
 
       <div className="relative mx-auto max-w-[1120px] px-6">
         <Reveal className="mx-auto mb-12 max-w-[54ch] text-center">
-          <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-            <span className="mr-2 text-green-dim/60">&gt;_</span>
-            in action
-          </span>
-          <h2 className="mt-4 mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04] font-extrabold tracking-[-0.035em]">
+          <h2 className="display mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04]">
             Watch it work.
           </h2>
           <p className="text-lg leading-relaxed text-muted">
-            The real app on a live Android device — logcat, device info, files, and the React Native hub,
+            The real app on a live Android device: logcat, device info, files, and the React Native hub,
             all without leaving the window.
           </p>
         </Reveal>
@@ -33,7 +29,7 @@ export function DemoMoment() {
               poster="/assets/demo-poster.webp"
               width={1280}
               height={810}
-              label="Droidective in action — pressing ⌘T to jump between live Logcat, Device Info, the File Explorer, and the React Native hub on a connected Android emulator"
+              label="Droidective in action: pressing ⌘T to jump between live Logcat, Device Info, the File Explorer, and the React Native hub on a connected Android emulator"
             />
           </div>
         </Reveal>

--- a/website/src/components/site/Faq.tsx
+++ b/website/src/components/site/Faq.tsx
@@ -5,7 +5,7 @@ import { faqs } from "@/lib/content"
 
 export function Faq() {
   return (
-    <section id="faq" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="faq" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center title="Questions, answered." />
       <Reveal className="mx-auto max-w-200">
         <Accordion type="single" collapsible>

--- a/website/src/components/site/Faq.tsx
+++ b/website/src/components/site/Faq.tsx
@@ -6,7 +6,7 @@ import { faqs } from "@/lib/content"
 export function Faq() {
   return (
     <section id="faq" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
-      <SectionHead center eyebrow="faq" title="Questions, answered." />
+      <SectionHead center title="Questions, answered." />
       <Reveal className="mx-auto max-w-200">
         <Accordion type="single" collapsible>
           {faqs.map((faq) => (

--- a/website/src/components/site/FeatureExplorer.tsx
+++ b/website/src/components/site/FeatureExplorer.tsx
@@ -15,11 +15,11 @@ export function FeatureExplorer() {
   return (
     <section id="features" className="mx-auto max-w-[1120px] px-6 py-32 max-[620px]:py-20">
       <SectionHead center eyebrow="every tool" title="Everything you need to debug faster.">
-        All 59 tools, grouped by what they're for. Open a group to see what's inside.
+        All 61 tools, grouped by what they're for. Open a group to see what's inside.
       </SectionHead>
 
       <Reveal className="mx-auto max-w-[840px]">
-        <div className="overflow-hidden rounded-2xl border border-white/[0.06]">
+        <div className="shell"><div className="core overflow-hidden">
           {featureGroups.map((group) => {
             const isOpen = open === group.name
             return (
@@ -67,7 +67,7 @@ export function FeatureExplorer() {
               </div>
             )
           })}
-        </div>
+        </div></div>
       </Reveal>
     </section>
   )

--- a/website/src/components/site/FinalCta.tsx
+++ b/website/src/components/site/FinalCta.tsx
@@ -24,11 +24,7 @@ export function FinalCta() {
             className="pointer-events-none absolute -top-20 left-1/2 h-40 w-[70%] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,rgba(105,161,6,0.1),transparent_70%)] blur-2xl"
           />
 
-          <p className="mb-5 font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-            <span className="mr-2 text-green-dim/60">&gt;_</span>
-            ready to ship faster?
-          </p>
-          <h2 ref={headingRef} className="mb-4 text-[clamp(28px,4vw,44px)] font-extrabold tracking-[-0.035em]">
+          <h2 ref={headingRef} className="display mb-4 text-[clamp(28px,4vw,44px)]">
             {reducedMotion || !inView ? (
               "Debug Android without the terminal."
             ) : (

--- a/website/src/components/site/FreeValue.tsx
+++ b/website/src/components/site/FreeValue.tsx
@@ -1,11 +1,11 @@
 import { Reveal } from "@/components/site/Reveal"
 import { GITHUB_URL } from "@/lib/content"
 
-/** Every figure here is checked against the repo: MIT LICENSE, 59 FeatureDefs
+/** Every figure here is checked against the repo: MIT LICENSE, 61 FeatureDefs
  *  in FeatureRegistry, and no paid tier or paywalled path anywhere in the app.
  *  No download CTA on purpose — the nav, hero, and closing CTA already carry it. */
 const lineItems = [
-  ["59 developer tools", "0.00"],
+  ["61 developer tools", "0.00"],
   ["Screen mirroring & recording", "0.00"],
   ["Reactotron + MCP server", "0.00"],
   ["APK Studio & Frida setup", "0.00"],
@@ -24,12 +24,8 @@ export function FreeValue() {
 
           <div className="relative grid grid-cols-[1fr_auto] items-center gap-14 max-[940px]:grid-cols-1 max-[940px]:gap-10">
             <div className="min-w-0">
-              <p className="mb-5 font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-                <span className="mr-2 text-green-dim/60">&gt;_</span>
-                the pricing page
-              </p>
-              <h2 className="mb-6 text-[clamp(34px,5vw,56px)] leading-[0.98] font-extrabold tracking-[-0.04em]">
-                59 tools.
+              <h2 className="display mb-6 text-[clamp(34px,5vw,56px)] leading-[0.98]">
+                61 tools.
                 <br />
                 <span className="text-green">$0.</span>
               </h2>

--- a/website/src/components/site/Hero.tsx
+++ b/website/src/components/site/Hero.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Download, Star } from "lucide-react"
+import { ArrowRight, Download } from "lucide-react"
 
 import BlurText from "@/components/BlurText"
 import DotGrid from "@/components/DotGrid"
@@ -7,7 +7,7 @@ import { Reveal } from "@/components/site/Reveal"
 import { Button } from "@/components/ui/button"
 import { useFinePointer } from "@/hooks/useFinePointer"
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
-import { APP_VERSION, DOWNLOAD_URL, GITHUB_URL } from "@/lib/content"
+import { DOWNLOAD_URL } from "@/lib/content"
 
 export function Hero() {
   const reducedMotion = usePrefersReducedMotion()
@@ -55,12 +55,12 @@ export function Hero() {
         {/* Eyebrow */}
         <Reveal>
           <p className="mb-7 font-mono text-[11.5px] font-medium tracking-[0.14em] text-green/70 uppercase max-[620px]:tracking-[0.1em]">
-            The macOS toolkit for Android &amp; React Native
+            Android &amp; React Native, without the terminal
           </p>
         </Reveal>
 
         {/* Headline */}
-        <h1 className="mb-7 max-w-[19ch] text-[clamp(38px,6vw,74px)] leading-[0.99] font-extrabold tracking-[-0.042em]">
+        <h1 className="display mb-7 max-w-[19ch] text-[clamp(38px,6vw,74px)] leading-[0.99] font-semibold tracking-[-0.045em]">
           {staticHeading ? (
             <>
               Everything between your code and your{" "}
@@ -83,31 +83,36 @@ export function Hero() {
 
         {/* Subheading */}
         <Reveal>
-          <p className="mb-9 max-w-[58ch] text-[clamp(15.5px,1.6vw,18.5px)] leading-[1.7] text-muted">
-            Device control, logs, React Native tooling, performance charts, APK workflows, and an MCP server
-            your AI can read — <strong className="font-semibold text-text">59 tools</strong> in one native
-            macOS workspace. No terminal required.
+          <p className="prose-balance mb-9 max-w-[54ch] text-[clamp(15.5px,1.6vw,18.5px)] leading-[1.7] text-muted">
+            Mirroring, logs, React Native tooling, performance and APK workflows.{" "}
+            <strong className="font-semibold text-text tnum">61 tools</strong> in one native
+            workspace, no terminal required.
           </p>
         </Reveal>
 
         {/* CTAs */}
         <Reveal>
-          <div className="mb-5 flex flex-wrap items-center justify-center gap-3.5">
+          <div className="mb-16 flex flex-wrap items-center justify-center gap-3.5">
             <Button
               asChild
               size="lg"
-              className="group/dl h-auto rounded-xl px-7 py-3.5 text-[15.5px] font-bold shadow-glow transition-all duration-200 hover:-translate-y-px hover:bg-green-bright hover:shadow-[0_0_0_1px_rgba(105,161,6,0.5),0_14px_40px_-8px_rgba(105,161,6,0.3)]"
+              className="group/dl h-auto rounded-full py-2.5 pr-2.5 pl-7 text-[15.5px] font-semibold shadow-glow transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] hover:-translate-y-0.5 hover:bg-green-bright hover:shadow-[0_0_0_1px_rgba(105,161,6,0.5),0_14px_40px_-8px_rgba(105,161,6,0.3)] active:scale-[0.98]"
             >
               <a href={DOWNLOAD_URL} data-dl="hero">
-                <Download className="transition-transform duration-200 group-hover/dl:-translate-y-px" aria-hidden />
                 Download for macOS
+                <span
+                  aria-hidden
+                  className="ml-1 flex size-7 items-center justify-center rounded-full bg-ink-900/20 transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover/dl:scale-105 group-hover/dl:bg-ink-900/30"
+                >
+                  <Download className="size-3.5 transition-transform duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover/dl:translate-y-px" />
+                </span>
               </a>
             </Button>
             <Button
               asChild
               variant="outline"
               size="lg"
-              className="group/ex h-auto rounded-xl border-white/[0.08] bg-white/[0.03] px-7 py-3.5 text-[15.5px] font-semibold transition-all duration-200 hover:-translate-y-px hover:border-white/[0.14] hover:bg-white/[0.06]"
+              className="group/ex h-auto rounded-full border-white/[0.08] bg-white/[0.03] px-7 py-3.5 text-[15.5px] font-medium transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] hover:-translate-y-0.5 hover:border-white/[0.14] hover:bg-white/[0.06] active:scale-[0.98]"
             >
               <a href="#workflows">
                 Explore features
@@ -119,28 +124,6 @@ export function Hero() {
             </Button>
           </div>
 
-          {/* Confidence line — version, license, requirements in one row */}
-          <div className="mb-16 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 font-mono text-[11.5px] text-faint/75">
-            <a
-              href={`${GITHUB_URL}/releases/tag/${APP_VERSION}`}
-              className="inline-flex items-center gap-1.5 transition-colors duration-150 hover:text-green"
-            >
-              <span className="relative flex size-1.5">
-                <span className="cta-breathe absolute inline-flex size-full rounded-full bg-green" />
-                <span className="relative inline-flex size-1.5 rounded-full bg-green" />
-              </span>
-              {APP_VERSION}
-            </a>
-            <span className="text-white/10">·</span>
-            <span className="inline-flex items-center gap-1.5">
-              <Star className="size-3" aria-hidden />
-              Free &amp; Open Source
-            </span>
-            <span className="text-white/10">·</span>
-            <span>macOS 14+</span>
-            <span className="text-white/10">·</span>
-            <span>Signed &amp; notarized</span>
-          </div>
         </Reveal>
 
         {/* The one hero product visual */}

--- a/website/src/components/site/HowItWorks.tsx
+++ b/website/src/components/site/HowItWorks.tsx
@@ -40,7 +40,7 @@ const steps = [
 
 export function HowItWorks() {
   return (
-    <section id="how" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="how" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center eyebrow="how it works" title="Connected in under a minute.">
         Three steps. The app handles the rest, and it even finds adb for you and offers a one-click install if it's
         missing.

--- a/website/src/components/site/HowItWorks.tsx
+++ b/website/src/components/site/HowItWorks.tsx
@@ -29,7 +29,7 @@ const steps = [
     n: "03",
     label: "go",
     title: "Press ⌘T and run",
-    body: "Search any of the 59 tools and run it. The Setup Doctor confirms your toolchain on first launch.",
+    body: "Search any of the 61 tools and run it. The Setup Doctor confirms your toolchain on first launch.",
     code: (
       <>
         <span className="text-green">⌘T</span> mirror screen   ↩
@@ -42,7 +42,7 @@ export function HowItWorks() {
   return (
     <section id="how" className="mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
       <SectionHead center eyebrow="how it works" title="Connected in under a minute.">
-        Three steps. The app handles the rest — it even finds adb for you and offers a one-click install if it's
+        Three steps. The app handles the rest, and it even finds adb for you and offers a one-click install if it's
         missing.
       </SectionHead>
       <div className="grid grid-cols-3 gap-4 max-[620px]:grid-cols-1">

--- a/website/src/components/site/McpSpotlight.tsx
+++ b/website/src/components/site/McpSpotlight.tsx
@@ -4,15 +4,15 @@ import { Reveal } from "@/components/site/Reveal"
 const points = [
   {
     lead: "10 tools, 8 resources",
-    rest: " — the same contract as Reactotron's own MCP server, so any client that speaks it already works.",
+    rest: ", the same contract as Reactotron's own MCP server, so any client that speaks it already works.",
   },
   {
     lead: "Redacted by default",
-    rest: " — the MCP boundary strips sensitive values before your agent ever sees them. The in-app timeline is never touched.",
+    rest: ". The MCP boundary strips sensitive values before your agent ever sees them. The in-app timeline is never touched.",
   },
   {
     lead: "Loopback only",
-    rest: " — bound to 127.0.0.1 with Origin validation and an optional bearer token. Off until you turn it on.",
+    rest: ", bound to 127.0.0.1 with Origin validation and an optional bearer token. Off until you turn it on.",
   },
 ]
 
@@ -30,17 +30,13 @@ export function McpSpotlight() {
 
       <div className="relative mx-auto grid max-w-[1120px] grid-cols-2 items-center gap-14 px-6 max-[940px]:grid-cols-1 max-[940px]:gap-10">
         <div className="min-w-0">
-          <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-            <span className="mr-2 text-green-dim/60">&gt;_</span>
-            ai · mcp
-          </span>
-          <h2 className="mt-4 mb-5 text-[clamp(28px,4vw,42px)] leading-[1.06] font-extrabold tracking-[-0.035em]">
+          <h2 className="display mb-5 text-[clamp(28px,4vw,42px)] leading-[1.06]">
             Your AI can finally{" "}
             <span className="text-green">see your app.</span>
           </h2>
           <p className="mb-7 text-[16.5px] leading-relaxed text-muted">
             Stop pasting logs into a chat window. Droidective runs an opt-in MCP server that hands your
-            agent the live runtime — the Reactotron timeline, store state, and every network request from
+            agent the live runtime: the Reactotron timeline, store state, and every network request from
             the app that's running right now.
           </p>
 

--- a/website/src/components/site/Nav.tsx
+++ b/website/src/components/site/Nav.tsx
@@ -28,11 +28,31 @@ export function Nav() {
   const [menuOpen, setMenuOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
 
+  /* A scroll listener fires on every frame and re-renders this tree each time.
+     One IntersectionObserver on a sentinel at the top of the page reports the
+     same boolean, and only when it actually changes. */
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 24)
-    onScroll()
-    window.addEventListener("scroll", onScroll, { passive: true })
-    return () => window.removeEventListener("scroll", onScroll)
+    const sentinel = document.createElement("div")
+    sentinel.setAttribute("aria-hidden", "true")
+    Object.assign(sentinel.style, {
+      position: "absolute",
+      top: "0",
+      left: "0",
+      height: "24px",
+      width: "1px",
+      pointerEvents: "none",
+    })
+    document.body.prepend(sentinel)
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setScrolled(!entry.isIntersecting),
+      { threshold: 0 },
+    )
+    observer.observe(sentinel)
+    return () => {
+      observer.disconnect()
+      sentinel.remove()
+    }
   }, [])
 
   useEffect(() => {

--- a/website/src/components/site/PaletteDemo.tsx
+++ b/website/src/components/site/PaletteDemo.tsx
@@ -140,7 +140,7 @@ export function PaletteDemo() {
           <b className="font-medium text-muted/70">esc</b> close
         </span>
         <span className="ml-auto">
-          <b className="font-medium text-muted/70">59</b> tools
+          <b className="font-medium text-muted/70 tnum">61</b> tools
         </span>
       </div>
     </div>

--- a/website/src/components/site/Platforms.tsx
+++ b/website/src/components/site/Platforms.tsx
@@ -1,0 +1,125 @@
+import { Apple, ArrowUpRight, Monitor } from "lucide-react"
+
+import { Reveal } from "@/components/site/Reveal"
+import { platforms } from "@/lib/content"
+import { cn } from "@/lib/utils"
+
+const marks = { macos: Apple, "windows-linux": Monitor } as const
+
+/** Where the app runs.
+ *
+ *  Deliberately two unequal panels rather than two matching cards: macOS is the
+ *  product and the ports are a beta, and a 50/50 grid would claim they are the
+ *  same offer. The larger panel carries the download; the smaller one is honest
+ *  about what is missing, because someone who installs a beta expecting the Mac
+ *  app files a bug that is really a copy problem. */
+export function Platforms() {
+  return (
+    <section id="platforms" className="relative px-6 py-24">
+      <div className="mx-auto max-w-[1140px]">
+        <Reveal className="mb-12 max-w-[62ch]">
+          <h2 className="display text-[clamp(28px,4.2vw,46px)] leading-[1.04]">
+            Built for the Mac. Now running on Windows and Linux.
+          </h2>
+          <p className="prose-balance mt-4 text-lg leading-relaxed text-muted">
+            Every tool is one Swift package with no interface in it, which is what let the
+            engine move to two more platforms without being rewritten.
+          </p>
+        </Reveal>
+
+        <div className="grid grid-cols-12 gap-5 max-[900px]:grid-cols-1">
+          {platforms.map((platform, index) => {
+            const Mark = marks[platform.id as keyof typeof marks]
+            const primary = platform.status === "stable"
+            return (
+              <Reveal
+                key={platform.id}
+                delay={index * 90}
+                className={cn(primary ? "col-span-7" : "col-span-5", "max-[900px]:col-span-1")}
+              >
+                <div className="shell shell-hover h-full">
+                  <div
+                    className={cn(
+                      "core flex h-full flex-col p-8 max-[620px]:p-6",
+                      primary &&
+                        "bg-[radial-gradient(120%_100%_at_0%_0%,rgba(105,161,6,0.09),transparent_58%)]",
+                    )}
+                  >
+                    <div className="mb-7 flex items-center gap-3">
+                      <span className="flex size-9 items-center justify-center rounded-lg border border-white/[0.07] bg-white/[0.03]">
+                        <Mark className="size-4 text-muted" strokeWidth={1.5} aria-hidden />
+                      </span>
+                      <h3 className="text-[17px] font-medium text-text">{platform.name}</h3>
+                      <span
+                        className={cn(
+                          "rounded-md px-2 py-0.5 font-mono text-[10.5px] tracking-wide",
+                          primary
+                            ? "bg-green/12 text-green"
+                            : "bg-amber/12 text-amber",
+                        )}
+                      >
+                        {platform.channel}
+                      </span>
+                    </div>
+
+                    <p
+                      className={cn(
+                        "display mb-3 leading-[1.15]",
+                        primary ? "text-[30px] max-[620px]:text-[25px]" : "text-[25px] max-[620px]:text-[22px]",
+                      )}
+                    >
+                      {platform.headline}
+                    </p>
+                    <p className="prose-balance mb-7 max-w-[42ch] text-[14.5px] leading-relaxed text-muted">
+                      {platform.detail}
+                    </p>
+
+                    <ul className="mb-8 grid gap-2.5 border-t border-white/[0.05] pt-6">
+                      {platform.points.map((point) => (
+                        <li key={point} className="flex gap-2.5 text-[13.5px] leading-snug text-faint">
+                          <span
+                            aria-hidden
+                            className={cn(
+                              "mt-[7px] h-px w-3 shrink-0",
+                              primary ? "bg-green/50" : "bg-white/15",
+                            )}
+                          />
+                          {point}
+                        </li>
+                      ))}
+                    </ul>
+
+                    <a
+                      href={platform.href}
+                      data-dl={platform.id === "macos" ? "platforms" : undefined}
+                      className={cn(
+                        "group/cta mt-auto inline-flex w-fit items-center gap-2 rounded-full py-2 pr-2 pl-5 text-[14px] font-medium transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98]",
+                        primary
+                          ? "bg-green text-ink-900 hover:bg-green-bright"
+                          : "border border-white/[0.09] bg-white/[0.03] text-text hover:border-white/20 hover:bg-white/[0.06]",
+                      )}
+                    >
+                      {platform.cta}
+                      <span
+                        aria-hidden
+                        className={cn(
+                          "flex size-6 items-center justify-center rounded-full transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover/cta:scale-105",
+                          primary ? "bg-ink-900/20" : "bg-white/[0.07]",
+                        )}
+                      >
+                        <ArrowUpRight
+                          className="size-3.5 transition-transform duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover/cta:translate-x-px group-hover/cta:-translate-y-px"
+                          strokeWidth={1.75}
+                        />
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </Reveal>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/website/src/components/site/ProductMocks.tsx
+++ b/website/src/components/site/ProductMocks.tsx
@@ -35,7 +35,7 @@ export function ApkMock() {
   ]
 
   return (
-    <Chrome title="APK Studio — app-release.apk">
+    <Chrome title="APK Studio · app-release.apk">
       <div className="flex gap-1 border-b border-white/[0.06] px-3 py-2">
         {tabs.map((t) => (
           <span
@@ -79,7 +79,7 @@ export function McpFlow() {
   ]
 
   return (
-    <Chrome title="Settings ▸ MCP — server running">
+    <Chrome title="Settings ▸ MCP · server running">
       <div className="p-5">
         <ul className="m-0 list-none p-0">
           {hops.map((hop, i) => (

--- a/website/src/components/site/Reveal.tsx
+++ b/website/src/components/site/Reveal.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react"
 
 import FadeContent from "@/components/FadeContent"
-import { useFinePointer } from "@/hooks/useFinePointer"
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
 
 interface RevealProps {
@@ -10,17 +9,23 @@ interface RevealProps {
   delay?: number
 }
 
-/** Scroll-reveal wrapper that renders children statically under reduced motion.
- *  The blur half of the reveal is desktop-only: animating `filter: blur()` on
- *  section-sized elements janks mobile GPUs, so touch devices fade only. */
+/** Scroll-reveal wrapper. Renders children statically under reduced motion.
+ *
+ *  The reveal moves and fades; it does not blur. Animating `filter: blur()`
+ *  repaints the whole subtree every frame for the length of the tween, and on a
+ *  page this long a fast scroll brings three or four sections into view at once,
+ *  so those repaints stack inside one frame budget. A `translateY` is composited
+ *  and costs the same whether it moves one element or a section of them.
+ *
+ *  This also drops the desktop/touch split the blur needed: one reveal now
+ *  behaves the same everywhere, so there is no second path to keep working. */
 export function Reveal({ children, className, delay = 0 }: RevealProps) {
   const reducedMotion = usePrefersReducedMotion()
-  const finePointer = useFinePointer()
   if (reducedMotion) {
     return <div className={className}>{children}</div>
   }
   return (
-    <FadeContent className={className} blur={finePointer} duration={600} delay={delay} threshold={0.08}>
+    <FadeContent className={className} y={18} duration={600} delay={delay} threshold={0.08}>
       {children}
     </FadeContent>
   )

--- a/website/src/components/site/SectionHead.tsx
+++ b/website/src/components/site/SectionHead.tsx
@@ -4,7 +4,14 @@ import { Reveal } from "@/components/site/Reveal"
 import { cn } from "@/lib/utils"
 
 interface SectionHeadProps {
-  eyebrow: string
+  /** Optional on purpose.
+   *
+   *  An eyebrow above every heading produces a templated rhythm where each
+   *  section announces itself the same way, and most of the labels repeat what
+   *  the heading already says ("faq" over "Questions, answered."). It earns its
+   *  place only where it categorises something the heading does not, so the
+   *  page keeps at most one per three sections. */
+  eyebrow?: string
   title: string
   children?: ReactNode
   center?: boolean
@@ -13,14 +20,21 @@ interface SectionHeadProps {
 export function SectionHead({ eyebrow, title, children, center = false }: SectionHeadProps) {
   return (
     <Reveal className={cn("mb-14 max-w-[62ch]", center && "mx-auto text-center")}>
-      <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-        <span className="mr-2 text-green-dim/60">&gt;_</span>
-        {eyebrow}
-      </span>
-      <h2 className="mt-4 mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04] font-extrabold tracking-[-0.035em]">
+      {eyebrow && (
+        <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
+          <span className="mr-2 text-green-dim/60">&gt;_</span>
+          {eyebrow}
+        </span>
+      )}
+      <h2
+        className={cn(
+          "display mb-4 text-[clamp(28px,4.2vw,46px)] leading-[1.04]",
+          eyebrow ? "mt-4" : "mt-0",
+        )}
+      >
         {title}
       </h2>
-      {children && <p className="text-lg leading-relaxed text-muted">{children}</p>}
+      {children && <p className="prose-balance text-lg leading-relaxed text-muted">{children}</p>}
     </Reveal>
   )
 }

--- a/website/src/components/site/TrustStrip.tsx
+++ b/website/src/components/site/TrustStrip.tsx
@@ -1,38 +1,69 @@
 import CountUp from "@/components/CountUp"
 import { Reveal } from "@/components/site/Reveal"
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
+import { APP_VERSION, GITHUB_URL } from "@/lib/content"
 
-/** A confidence signal, not a section: one enclosed row that reads in under two
- *  seconds. Bordered on all four sides to echo the header pill. */
+/** The confidence signal, directly under the hero rather than inside it: the
+ *  hero carries the value proposition and the CTA, this carries the facts that
+ *  make the CTA safe to press.
+ *
+ *  Four facts in a divided row, not a run of middle-dots. Dot-separated lists
+ *  read as one long string; a rule between cells reads as four separate claims,
+ *  which is what these are. */
+const facts: { value: string; label: string; href?: string }[] = [
+  { value: APP_VERSION, label: "Latest release", href: `${GITHUB_URL}/releases/tag/${APP_VERSION}` },
+  { value: "MIT", label: "Free and open source", href: `${GITHUB_URL}/blob/main/LICENSE` },
+  { value: "macOS 14+", label: "Signed and notarized" },
+  { value: "Windows · Linux", label: "On the beta channel", href: `${GITHUB_URL}/releases` },
+]
+
 export function TrustStrip() {
   const reducedMotion = usePrefersReducedMotion()
 
   return (
-    <section className="px-6 pb-6">
+    <section className="px-6 pb-10">
       <Reveal className="mx-auto max-w-[1020px]">
-        <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-3 rounded-2xl border border-white/[0.07] bg-white/[0.015] px-6 py-5 font-mono text-[12px] text-muted/75 max-[620px]:gap-x-4 max-[620px]:px-4 max-[620px]:text-[11px]">
-          <span className="inline-flex items-baseline gap-1.5">
-            <b className="text-[15px] font-bold text-green">
-              {reducedMotion ? 59 : <CountUp to={59} duration={1.4} />}+
-            </b>
-            developer tools
-          </span>
-          <span aria-hidden className="text-white/10">
-            ·
-          </span>
-          <span>Native macOS</span>
-          <span aria-hidden className="text-white/10">
-            ·
-          </span>
-          <span>Android + React Native</span>
-          <span aria-hidden className="text-white/10">
-            ·
-          </span>
-          <span>Free &amp; Open Source</span>
-          <span aria-hidden className="text-white/10 max-[620px]:hidden">
-            ·
-          </span>
-          <span className="max-[620px]:hidden">Signed &amp; Notarized</span>
+        <div className="shell">
+          <div className="core grid grid-cols-[auto_1fr] items-stretch gap-px overflow-hidden max-[860px]:grid-cols-1">
+            {/* The headline number carries its own weight, so it sits outside
+                the divided cells rather than becoming a fifth one. */}
+            <div className="flex items-center gap-3 px-7 py-5 max-[860px]:justify-center">
+              <span className="tnum text-[34px] leading-none font-semibold text-green">
+                {reducedMotion ? 61 : <CountUp to={61} duration={1.4} />}
+              </span>
+              <span className="max-w-[10ch] text-[13px] leading-[1.3] text-muted">
+                tools in one workspace
+              </span>
+            </div>
+
+            <dl className="grid grid-cols-4 max-[860px]:grid-cols-2">
+              {facts.map((fact) => {
+                const body = (
+                  <>
+                    <dt className="tnum text-[13px] font-medium text-text">{fact.value}</dt>
+                    <dd className="mt-0.5 text-[11.5px] leading-snug text-faint">{fact.label}</dd>
+                  </>
+                )
+                return (
+                  <div
+                    key={fact.label}
+                    className="border-l border-white/[0.05] px-5 py-5 max-[860px]:border-t max-[860px]:first:border-t-0 max-[860px]:nth-2:border-t-0"
+                  >
+                    {fact.href ? (
+                      <a
+                        href={fact.href}
+                        className="block transition-colors duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] hover:[&>dt]:text-green"
+                      >
+                        {body}
+                      </a>
+                    ) : (
+                      body
+                    )}
+                  </div>
+                )
+              })}
+            </dl>
+          </div>
         </div>
       </Reveal>
     </section>

--- a/website/src/components/site/UseCaseMoments.tsx
+++ b/website/src/components/site/UseCaseMoments.tsx
@@ -5,7 +5,7 @@ import { useCaseMoments } from "@/lib/content"
  *  then the answer. Deliberately compact: no images, no big cards. */
 export function UseCaseMoments() {
   return (
-    <section className="mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-16">
+    <section className="section-contained mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-16">
       <Reveal className="mb-12 max-w-[52ch]">
         <h2 className="display text-[clamp(26px,3.6vw,38px)] leading-[1.08]">
           Built for the moments that slow you down.

--- a/website/src/components/site/UseCaseMoments.tsx
+++ b/website/src/components/site/UseCaseMoments.tsx
@@ -7,11 +7,7 @@ export function UseCaseMoments() {
   return (
     <section className="mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-16">
       <Reveal className="mb-12 max-w-[52ch]">
-        <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
-          <span className="mr-2 text-green-dim/60">&gt;_</span>
-          moments
-        </span>
-        <h2 className="mt-4 text-[clamp(26px,3.6vw,38px)] leading-[1.08] font-extrabold tracking-[-0.03em]">
+        <h2 className="display text-[clamp(26px,3.6vw,38px)] leading-[1.08]">
           Built for the moments that slow you down.
         </h2>
       </Reveal>

--- a/website/src/components/site/WorkflowTabs.tsx
+++ b/website/src/components/site/WorkflowTabs.tsx
@@ -19,7 +19,7 @@ export function WorkflowTabs() {
   return (
     <section id="workflows" className="mx-auto max-w-[1120px] px-6 pt-20 pb-32 max-[620px]:pt-14 max-[620px]:pb-20">
       <SectionHead eyebrow="workflows" title="Built for how you debug.">
-        Not a pile of features — six workflows that cover the whole loop between writing code and
+        Not a pile of features. Six workflows that cover the whole loop between writing code and
         understanding what your app actually did.
       </SectionHead>
 

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -271,3 +271,33 @@ body {
 svg.lucide {
   stroke-width: 1.75;
 }
+
+/* ---------------------------------------------------------------------------
+ * Off-screen sections do no render work.
+ *
+ * The page is ~15,000px tall. Without this the browser lays out and paints
+ * every section on load and re-does that work whenever anything invalidates,
+ * even for the ten sections nobody has scrolled to. `content-visibility: auto`
+ * lets it skip a section entirely until it approaches the viewport.
+ *
+ * `contain-intrinsic-size: auto <estimate>` is the part that keeps the
+ * scrollbar honest: the browser uses the estimate before a section has ever
+ * rendered, then *remembers the real height* and uses that from then on, so
+ * the page does not resize under the thumb on the way back up.
+ *
+ * Applied only to sections with no decoration escaping their own box, because
+ * this establishes containment and would clip anything that does. The hero and
+ * the MCP section are excluded for exactly that reason.
+ * ------------------------------------------------------------------------- */
+.section-contained {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 720px;
+}
+
+/* The changelog runs to ~1,600px, so the shared estimate would misreport the
+   scrollbar by nearly a thousand pixels until it first renders. Every other
+   contained section measures between 515px and 982px, which 720 covers. */
+.section-contained-tall {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 1650px;
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,3 +1,8 @@
+/* Self-hosted variable fonts. Replaces the render-blocking Google Fonts
+   stylesheet: two fewer preconnects, no FOUT from a third-party round trip,
+   and the mono actually ships with the bundle. */
+@import "@fontsource-variable/geist/index.css";
+@import "@fontsource-variable/geist-mono/index.css";
 @import "tailwindcss";
 
 @theme {
@@ -39,9 +44,15 @@
   /* A single warm wink to the detective hat — used almost never */
   --color-amber: #f5b544;
 
-  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
-    system-ui, sans-serif;
+  /* Geist carries the product's register: a grotesk with real character at
+     display sizes that stays neutral at 15px. The system stack stays as the
+     fallback so a failed font load still renders SF Pro on the Mac this app
+     ships for. */
+  --font-sans: "Geist Variable", -apple-system, BlinkMacSystemFont,
+    "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-display: "Geist Variable", -apple-system, BlinkMacSystemFont,
+    "SF Pro Display", system-ui, sans-serif;
 
   /* shadcn semantic tokens, mapped onto the brand */
   --color-background: #0d0f0e;
@@ -63,12 +74,23 @@
   --color-input: rgba(231, 234, 229, 0.14);
   --color-ring: #69a106;
 
+  /* ONE radius system, concentric by construction. A shell at --radius-shell
+     with --shell-pad of padding holds a core at --radius-core, so the curves
+     stay parallel instead of fighting. Nothing on this site invents a radius
+     outside this scale. */
+  --radius-shell: 24px;
+  --radius-core: 18px;
   --radius-lg: 16px;
   --radius-md: 12px;
   --radius-sm: 8px;
+  --radius-pill: 999px;
 
   --shadow-glow: 0 0 0 1px rgba(105, 161, 6, 0.45),
     0 10px 30px -8px rgba(105, 161, 6, 0.25);
+  /* Ambient depth, tinted to the ink ramp rather than pure black. A neutral
+     black shadow on a green-tinted graphite reads as a hole, not a lift. */
+  --shadow-lift: 0 1px 1px rgba(4, 6, 5, 0.5), 0 8px 24px -12px rgba(4, 8, 5, 0.7);
+  --shadow-lift-lg: 0 1px 1px rgba(4, 6, 5, 0.5), 0 24px 60px -24px rgba(4, 8, 5, 0.8);
 
   /* Glass surfaces */
   --color-glass: rgba(18, 21, 20, 0.72);
@@ -167,4 +189,85 @@ body {
   .cta-breathe {
     animation: none;
   }
+}
+
+/* ---------------------------------------------------------------------------
+ * Nested enclosures (shell + core)
+ *
+ * A premium surface is never a flat rectangle on the page. It is a machined
+ * tray holding a plate: an outer shell with its own hairline and padding, and
+ * an inner core with its own fill and a top highlight, at a radius calculated
+ * so the two curves stay concentric.
+ *
+ * Usage:  <div class="shell"><div class="core"> ... </div></div>
+ * ------------------------------------------------------------------------- */
+.shell {
+  --shell-pad: 6px;
+  padding: var(--shell-pad);
+  border-radius: var(--radius-shell);
+  border: 1px solid rgba(231, 234, 229, 0.06);
+  background: rgba(231, 234, 229, 0.022);
+  box-shadow: var(--shadow-lift);
+}
+
+.core {
+  border-radius: calc(var(--radius-shell) - var(--shell-pad));
+  background: var(--color-ink-800);
+  /* The single light source for the whole page sits above: every core catches
+     it on its top edge only. */
+  box-shadow: inset 0 1px 0 rgba(231, 234, 229, 0.055);
+}
+
+/* A shell that lights up when the pointer is over it. The highlight is a
+   border-colour shift, not a glow — glows are the AI tell this palette avoids. */
+.shell-hover {
+  transition:
+    border-color 700ms cubic-bezier(0.32, 0.72, 0, 1),
+    background-color 700ms cubic-bezier(0.32, 0.72, 0, 1),
+    transform 700ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.shell-hover:hover {
+  border-color: rgba(105, 161, 6, 0.28);
+  background: rgba(105, 161, 6, 0.035);
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell-hover,
+  .shell-hover:hover {
+    transition: none;
+    transform: none;
+  }
+}
+
+/* Tabular figures everywhere a number carries meaning, so columns of counts
+   and versions do not jitter between values. */
+.tnum {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+/* Display type: Geist tightens well, and the optical size wants a touch less
+   tracking as it grows. */
+.display {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+
+/* Body copy that should never orphan its last word. */
+.prose-balance {
+  text-wrap: pretty;
+}
+
+/* Icon weight is a single decision, not a per-call-site one.
+ *
+ * lucide ships at stroke-width 2, which reads heavy beside Geist at these
+ * sizes. 1.75 keeps the glyphs precise without turning them into hairlines
+ * that disappear on the graphite. Set once here so no icon can drift; a call
+ * site that genuinely needs another weight still overrides with the prop. */
+svg.lucide {
+  stroke-width: 1.75;
 }

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -17,7 +17,7 @@ export const LINKEDIN_URL = "https://www.linkedin.com/in/rohindh"
 export const RELEASES_URL = `${GITHUB_URL}/releases`
 // GitHub's permanent latest-release asset URL: every release uploads a
 // stable-named Droidective.dmg (see ci.yml), so this always serves the
-// newest version — no appcast fetch, nothing cached to go stale.
+// newest version. No appcast fetch, nothing cached to go stale.
 export const DOWNLOAD_URL = `${GITHUB_URL}/releases/latest/download/Droidective.dmg`
 export const APP_VERSION = "v3.11.0"
 
@@ -67,7 +67,7 @@ export const workflows: Workflow[] = [
     icon: Atom,
     title: "Understand what your app does while it runs",
     blurb:
-      "Reactotron is built in — no desktop app to install. Point your client at Droidective and a live timeline of logs, actions, state, and network requests streams in beside a Hermes JS console.",
+      "Reactotron is built in, so there is no desktop app to install. Point your client at Droidective and a live timeline of logs, actions, state, and network requests streams in beside a Hermes JS console.",
     features: ["Reactotron timeline", "Hermes JS console", "Redux & state browser", "Network inspector", "Reload JS & dev menu", "Metro port forwarding"],
     image: "/assets/screenshot-react.webp",
     alt: "Droidective's React Native hub with quick-action cards for reload JS, dev menu and process death, plus a Metro bundler section",
@@ -79,7 +79,7 @@ export const workflows: Workflow[] = [
     icon: Cast,
     title: "Drive the device without touching a terminal",
     blurb:
-      "Mirror and control the screen, browse the filesystem, manage every installed app, and pair over Wi-Fi — in tabs that keep running while you work elsewhere, or split side by side.",
+      "Mirror and control the screen, browse the filesystem, manage every installed app, and pair over Wi-Fi. All of it in tabs that keep running while you work elsewhere, or split side by side.",
     features: ["Screen mirror & control", "Screen recording", "File explorer", "App management", "Wireless ADB pairing", "Tabs & split panes"],
     video: "/assets/tour-tabs.mp4",
     image: "/assets/poster-tabs.webp",
@@ -92,7 +92,7 @@ export const workflows: Workflow[] = [
     icon: Activity,
     title: "Watch the numbers move in real time",
     blurb:
-      "Per-core CPU, system RAM, app FPS and jank, and network throughput — charted as they happen with a hover crosshair. Record a session and export it to JSON or CSV.",
+      "Per-core CPU, system RAM, app FPS and jank, and network throughput, charted as they happen with a hover crosshair. Record a session and export it to JSON or CSV.",
     features: ["Per-core CPU", "System & per-process RAM", "FPS & jank", "Network throughput", "Session recording", "JSON & CSV export"],
     image: "/assets/screenshot-performance.webp",
     alt: "Droidective performance monitor charting per-core CPU, system RAM and network throughput live during a recording",
@@ -104,7 +104,7 @@ export const workflows: Workflow[] = [
     icon: Boxes,
     title: "Open an APK and see everything inside it",
     blurb:
-      "One workspace over a single loaded APK — inspect the manifest and signing certs, decompile with jadx or apktool, recompile, and re-sign. AAB bundles convert to installable APKs too.",
+      "One workspace over a single loaded APK: inspect the manifest and signing certs, decompile with jadx or apktool, recompile, and re-sign. AAB bundles convert to installable APKs too.",
     features: ["Manifest & cert inspection", "jadx + apktool decompile", "Recompile & re-sign", "AAB → APK conversion", "Keystore creation", "Frida server setup"],
     mock: "apk",
   },
@@ -115,7 +115,7 @@ export const workflows: Workflow[] = [
     icon: Sparkles,
     title: "Let your AI agent read the running app",
     blurb:
-      "An opt-in MCP server exposes Reactotron's timeline, state, and network data to Claude Code, Cursor, and any MCP client — 10 tools and 8 resources over loopback HTTP, redacted by default.",
+      "An opt-in MCP server exposes Reactotron's timeline, state, and network data to Claude Code, Cursor, and any MCP client. Ten tools and eight resources over loopback HTTP, redacted by default.",
     features: ["10 MCP tools", "8 MCP resources", "Live timeline access", "State & network context", "Redaction on by default", "127.0.0.1 only"],
     mock: "mcp",
   },
@@ -146,43 +146,95 @@ export const comparisonRows: { workflow: string; old: string; nu: string }[] = [
   { workflow: "Price", old: "Varies per tool", nu: "Free · MIT · no tiers" },
 ]
 
-/** Grouped feature explorer — collapsed by default so the page stays calm. */
+/** Grouped feature explorer, collapsed by default so the page stays calm.
+ *  The six group counts sum to the registry's 61. When a feature lands in the
+ *  app, its group count moves here too; a total that does not add up is the
+ *  one thing a reader can check against the app itself. */
 export const featureGroups: { name: string; icon: LucideIcon; count: string; items: string[] }[] = [
   {
     name: "React Native",
     icon: Atom,
-    count: "6 tools",
-    items: ["Reactotron (built in)", "Hermes JS console", "Reactotron MCP server", "Reload JS & dev menu", "Metro port forwarding", "Dev-server host override"],
+    count: "8 tools",
+    items: ["Reactotron (built in)", "Hermes JS console", "Reactotron MCP server", "Dev menu", "Reload JS", "Deep links", "Simulate process death", "Dev-server host"],
   },
   {
-    name: "Device control",
+    name: "Screen, mirror & capture",
     icon: Cast,
-    count: "12 tools",
-    items: ["Screen mirror & control", "Screen recording", "Screenshot editor", "File explorer", "Apps explorer", "Install APK", "Deep links", "Send text", "Wireless ADB & pairing", "Private DNS", "Root status", "Emulator manager"],
-  },
-  {
-    name: "Logs & diagnostics",
-    icon: ScrollText,
-    count: "7 tools",
-    items: ["Live logcat", "iOS unified logs", "Crash catcher", "Bug report", "Device info & getprop", "Terminal (split panes)", "Custom commands"],
-  },
-  {
-    name: "Performance",
-    icon: Activity,
-    count: "4 tools",
-    items: ["Per-core CPU & RAM", "FPS & jank monitor", "Per-process stats", "Network throughput"],
-  },
-  {
-    name: "APK & security",
-    icon: Boxes,
     count: "6 tools",
-    items: ["APK Studio", "APK inspector", "Decompile (jadx / apktool)", "Sign & zipalign", "AAB → APK converter", "Frida server setup"],
+    items: ["Mirror screen & control", "Mirror Wall (6 devices)", "Screenshot editor", "Screen recording", "Video editor", "Demo mode"],
   },
   {
-    name: "State simulation",
+    name: "Device & connection",
+    icon: Wifi,
+    count: "9 tools",
+    items: ["Wireless ADB & QR pairing", "Emulators & simulators", "Network speed monitor", "Wi-Fi", "Private DNS", "Reverse port", "Copy device IP", "Connection hub", "Send text"],
+  },
+  {
+    name: "Device state",
     icon: SlidersHorizontal,
-    count: "10 tools",
-    items: ["Fake battery", "Dark mode", "Demo mode", "Locale override", "Font & density scale", "Proxy override", "Developer settings", "Push notifications (iOS)", "Sandbox browser", "System restrictions"],
+    count: "13 tools",
+    items: ["File explorer", "Device info & getprop", "Developer settings", "System restrictions", "Fake battery", "Dark mode", "Font & density", "Animation scale", "Locale override", "Network toggles", "HTTP proxy", "Push notifications (iOS)", "Simulate hub"],
+  },
+  {
+    name: "Apps & APK",
+    icon: Boxes,
+    count: "16 tools",
+    items: ["Apps explorer", "Install APK / XAPK / APKM", "APK Studio", "APK inspector", "Decompile (jadx / apktool)", "Sign & zipalign", "AAB to APK", "Frida server setup", "Manage app", "Permissions", "App info", "Memory usage", "Sandbox browser", "Current activity", "Foreground bundle id", "Monkey test"],
+  },
+  {
+    name: "Logs, diagnostics & tools",
+    icon: ScrollText,
+    count: "9 tools",
+    items: ["Columnar logcat", "iOS unified logs", "Crash catcher", "Bug report", "Performance monitor", "Root status", "API testing", "Terminal (split panes)", "Custom commands"],
+  },
+]
+
+/** Where the app runs today. The site said "macOS" and nothing else for three
+ *  releases after the Windows and Linux builds started shipping on the beta
+ *  channel, which made the ports invisible to everyone who was not already
+ *  reading release notes. Stated plainly, including what the ports do not have
+ *  yet, because a beta oversold is a support ticket. */
+export interface Platform {
+  id: string
+  name: string
+  channel: string
+  status: "stable" | "beta"
+  headline: string
+  detail: string
+  points: string[]
+  href: string
+  cta: string
+}
+
+export const platforms: Platform[] = [
+  {
+    id: "macos",
+    name: "macOS",
+    channel: "Stable",
+    status: "stable",
+    headline: "The full app",
+    detail:
+      "All 61 tools, Developer ID signed and notarized, universal for Apple silicon and Intel. Updates install themselves in the background.",
+    points: ["macOS 14 Sonoma or later", "Signed, notarized, no Gatekeeper prompt", "Universal binary", "Self-updating"],
+    href: DOWNLOAD_URL,
+    cta: "Download the DMG",
+  },
+  {
+    id: "windows-linux",
+    name: "Windows and Linux",
+    channel: "Beta",
+    status: "beta",
+    headline: "29 of the 32 screens",
+    detail:
+      "The same engine behind a Tauri interface, shipping on beta releases. The mirror, the Mirror Wall, screen record, Reactotron, the JS console and APK Studio are all there.",
+    points: [
+      "NSIS installer and MSI for Windows",
+      ".deb and AppImage for Linux",
+      "Not signed, and updated by hand",
+      "No video editor, Frida, or Command Log yet",
+    ],
+    href: `${GITHUB_URL}/releases`,
+    cta: "Find a beta release",
   },
 ]
 
@@ -190,7 +242,7 @@ export const featureGroups: { name: string; icon: LucideIcon; count: string; ite
 export const useCaseMoments: { quote: string; answer: string; href: string }[] = [
   { quote: "“The app is crashing.”", answer: "Open the crash catcher, read the split-out trace, and copy it Slack-ready.", href: "/for-qa-and-testers.html" },
   { quote: "“The app feels slow.”", answer: "Chart CPU, RAM, FPS and jank live, then record the session and export it.", href: "/for-android-developers.html" },
-  { quote: "“I need to inspect this APK.”", answer: "Drop it into APK Studio — manifest, certs, decompiled source, re-sign.", href: "/for-security-testers.html" },
+  { quote: "“I need to inspect this APK.”", answer: "Drop it into APK Studio for the manifest, certs, decompiled source and a re-sign.", href: "/for-security-testers.html" },
   { quote: "“What is my RN app doing?”", answer: "Reactotron streams the timeline; MCP hands the same context to your AI.", href: "/react-native-debugger.html" },
 ]
 
@@ -239,12 +291,12 @@ export const releases: { version: string; date: string; latest?: boolean; html: 
 ]
 
 export const faqs: { q: string; html: string }[] = [
-  { q: "Is it really free?", html: "Yes. Droidective is MIT-licensed and fully open source — no account, no paywall, no pro tier. Star it, fork it, ship it." },
-  { q: "Is it signed and safe to open?", html: "Yes. Release builds are signed with an Apple Developer ID and notarized by Apple, so they open with a normal double-click — no Gatekeeper workaround needed. Everything is open source, and you can build from source if you prefer." },
-  { q: "Do I need a rooted device?", html: "No. Everything works on a normal device. A few extras — full-filesystem browsing, saved Wi-Fi passwords, SELinux mode and read-write remount — unlock automatically when root is available." },
-  { q: "What do I need installed?", html: "Just Android <code>adb</code>. Droidective finds it via <code>ANDROID_HOME</code>, the default SDK path, or Homebrew, and offers a one-click install if it's missing. <code>scrcpy</code> and <code>ffmpeg</code> ship inside the app, so mirroring, recording, and video export work out of the box — only the Android <code>emulator</code> is optional, for AVD management." },
-  { q: "Does it send my data anywhere?", html: 'Anonymous crash reports and usage analytics are on by default (opt-out) — both disclosed on first launch and controlled in Settings → Privacy. Device serials, file paths, and command contents are never sent. See the <a href="/privacy.html">privacy page</a> for details.' },
-  { q: "Does it work with React Native?", html: "Yes — there's a dedicated React Native hub: open the dev menu, reload the JS bundle, reverse the Metro port, save deep links per app, and set the dev-server host." },
+  { q: "Is it really free?", html: "Yes. Droidective is MIT-licensed and fully open source. No account, no paywall, no pro tier. Star it, fork it, ship it." },
+  { q: "Is it signed and safe to open?", html: "Yes. Release builds are signed with an Apple Developer ID and notarized by Apple, so they open with a normal double-click, with no Gatekeeper workaround needed. Everything is open source, and you can build from source if you prefer." },
+  { q: "Do I need a rooted device?", html: "No. Everything works on a normal device. A few extras (full-filesystem browsing, saved Wi-Fi passwords, SELinux mode and read-write remount) unlock automatically when root is available." },
+  { q: "What do I need installed?", html: "Just Android <code>adb</code>. Droidective finds it via <code>ANDROID_HOME</code>, the standard SDK paths, or your login shell, and Settings ▸ Doctor links to the download when it is missing. The <code>scrcpy</code> server, <code>ffmpeg</code>, bundletool and uber-apk-signer all ship inside the app, so mirroring, recording, video export and APK signing work out of the box. Only the Android <code>emulator</code> is optional, for AVD management." },
+  { q: "Does it send my data anywhere?", html: 'Anonymous crash reports and usage analytics are on by default and can be turned off. Both are disclosed on first launch and controlled in Settings → Privacy. Device serials, file paths, and command contents are never sent. See the <a href="/privacy.html">privacy page</a> for details.' },
+  { q: "Does it work with React Native?", html: "Yes. There is a dedicated React Native hub: open the dev menu, reload the JS bundle, reverse the Metro port, save deep links per app, and set the dev-server host." },
   { q: "Apple Silicon or Intel?", html: "Both. Droidective runs on any Mac with macOS 14 Sonoma or later." },
 ]
 


### PR DESCRIPTION
The site described a v2-era, macOS-only product. The content half was the worse
half.

## Content

| Claim | Was | Is |
| --- | --- | --- |
| Tool count | 59 in 6 places, 60 in 8 more | **61** |
| `softwareVersion` (structured data) | `3.0.0` | `3.11.0` |
| Feature explorer | claimed 61, listed 45 | six groups summing to 61 |
| Windows and Linux | never mentioned | a section of their own |
| "What do I need installed?" | "or Homebrew, and offers a one-click install" | Homebrew installs were dropped in v3.1.0 |

`All 60 tools →` was on all seven SEO subpages. The palette demo's own footer
said 59 while the hero above it said 61.

**The ports were invisible.** Three releases have shipped Windows and Linux on
the beta channel and the only trace on the site was one sentence inside a
changelog entry. The new **Platforms** section is two deliberately *unequal*
panels, because a 50/50 grid would claim the beta is the same offer as the Mac
app. It states what is missing (unsigned, updated by hand, no video editor,
Frida or Command Log) rather than letting someone discover it after installing.

The feature taxonomy now sums to the registry exactly, so a reader can check it
against the app. Mirror Wall, API Testing, the video editor and QR pairing were
all absent.

## Type and surface

- **Geist + Geist Mono, self-hosted.** The body stack was `-apple-system`, and
  JetBrains Mono came from a render-blocking Google Fonts stylesheet. Two
  preconnects and a third-party round trip removed; the faces bundle with the
  build.
- **One radius system** with concentric `shell`/`core` enclosures replacing the
  assorted `rounded-2xl border` cards, so a surface reads as a plate in a tray.
- **Shadows tinted to the ink ramp.** Neutral black on green-tinted graphite
  reads as a hole rather than a lift.

## Composition

- The hero carried **five stacked text elements**. The version and license strip
  moved out to the trust strip below it, where it is a divided four-cell row
  rather than a run of four middle-dots.
- **Section eyebrows: 10 to 5** across seventeen sections. `SectionHead` stamped
  one on every section and most only restated the heading ("faq" above
  "Questions, answered."). The five that survive categorise something the
  heading does not.
- Pill CTAs with the trailing glyph in its own nested circle, one easing curve,
  and a press state.

## One real defect

`Nav` ran `window.addEventListener("scroll")`, re-rendering the nav tree on
every scroll frame. It is now an IntersectionObserver on a sentinel, which
reports the same boolean only when it changes.

## A deliberate omission

Em-dashes are gone from the marketing copy but **not** from the changelog
entries. Those are the release notes verbatim; stripping them would diverge from
`RELEASE_NOTES.md` and the next release PR would paste them straight back.

## Verification

Browser-checked at desktop and at 414px. `npm run build` and `npm run lint`
clean; the single remaining lint warning predates this branch and is in an
untouched file. No route, slug, anchor id or nav label changed, so nothing moves
for SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
