### PR TITLE
Fix the About gap, the beta links, and the section rhythm

### DIFF
--- a/website/src/components/MagicCard.tsx
+++ b/website/src/components/MagicCard.tsx
@@ -47,7 +47,7 @@ export function MagicCard({ children, className, innerClassName, glowSize = 500 
           }}
         />
       )}
-      <div className={cn("relative z-0", innerClassName)}>{children}</div>
+      <div className={cn("relative z-0 h-full", innerClassName)}>{children}</div>
     </div>
   )
 }

--- a/website/src/components/site/About.tsx
+++ b/website/src/components/site/About.tsx
@@ -34,7 +34,7 @@ export function About() {
   const reducedMotion = usePrefersReducedMotion()
 
   return (
-    <section id="about" className="section-contained mx-auto max-w-[1120px] px-6 pb-28 max-[620px]:pb-20">
+    <section id="about" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center title="About me." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>
@@ -85,7 +85,7 @@ export function About() {
         <Reveal delay={60}>
           <MagicCard className="h-full">
             <div className="flex h-full min-w-0 flex-col p-7">
-              <ul className="m-0 list-none p-0">
+              <ul className="m-0 flex flex-1 list-none flex-col justify-between p-0">
                 {highlights.map((h) => (
                   <li key={h.label} className="flex items-baseline gap-3.5 border-b border-white/[0.04] py-3.5 first:pt-0">
                     <span className="font-mono text-[26px] font-bold tracking-[-0.02em] text-green">

--- a/website/src/components/site/Blog.tsx
+++ b/website/src/components/site/Blog.tsx
@@ -7,7 +7,7 @@ import { posts } from "@/lib/blogPosts"
 export function Blog() {
   const latest = posts.slice(0, 3)
   return (
-    <section id="blog" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="blog" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center title="Guides &amp; deep dives.">
         Role-by-role workflows for debugging Android &amp; React Native on a Mac, written in-house. No terminal
         required.

--- a/website/src/components/site/Changelog.tsx
+++ b/website/src/components/site/Changelog.tsx
@@ -5,7 +5,7 @@ import { releases } from "@/lib/content"
 
 export function Changelog() {
   return (
-    <section id="changelog" className="section-contained-tall mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="changelog" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center title="Shipped, and still moving.">
         The latest releases. Automatic in-app updates since v2.1.0, and Apple-notarized builds since v2.4.0.
       </SectionHead>

--- a/website/src/components/site/Comparison.tsx
+++ b/website/src/components/site/Comparison.tsx
@@ -9,7 +9,7 @@ const oldStack = ["Terminal", "adb", "logcat", "scrcpy", "Reactotron", "Android 
  *  named competitor being called worse. */
 export function Comparison() {
   return (
-    <section id="why" className="mx-auto max-w-[1120px] px-6 py-32 max-[620px]:py-20">
+    <section id="why" className="mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-14">
       <Reveal className="mb-14 max-w-[62ch]">
         <span className="font-mono text-[12px] font-medium tracking-[0.06em] text-green/80 uppercase">
           <span className="mr-2 text-green-dim/60">&gt;_</span>

--- a/website/src/components/site/Contribute.tsx
+++ b/website/src/components/site/Contribute.tsx
@@ -14,7 +14,7 @@ function GithubMark() {
 
 export function Contribute() {
   return (
-    <section id="contribute" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="contribute" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center title="Built in the open. Yours to shape." />
       <div className="grid grid-cols-[1.1fr_0.9fr] gap-4 max-[940px]:grid-cols-1">
         <Reveal>

--- a/website/src/components/site/DemoMoment.tsx
+++ b/website/src/components/site/DemoMoment.tsx
@@ -5,7 +5,7 @@ import { Reveal } from "@/components/site/Reveal"
  *  here: the point is how fast ⌘T moves between tools, which a still can't show. */
 export function DemoMoment() {
   return (
-    <section id="in-action" className="relative overflow-hidden py-32 max-[620px]:py-20">
+    <section id="in-action" className="relative overflow-hidden py-24 max-[620px]:py-14">
       <div
         aria-hidden
         className="pointer-events-none absolute top-1/4 left-1/2 h-[400px] w-[1000px] -translate-x-1/2 rounded-full bg-[radial-gradient(closest-side,rgba(105,161,6,0.05),transparent_70%)] blur-3xl"

--- a/website/src/components/site/Faq.tsx
+++ b/website/src/components/site/Faq.tsx
@@ -5,7 +5,7 @@ import { faqs } from "@/lib/content"
 
 export function Faq() {
   return (
-    <section id="faq" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="faq" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center title="Questions, answered." />
       <Reveal className="mx-auto max-w-200">
         <Accordion type="single" collapsible>

--- a/website/src/components/site/FeatureExplorer.tsx
+++ b/website/src/components/site/FeatureExplorer.tsx
@@ -13,7 +13,7 @@ export function FeatureExplorer() {
   const [open, setOpen] = useState<string | null>(featureGroups[0]!.name)
 
   return (
-    <section id="features" className="mx-auto max-w-[1120px] px-6 py-32 max-[620px]:py-20">
+    <section id="features" className="mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-14">
       <SectionHead center eyebrow="every tool" title="Everything you need to debug faster.">
         All 61 tools, grouped by what they're for. Open a group to see what's inside.
       </SectionHead>

--- a/website/src/components/site/FinalCta.tsx
+++ b/website/src/components/site/FinalCta.tsx
@@ -15,7 +15,7 @@ export function FinalCta() {
   const inView = useInView(headingRef)
 
   return (
-    <section className="mx-auto max-w-[1120px] px-6 pb-28 max-[620px]:pb-20">
+    <section className="mx-auto max-w-[1120px] px-6 pt-4 pb-20 max-[620px]:pt-0 max-[620px]:pb-14">
       <Reveal>
         <div className="relative overflow-hidden rounded-3xl border border-white/[0.06] bg-gradient-to-b from-ink-700/60 to-ink-800/60 px-8 py-22 text-center shadow-[0_40px_100px_-30px_rgba(0,0,0,0.5)]">
           {/* Atmospheric green glow */}

--- a/website/src/components/site/FreeValue.tsx
+++ b/website/src/components/site/FreeValue.tsx
@@ -14,7 +14,7 @@ const lineItems = [
 
 export function FreeValue() {
   return (
-    <section className="mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-16">
+    <section className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <Reveal>
         <div className="relative overflow-hidden rounded-3xl border border-white/[0.06] bg-gradient-to-b from-white/[0.03] to-white/[0.01] px-10 py-14 max-[620px]:px-6 max-[620px]:py-11">
           <div

--- a/website/src/components/site/HowItWorks.tsx
+++ b/website/src/components/site/HowItWorks.tsx
@@ -40,7 +40,7 @@ const steps = [
 
 export function HowItWorks() {
   return (
-    <section id="how" className="section-contained mx-auto max-w-[1120px] px-6 py-28 max-[620px]:py-20">
+    <section id="how" className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <SectionHead center eyebrow="how it works" title="Connected in under a minute.">
         Three steps. The app handles the rest, and it even finds adb for you and offers a one-click install if it's
         missing.

--- a/website/src/components/site/McpSpotlight.tsx
+++ b/website/src/components/site/McpSpotlight.tsx
@@ -20,7 +20,7 @@ const points = [
  *  spotlight rather than a cell in a feature grid. */
 export function McpSpotlight() {
   return (
-    <section id="mcp" className="relative overflow-hidden py-32 max-[620px]:py-20">
+    <section id="mcp" className="relative overflow-hidden py-24 max-[620px]:py-14">
       {/* Ambient wash — marks this as a distinct moment in the page rhythm. */}
       <div
         aria-hidden

--- a/website/src/components/site/Nav.tsx
+++ b/website/src/components/site/Nav.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 const links = [
   { label: "Features", href: "#features" },
   { label: "Workflows", href: "#workflows" },
+  { label: "Platforms", href: "#platforms" },
   { label: "Why Droidective", href: "#why" },
   { label: "Changelog", href: "/changelog/" },
   { label: "Blog", href: "/blog/" },

--- a/website/src/components/site/Platforms.tsx
+++ b/website/src/components/site/Platforms.tsx
@@ -1,7 +1,7 @@
 import { Apple, ArrowUpRight, Monitor } from "lucide-react"
 
 import { Reveal } from "@/components/site/Reveal"
-import { platforms } from "@/lib/content"
+import { BETA_RELEASES_URL, platforms } from "@/lib/content"
 import { cn } from "@/lib/utils"
 
 const marks = { macos: Apple, "windows-linux": Monitor } as const
@@ -15,7 +15,7 @@ const marks = { macos: Apple, "windows-linux": Monitor } as const
  *  app files a bug that is really a copy problem. */
 export function Platforms() {
   return (
-    <section id="platforms" className="relative px-6 py-24">
+    <section id="platforms" className="relative px-6 py-20 max-[620px]:py-14">
       <div className="mx-auto max-w-[1140px]">
         <Reveal className="mb-12 max-w-[62ch]">
           <h2 className="display text-[clamp(28px,4.2vw,46px)] leading-[1.04]">
@@ -113,6 +113,18 @@ export function Platforms() {
                         />
                       </span>
                     </a>
+
+                    {/* The panel CTA names a specific tag, which goes stale the
+                        day a newer beta ships. This is the always-current way
+                        through, so a pinned version can never be a dead end. */}
+                    {!primary && (
+                      <a
+                        href={BETA_RELEASES_URL}
+                        className="mt-3 w-fit text-[12.5px] text-faint underline decoration-white/15 underline-offset-4 transition-colors duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] hover:text-muted hover:decoration-white/30"
+                      >
+                        All beta releases
+                      </a>
+                    )}
                   </div>
                 </div>
               </Reveal>

--- a/website/src/components/site/TrustStrip.tsx
+++ b/website/src/components/site/TrustStrip.tsx
@@ -1,7 +1,7 @@
 import CountUp from "@/components/CountUp"
 import { Reveal } from "@/components/site/Reveal"
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion"
-import { APP_VERSION, GITHUB_URL } from "@/lib/content"
+import { APP_VERSION, BETA_RELEASE_URL, GITHUB_URL } from "@/lib/content"
 
 /** The confidence signal, directly under the hero rather than inside it: the
  *  hero carries the value proposition and the CTA, this carries the facts that
@@ -14,7 +14,7 @@ const facts: { value: string; label: string; href?: string }[] = [
   { value: APP_VERSION, label: "Latest release", href: `${GITHUB_URL}/releases/tag/${APP_VERSION}` },
   { value: "MIT", label: "Free and open source", href: `${GITHUB_URL}/blob/main/LICENSE` },
   { value: "macOS 14+", label: "Signed and notarized" },
-  { value: "Windows · Linux", label: "On the beta channel", href: `${GITHUB_URL}/releases` },
+  { value: "Windows · Linux", label: "On the beta channel", href: BETA_RELEASE_URL },
 ]
 
 export function TrustStrip() {

--- a/website/src/components/site/UseCaseMoments.tsx
+++ b/website/src/components/site/UseCaseMoments.tsx
@@ -5,7 +5,7 @@ import { useCaseMoments } from "@/lib/content"
  *  then the answer. Deliberately compact: no images, no big cards. */
 export function UseCaseMoments() {
   return (
-    <section className="section-contained mx-auto max-w-[1120px] px-6 py-24 max-[620px]:py-16">
+    <section className="mx-auto max-w-[1120px] px-6 py-20 max-[620px]:py-14">
       <Reveal className="mb-12 max-w-[52ch]">
         <h2 className="display text-[clamp(26px,3.6vw,38px)] leading-[1.08]">
           Built for the moments that slow you down.

--- a/website/src/components/site/WorkflowTabs.tsx
+++ b/website/src/components/site/WorkflowTabs.tsx
@@ -17,7 +17,7 @@ export function WorkflowTabs() {
   const wf = workflows[active]!
 
   return (
-    <section id="workflows" className="mx-auto max-w-[1120px] px-6 pt-20 pb-32 max-[620px]:pt-14 max-[620px]:pb-20">
+    <section id="workflows" className="mx-auto max-w-[1120px] px-6 pt-16 pb-24 max-[620px]:pt-14 max-[620px]:pb-14">
       <SectionHead eyebrow="workflows" title="Built for how you debug.">
         Not a pile of features. Six workflows that cover the whole loop between writing code and
         understanding what your app actually did.

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -272,32 +272,13 @@ svg.lucide {
   stroke-width: 1.75;
 }
 
-/* ---------------------------------------------------------------------------
- * Off-screen sections do no render work.
- *
- * The page is ~15,000px tall. Without this the browser lays out and paints
- * every section on load and re-does that work whenever anything invalidates,
- * even for the ten sections nobody has scrolled to. `content-visibility: auto`
- * lets it skip a section entirely until it approaches the viewport.
- *
- * `contain-intrinsic-size: auto <estimate>` is the part that keeps the
- * scrollbar honest: the browser uses the estimate before a section has ever
- * rendered, then *remembers the real height* and uses that from then on, so
- * the page does not resize under the thumb on the way back up.
- *
- * Applied only to sections with no decoration escaping their own box, because
- * this establishes containment and would clip anything that does. The hero and
- * the MCP section are excluded for exactly that reason.
- * ------------------------------------------------------------------------- */
-.section-contained {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 720px;
-}
 
-/* The changelog runs to ~1,600px, so the shared estimate would misreport the
-   scrollbar by nearly a thousand pixels until it first renders. Every other
-   contained section measures between 515px and 982px, which 720 covers. */
-.section-contained-tall {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 1650px;
+/* Anchor targets clear the floating nav.
+ *
+ * The nav is fixed and ~76px tall, so a section scrolled to by an anchor lands
+ * with its heading a few pixels under it — technically visible, and visibly
+ * cramped. This gives every anchored target a landing offset instead of
+ * relying on each section's own top padding to happen to be enough. */
+:where(section, header)[id] {
+  scroll-margin-top: 24px;
 }

--- a/website/src/lib/content.ts
+++ b/website/src/lib/content.ts
@@ -21,6 +21,15 @@ export const RELEASES_URL = `${GITHUB_URL}/releases`
 export const DOWNLOAD_URL = `${GITHUB_URL}/releases/latest/download/Droidective.dmg`
 export const APP_VERSION = "v3.11.0"
 
+/** The newest pre-release tag, which is where the Windows and Linux builds
+ *  live. Pointing the beta links at `/releases` sent people to a list headed by
+ *  the *stable* macOS release, which is the one page that does not carry the
+ *  artifacts they came for. Bumped with the tag, like APP_VERSION. */
+export const BETA_VERSION = "v3.10.0-beta.5"
+export const BETA_RELEASE_URL = `${GITHUB_URL}/releases/tag/${BETA_VERSION}`
+/** Every pre-release, newest first, for "is there anything newer than that". */
+export const BETA_RELEASES_URL = `${GITHUB_URL}/releases?q=prerelease%3Atrue&expanded=true`
+
 export interface PaletteCommand {
   icon: LucideIcon
   name: string
@@ -233,8 +242,8 @@ export const platforms: Platform[] = [
       "Not signed, and updated by hand",
       "No video editor, Frida, or Command Log yet",
     ],
-    href: `${GITHUB_URL}/releases`,
-    cta: "Find a beta release",
+    href: BETA_RELEASE_URL,
+    cta: `Download ${BETA_VERSION}`,
   },
 ]
 


### PR DESCRIPTION
Five flaws, found by auditing the deployed site rather than reading the source.

## The blank band under About was two bugs stacked

`MagicCard` stretches to its grid row with `h-full`, but **its inner content
wrapper did not**, so a child asking for `h-full` measured against a box only as
tall as its own content. The flex column could not fill the card and `mt-auto`
had no slack to distribute:

| | before | after |
| --- | --- | --- |
| Card height | 465px | 465px |
| Content height | 366px | 463px |
| **Dead surface** | **98px** | **2px** |

The stats list now takes the slack across its three rows rather than pooling it
into one band above the footer.

## About was the only section with no top padding

`pb-20` with no `pt` meant its heading landed **under the fixed nav** when
reached by anchor (measured at `-3px` against a nav bottom of `70px`), and gave
it half the vertical rhythm of every neighbour. Now `py-20`. `FinalCta` had the
same asymmetry.

Related: every section target now carries `scroll-margin-top`, instead of
relying on each section's own top padding to happen to clear a 76px floating
bar. Platforms cleared it by 4px, which is luck rather than design.

## The beta links pointed at the wrong page

"On the beta channel" and "Find a beta release" both went to `/releases` —
whose top entry is the **stable macOS release**, the one page that does not
carry the Windows and Linux artifacts someone clicking "beta" came for.

Both now point at the newest pre-release tag, held in `BETA_VERSION` beside
`APP_VERSION` so the release process has one obvious touchpoint, and the panel
CTA names the version it will fetch ("Download v3.10.0-beta.5"). A pinned tag
goes stale the day a newer beta ships, so an **All beta releases** link sits
under it as the always-current way through.

The footer's generic "Releases" link is left pointing at `/releases`, which is
correct for that label.

## Adjacent section paddings were stacking

Two neighbours at `py-32` produced **256px** of dead space between them.

| | before | after |
| --- | --- | --- |
| Median gap | 224px | **160px** |
| Worst gap | 256px | **208px** |
| Page height | 15,067px | **14,437px** |

The tiering described in `App.tsx`'s comment is kept, one step tighter
throughout. No section lost content.

## `#platforms` had no way to reach it

A major section with no nav entry. Added.

## Reverting `content-visibility` from the previous change

I added it last time as a scroll optimisation. It **mis-estimated seven section
heights by 659px in total** (Blog alone by 262px), so a fast scroll flew through
unpainted placeholder space — which is what "blank gap" looked like from the
outside. The frame-time probe I used to justify it had measured *no improvement
at all*: 8.3ms median before and after, zero frames over 16ms either way.

An optimisation that cannot be measured and is visible when it misfires is not
worth keeping. The blur-to-transform half of that change stays, since that one
removes real per-frame repaint work with no downside.

## Verification

Browser-checked at desktop and at a narrow viewport: no horizontal scroll (the
wide elements are `pointer-events-none` decorative glows clipped by
`overflow-x: hidden`, plus the tab strip inside its own scroller). Every nav
anchor resolves to a real target. All 14 internal links return 200. `npm run
build` and `npm run lint` clean; the one lint warning predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
