### PR TITLE
Retry a bind refused by our own closing listener

### DIFF
--- a/droidectived/Sources/DaemonCore/ReactotronRelay.swift
+++ b/droidectived/Sources/DaemonCore/ReactotronRelay.swift
@@ -163,7 +163,7 @@ public actor ReactotronRelay {
 
         let host = loopbackOnly ? "127.0.0.1" : "0.0.0.0"
         do {
-            channel = try await bootstrap.bind(host: host, port: port).get()
+            channel = try await Self.bindRetryingAddressInUse(bootstrap, host: host, port: port)
         } catch {
             // The one failure worth naming: another Reactotron — upstream's app,
             // or a second copy of this one — already has the port. "Address
@@ -179,6 +179,47 @@ public actor ReactotronRelay {
         }
         settle(into: .running)
         emit(.listening(port: boundPort ?? port))
+    }
+
+    /// How long a bind keeps retrying `EADDRINUSE` before reporting it.
+    ///
+    /// Short enough that a genuine holder — upstream's Reactotron app, a second
+    /// copy of this one — is still reported promptly, long enough to outlast our
+    /// own previous listener finishing its teardown.
+    private static let rebindAttempts = 6
+    private static let rebindDelay = Duration.milliseconds(40)
+
+    /// Binds, retrying `EADDRINUSE` for a bounded window.
+    ///
+    /// `stop()` awaits the channel's `closeFuture` *and* the event-loop group's
+    /// graceful shutdown, which are the strongest completion signals NIO offers,
+    /// and it is still possible for a bind moments later to be refused. The
+    /// window is between the last fd closing and the kernel releasing the
+    /// listening socket, and no future can report the second one — `SO_REUSEADDR`
+    /// does not cover it either, because that waives `TIME_WAIT`, not a socket
+    /// still in `LISTEN`.
+    ///
+    /// So this is not a workaround for a teardown that returns early. It is the
+    /// ordinary handling for acquiring a contended kernel resource: retry
+    /// briefly, then report. `stoppingReleasesThePort` is what caught it —
+    /// twice on CI, on the *second* bind of a port this process had just
+    /// released, which is the case a foreign holder cannot explain.
+    ///
+    /// Only `EADDRINUSE` is retried. Every other bind failure is a fact that a
+    /// second attempt cannot change, and retrying it would just delay the error.
+    private static func bindRetryingAddressInUse(
+        _ bootstrap: ServerBootstrap, host: String, port: Int
+    ) async throws -> any Channel {
+        for attempt in 1... {
+            do {
+                return try await bootstrap.bind(host: host, port: port).get()
+            } catch let error as IOError where error.errnoCode == EADDRINUSE {
+                guard attempt < rebindAttempts else { throw error }
+                try? await Task.sleep(for: rebindDelay)
+            }
+        }
+        // `1...` never terminates; the loop leaves via return or throw.
+        throw RelayError.bindFailed("unreachable")
     }
 
     /// An event stream. Several may be open at once — the timeline reads one and

--- a/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
@@ -361,6 +361,54 @@ import Testing
         }
     }
 
+    /// A port that is busy *right now* but free a moment later must not be
+    /// reported as taken.
+    ///
+    /// This is the window `stoppingReleasesThePort` kept failing in: a bind
+    /// refused on a port this process itself had just released, after `stop()`
+    /// had already awaited the channel's `closeFuture` and the event-loop
+    /// group's shutdown. A foreign holder cannot explain that, and no NIO future
+    /// reports the kernel releasing the listening socket, so the bind retries
+    /// briefly instead of trusting the first answer.
+    ///
+    /// A real listener stands in for the closing one: same errno, same shape,
+    /// and it is released on a timer rather than by chance, so the test proves
+    /// the retry rather than waiting on a race to go the right way.
+    @Test func aPortFreedDuringTheRetryWindowIsStillBound() async throws {
+        let port = 31_477
+        let squatter = ReactotronRelay(port: port)
+        try await squatter.start()
+
+        // Released after one retry interval and well inside the window, so the
+        // first attempt is guaranteed to fail and a later one to succeed.
+        let release = Task {
+            try? await Task.sleep(for: .milliseconds(60))
+            await squatter.stop()
+        }
+
+        let relay = ReactotronRelay(port: port)
+        try await relay.start()
+        #expect(await relay.boundPort == port)
+        await relay.stop()
+        _ = await release.value
+    }
+
+    /// The other half: a holder that never goes away is still reported, and with
+    /// the message that names the likely cause rather than the errno. Without
+    /// this, a retry window could quietly become an infinite one.
+    @Test func aPortHeldThroughoutIsReportedAsInUse() async throws {
+        let port = 31_483
+        let squatter = ReactotronRelay(port: port)
+        try await squatter.start()
+        defer { Task { await squatter.stop() } }
+
+        let relay = ReactotronRelay(port: port)
+        await #expect(throws: ReactotronRelay.RelayError.self) {
+            try await relay.start()
+        }
+        #expect(await relay.isRunning == false)
+    }
+
     @Test func aStartAndAStopThatRaceLeaveAConsistentRelay() async throws {
         // The sequence a timeline tab makes every time it is closed and
         // reopened, and the one React's double-mount makes on the very first


### PR DESCRIPTION
`stoppingReleasesThePort` has now failed twice more on CI, including on the
**v3.11.0 release run**. Both times it was read as a foreign process holding
port 28411 and answered by trying more ports (#323). That reading was wrong,
and the port fallback could never have helped.

## Why the fallback could not have worked

It only guards the **first** bind:

```swift
do { try await relay.start() }              // line 338, guarded
catch ReactotronRelay.RelayError.portInUse { ...continue }
...
let second = ReactotronRelay(port: port)
try await second.start()                     // line 357, NOT guarded, by design
```

The reported port is **28411, the first candidate**. Had the first bind failed,
the catch would have fired and moved to 29617. It did not, so the error escaped
from the second bind: the port this process had *just* bound and released. That
is precisely the case the test's own comment says a foreign holder cannot
explain, and it is right.

(I checked that the bare-case `catch` pattern really does match an enum case
carrying an associated value, so "the catch silently never matched" is ruled
out.)

## What is actually happening

`stop()` returns before the kernel has released the listening socket. It already
awaits the channel's `closeFuture` *and* the event-loop group's graceful
shutdown, which are the strongest completion signals NIO offers, and neither
reports that last step. `SO_REUSEADDR` does not cover it: it waives `TIME_WAIT`,
not a socket still in `LISTEN`.

The CI log agrees. Four of these sit immediately before the failure:

```
ERROR: Cannot schedule tasks on an EventLoop that has already shut down.
```

That is the teardown still in flight while the next bind is attempted.

## The fix

A bind retries `EADDRINUSE` for a bounded window (6 attempts, 40ms apart)
instead of trusting the first answer. Only `EADDRINUSE` is retried; every other
bind failure is a fact a second attempt cannot change, and retrying it would
only delay the error.

This is not a workaround for a teardown that returns early. There is no future
that reports the kernel releasing a listening socket, so retrying briefly is the
ordinary handling for acquiring a contended resource.

**The user-visible bug is the same one.** Stopping Reactotron and starting it
again could report "another Reactotron is probably running" with nothing on the
port, and the feature refused to come back until the app was relaunched.

## Tests, and why both

- `aPortFreedDuringTheRetryWindowIsStillBound` puts a real listener on the port
  and releases it on a timer inside the window, so it proves the retry rather
  than waiting on a race to go the right way. **With the retry removed it fails
  with the exact CI error** (`Port 31477 is already in use`), which is how I
  verified it has teeth.
- `aPortHeldThroughoutIsReportedAsInUse` holds the port for the whole test and
  asserts the error still arrives, so the retry window cannot quietly become an
  infinite one. It passes with or without the retry, which is the point.

408 tests green locally, `swift build -Xswiftc -warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
