### PR TITLE
Let any tab open in a window of its own, and keep its work when it moves

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/TabDropRouter.swift
+++ b/ADBKit/Sources/ADBKit/Features/TabDropRouter.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// The one table deciding what a dropped tab does — the tab-drag twin of
+/// `FileDropRouter`.
+///
+/// A tab can now be dropped on four kinds of place (its own strip, its own
+/// pane, *another window's* strip, another window's pane) and the answer
+/// differs in ways that are easy to get subtly wrong: a tab arriving from
+/// elsewhere must never split the window it lands in, and a split must only be
+/// promised when there is something to leave behind. Keeping the decision here,
+/// pure, means the drop targets and the hover previews read the same rule
+/// instead of two hand-written approximations of it.
+public enum TabDropRouter {
+    /// A tab drag in flight: what is moving, and which window it left.
+    public struct Drag: Sendable, Equatable {
+        public let featureID: String
+        public let source: WorkspaceID
+
+        public init(featureID: String, source: WorkspaceID) {
+            self.featureID = featureID
+            self.source = source
+        }
+    }
+
+    /// Where the drop landed.
+    public enum Target: Sendable, Equatable {
+        /// A pane's tab strip — precise placement, and never a split.
+        case strip(group: Int, before: String?)
+        /// A pane's content. In a split window this means "move into this
+        /// pane"; in a single-pane window it is the drop-to-split gesture.
+        case pane(group: Int)
+    }
+
+    /// What to do about it.
+    public enum Outcome: Sendable, Equatable {
+        /// Nothing: the tab was dropped where it already is.
+        case ignore
+        /// Place it within the window that already holds it.
+        case place(group: Int, before: String?)
+        /// Split this window's single pane, moving the tab into the new one.
+        case split
+        /// It belongs to another window — move it here, at this slot.
+        case handoff(source: WorkspaceID, group: Int, before: String?)
+    }
+
+    /// The receiving window's shape, as far as this decision cares.
+    public struct Shape: Sendable, Equatable {
+        /// Whether the window already has two panes.
+        public let isSplit: Bool
+        /// How many tabs the dropped-on pane holds.
+        public let paneTabCount: Int
+
+        public init(isSplit: Bool, paneTabCount: Int) {
+            self.isSplit = isSplit
+            self.paneTabCount = paneTabCount
+        }
+    }
+
+    /// Where a dropped tab should go.
+    ///
+    /// - Parameters:
+    ///   - drag: the tab in flight and the window it came from.
+    ///   - window: the window the drop landed in.
+    ///   - target: the strip slot or pane under the cursor.
+    ///   - shape: the receiving window's panes.
+    public static func outcome(
+        drag: Drag,
+        window: WorkspaceID,
+        target: Target,
+        shape: Shape
+    ) -> Outcome {
+        // A tab from another window is being *moved in*, never split off: the
+        // user is consolidating, and a split the receiver did not ask for is an
+        // extra pane to undo. A cross-window drop on a pane therefore behaves
+        // like a drop on that pane's strip.
+        guard drag.source == window else {
+            switch target {
+            case .strip(let group, let before):
+                return .handoff(source: drag.source, group: group, before: before)
+            case .pane(let group):
+                return .handoff(source: drag.source, group: group, before: nil)
+            }
+        }
+
+        switch target {
+        case .strip(let group, let before):
+            // Dropped on itself: `SidebarOrdering` would treat it as a no-op
+            // anyway, but saying so here keeps the guideline and the action
+            // agreeing about when nothing is going to happen.
+            guard before != drag.featureID else { return .ignore }
+            return .place(group: group, before: before)
+
+        case .pane(let group):
+            guard !shape.isSplit else { return .place(group: group, before: nil) }
+            // Only promise a split the workspace will honour: `Workspace.split`
+            // requires something to stay behind, so a lone tab dropped on its
+            // own pane does nothing rather than showing a preview that lies.
+            return shape.paneTabCount > 1 ? .split : .ignore
+        }
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/TabHandoff.swift
+++ b/ADBKit/Sources/ADBKit/Features/TabHandoff.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Moving one tab out of a window: what the receiving window opens with.
+///
+/// A tab that leaves its window has to take its *context* with it, or the move
+/// silently changes what the user is looking at. The context is exactly what a
+/// window persists, so the seed is a `WindowState` and the receiving window
+/// restores from it through the same path a relaunch uses — no second restore
+/// code, and no way for the two to drift.
+///
+/// Pure and value-typed so the rules below are tested without a window.
+public enum TabHandoff {
+    /// Per-feature state the source window holds on the moving tab's behalf.
+    ///
+    /// A window keeps a few pieces of state *for* a feature rather than inside
+    /// it, because they outlive the view: the terminal's working directories
+    /// (snapshotted when its shells are killed) and the Mirror Wall's chosen
+    /// devices. Those have to travel with the tab; nothing else does. Handing
+    /// a torn-off Logcat the source's terminal directories would resurrect
+    /// them in a window that has no Terminal tab.
+    public struct Carry: Sendable, Equatable {
+        /// Working directories of the source's terminal shells, snapshotted as
+        /// they were killed for the move. Only meaningful for `terminal`.
+        public var terminalResumeDirs: [String]?
+        /// Devices the source's Mirror Wall showed, in tile order. Only
+        /// meaningful for `mirror-wall`.
+        public var mirrorWallSerials: [String]?
+
+        public init(terminalResumeDirs: [String]? = nil, mirrorWallSerials: [String]? = nil) {
+            self.terminalResumeDirs = terminalResumeDirs
+            self.mirrorWallSerials = mirrorWallSerials
+        }
+
+        public static let none = Carry()
+    }
+
+    /// The feature id whose tab owns `Carry.terminalResumeDirs`.
+    public static let terminalFeatureID = "terminal"
+    /// The feature id whose tab owns `Carry.mirrorWallSerials`.
+    public static let mirrorWallFeatureID = "mirror-wall"
+
+    /// The receiving window's opening state.
+    ///
+    /// - The device and app bundle are **inherited**, never re-picked: a window
+    ///   opened by any other route deliberately lands on a device no other
+    ///   window holds (`firstFreeSerial`), which for a moved tab would swap the
+    ///   device out from under it — you tore off one phone's logcat and got
+    ///   another's.
+    /// - Exactly one tab, in one pane. Home is not seeded: the strip's
+    ///   permanent house button is always one click away, and a moved tab
+    ///   arriving beside a Home tab it didn't ask for reads as clutter.
+    /// - Carried state is filtered to the feature that owns it (see `Carry`).
+    public static func seed(
+        featureID: String,
+        from source: WindowState,
+        newID: WorkspaceID,
+        carrying carry: Carry = .none
+    ) -> WindowState {
+        WindowState(
+            id: newID,
+            serial: source.serial,
+            bundleId: source.bundleId,
+            tabGroups: [TabGroupState(tabs: [featureID], activeTab: featureID)],
+            focusedGroup: 0,
+            terminalResumeDirs: featureID == terminalFeatureID ? carry.terminalResumeDirs : nil,
+            mirrorWallSerials: featureID == mirrorWallFeatureID ? carry.mirrorWallSerials : nil
+        )
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/TearOffFrame.swift
+++ b/ADBKit/Sources/ADBKit/Features/TearOffFrame.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Where a window torn off by a drag lands on screen.
+///
+/// Pure geometry, like `MirrorWall.windowFrames` — the App layer measures the
+/// drag and the screen, this decides the rectangle, so the fiddly part
+/// (clamping a window bigger than the screen it was dropped on) is tested
+/// without a display. Deliberately no `CGRect`/`CGSize`: this is portable
+/// ADBKit and the App layer converts, exactly as it does for `TileFrame`.
+///
+/// `Rect` and `Point` are AppKit screen coordinates — origin bottom-left, y
+/// **up**. The two *inset* inputs are view coordinates instead, y **down** from
+/// the window's top-left, because that is how the tab strip is laid out and
+/// measured. The two conventions meeting is the whole reason this is worth
+/// testing rather than inlining.
+public enum TearOffFrame {
+    /// A size in points.
+    public struct Size: Sendable, Equatable {
+        public var width: Double
+        public var height: Double
+
+        public init(width: Double, height: Double) {
+            self.width = width
+            self.height = height
+        }
+    }
+
+    /// A position in points.
+    public struct Point: Sendable, Equatable {
+        public var x: Double
+        public var y: Double
+
+        public init(x: Double, y: Double) {
+            self.x = x
+            self.y = y
+        }
+    }
+
+    /// A rectangle in screen coordinates.
+    public struct Rect: Sendable, Equatable {
+        public var x: Double
+        public var y: Double
+        public var width: Double
+        public var height: Double
+
+        public init(x: Double, y: Double, width: Double, height: Double) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+        }
+
+        public var minX: Double { x }
+        public var maxX: Double { x + width }
+        public var minY: Double { y }
+        public var maxY: Double { y + height }
+    }
+
+    /// The new window's frame.
+    ///
+    /// The rule is that **the dragged chip lands under the cursor**, so the
+    /// window reads as growing out of the tab you were holding rather than
+    /// appearing at some unrelated spot. The moved tab is the only one in the
+    /// new window, so it will be the strip's *first* chip — `stripOrigin` says
+    /// where that sits, and `grabOffset` says where inside the chip the pointer
+    /// was.
+    ///
+    /// - Parameters:
+    ///   - dropPoint: Where the drag was released, in screen coordinates.
+    ///   - grabOffset: The pointer's position inside the dragged chip, from the
+    ///     chip's top-left, y down.
+    ///   - stripOrigin: Where the first chip's top-left sits inside the window,
+    ///     from the window's top-left, y down.
+    ///   - sourceSize: The size of the window the tab came from — a torn-off
+    ///     window inherits it, so the feature gets the room it already had.
+    ///   - screen: The visible frame of the screen the drop landed on (i.e.
+    ///     excluding the menu bar and Dock).
+    ///   - minimum: The app's minimum window size.
+    public static func frame(
+        dropPoint: Point,
+        grabOffset: Size,
+        stripOrigin: Point,
+        sourceSize: Size,
+        screen: Rect,
+        minimum: Size
+    ) -> Rect {
+        // Fit the screen, but never below the app's floor: a screen smaller
+        // than the minimum yields an oversized window, which the origin clamp
+        // below then pins by its top-left rather than letting the title bar
+        // fall off.
+        let width = max(minimum.width, min(sourceSize.width, screen.width))
+        let height = max(minimum.height, min(sourceSize.height, screen.height))
+
+        let left = dropPoint.x - grabOffset.width - stripOrigin.x
+        // `grabOffset` and `stripOrigin` measure downward, so both raise the
+        // window's top edge above the cursor; the origin is that top minus the
+        // height.
+        let top = dropPoint.y + grabOffset.height + stripOrigin.y
+
+        // Deliberately asymmetric clamps. A window wider than the screen keeps
+        // its *left* edge on screen (that is where the strip and its chips
+        // are), and one taller keeps its *top* (that is where the title bar and
+        // the strip are). Clamping both the same way would push one of them
+        // off, which is how a window ends up unusable on a small display.
+        let x = max(min(left, screen.maxX - width), screen.minX)
+        let y = min(max(top - height, screen.minY), screen.maxY - height)
+
+        return Rect(x: x, y: y, width: width, height: height)
+    }
+}

--- a/ADBKit/Sources/ADBKit/Features/Workspace.swift
+++ b/ADBKit/Sources/ADBKit/Features/Workspace.swift
@@ -109,6 +109,39 @@ public struct Workspace: Sendable, Equatable {
         focusedGroup = groupIndex(of: id) ?? focusedGroup
     }
 
+    /// Whether `id` can leave this workspace for *another window*.
+    ///
+    /// Only that it is open: moving a window's last tab into another window is
+    /// a legitimate way to consolidate two windows, and leaves this one showing
+    /// `fallback` exactly as closing that tab would.
+    public func canDetach(_ id: String) -> Bool {
+        groupIndex(of: id) != nil
+    }
+
+    /// Whether `id` can leave for a window *of its own*.
+    ///
+    /// Stricter, because something has to stay behind: a workspace whose only
+    /// tab left for a new window would not be a move, it would be the *window*
+    /// moving — and the window already moves. Same "something must stay"
+    /// precondition `split` carries, counted across both panes rather than
+    /// within one, because detaching collapses an emptied pane.
+    public func canDetachToNewWindow(_ id: String) -> Bool {
+        canDetach(id) && totalTabs > 1
+    }
+
+    /// Remove `id` from this workspace and return it, for a handoff to another
+    /// window.
+    ///
+    /// Deliberately the same removal `close` performs — collapse an emptied
+    /// second pane, keep `focusedGroup` in range, and never leave the workspace
+    /// empty — because a window that has just given its last tab away should
+    /// look exactly like one whose last tab was closed, rather than a blank.
+    public mutating func detach(_ id: String) -> String? {
+        guard canDetach(id) else { return nil }
+        close(id)
+        return id
+    }
+
     /// Split the workspace: move `id` into a new second pane. Requires its pane
     /// to hold more than one tab (something must stay behind) and no existing
     /// split.
@@ -132,7 +165,12 @@ public struct Workspace: Sendable, Equatable {
     public mutating func drop(_ id: String, intoGroup dest: Int, before targetID: String?) {
         guard let src = groupIndex(of: id) else { return }
         if src == dest {
-            if let targetID { reorder(id, before: targetID) }
+            // A nil target is the strip's dead space past the last chip, which
+            // means "put it at the end" — `reorder` already reads it that way.
+            // Skipping the call for nil made that a dead drop in the tab's own
+            // pane while working across panes, which is the asymmetry the strip
+            // documents itself as *not* having.
+            reorder(id, before: targetID)
         } else {
             move(id, toGroup: dest)
             if let targetID { reorder(id, before: targetID) }

--- a/ADBKit/Tests/ADBKitTests/TabDropRouterTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TabDropRouterTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// What a dropped tab does, by where it came from and where it landed.
+@Suite struct TabDropRouterTests {
+    private let here = WorkspaceID("here")
+    private let there = WorkspaceID("there")
+
+    private func drag(_ featureID: String = "logcat", from source: WorkspaceID) -> TabDropRouter.Drag {
+        TabDropRouter.Drag(featureID: featureID, source: source)
+    }
+
+    private func outcome(
+        _ drag: TabDropRouter.Drag,
+        _ target: TabDropRouter.Target,
+        isSplit: Bool = false,
+        paneTabCount: Int = 3
+    ) -> TabDropRouter.Outcome {
+        TabDropRouter.outcome(
+            drag: drag,
+            window: here,
+            target: target,
+            shape: TabDropRouter.Shape(isSplit: isSplit, paneTabCount: paneTabCount))
+    }
+
+    // MARK: - Within the window that owns the tab
+
+    @Test func aDropOnItsOwnStripPlacesTheTab() {
+        #expect(outcome(drag(from: here), .strip(group: 0, before: "wifi"))
+            == .place(group: 0, before: "wifi"))
+    }
+
+    @Test func aDropOnTheStripsDeadSpacePlacesItAtTheEnd() {
+        #expect(outcome(drag(from: here), .strip(group: 1, before: nil))
+            == .place(group: 1, before: nil))
+    }
+
+    @Test func aDropOnTheTabItselfIsIgnored() {
+        #expect(outcome(drag("logcat", from: here), .strip(group: 0, before: "logcat")) == .ignore)
+    }
+
+    @Test func aDropOnAPaneOfASplitWindowMovesItIntoThatPane() {
+        #expect(outcome(drag(from: here), .pane(group: 1), isSplit: true)
+            == .place(group: 1, before: nil))
+    }
+
+    @Test func aDropOnTheOnlyPanesContentSplitsIt() {
+        #expect(outcome(drag(from: here), .pane(group: 0), isSplit: false, paneTabCount: 2) == .split)
+    }
+
+    /// The preview and the action have to agree: `Workspace.split` refuses when
+    /// nothing would stay behind, so this must not offer a split either.
+    @Test func aLoneTabDroppedOnItsOwnPaneDoesNothing() {
+        #expect(outcome(drag(from: here), .pane(group: 0), isSplit: false, paneTabCount: 1) == .ignore)
+    }
+
+    // MARK: - From another window
+
+    @Test func aTabFromAnotherWindowLandingOnTheStripIsAHandoffAtThatSlot() {
+        #expect(outcome(drag(from: there), .strip(group: 1, before: "wifi"))
+            == .handoff(source: there, group: 1, before: "wifi"))
+    }
+
+    /// The rule worth having a test for: consolidating into a window must not
+    /// silently split it.
+    @Test func aTabFromAnotherWindowNeverSplitsTheReceiver() {
+        #expect(outcome(drag(from: there), .pane(group: 0), isSplit: false, paneTabCount: 5)
+            == .handoff(source: there, group: 0, before: nil))
+    }
+
+    @Test func aTabFromAnotherWindowLandingOnASplitPaneGoesToThatPane() {
+        #expect(outcome(drag(from: there), .pane(group: 1), isSplit: true)
+            == .handoff(source: there, group: 1, before: nil))
+    }
+
+    /// Two windows can each hold a tab with the same id, so "the id matches the
+    /// drop target" is not the same question as "it was dropped on itself".
+    /// Only the second is a no-op; the first is a merge.
+    @Test func aSameIdTabFromAnotherWindowIsAHandoffNotAnIgnore() {
+        #expect(outcome(drag("logcat", from: there), .strip(group: 0, before: "logcat"))
+            == .handoff(source: there, group: 0, before: "logcat"))
+    }
+
+    @Test func aLoneTabFromAnotherWindowStillMovesIn() {
+        // `paneTabCount` describes the *receiver*; whether the source has
+        // anything left is `Workspace.canDetach`'s question, asked earlier.
+        #expect(outcome(drag(from: there), .pane(group: 0), isSplit: false, paneTabCount: 1)
+            == .handoff(source: there, group: 0, before: nil))
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TabHandoffTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TabHandoffTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// Moving a tab out of its window: what leaves, and what travels with it.
+@Suite struct TabHandoffTests {
+    private let sourceID = WorkspaceID("source")
+    private let newID = WorkspaceID("destination")
+
+    private func source(
+        serial: String? = "PIXEL8",
+        bundleId: String? = "com.example.app"
+    ) -> WindowState {
+        WindowState(
+            id: sourceID,
+            serial: serial,
+            bundleId: bundleId,
+            tabGroups: [TabGroupState(tabs: ["home", "logcat", "terminal"], activeTab: "logcat")],
+            focusedGroup: 0,
+            terminalResumeDirs: ["/Users/dev/project", "/tmp"],
+            mirrorWallSerials: ["PIXEL8", "GALAXY"]
+        )
+    }
+
+    // MARK: - Inherited context
+
+    @Test func seedInheritsTheSourcesDeviceAndBundle() {
+        let seed = TabHandoff.seed(featureID: "logcat", from: source(), newID: newID)
+        #expect(seed.serial == "PIXEL8")
+        #expect(seed.bundleId == "com.example.app")
+    }
+
+    @Test func seedUsesTheNewWorkspaceIDNotTheSources() {
+        let seed = TabHandoff.seed(featureID: "logcat", from: source(), newID: newID)
+        #expect(seed.id == newID)
+    }
+
+    @Test func seedWithoutASourceDeviceCarriesNoDevice() {
+        let seed = TabHandoff.seed(
+            featureID: "logcat", from: source(serial: nil, bundleId: nil), newID: newID)
+        #expect(seed.serial == nil)
+        #expect(seed.bundleId == nil)
+    }
+
+    // MARK: - Exactly one tab
+
+    @Test func seedOpensOnlyTheMovedTab() {
+        let seed = TabHandoff.seed(featureID: "logcat", from: source(), newID: newID)
+        #expect(seed.tabGroups == [TabGroupState(tabs: ["logcat"], activeTab: "logcat")])
+        #expect(seed.focusedGroup == 0)
+    }
+
+    @Test func seedDoesNotCarryTheSourcesOtherTabs() {
+        let seed = TabHandoff.seed(featureID: "logcat", from: source(), newID: newID)
+        let tabs = seed.tabGroups?.flatMap(\.tabs) ?? []
+        #expect(!tabs.contains("home"))
+        #expect(!tabs.contains("terminal"))
+    }
+
+    // MARK: - Carried state is filtered to the feature that owns it
+
+    @Test func terminalCarriesItsWorkingDirectories() {
+        let carry = TabHandoff.Carry(terminalResumeDirs: ["/Users/dev/project"])
+        let seed = TabHandoff.seed(
+            featureID: "terminal", from: source(), newID: newID, carrying: carry)
+        #expect(seed.terminalResumeDirs == ["/Users/dev/project"])
+        #expect(seed.mirrorWallSerials == nil)
+    }
+
+    @Test func mirrorWallCarriesItsDevices() {
+        let carry = TabHandoff.Carry(mirrorWallSerials: ["A", "B"])
+        let seed = TabHandoff.seed(
+            featureID: "mirror-wall", from: source(), newID: newID, carrying: carry)
+        #expect(seed.mirrorWallSerials == ["A", "B"])
+        #expect(seed.terminalResumeDirs == nil)
+    }
+
+    /// The whole point of filtering: a torn-off Logcat must not resurrect the
+    /// source's terminal directories in a window with no Terminal tab, nor its
+    /// wall devices in a window with no wall.
+    @Test func anyOtherFeatureCarriesNeither() {
+        let carry = TabHandoff.Carry(
+            terminalResumeDirs: ["/tmp"], mirrorWallSerials: ["A"])
+        let seed = TabHandoff.seed(
+            featureID: "logcat", from: source(), newID: newID, carrying: carry)
+        #expect(seed.terminalResumeDirs == nil)
+        #expect(seed.mirrorWallSerials == nil)
+    }
+
+    /// The source's own persisted values are never read for the carry — they
+    /// describe the *source's* live state, and by the time a handoff happens
+    /// the terminal has been re-snapshotted. Passing no carry means none.
+    @Test func withoutACarryNothingTravelsEvenIfTheSourceHasIt() {
+        let seed = TabHandoff.seed(featureID: "terminal", from: source(), newID: newID)
+        #expect(seed.terminalResumeDirs == nil)
+        let wall = TabHandoff.seed(featureID: "mirror-wall", from: source(), newID: newID)
+        #expect(wall.mirrorWallSerials == nil)
+    }
+
+    // MARK: - Round trip
+
+    /// The seed is a `WindowState` precisely so the receiving window restores
+    /// through the same path a relaunch uses — so it has to survive the store's
+    /// encoding unchanged.
+    @Test func seedRoundTripsThroughJSON() throws {
+        let carry = TabHandoff.Carry(terminalResumeDirs: ["/Users/dev"])
+        let seed = TabHandoff.seed(
+            featureID: "terminal", from: source(), newID: newID, carrying: carry)
+        let data = try JSONEncoder().encode(seed)
+        let decoded = try JSONDecoder().decode(WindowState.self, from: data)
+        #expect(decoded == seed)
+    }
+
+    @Test func aTornOffWindowRoundTripsThroughTheLayout() throws {
+        var layout = LayoutState()
+        let seed = TabHandoff.seed(featureID: "logcat", from: source(), newID: newID)
+        layout.upsertWindow(seed)
+        let data = try JSONEncoder().encode(layout)
+        let decoded = try JSONDecoder().decode(LayoutState.self, from: data)
+        #expect(decoded.windows?.contains(seed) == true)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/TearOffFrameTests.swift
+++ b/ADBKit/Tests/ADBKitTests/TearOffFrameTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// Where a torn-off window lands. Screen coordinates are y-**up**; the chip and
+/// strip insets are y-**down** from the window's top-left.
+@Suite struct TearOffFrameTests {
+    /// A 1920×1080 screen at the origin, with 25 pt of menu bar taken off the
+    /// top — the shape `NSScreen.visibleFrame` actually has.
+    private let screen = TearOffFrame.Rect(x: 0, y: 0, width: 1920, height: 1055)
+    private let sourceSize = TearOffFrame.Size(width: 1200, height: 800)
+    private let minimum = TearOffFrame.Size(width: 760, height: 480)
+    /// The first chip sits past the Home button and its divider.
+    private let stripOrigin = TearOffFrame.Point(x: 52, y: 28)
+
+    private func frame(
+        droppedAt point: TearOffFrame.Point,
+        grab: TearOffFrame.Size = TearOffFrame.Size(width: 40, height: 14),
+        source: TearOffFrame.Size? = nil,
+        screen: TearOffFrame.Rect? = nil
+    ) -> TearOffFrame.Rect {
+        TearOffFrame.frame(
+            dropPoint: point,
+            grabOffset: grab,
+            stripOrigin: stripOrigin,
+            sourceSize: source ?? sourceSize,
+            screen: screen ?? self.screen,
+            minimum: minimum
+        )
+    }
+
+    // MARK: - The chip lands under the cursor
+
+    /// Drop points here are chosen so nothing clamps — an 800 pt window dropped
+    /// low on the screen gets pushed up, and then the chip deliberately *isn't*
+    /// under the cursor any more (`aDropNearTheBottomEdgeClampsInside` covers
+    /// that case).
+    @Test func theDraggedChipLandsUnderTheCursor() {
+        let drop = TearOffFrame.Point(x: 800, y: 900)
+        let result = frame(droppedAt: drop)
+        // Where the chip will be in the new window, converted back to screen
+        // coordinates — the cursor should be exactly there.
+        let chipLeft = result.minX + stripOrigin.x
+        let chipTop = result.maxY - stripOrigin.y
+        #expect(chipLeft + 40 == drop.x)
+        #expect(chipTop - 14 == drop.y)
+    }
+
+    @Test func aDifferentGrabOffsetShiftsTheWindowWithIt() {
+        let drop = TearOffFrame.Point(x: 700, y: 900)
+        let near = frame(droppedAt: drop, grab: TearOffFrame.Size(width: 10, height: 4))
+        let far = frame(droppedAt: drop, grab: TearOffFrame.Size(width: 90, height: 4))
+        // Grabbing further right in the chip puts the window further left, so
+        // that point of the chip still ends up under the cursor.
+        #expect(far.minX == near.minX - 80)
+    }
+
+    @Test func theWindowInheritsTheSourceWindowsSize() {
+        let result = frame(droppedAt: TearOffFrame.Point(x: 800, y: 900))
+        #expect(result.width == 1200)
+        #expect(result.height == 800)
+    }
+
+    // MARK: - Clamping into the screen
+
+    @Test func aDropNearTheRightEdgeClampsInside() {
+        let result = frame(droppedAt: TearOffFrame.Point(x: 1900, y: 600))
+        #expect(result.maxX == screen.maxX)
+        #expect(result.minX >= screen.minX)
+    }
+
+    @Test func aDropNearTheBottomEdgeClampsInside() {
+        let result = frame(droppedAt: TearOffFrame.Point(x: 800, y: 10))
+        #expect(result.minY == screen.minY)
+        #expect(result.maxY <= screen.maxY)
+    }
+
+    @Test func aDropNearTheTopEdgeClampsInside() {
+        let result = frame(droppedAt: TearOffFrame.Point(x: 800, y: 1050))
+        #expect(result.maxY == screen.maxY)
+    }
+
+    @Test func aDropInTheBottomRightCornerClampsOnBothAxes() {
+        let result = frame(droppedAt: TearOffFrame.Point(x: 1915, y: 5))
+        #expect(result.maxX == screen.maxX)
+        #expect(result.minY == screen.minY)
+    }
+
+    @Test func aDropOnAScreenWithANonZeroOriginStaysOnThatScreen() {
+        // A second display sitting to the right of the main one.
+        let second = TearOffFrame.Rect(x: 1920, y: 0, width: 1280, height: 800)
+        let result = frame(
+            droppedAt: TearOffFrame.Point(x: 3100, y: 400), screen: second)
+        #expect(result.minX >= second.minX)
+        #expect(result.maxX <= second.maxX)
+        #expect(result.minY >= second.minY)
+        #expect(result.maxY <= second.maxY)
+    }
+
+    // MARK: - Size limits
+
+    @Test func aSourceWindowBiggerThanTheScreenShrinksToFit() {
+        let huge = TearOffFrame.Size(width: 4000, height: 3000)
+        let result = frame(droppedAt: TearOffFrame.Point(x: 800, y: 600), source: huge)
+        #expect(result.width == screen.width)
+        #expect(result.height == screen.height)
+    }
+
+    @Test func neverGoesBelowTheMinimumSize() {
+        let tiny = TearOffFrame.Size(width: 100, height: 100)
+        let result = frame(droppedAt: TearOffFrame.Point(x: 800, y: 600), source: tiny)
+        #expect(result.width == minimum.width)
+        #expect(result.height == minimum.height)
+    }
+
+    /// A window that cannot fit keeps its top-left corner reachable: the title
+    /// bar and the tab strip live there, so pinning the other corners would
+    /// leave the window undraggable and the tabs unreachable.
+    @Test func aScreenSmallerThanTheMinimumStillYieldsTheMinimumPinnedTopLeft() {
+        let cramped = TearOffFrame.Rect(x: 0, y: 0, width: 500, height: 400)
+        let result = frame(droppedAt: TearOffFrame.Point(x: 250, y: 200), screen: cramped)
+        #expect(result.width == minimum.width)
+        #expect(result.height == minimum.height)
+        #expect(result.minX == cramped.minX)
+        #expect(result.maxY == cramped.maxY)
+    }
+
+    // MARK: - Invariant
+
+    @Test(arguments: [
+        TearOffFrame.Point(x: 0, y: 0),
+        TearOffFrame.Point(x: 1920, y: 1055),
+        TearOffFrame.Point(x: -400, y: 500),
+        TearOffFrame.Point(x: 5000, y: -500),
+        TearOffFrame.Point(x: 960, y: 527),
+    ])
+    func theResultIsAlwaysFullyOnScreenWhenTheScreenAllowsIt(drop: TearOffFrame.Point) {
+        let result = frame(droppedAt: drop)
+        #expect(result.minX >= screen.minX)
+        #expect(result.maxX <= screen.maxX)
+        #expect(result.minY >= screen.minY)
+        #expect(result.maxY <= screen.maxY)
+    }
+
+    @Test func anEmptyScreenRectDoesNotCrashAndYieldsTheMinimum() {
+        let empty = TearOffFrame.Rect(x: 0, y: 0, width: 0, height: 0)
+        let result = frame(droppedAt: TearOffFrame.Point(x: 0, y: 0), screen: empty)
+        #expect(result.width == minimum.width)
+        #expect(result.height == minimum.height)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WorkspaceRegistryTests.swift
@@ -302,4 +302,54 @@ import Testing
         #expect(String(data: encoded, encoding: .utf8) == "\"abc-123\"")
         #expect(try JSONDecoder().decode(WorkspaceID.self, from: encoded) == WorkspaceID("abc-123"))
     }
+
+    // MARK: - Tear-off: two windows on one device
+
+    /// Tearing a tab out of a window makes "two windows on one device" the
+    /// normal case rather than the unusual one, because the moved tab inherits
+    /// its source's device. The rules have to stay stable under that.
+    @Test func twoWindowsOnOneDeviceResolveToTheFirst() {
+        let registry = registry([(w1, "PIXEL8", ["logcat"]), (w2, "PIXEL8", ["performance"])])
+        #expect(registry.owner(ofDevice: "PIXEL8") == w1)
+        #expect(registry.owner(ofDevice: "PIXEL8", excluding: w1) == w2)
+    }
+
+    @Test func aDoublyHeldDeviceIsStillTakenForANewWindow() {
+        let registry = registry([(w1, "PIXEL8", []), (w2, "PIXEL8", [])])
+        #expect(registry.unclaimed(from: ["PIXEL8", "GALAXY"]) == ["GALAXY"])
+    }
+
+    /// The ordering the handoff depends on: the source releases the exclusive
+    /// feature *before* the destination opens it, so the destination never sees
+    /// a conflict and never starts a second encoder on the device.
+    @Test func detachingAnExclusiveFeatureClearsTheConflictForTheDestination() {
+        var registry = registry([(w1, "PIXEL8", ["scrcpy"]), (w2, "PIXEL8", [])])
+        #expect(registry.conflict(opening: "scrcpy", in: w2) != nil)
+        registry.setOpenFeatures([], for: w1) // the source detached it
+        #expect(registry.conflict(opening: "scrcpy", in: w2) == nil)
+    }
+
+    /// The reverse ordering is what the handoff must never do: open first, then
+    /// close. This asserts the state that would produce — a real conflict — so
+    /// the ordering requirement is documented by a test rather than a comment.
+    @Test func openingBeforeTheSourceReleasesWouldConflict() {
+        let registry = registry([(w1, "PIXEL8", ["scrcpy"]), (w2, "PIXEL8", ["scrcpy"])])
+        #expect(registry.conflict(opening: "scrcpy", in: w2)
+            == .featureOwnedElsewhere(w1, featureID: "scrcpy"))
+    }
+
+    /// A non-exclusive feature moved to a second window on the same device is
+    /// never blocked — two logcats on one device is normal.
+    @Test func aDuplicableFeatureOnOneDeviceNeverConflicts() {
+        let registry = registry([(w1, "PIXEL8", ["logcat"]), (w2, "PIXEL8", ["logcat"])])
+        #expect(registry.conflict(opening: "logcat", in: w2) == nil)
+    }
+
+    /// Two windows on one device still get different tints: the tint tells
+    /// *windows* apart, not devices, and the title carries the device name.
+    @Test func twoWindowsOnOneDeviceStillTintDifferently() {
+        let first = WorkspaceRegistry.tintIndex(ofWindow: 2, paletteSize: 6)
+        let second = WorkspaceRegistry.tintIndex(ofWindow: 3, paletteSize: 6)
+        #expect(first != second)
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/WorkspaceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/WorkspaceTests.swift
@@ -109,6 +109,20 @@ import Testing
         #expect(ws.openTabs(inGroup: 0) == ["b", "a", "c"])
     }
 
+    /// The strip's dead space past the last chip drops to the end. It read as a
+    /// dead drop in the tab's own pane while working across panes.
+    @Test func dropWithNoTargetInTheSamePaneMovesToTheEnd() {
+        var ws = make([["a", "b", "c"]])
+        ws.drop("a", intoGroup: 0, before: nil)
+        #expect(ws.openTabs(inGroup: 0) == ["b", "c", "a"])
+    }
+
+    @Test func dropWithNoTargetIsStillANoOpForTheLastTab() {
+        var ws = make([["a", "b", "c"]])
+        ws.drop("c", intoGroup: 0, before: nil)
+        #expect(ws.openTabs(inGroup: 0) == ["a", "b", "c"])
+    }
+
     @Test func dropAcrossPanesMovesAndPositions() {
         var ws = make([["home", "logcat"], ["x", "y"]], focused: 0)
         ws.drop("logcat", intoGroup: 1, before: "y")
@@ -163,5 +177,111 @@ import Testing
         #expect(ws.groups.count == 1)
         #expect(ws.openTabs(inGroup: 0) == ["home"])
         #expect(ws.focusedGroup == 0)
+    }
+
+    // MARK: - detach (moving a tab to another window)
+
+    /// The two rules differ on exactly one case: a workspace's last tab may go
+    /// to another *open* window (consolidating two windows) but not to a window
+    /// of its own, which would just be this window moving.
+    @Test func theWorkspacesOnlyTabCanMoveToAnotherWindowButNotToANewOne() {
+        var ws = Workspace(fallback: "home")
+        #expect(ws.canDetach("home"))
+        #expect(ws.canDetachToNewWindow("home") == false)
+        #expect(ws.detach("home") == "home")
+        #expect(ws.openTabs(inGroup: 0) == ["home"]) // fallback reseeded
+    }
+
+    @Test func cannotDetachATabThatIsNotOpen() {
+        var ws = make([["home", "logcat"]])
+        #expect(ws.canDetach("performance") == false)
+        #expect(ws.canDetachToNewWindow("performance") == false)
+        #expect(ws.detach("performance") == nil)
+        #expect(ws.totalTabs == 2)
+    }
+
+    @Test func canDetachWhenAnotherTabRemainsInTheSamePane() {
+        var ws = make([["home", "logcat"]])
+        #expect(ws.canDetach("logcat"))
+        #expect(ws.canDetachToNewWindow("logcat"))
+        #expect(ws.detach("logcat") == "logcat")
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+    }
+
+    /// A tab that is the last one across *both* panes still cannot claim a new
+    /// window — the count is workspace-wide, not per pane.
+    @Test func aSplitWithOneTabEachStillAllowsANewWindow() {
+        var ws = make([["logcat"], ["wifi"]], focused: 0)
+        #expect(ws.canDetachToNewWindow("logcat"))
+        _ = ws.detach("logcat")
+        #expect(ws.isSplit == false)
+        #expect(ws.openTabs(inGroup: 0) == ["wifi"])
+        #expect(ws.canDetachToNewWindow("wifi") == false) // now the only one
+    }
+
+    /// "Something must stay behind" is counted across both panes, unlike
+    /// `split` — detaching a lone tab out of one pane collapses that pane and
+    /// leaves the other one holding the workspace.
+    @Test func canDetachAPanesLastTabWhenTheOtherPaneHasTabs() {
+        var ws = make([["home", "logcat"], ["performance"]], focused: 1)
+        #expect(ws.canDetach("performance"))
+        #expect(ws.detach("performance") == "performance")
+        #expect(ws.isSplit == false)
+        #expect(ws.openTabs(inGroup: 0) == ["home", "logcat"])
+        #expect(ws.focusedGroup == 0) // clamped back into range
+    }
+
+    /// A window that has given its last tab away should look like one whose
+    /// last tab was closed — showing Home — rather than a blank.
+    @Test func detachingTheLastTabLeavesTheFallbackBehind() {
+        var ws = make([["logcat", "performance"]])
+        _ = ws.detach("logcat")
+        #expect(ws.openTabs(inGroup: 0) == ["performance"])
+        _ = ws.detach("performance")
+        #expect(ws.openTabs(inGroup: 0) == ["home"])
+        #expect(ws.totalTabs == 1)
+    }
+
+    @Test func detachMovesFocusToASurvivingTabInTheSamePane() {
+        var ws = make([["home", "logcat", "performance"]])
+        ws.open("logcat") // make it active
+        #expect(ws.activeTab == "logcat")
+        _ = ws.detach("logcat")
+        #expect(ws.activeTab == "performance") // the tab that slid into the slot
+    }
+
+    @Test func detachingAnInactiveTabLeavesTheActiveOneAlone() {
+        var ws = make([["home", "logcat", "performance"]])
+        ws.open("performance")
+        _ = ws.detach("logcat")
+        #expect(ws.activeTab == "performance")
+        #expect(ws.openTabs(inGroup: 0) == ["home", "performance"])
+    }
+
+    @Test func detachFromTheFirstPanePromotesTheOther() {
+        var ws = make([["home"], ["logcat", "performance"]], focused: 0)
+        _ = ws.detach("home")
+        #expect(ws.isSplit == false)
+        #expect(ws.openTabs(inGroup: 0) == ["logcat", "performance"])
+        #expect(ws.focusedGroup == 0)
+    }
+
+    /// A detached id must be gone for good, so the receiving window can open it
+    /// without breaking the "a feature is open in at most one tab" invariant —
+    /// and so the source can open it again later.
+    @Test func aDetachedIdCanBeOpenedAgainInTheSameWorkspace() {
+        var ws = make([["home", "logcat"]])
+        _ = ws.detach("logcat")
+        #expect(ws.groupIndex(of: "logcat") == nil)
+        ws.open("logcat")
+        #expect(ws.openTabs(inGroup: 0) == ["home", "logcat"])
+        #expect(ws.totalTabs == 2) // not duplicated
+    }
+
+    @Test func detachDoesNotDisturbTheOtherPane() {
+        var ws = make([["home", "logcat"], ["performance", "wifi"]], focused: 0)
+        _ = ws.detach("logcat")
+        #expect(ws.openTabs(inGroup: 1) == ["performance", "wifi"])
+        #expect(ws.groups.count == 2)
     }
 }

--- a/App/Sources/ADTApp.swift
+++ b/App/Sources/ADTApp.swift
@@ -410,6 +410,12 @@ struct ADTApp: App {
 
                 Divider()
 
+                // ⌃⌘N: ⌘N is the Terminal's and ⇧⌘N opens a plain window, so
+                // moving a tab out sits beside them rather than on top of one.
+                TabHandoffCommands(core: core)
+
+                Divider()
+
                 // Control-based so they don't fight the form fields' Tab focus
                 // traversal or the palette's ⌘1–9 result jumps.
                 Button("Next Tab") { appState?.selectNextTab() }

--- a/App/Sources/FeatureDetail/NativeTerminalView.swift
+++ b/App/Sources/FeatureDetail/NativeTerminalView.swift
@@ -712,6 +712,10 @@ struct NativeTerminalView: NSViewRepresentable {
     /// registration so hidden keep-alive tabs can't capture drags (see
     /// `DroidTerminalView.setAcceptsFileDrops`).
     let isVisibleTab: Bool
+    /// Whether the window rendering this pane still owns the shell. False for
+    /// the final update pass of a window whose Terminal tab has moved away —
+    /// which must not reclaim the live view from the window that took it.
+    let isOwned: Bool
     @Environment(\.windowOpacity) private var windowOpacity
 
     /// Remembers the last activation state so focus is grabbed only on the
@@ -745,6 +749,11 @@ struct NativeTerminalView: NSViewRepresentable {
             session?.onFocus?()
         }
         if terminal.superview !== container {
+            // Only the owning window may take the live view. Both containers
+            // are in real windows during a Terminal move — the receiving one
+            // and the departing one's last update pass — so the window check
+            // that would seem to separate them does not; ownership does.
+            guard isOwned else { return }
             // Evict whatever an earlier session left mounted here.
             for stale in container.subviews where stale !== terminal {
                 stale.removeFromSuperview()
@@ -769,3 +778,4 @@ struct NativeTerminalView: NSViewRepresentable {
         coordinator.wasActive = isActive
     }
 }
+

--- a/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
+++ b/App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift
@@ -28,7 +28,15 @@ enum ApiSidebarSection: String, CaseIterable, Identifiable {
 
 struct ApiClientView: View {
     @Environment(AppState.self) private var state
-    @State private var model = ApiClientModel()
+    /// Held per window by `FeatureStateStore`, not as `@State`, so the request
+    /// being edited, its response and the loaded collections survive the view
+    /// being rebuilt — which is what moving this tab to another window does.
+    private var model: ApiClientModel {
+        state.featureState(ApiClientModel.self, for: "api-client") { ApiClientModel() }
+    }
+    /// A bindable handle for the few controls that need write access; the
+    /// projection `@State` gave for free is not available on a computed one.
+    private var bindable: Bindable<ApiClientModel> { Bindable(model) }
 
     @AppStorage("apiSidebarSection") private var sidebarSection: ApiSidebarSection = .collections
     @AppStorage("apiRequestTab") private var requestTab: ApiRequestTab = .params
@@ -195,7 +203,7 @@ struct ApiClientView: View {
                 .buttonStyle(.borderless)
                 .help(showSidebar ? "Hide sidebar" : "Show sidebar")
 
-                Picker("", selection: $model.current.method) {
+                Picker("", selection: bindable.current.method) {
                     ForEach(HttpMethod.allCases) { method in
                         Text(method.rawValue).tag(method)
                     }
@@ -233,7 +241,7 @@ struct ApiClientView: View {
     }
 
     private var urlField: some View {
-        TextField("Enter a URL or paste a cURL command", text: $model.current.url)
+        TextField("Enter a URL or paste a cURL command", text: bindable.current.url)
             .textFieldStyle(.roundedBorder)
             .font(.app(.body, design: .monospaced))
             .onSubmit { model.send() }
@@ -334,7 +342,7 @@ struct ApiClientView: View {
     }
 
     private var environmentPicker: some View {
-        Picker("", selection: $model.data.activeEnvironmentId) {
+        Picker("", selection: bindable.data.activeEnvironmentId) {
             Text("No environment").tag(String?.none)
             ForEach(model.data.environments) { environment in
                 Text(environment.name).tag(Optional(environment.id))

--- a/App/Sources/FeatureDetail/Views/AppsExplorerModel.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerModel.swift
@@ -1,0 +1,38 @@
+import ADBKit
+import Foundation
+
+/// The Apps explorer's list and what the user has done with it, kept per window
+/// by `FeatureStateStore` rather than as view `@State`.
+///
+/// Reading every installed app off a device takes a couple of seconds and a
+/// handful of `adb shell` round trips, and the view used to do it again on every
+/// mount — so a tab moving to another window dropped the list, the search, the
+/// scope and the selected app, and made the user wait for a list they were
+/// already looking at. `loadedSerial` records which device the list came from,
+/// so a remount asking about the same one keeps it while a device switch still
+/// re-reads.
+@MainActor
+@Observable
+final class AppsExplorerModel {
+    /// Every installed app, nil until the first read finishes.
+    var apps: [AppListing]?
+    /// Enabled/disabled/removed per package, read alongside the list.
+    var states: [String: AppLifecycle] = [:]
+    /// The device `apps` was read from.
+    var loadedSerial: String?
+
+    var search = ""
+    var scope = AppsScope.user
+    var selectedPackage: String?
+    /// Packages an uninstall attempt proved can't actually be removed (it
+    /// reported success but the package stayed). Their Uninstall button is
+    /// dropped, leaving Disable.
+    var notRemovable: Set<String> = []
+}
+
+/// Which apps the explorer lists.
+enum AppsScope: String, CaseIterable {
+    case all = "All"
+    case user = "User"
+    case system = "System"
+}

--- a/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/AppsExplorerView.swift
@@ -7,22 +7,42 @@ import SwiftUI
 /// permission toggles.
 struct AppsExplorerView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @Environment(\.colorScheme) private var colorScheme
-    @State private var apps: [AppListing]?
-    @State private var states: [String: AppLifecycle] = [:]
-    @State private var search = ""
-    @State private var scope = Scope.user
-    @State private var selectedPackage: String?
-    /// Packages an uninstall attempt proved can't actually be removed (it
-    /// reported success but the package stayed). Their Uninstall button is
-    /// dropped, leaving Disable.
-    @State private var notRemovable: Set<String> = []
 
-    enum Scope: String, CaseIterable {
-        case all = "All"
-        case user = "User"
-        case system = "System"
+    /// The list and what the user has done with it, held by the window rather
+    /// than by this view: re-reading every installed app because a tab moved is
+    /// a wait for something already on screen. See `AppsExplorerModel`.
+    private var model: AppsExplorerModel {
+        state.featureState(AppsExplorerModel.self, for: tabFeatureID) { AppsExplorerModel() }
     }
+
+    private var apps: [AppListing]? {
+        get { model.apps }
+        nonmutating set { model.apps = newValue }
+    }
+    private var states: [String: AppLifecycle] {
+        get { model.states }
+        nonmutating set { model.states = newValue }
+    }
+    private var search: String {
+        get { model.search }
+        nonmutating set { model.search = newValue }
+    }
+    private var scope: Scope {
+        get { model.scope }
+        nonmutating set { model.scope = newValue }
+    }
+    private var selectedPackage: String? {
+        get { model.selectedPackage }
+        nonmutating set { model.selectedPackage = newValue }
+    }
+    private var notRemovable: Set<String> {
+        get { model.notRemovable }
+        nonmutating set { model.notRemovable = newValue }
+    }
+
+    private typealias Scope = AppsScope
 
     private var serial: String { state.targetSerials.first ?? "" }
 
@@ -49,6 +69,9 @@ struct AppsExplorerView: View {
             }
         }
         .task(id: state.targetSerials.first ?? "") {
+            // A tab that moved brings the list with it. Only a device it hasn't
+            // read yet is worth the round trips.
+            guard model.apps == nil || model.loadedSerial != serial else { return }
             await loadApps()
         }
     }
@@ -121,12 +144,19 @@ struct AppsExplorerView: View {
     }
 
     private var searchField: some View {
-        TextField("Search name, version, or bundle…", text: $search)
+        TextField("Search name, version, or bundle…", text: searchBinding)
             .brandField()
     }
 
+    private var searchBinding: Binding<String> {
+        Binding(get: { search }, set: { search = $0 })
+    }
+    private var scopeBinding: Binding<Scope> {
+        Binding(get: { scope }, set: { scope = $0 })
+    }
+
     private var scopePicker: some View {
-        Picker("", selection: $scope) {
+        Picker("", selection: scopeBinding) {
             ForEach(Scope.allCases, id: \.self) { scope in
                 Text(scope.rawValue).tag(scope)
             }
@@ -242,6 +272,7 @@ struct AppsExplorerView: View {
             selectedPackage = nil
         }
         guard let serial = state.targetSerials.first else { return }
+        model.loadedSerial = serial
         let (listing, lifecycle) = await CommandLog.userInitiated {
             async let listing = try? state.env.engine.appsExplorer.listAll(serial: serial)
             async let lifecycle = state.env.engine.systemApps.states(serial: serial)

--- a/App/Sources/FeatureDetail/Views/CrashModel.swift
+++ b/App/Sources/FeatureDetail/Views/CrashModel.swift
@@ -1,0 +1,39 @@
+import ADBKit
+import Foundation
+
+/// The crashes the Crash Catcher has collected, kept per window by
+/// `FeatureStateStore` rather than as view `@State`.
+///
+/// The most expensive state in the app to lose: a fetch reads up to 16 MB of
+/// logcat and parses it into Java, native, RN and ANR reports. Rebuilding that
+/// because a tab moved to another window is a visible stall for something the
+/// user had already waited for — and a crash buffer that has since rolled may
+/// not even come back.
+///
+/// The *watch* is not here: it is live work owned by the view's task, and it
+/// re-arms on the next appearance.
+@MainActor
+@Observable
+final class CrashModel {
+    var reports: [CrashReport] = []
+    var selectedID: CrashReport.ID?
+    /// A fetch has completed at least once, so an empty list means "no
+    /// crashes" rather than "not looked yet".
+    var fetched = false
+    /// The last fetch errored (adb missing, device dropped mid-read). Cleared
+    /// by the next successful fetch; drives the error empty state so a failed
+    /// read never masquerades as "still checking" or "no crashes".
+    var fetchFailed = false
+    var kindFilter: CrashReport.Kind?
+    var processFilter: String?
+    var searchInput = ""
+    var search = ""
+    var showRaw = false
+    /// Hide crashes at or before this timestamp on this serial — set by Clear
+    /// buffer, which empties the crash buffer but can't touch the main-buffer
+    /// fallback the same crashes would resurface from. Scoped to the serial it
+    /// was set on so a device switch never hides another device's crashes.
+    /// Logcat timestamps carry no year, so the lexicographic compare mis-hides
+    /// only across a Dec→Jan rollover, and only until the view reopens.
+    var clearedBefore: (serial: String, mark: String)?
+}

--- a/App/Sources/FeatureDetail/Views/CrashView.swift
+++ b/App/Sources/FeatureDetail/Views/CrashView.swift
@@ -8,28 +8,57 @@ import SwiftUI
 struct CrashView: View {
     @Environment(AppState.self) private var state
     @Environment(ResizeActivity.self) private var resizeActivity: ResizeActivity?
-    @State private var reports: [CrashReport] = []
-    @State private var selectedID: CrashReport.ID?
+    /// The collected crashes and the filters over them, kept per window so a
+    /// tab moving to another window doesn't throw away a 16 MB fetch. Live
+    /// work (the fetch in flight, the watch) stays view-local.
+    private var model: CrashModel {
+        state.featureState(CrashModel.self, for: "crash-catcher") { CrashModel() }
+    }
+    private var bindable: Bindable<CrashModel> { Bindable(model) }
+    private var reports: [CrashReport] {
+        get { model.reports }
+        nonmutating set { model.reports = newValue }
+    }
+    private var selectedID: CrashReport.ID? {
+        get { model.selectedID }
+        nonmutating set { model.selectedID = newValue }
+    }
+    private var fetched: Bool {
+        get { model.fetched }
+        nonmutating set { model.fetched = newValue }
+    }
+    private var fetchFailed: Bool {
+        get { model.fetchFailed }
+        nonmutating set { model.fetchFailed = newValue }
+    }
+    private var kindFilter: CrashReport.Kind? {
+        get { model.kindFilter }
+        nonmutating set { model.kindFilter = newValue }
+    }
+    private var processFilter: String? {
+        get { model.processFilter }
+        nonmutating set { model.processFilter = newValue }
+    }
+    private var searchInput: String {
+        get { model.searchInput }
+        nonmutating set { model.searchInput = newValue }
+    }
+    private var search: String {
+        get { model.search }
+        nonmutating set { model.search = newValue }
+    }
+    private var showRaw: Bool {
+        get { model.showRaw }
+        nonmutating set { model.showRaw = newValue }
+    }
     @State private var loading = false
-    @State private var fetched = false
-    /// The last fetch errored (adb missing, device dropped mid-read). Cleared
-    /// by the next successful fetch; drives the error empty state so a failed
-    /// read never masquerades as "still checking" or "no crashes".
-    @State private var fetchFailed = false
     @State private var watching = false
-    @State private var kindFilter: CrashReport.Kind?
-    @State private var processFilter: String?
-    @State private var searchInput = ""
-    @State private var search = ""
-    @State private var showRaw = false
     @State private var confirmClear = false
-    /// Hide crashes at or before this timestamp on this serial — set by Clear
-    /// buffer, which empties the crash buffer but can't touch the main-buffer
-    /// fallback the same crashes would resurface from. Scoped to the serial it
-    /// was set on so a device switch never hides another device's crashes.
-    /// Logcat timestamps carry no year, so the lexicographic compare mis-hides
-    /// only across a Dec→Jan rollover, and only until the view reopens.
-    @State private var clearedBefore: (serial: String, mark: String)?
+    /// See `CrashModel.clearedBefore`.
+    private var clearedBefore: (serial: String, mark: String)? {
+        get { model.clearedBefore }
+        nonmutating set { model.clearedBefore = newValue }
+    }
     @State private var refreshToken = 0
     /// Measured pane width — below ~700pt (a narrow split pane) the toolbar
     /// reflows to two rows and the crash list narrows proportionally.
@@ -152,7 +181,7 @@ struct CrashView: View {
     private var kindPicker: some View {
         HStack(spacing: 6) {
             Text("Kind")
-            Picker("Kind", selection: $kindFilter) {
+            Picker("Kind", selection: bindable.kindFilter) {
                 Text("All").tag(CrashReport.Kind?.none)
                 ForEach(presentKinds, id: \.self) { kind in
                     Text(kind.label).tag(CrashReport.Kind?.some(kind))
@@ -170,7 +199,7 @@ struct CrashView: View {
         if processes.count > 1 {
             HStack(spacing: 6) {
                 Text("Process")
-                Picker("Process", selection: $processFilter) {
+                Picker("Process", selection: bindable.processFilter) {
                     Text("All").tag(String?.none)
                     ForEach(processes, id: \.self) { process in
                         Text(process).tag(String?.some(process))
@@ -184,7 +213,7 @@ struct CrashView: View {
     }
 
     private var filterField: some View {
-        TextField("Filter crashes…", text: $searchInput)
+        TextField("Filter crashes…", text: bindable.searchInput)
             .brandField()
             .frame(maxWidth: 180)
             .help("Show only crashes containing this text")
@@ -240,7 +269,7 @@ struct CrashView: View {
     }
 
     private var crashList: some View {
-        List(selection: $selectedID) {
+        List(selection: bindable.selectedID) {
             ForEach(filteredReports) { report in
                 CrashRow(report: report)
                     .tag(report.id)
@@ -331,7 +360,7 @@ struct CrashView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            Toggle("Raw log", isOn: $showRaw)
+            Toggle("Raw log", isOn: bindable.showRaw)
                 .toggleStyle(.checkbox)
                 .font(.app(.caption))
                 .help("Show the original logcat lines instead of just the messages")

--- a/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
+++ b/App/Sources/FeatureDetail/Views/CustomCommandsView.swift
@@ -5,16 +5,54 @@ import SwiftUI
 /// adb argument vectors, plain terminal command lines, or script files.
 struct CustomCommandsView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @State private var commands: [CustomCommand] = []
-    @State private var editing: CustomCommand?
-    @State private var showEditor = false
-    @State private var showPresets = false
-    @State private var draftName = ""
-    @State private var draftCommand = ""
-    @State private var draftNeedsBundle = false
-    @State private var draftRunsInTerminal = false
-    @State private var draftTerminal: CustomCommandTerminal = .droidective
     @State private var pendingDelete: CustomCommand?
+
+    /// The command being written, held by the window rather than by this view
+    /// so a tab moving doesn't empty the editor. See `CustomCommandDraftModel`.
+    private var draft: CustomCommandDraftModel {
+        state.featureState(CustomCommandDraftModel.self, for: tabFeatureID) {
+            CustomCommandDraftModel()
+        }
+    }
+
+    private var editing: CustomCommand? {
+        get { draft.editing }
+        nonmutating set { draft.editing = newValue }
+    }
+    private var showEditor: Bool {
+        get { draft.showEditor }
+        nonmutating set { draft.showEditor = newValue }
+    }
+    private var showPresets: Bool {
+        get { draft.showPresets }
+        nonmutating set { draft.showPresets = newValue }
+    }
+    private var draftName: String {
+        get { draft.draftName }
+        nonmutating set { draft.draftName = newValue }
+    }
+    private var draftCommand: String {
+        get { draft.draftCommand }
+        nonmutating set { draft.draftCommand = newValue }
+    }
+    private var draftNeedsBundle: Bool {
+        get { draft.draftNeedsBundle }
+        nonmutating set { draft.draftNeedsBundle = newValue }
+    }
+    private var draftRunsInTerminal: Bool {
+        get { draft.draftRunsInTerminal }
+        nonmutating set { draft.draftRunsInTerminal = newValue }
+    }
+    private var draftTerminal: CustomCommandTerminal {
+        get { draft.draftTerminal }
+        nonmutating set { draft.draftTerminal = newValue }
+    }
+
+    private func bind<T>(_ keyPath: ReferenceWritableKeyPath<CustomCommandDraftModel, T>) -> Binding<T> {
+        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -106,8 +144,8 @@ struct CustomCommandsView: View {
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task { commands = await state.env.stores.customCommands.load() }
-        .sheet(isPresented: $showEditor) { editor }
-        .sheet(isPresented: $showPresets) { presetLibrary }
+        .sheet(isPresented: bind(\.showEditor)) { editor }
+        .sheet(isPresented: bind(\.showPresets)) { presetLibrary }
         .confirmationDialog(
             "Delete “\(pendingDelete?.name ?? "")”?",
             isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
@@ -137,7 +175,7 @@ struct CustomCommandsView: View {
 
             VStack(alignment: .leading, spacing: 5) {
                 Text("Name").font(.app(.caption)).foregroundStyle(.textMuted)
-                TextField("What it does — e.g. Restart app", text: $draftName)
+                TextField("What it does — e.g. Restart app", text: bind(\.draftName))
                     .brandField()
             }
 
@@ -171,14 +209,14 @@ struct CustomCommandsView: View {
 
             VStack(alignment: .leading, spacing: 5) {
                 Text("Output").font(.app(.caption)).foregroundStyle(.textMuted)
-                Picker("Show output", selection: $draftRunsInTerminal) {
+                Picker("Show output", selection: bind(\.draftRunsInTerminal)) {
                     Text("Silently (toast)").tag(false)
                     Text("In a terminal").tag(true)
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
                 if draftRunsInTerminal {
-                    Picker("Terminal", selection: $draftTerminal) {
+                    Picker("Terminal", selection: bind(\.draftTerminal)) {
                         ForEach(CustomCommandTerminal.allCases, id: \.self) { terminal in
                             Text(terminal.displayName).tag(terminal)
                         }
@@ -192,7 +230,7 @@ struct CustomCommandsView: View {
                     .foregroundStyle(.textMuted)
             }
 
-            SwitchRow("Requires a saved bundle", isOn: $draftNeedsBundle)
+            SwitchRow("Requires a saved bundle", isOn: bind(\.draftNeedsBundle))
 
             HStack {
                 Spacer()
@@ -223,7 +261,7 @@ struct CustomCommandsView: View {
     /// Each line runs in order — multi-line always routes through the shell.
     private var commandEditor: some View {
         ZStack(alignment: .topLeading) {
-            TextEditor(text: $draftCommand)
+            TextEditor(text: bind(\.draftCommand))
                 .font(.app(.body, design: .monospaced))
                 .scrollContentBackground(.hidden)
                 .padding(.horizontal, 4)

--- a/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
+++ b/App/Sources/FeatureDetail/Views/DecompileBrowserView.swift
@@ -9,42 +9,91 @@ import UniformTypeIdentifiers
 /// CodeMirror editor (syntax highlighting, line numbers, ⌘F find).
 struct DecompileBrowserView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @Environment(\.colorScheme) private var colorScheme
 
-    @State private var mode: DecompileService.Mode = .jadx
-    @State private var toolReady = false
-    @State private var checkingTool = true
-    @State private var download = DownloadState()
-
-    @State private var apkURL: URL?
+    /// Work in flight, which a move genuinely interrupts: the decompile and
+    /// the code search both belong to a `.task` SwiftUI cancels on unmount.
     @State private var busy = false
-    @State private var status: String?
+    @State private var searching = false
     @State private var dropTargeted = false
-
-    @State private var root: FileNode?
-    @State private var selection: String?
-    @State private var fileText: String?
-    @State private var fileLanguage = ""
-    @State private var targetLine = 0
     /// Bumped on every file open so a slow read can't overwrite a newer one.
     @State private var fileLoadID = 0
     @State private var findToken = 0
 
-    @State private var filter = ""
-    @State private var searchScope: SearchScope = .name
-    @State private var searchHits: [DecompileService.SearchHit] = []
-    @State private var searching = false
+    /// A non-nil injected APK embeds the browser in APK Studio: it decompiles
+    /// that APK directly (skipping the picker) and drops its "decompile
+    /// another" button — the workspace owns APK selection there, which is why
+    /// this one is passed in on every rebuild rather than kept.
+    private let injectedAPK: URL?
     private let embedded: Bool
 
-    /// A non-nil `apkURL` embeds the browser in APK Studio: it decompiles that
-    /// APK directly (skipping the picker) and drops its "decompile another"
-    /// button — the workspace owns APK selection.
     init(apkURL: URL? = nil) {
-        _apkURL = State(initialValue: apkURL)
+        injectedAPK = apkURL
         embedded = apkURL != nil
     }
 
-    private enum SearchScope: String, CaseIterable { case name = "File name", contents = "Code" }
+    /// The tree and the browsing of it, held by the window rather than by this
+    /// view: a decompile takes minutes. See `DecompileModel`.
+    private var model: DecompileModel {
+        state.featureState(DecompileModel.self, for: tabFeatureID) { DecompileModel() }
+    }
+
+    private var mode: DecompileService.Mode {
+        get { model.mode }
+        nonmutating set { model.mode = newValue }
+    }
+    private var toolReady: Bool {
+        get { model.toolReady }
+        nonmutating set { model.toolReady = newValue }
+    }
+    private var checkingTool: Bool {
+        get { model.checkingTool }
+        nonmutating set { model.checkingTool = newValue }
+    }
+    private var download: DownloadState { model.download }
+    private var apkURL: URL? {
+        get { embedded ? injectedAPK : model.apkURL }
+        nonmutating set { model.apkURL = newValue }
+    }
+    private var status: String? {
+        get { model.status }
+        nonmutating set { model.status = newValue }
+    }
+    private var root: FileNode? {
+        get { model.root }
+        nonmutating set { model.root = newValue }
+    }
+    private var selection: String? {
+        get { model.selection }
+        nonmutating set { model.selection = newValue }
+    }
+    private var fileText: String? {
+        get { model.fileText }
+        nonmutating set { model.fileText = newValue }
+    }
+    private var fileLanguage: String {
+        get { model.fileLanguage }
+        nonmutating set { model.fileLanguage = newValue }
+    }
+    private var targetLine: Int {
+        get { model.targetLine }
+        nonmutating set { model.targetLine = newValue }
+    }
+    private var filter: String {
+        get { model.filter }
+        nonmutating set { model.filter = newValue }
+    }
+    private var searchScope: SearchScope {
+        get { model.searchScope }
+        nonmutating set { model.searchScope = newValue }
+    }
+    private var searchHits: [DecompileService.SearchHit] {
+        get { model.searchHits }
+        nonmutating set { model.searchHits = newValue }
+    }
+
+    private typealias SearchScope = DecompileSearchScope
 
     private var toolName: String { mode == .jadx ? "jadx" : "apktool" }
 
@@ -150,7 +199,7 @@ struct DecompileBrowserView: View {
     }
 
     private var modePicker: some View {
-        Picker("Decompiler", selection: $mode) {
+        Picker("Decompiler", selection: modeBinding) {
             Text("Java (jadx)").tag(DecompileService.Mode.jadx)
             Text("Smali + resources (apktool)").tag(DecompileService.Mode.apktool)
         }
@@ -175,7 +224,11 @@ struct DecompileBrowserView: View {
                         .foregroundStyle(.textMuted).multilineTextAlignment(.center).frame(maxWidth: 480)
                     HStack {
                         Button("Try again") { Task { await runDecompile() } }
-                        Button("Choose another APK") { apkURL = nil }
+                        // Embedded in APK Studio the workspace owns which APK
+                        // is loaded, so there is nothing here to pick.
+                        if !embedded {
+                            Button("Choose another APK") { apkURL = nil }
+                        }
                     }
                 }
             }
@@ -224,12 +277,12 @@ struct DecompileBrowserView: View {
 
     private func sidebar(_ root: FileNode) -> some View {
         VStack(spacing: 6) {
-            Picker("", selection: $searchScope) {
+            Picker("", selection: searchScopeBinding) {
                 ForEach(SearchScope.allCases, id: \.self) { Text($0.rawValue).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-            TextField(searchScope == .name ? "Filter files…" : "Search code…", text: $filter)
+            TextField(searchScope == .name ? "Filter files…" : "Search code…", text: filterBinding)
                 .textFieldStyle(.roundedBorder)
                 .onSubmit { if searchScope == .contents { Task { await runSearch(in: root) } } }
                 .onChange(of: searchScope) { _, _ in searchHits = [] }
@@ -349,9 +402,23 @@ struct DecompileBrowserView: View {
     }
 
     private func prepare() async {
-        await checkTool()
+        // A tab that moved brings its answer with it, so don't re-ask: the
+        // tools were resolved once already, and re-running jadx because a
+        // window changed is the restart this whole mechanism exists to avoid.
+        if !toolReady { await checkTool() }
         guard toolReady, apkURL != nil else { return }
+        guard root == nil || model.treeKey != prepKey else { return }
         await runDecompile()
+    }
+
+    private var modeBinding: Binding<DecompileService.Mode> {
+        Binding(get: { mode }, set: { mode = $0 })
+    }
+    private var searchScopeBinding: Binding<SearchScope> {
+        Binding(get: { searchScope }, set: { searchScope = $0 })
+    }
+    private var filterBinding: Binding<String> {
+        Binding(get: { filter }, set: { filter = $0 })
     }
 
     private func runDecompile() async {
@@ -368,10 +435,12 @@ struct DecompileBrowserView: View {
             let tree = await Task.detached { DecompileService.tree(at: dir) }.value
             guard !Task.isCancelled else { return }
             root = tree
+            model.treeKey = prepKey
             status = nil
         } catch {
             status = error.localizedDescription
             root = nil
+            model.treeKey = nil
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/DecompileModel.swift
+++ b/App/Sources/FeatureDetail/Views/DecompileModel.swift
@@ -1,0 +1,58 @@
+import ADBKit
+import Foundation
+
+/// A decompiled APK and the browsing of it, kept per window by
+/// `FeatureStateStore` rather than as view `@State`.
+///
+/// jadx and apktool take *minutes* on a real APK, and produce tens of thousands
+/// of files. Rebuilding the view — which a tab does whenever it moves to the
+/// other split pane or to another window — used to throw the tree away and run
+/// the decompiler again from the top. `treeKey` records which APK and
+/// decompiler produced the tree, so a remount asking the same question keeps
+/// its answer and a different one still re-runs.
+///
+/// The decompile *in flight* does not survive: it belongs to the view's
+/// `.task`, which SwiftUI cancels on unmount, so a move mid-run starts it over.
+/// That is the honest read — nothing else owns the process — and it costs only
+/// the run the user is already waiting on.
+@MainActor
+@Observable
+final class DecompileModel {
+    /// jadx (Java) or apktool (smali + resources).
+    var mode: DecompileService.Mode = .jadx
+    /// Whether the decompiler and a Java runtime are both present. Kept so a
+    /// move doesn't flash the setup gate on its way back to the browser.
+    var toolReady = false
+    var checkingTool = true
+    /// A tool download in progress. The install task outlives the view that
+    /// started it, so its progress has to land somewhere the next view can see.
+    let download = DownloadState()
+
+    /// The APK being browsed, when the browser picked it itself. APK Studio
+    /// injects its own and this stays nil — the workspace owns the selection
+    /// there, and its session already moves with the tab.
+    var apkURL: URL?
+    /// The setup or decompile failure to show, nil when all is well.
+    var status: String?
+
+    /// The decompiled file tree, and what `prepKey` built it — the APK and the
+    /// decompiler it came from.
+    var root: FileNode?
+    var treeKey: String?
+
+    var selection: String?
+    var fileText: String?
+    var fileLanguage = ""
+    /// The line the editor should jump to and highlight (0 = none).
+    var targetLine = 0
+
+    var filter = ""
+    var searchScope = DecompileSearchScope.name
+    var searchHits: [DecompileService.SearchHit] = []
+}
+
+/// What the sidebar's search box searches: file names, or the code itself.
+enum DecompileSearchScope: String, CaseIterable {
+    case name = "File name"
+    case contents = "Code"
+}

--- a/App/Sources/FeatureDetail/Views/DeepLinksView.swift
+++ b/App/Sources/FeatureDetail/Views/DeepLinksView.swift
@@ -5,12 +5,38 @@ import SwiftUI
 /// into both the standalone screen and the React Native hub.
 struct DeepLinksSection: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @State private var links: [DeepLink] = []
-    @State private var editingLink: DeepLink?
-    @State private var showEditor = false
-    @State private var draftLabel = ""
-    @State private var draftURL = ""
     @State private var pendingDelete: DeepLink?
+
+    /// The half-typed link, held by the window rather than by this view so a
+    /// tab moving doesn't empty the editor. See `DeepLinkDraftModel`. Keyed by
+    /// tab, because this section appears both on its own screen and inside the
+    /// React Native hub.
+    private var draft: DeepLinkDraftModel {
+        state.featureState(DeepLinkDraftModel.self, for: tabFeatureID) { DeepLinkDraftModel() }
+    }
+
+    private var editingLink: DeepLink? {
+        get { draft.editingLink }
+        nonmutating set { draft.editingLink = newValue }
+    }
+    private var showEditor: Bool {
+        get { draft.showEditor }
+        nonmutating set { draft.showEditor = newValue }
+    }
+    private var draftLabel: String {
+        get { draft.draftLabel }
+        nonmutating set { draft.draftLabel = newValue }
+    }
+    private var draftURL: String {
+        get { draft.draftURL }
+        nonmutating set { draft.draftURL = newValue }
+    }
+
+    private func bind<T>(_ keyPath: ReferenceWritableKeyPath<DeepLinkDraftModel, T>) -> Binding<T> {
+        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
+    }
 
     var body: some View {
         HubSection("Deep links", subtitle: "Saved per app — launch a URL on the device in one click.") {
@@ -41,7 +67,7 @@ struct DeepLinksSection: View {
             }
         }
         .task(id: state.selectedBundleId) { await loadLinks() }
-        .sheet(isPresented: $showEditor) { editor }
+        .sheet(isPresented: bind(\.showEditor)) { editor }
         .confirmationDialog(
             "Delete “\(pendingDelete?.label ?? "")”?",
             isPresented: Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } }),
@@ -95,9 +121,9 @@ struct DeepLinksSection: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(editingLink == nil ? "Add Deep Link" : "Edit Deep Link")
                 .font(.app(.headline))
-            TextField("URL (e.g. myapp://orders/123)", text: $draftURL)
+            TextField("URL (e.g. myapp://orders/123)", text: bind(\.draftURL))
                 .brandField()
-            TextField("Label (optional)", text: $draftLabel)
+            TextField("Label (optional)", text: bind(\.draftLabel))
                 .brandField()
             HStack {
                 Spacer()

--- a/App/Sources/FeatureDetail/Views/DraftModels.swift
+++ b/App/Sources/FeatureDetail/Views/DraftModels.swift
@@ -1,0 +1,51 @@
+import ADBKit
+import Foundation
+
+/// Half-written input, kept per window by `FeatureStateStore` rather than as
+/// view `@State`.
+///
+/// These three screens are the app's typing surfaces, and what is in their
+/// fields exists nowhere else until the user presses Send or Save. A tab moving
+/// to another window rebuilt the view and cleared them — a paragraph of text
+/// destined for a device, a deep link half typed, a shell command being
+/// composed. Nothing here is expensive to produce again *except* by hand, which
+/// is the kind that annoys most.
+@MainActor
+@Observable
+final class SendTextModel {
+    /// The message waiting to be sent.
+    var text = ""
+    /// The "new snippet" popover: whether it is open and what is in it.
+    var creatingSnippet = false
+    var newSnippetName = ""
+    var newSnippetText = ""
+    /// How the library below is being looked at.
+    var snippetSearch = ""
+    var showAllSnippets = false
+}
+
+/// A deep link being added or edited. The editor is a sheet, so this carries
+/// which link is being edited as well as the fields — a move that dropped the
+/// sheet but kept the text would be worse than dropping both.
+@MainActor
+@Observable
+final class DeepLinkDraftModel {
+    var showEditor = false
+    var editingLink: DeepLink?
+    var draftLabel = ""
+    var draftURL = ""
+}
+
+/// A custom command being added or edited, fields and all.
+@MainActor
+@Observable
+final class CustomCommandDraftModel {
+    var showEditor = false
+    var showPresets = false
+    var editing: CustomCommand?
+    var draftName = ""
+    var draftCommand = ""
+    var draftNeedsBundle = false
+    var draftRunsInTerminal = false
+    var draftTerminal: CustomCommandTerminal = .droidective
+}

--- a/App/Sources/FeatureDetail/Views/FileExplorerModel.swift
+++ b/App/Sources/FeatureDetail/Views/FileExplorerModel.swift
@@ -1,0 +1,23 @@
+import ADBKit
+import Foundation
+
+/// The File Explorer's place on the device, kept per window by
+/// `FeatureStateStore` rather than as view `@State`.
+///
+/// Where you had browsed to is the whole point of the feature — being dropped
+/// back at `/sdcard` because the tab moved to another window is exactly the
+/// kind of "it restarted" that a move should not do. The directory *listing*
+/// deliberately stays in the view: it reloads from the path in one `ls`, and a
+/// listing that was current a minute ago is worse than one fetched now.
+@MainActor
+@Observable
+final class FileExplorerModel {
+    /// The browsed path, split into components.
+    var pathComponents: [String] = []
+    var selection: Set<String> = []
+    /// Device-side clipboard: source paths plus whether to move (cut).
+    var clipboard: (paths: [String], isCut: Bool)?
+    var isRooted = false
+    /// When on (rooted devices only), browse the whole filesystem from "/" via su.
+    var rootMode = false
+}

--- a/App/Sources/FeatureDetail/Views/FileExplorerView.swift
+++ b/App/Sources/FeatureDetail/Views/FileExplorerView.swift
@@ -6,22 +6,42 @@ import SwiftUI
 /// surface in the progress strip.
 struct FileExplorerView: View {
     @Environment(AppState.self) private var state
-    @State private var pathComponents: [String] = []
+    /// Where you had browsed to, kept per window so it survives this view being
+    /// rebuilt — which is what moving the tab to another window does. The
+    /// listing itself stays view-local and reloads from the path.
+    private var model: FileExplorerModel {
+        state.featureState(FileExplorerModel.self, for: "file-explorer") { FileExplorerModel() }
+    }
+    private var pathComponents: [String] {
+        get { model.pathComponents }
+        nonmutating set { model.pathComponents = newValue }
+    }
+    private var selection: Set<String> {
+        get { model.selection }
+        nonmutating set { model.selection = newValue }
+    }
+    /// Device-side clipboard: source paths plus whether to move (cut).
+    private var clipboard: (paths: [String], isCut: Bool)? {
+        get { model.clipboard }
+        nonmutating set { model.clipboard = newValue }
+    }
     @State private var entries: [FsEntry]?
     @State private var reloadToken = 0
-    @State private var selection: Set<String> = []
-
-    /// Device-side clipboard: source paths plus whether to move (cut).
-    @State private var clipboard: (paths: [String], isCut: Bool)?
     @State private var confirmingDelete: [FsEntry] = []
     @State private var newFolderName = ""
     @State private var showNewFolder = false
     @State private var infoTarget: FsEntry?
     @State private var infoDetails: FileExplorerService.FileInfo?
     @FocusState private var listFocused: Bool
-    @State private var isRooted = false
+    private var isRooted: Bool {
+        get { model.isRooted }
+        nonmutating set { model.isRooted = newValue }
+    }
     /// When on (rooted devices only), browse the whole filesystem from "/" via su.
-    @State private var rootMode = false
+    private var rootMode: Bool {
+        get { model.rootMode }
+        nonmutating set { model.rootMode = newValue }
+    }
 
     private var currentPath: String {
         if rootMode {
@@ -170,7 +190,7 @@ struct FileExplorerView: View {
             .controlSize(.small)
 
             if isRooted {
-                Toggle("Root", isOn: $rootMode)
+                Toggle("Root", isOn: Binding(get: { model.rootMode }, set: { model.rootMode = $0 }))
                     .toggleStyle(.button)
                     .controlSize(.small)
                     .help("Browse the whole filesystem as root")

--- a/App/Sources/FeatureDetail/Views/LogcatModel.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatModel.swift
@@ -1,0 +1,47 @@
+import ADBKit
+import Foundation
+
+/// Logcat's state that should outlive its view.
+///
+/// Held per window by `FeatureStateStore`, not as view `@State`, so the buffer
+/// and the filters that make sense of it survive the tab being rebuilt —
+/// moving to the other split pane, or to another window. Losing a few thousand
+/// collected lines because a tab changed places is the kind of thing that makes
+/// a move feel like a restart.
+///
+/// The live `adb logcat` process deliberately does *not* live here: it is
+/// owned by the view's `.task` and reattaches in milliseconds, so keeping the
+/// stream itself continuous across a move would be invasive for no visible
+/// gain. The buffer is what is expensive to rebuild — it cannot be, it is gone.
+@MainActor
+@Observable
+final class LogcatModel {
+    /// Everything collected so far, capped by `LogcatView.maxLines`.
+    var lines: [LogLine] = []
+    /// Streaming is held; new lines are dropped rather than buffered.
+    var paused = false
+    /// The level filter ("All", "Error", …) — part of the stream's arguments,
+    /// so changing it restarts the stream and clears the buffer.
+    var level = "All"
+    /// Restrict to one app's pid, and to one tag.
+    var packageFilter: String?
+    var tagFilter: String?
+    /// What the user is typing, debounced into `search`, which is what the
+    /// filtering actually reads (one rebuild per pause, not per keystroke).
+    var searchInput = ""
+    var search = ""
+    /// pid → process name, from a periodic `ps` snapshot. Carried across a
+    /// move so the process column does not blank out and re-probe.
+    var processNames: [String: String] = [:]
+    /// The stream query (`LogcatView.taskKey`) the buffer was collected under.
+    ///
+    /// A restart with the *same* query is a remount — the tab moved to another
+    /// window or pane — and must keep what it had. A different query is a
+    /// different question (another device, level or app), whose answers must
+    /// not be mixed in with the old ones, so that clears.
+    var bufferKey: String?
+    /// One-shot: the App filter is seeded from the device bar's chosen bundle
+    /// the first time the view appears, then left alone. Kept here so a move
+    /// does not re-seed over a filter the user has since changed.
+    var seededPackageFilter = false
+}

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -11,16 +11,52 @@ struct LogcatView: View {
     static let maxLines = 5000
 
     @Environment(AppState.self) private var state
-    @State private var lines: [LogLine] = []
-    @State private var paused = false
-    @State private var level = "All"
-    @State private var packageFilter: String?
-    @State private var tagFilter: String?
+
+    /// The buffer and its filters, held per window by `FeatureStateStore` so
+    /// they survive this view being rebuilt — which is what a tab moving to the
+    /// other pane, or to another window, does. Resolved per render rather than
+    /// stored: the store is a plain dictionary, not observable, so resolving
+    /// from `body` writes nothing that could invalidate the read (see
+    /// `FeatureStateStore`); the *model* is observable, so reading through it
+    /// tracks changes normally.
+    private var model: LogcatModel {
+        state.featureState(LogcatModel.self, for: "logcat") { LogcatModel() }
+    }
+
+    // Accessors, so the buffer's many use sites read exactly as they did when
+    // these were `@State`. `nonmutating set` because the storage is the model,
+    // not the view.
+    private var lines: [LogLine] {
+        get { model.lines }
+        nonmutating set { model.lines = newValue }
+    }
+    private var paused: Bool {
+        get { model.paused }
+        nonmutating set { model.paused = newValue }
+    }
+    private var level: String {
+        get { model.level }
+        nonmutating set { model.level = newValue }
+    }
+    private var packageFilter: String? {
+        get { model.packageFilter }
+        nonmutating set { model.packageFilter = newValue }
+    }
+    private var tagFilter: String? {
+        get { model.tagFilter }
+        nonmutating set { model.tagFilter = newValue }
+    }
     /// What the user is typing; debounced into `search` (which triggers a full
     /// re-filter and NSTextView rebuild) so a fast typist over a full buffer
     /// pays for one rebuild per pause, not one per keystroke.
-    @State private var searchInput = ""
-    @State private var search = ""
+    private var searchInput: String {
+        get { model.searchInput }
+        nonmutating set { model.searchInput = newValue }
+    }
+    private var search: String {
+        get { model.search }
+        nonmutating set { model.search = newValue }
+    }
     /// Measured toolbar width — below ~560pt (a narrow split pane) the
     /// toolbar reflows to two rows instead of clipping.
     @State private var toolbarWidth: CGFloat = 0
@@ -34,7 +70,10 @@ struct LogcatView: View {
     @State private var waitingForPackage: String?
     @State private var streamingPid: Int?
     /// pid → process name (a periodic `ps` snapshot) for the process column.
-    @State private var processNames: [String: String] = [:]
+    private var processNames: [String: String] {
+        get { model.processNames }
+        nonmutating set { model.processNames = newValue }
+    }
     /// The live streamer, held so visibility changes can re-pace its flushing
     /// without restarting the stream (a restart would clear the feed).
     @State private var streamer: LogcatStreamer?
@@ -51,7 +90,10 @@ struct LogcatView: View {
     @State private var feedVisible = true
     /// One-shot: the App filter is seeded from the device bar's chosen bundle
     /// the first time the view appears, then left to the user.
-    @State private var seededPackageFilter = false
+    private var seededPackageFilter: Bool {
+        get { model.seededPackageFilter }
+        nonmutating set { model.seededPackageFilter = newValue }
+    }
     /// Mirrors the log pane's edge/scrollability state; drives the jump buttons.
     @State private var edges = LogScrollEdges()
     /// Set by the jump buttons to ask the pane to snap to an edge.
@@ -171,7 +213,8 @@ struct LogcatView: View {
     private var levelPicker: some View {
         HStack(spacing: 6) {
             Text("Level")
-            Picker("Level", selection: $level) {
+            Picker("Level", selection: Binding(
+                get: { model.level }, set: { model.level = $0 })) {
                 ForEach(Self.levels, id: \.value) { item in
                     Text(item.label).tag(item.value)
                 }
@@ -193,7 +236,8 @@ struct LogcatView: View {
     }
 
     private var filterField: some View {
-        TextField("Filter lines…", text: $searchInput)
+        TextField("Filter lines…", text: Binding(
+            get: { model.searchInput }, set: { model.searchInput = $0 }))
             .brandField()
             .frame(maxWidth: 220)
             .help("Show only the lines containing this text")
@@ -522,7 +566,19 @@ struct LogcatView: View {
     /// level, or app filter changes. Outer loop survives app restarts (pid
     /// changes) and transient stream deaths.
     private func streamLoop() async {
-        lines.removeAll()
+        // Clear only when the *question* changed. `.task(id:)` also restarts
+        // this loop when the view is simply rebuilt — which is what moving the
+        // tab to another window or pane does — and dropping the buffer there
+        // would make a move indistinguishable from a restart.
+        // `.task(id:)` also restarts this loop when the view is merely rebuilt —
+        // which is what moving the tab to another window or pane does. Clearing
+        // there would make a move indistinguishable from a restart, so the
+        // buffer is only dropped when the *question* changed.
+        let keepingBuffer = model.bufferKey == taskKey && !lines.isEmpty
+        if !keepingBuffer {
+            lines.removeAll()
+            model.bufferKey = taskKey
+        }
         waitingForPackage = nil
         streamingPid = nil
         guard let serial = state.targetSerials.first else { return }
@@ -573,7 +629,15 @@ struct LogcatView: View {
                 streamingPid = pid
             }
 
-            let filters = LogcatFilters(level: level == "All" ? nil : level, pid: pid)
+            // No replay when the buffer is being kept: `adb logcat -T n` opens
+            // by reprinting the device's last n lines, which are already held,
+            // so a moved tab would show its recent history twice. Starting at
+            // the live edge instead costs only the lines emitted during the
+            // restart itself — milliseconds, and the trade "buffers, not stream
+            // continuity" already accepts.
+            let filters = LogcatFilters(
+                tail: keepingBuffer ? 0 : LogcatFilters().tail,
+                level: level == "All" ? nil : level, pid: pid)
             guard let stream = try? await streamer.start(serial: serial, filters: filters) else { return }
 
             if !recordedCommand {

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorTabModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorTabModel.swift
@@ -1,0 +1,56 @@
+import ADBKit
+import Foundation
+
+/// A tab's live mirror session, kept per window by `FeatureStateStore` rather
+/// than as view `@State`.
+///
+/// A mirror is the most expensive thing a tab can hold: a scrcpy server on the
+/// device, a video encoder, an `adb forward` tunnel and a decoder on this side.
+/// Rebuilding the view — which a tab does whenever it moves to the other split
+/// pane or to another window — used to tear all of that down and start it
+/// again, so a move flashed "Connecting…" and cost a second or two of black
+/// while the device re-primed. Worse, a recording in progress went with it.
+///
+/// The session survives instead. The display layer it feeds is adopted by the
+/// receiving window's view (`MirrorLayerNSView.adopt(displayLayer:)`), which is
+/// the whole reason that method exists; nothing about the stream is touched.
+///
+/// Everything here is about the *session*, not the view — including the
+/// in-flight connect, which must be allowed to finish rather than be cancelled
+/// half-way by a window change and leave a started-but-dead model behind.
+@MainActor
+@Observable
+final class MirrorTabModel {
+    /// The live session, nil when nothing is connected.
+    var session: MirrorViewModel?
+    /// The in-flight (re)connect, so a newer one can cancel and supersede it.
+    var connectTask: Task<Void, Never>?
+    /// Identifies the recording leave guard, so a stale clear can't wipe
+    /// another's — and so the window this tab moves to re-registers the same one.
+    let exitGuardID = UUID()
+
+    /// Give the device up for good — the tab closed, or its window did.
+    func shutDown() {
+        connectTask?.cancel()
+        connectTask = nil
+        let leaving = session
+        session = nil
+        Task { await leaving?.stop() }
+    }
+}
+
+/// The Mirror Wall's live sessions, kept the same way and for the same reasons —
+/// six of them at once, which is six encoders a move used to stop and restart.
+@MainActor
+@Observable
+final class MirrorWallTabModel {
+    var wall: MirrorWallModel?
+
+    /// Terminal, unlike `suspend()`: a wall that has been shut down refuses to
+    /// start anything else, which is what stops a tab closing during quit from
+    /// resurrecting a session that then outlives the process.
+    func shutDown() {
+        wall?.shutDown()
+        wall = nil
+    }
+}

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorVideoView.swift
@@ -101,6 +101,12 @@ final class MirrorLayerNSView: NSView {
     }
 
     private func syncDisplayLayerFrame() {
+        // Only the view the layer currently belongs to may size it. A tab
+        // moving between windows leaves two of these alive for a moment — the
+        // one being torn down still lays out — and a stale one resizing a layer
+        // that has already been adopted elsewhere letterboxes the video against
+        // a pane it is no longer in. Same rule as the terminal's `owns`.
+        guard displayLayer.superlayer === layer else { return }
         guard displayLayer.frame != bounds, bounds.width > 0, bounds.height > 0 else { return }
         // Sublayer frame changes are implicitly animated — a 0.25s lag per
         // divider tick reads as the video chasing the drag. Snap instead.

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -32,8 +32,6 @@ final class MirrorViewModel {
     private(set) var videoSize: CGSize?
     /// Set when a screenshot is captured; the view shows the Discard/Save/Edit prompt.
     var pendingScreenshot: NSImage?
-    /// Set when "Edit" is chosen for a screenshot; the view opens the editor on it.
-    var editingScreenshot: NSImage?
     /// Set when the user picks "Edit" from the post-recording prompt; the view
     /// opens the video editor on it.
     var finishedRecording: URL?

--- a/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
+++ b/App/Sources/FeatureDetail/Views/Mirror/MirrorViewModel.swift
@@ -32,9 +32,6 @@ final class MirrorViewModel {
     private(set) var videoSize: CGSize?
     /// Set when a screenshot is captured; the view shows the Discard/Save/Edit prompt.
     var pendingScreenshot: NSImage?
-    /// Set when the user picks "Edit" from the post-recording prompt; the view
-    /// opens the video editor on it.
-    var finishedRecording: URL?
     /// Set when a recording stops; the view shows the Discard/Save/Edit prompt.
     var pendingRecording: URL?
     /// Set when recording fails to start; the view surfaces it as a toast.

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -16,6 +16,7 @@ let mirrorWallColumnsKey = "mirrorWallColumns"
 /// out into its own window.
 struct MirrorWallView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @Environment(\.tabIsActive) private var tabIsActive
     @Environment(\.openWindow) private var openWindow
     @AppStorage(mirrorWallColumnsKey) private var manualColumns = 0
@@ -25,7 +26,6 @@ struct MirrorWallView: View {
     @State private var dragging: String?
     @State private var dropSlot: DropSlot?
     @State private var pendingScreenshot: NSImage?
-    @State private var editingScreenshot: NSImage?
 
     /// Where a dragged tile would land: before a serial, or at the end.
     enum DropSlot: Equatable {
@@ -33,16 +33,23 @@ struct MirrorWallView: View {
         case end
     }
 
+    /// A tile's screenshot and the markup on it, held by the window rather
+    /// than by this view, so moving the wall's tab doesn't throw away an
+    /// annotation in progress.
+    private var editor: ScreenshotEditorModel {
+        state.featureState(ScreenshotEditorModel.self, for: tabFeatureID) { ScreenshotEditorModel() }
+    }
+
     var body: some View {
         ZStack {
-            if let editingScreenshot {
-                ScreenshotEditorView(image: editingScreenshot) { self.editingScreenshot = nil }
+            if editor.image != nil {
+                ScreenshotEditorView(model: editor)
             } else {
                 wallContent
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .imageDecision(image: $pendingScreenshot) { editingScreenshot = $0 }
+        .imageDecision(image: $pendingScreenshot) { editor.open($0) }
         .task {
             // A wall that has been shut down is inert for good (that's what
             // stops it resurrecting sessions during teardown), so a view whose

--- a/App/Sources/FeatureDetail/Views/MirrorWallView.swift
+++ b/App/Sources/FeatureDetail/Views/MirrorWallView.swift
@@ -20,8 +20,9 @@ struct MirrorWallView: View {
     @Environment(\.tabIsActive) private var tabIsActive
     @Environment(\.openWindow) private var openWindow
     @AppStorage(mirrorWallColumnsKey) private var manualColumns = 0
-    @State private var wall: MirrorWallModel?
-    /// Delayed teardown for a hidden wall; cancelled if the tab returns in time.
+    /// Delayed teardown for a hidden wall; cancelled if the tab returns in
+    /// time. The one piece of this that really is the view's: it is about the
+    /// tab being hidden *here*, and a tab that moves is not hidden any more.
     @State private var teardownTask: Task<Void, Never>?
     @State private var dragging: String?
     @State private var dropSlot: DropSlot?
@@ -40,6 +41,17 @@ struct MirrorWallView: View {
         state.featureState(ScreenshotEditorModel.self, for: tabFeatureID) { ScreenshotEditorModel() }
     }
 
+    /// The wall's live sessions, held by the window rather than by this view so
+    /// a tab moving keeps its six streams. See `MirrorWallTabModel`.
+    private var wallTab: MirrorWallTabModel {
+        state.featureState(MirrorWallTabModel.self, for: tabFeatureID) { MirrorWallTabModel() }
+    }
+
+    private var wall: MirrorWallModel? {
+        get { wallTab.wall }
+        nonmutating set { wallTab.wall = newValue }
+    }
+
     var body: some View {
         ZStack {
             if editor.image != nil {
@@ -52,15 +64,19 @@ struct MirrorWallView: View {
         .imageDecision(image: $pendingScreenshot) { editor.open($0) }
         .task {
             // A wall that has been shut down is inert for good (that's what
-            // stops it resurrecting sessions during teardown), so a view whose
-            // `@State` outlived its own `onDisappear` — a tab moved between
-            // panes — must build a fresh one instead of showing black tiles
-            // nothing can revive.
+            // stops it resurrecting sessions during teardown), so a tab that
+            // finds one has to build a fresh one instead of showing black tiles
+            // nothing can revive. A tab that merely *moved* brings a live wall
+            // with it and keeps every tile streaming.
             if wall == nil || wall?.isShutDown == true {
                 wall = MirrorWallModel(
                     adb: state.env.engine.client, locator: state.env.engine.locator)
             }
             sync()
+            // Re-publish what this window is mirroring: the window a tab moves
+            // to inherits no claims, and `onChange` won't fire for it because
+            // from its point of view nothing changed.
+            state.noteMirrorClaims(wall?.liveSerials ?? [], featureID: tabFeatureID)
         }
         .onChange(of: selection) { syncSelection() }
         .onChange(of: connectedSerials) { syncSelection() }
@@ -75,7 +91,7 @@ struct MirrorWallView: View {
             }
         }
         .onChange(of: wall?.liveSerials) { _, live in
-            state.noteMirrorClaims(live ?? [], featureID: "mirror-wall")
+            state.noteMirrorClaims(live ?? [], featureID: tabFeatureID)
         }
         .onReceive(NotificationCenter.default.publisher(
             for: NSWindow.didChangeOcclusionStateNotification)
@@ -94,11 +110,10 @@ struct MirrorWallView: View {
                 scheduleHiddenTeardown()
             }
         }
-        .onDisappear {
-            teardownTask?.cancel()
-            wall?.shutDown()
-            state.noteMirrorClaims([], featureID: "mirror-wall")
-        }
+        // Only this window's grace timer is cancelled. The wall itself stays:
+        // this also runs when the tab is merely moving, and `stopBackgroundWork`
+        // is where a close and a move are told apart.
+        .onDisappear { teardownTask?.cancel() }
     }
 
     @ViewBuilder private var wallContent: some View {

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -42,9 +42,10 @@ struct ScreenMirrorView: View {
     @State private var exitGuardID = UUID()
     /// Delayed teardown for a hidden tab; cancelled if the tab returns in time.
     @State private var teardownTask: Task<Void, Never>?
-    /// The screenshot editor's state when this mirror is a *window* rather than
-    /// a tab — see `editor`.
+    /// The two editors' state when this mirror is a *window* rather than a tab
+    /// — see `editor`.
     @State private var windowEditor = ScreenshotEditorModel()
+    @State private var windowVideoEditor = VideoEditorModel()
 
     /// Where the screenshot editor keeps the capture and its markup.
     ///
@@ -59,6 +60,13 @@ struct ScreenMirrorView: View {
             : state.featureState(ScreenshotEditorModel.self, for: tabFeatureID) { ScreenshotEditorModel() }
     }
 
+    /// The video editor a finished recording opens in, kept the same way.
+    private var videoEditor: VideoEditorModel {
+        tabFeatureID == MirrorWindow.featureID
+            ? windowVideoEditor
+            : state.featureState(VideoEditorModel.self, for: tabFeatureID) { VideoEditorModel() }
+    }
+
     var body: some View {
         ZStack {
             // The editor takes the whole pane ahead of the mirror: an
@@ -66,22 +74,19 @@ struct ScreenMirrorView: View {
             // disconnects (which drops `model`) must not take it down with it.
             if editor.image != nil {
                 ScreenshotEditorView(model: editor)
-            } else if let model {
+            } else if let source = videoEditor.source {
                 // After Edit, take over the whole pane with the editor (full
-                // screen, not a sheet) so its tools are fully usable; closing it
-                // returns to the live mirror.
-                if let url = model.finishedRecording {
-                    VideoEditorPane(source: .recording(url)) {
-                        try? FileManager.default.removeItem(at: url)
-                        model.finishedRecording = nil
-                    }
-                    .id(url)
-                } else {
-                    MirrorStage(
-                        model: model,
-                        onReconnect: reconnectCurrent,
-                        onPopOut: popOutAction)
+                // screen, not a sheet) so its tools are fully usable; closing
+                // it returns to the live mirror.
+                VideoEditorPane(source: source) {
+                    try? FileManager.default.removeItem(at: source.url)
+                    videoEditor.close()
                 }
+            } else if let model {
+                MirrorStage(
+                    model: model,
+                    onReconnect: reconnectCurrent,
+                    onPopOut: popOutAction)
             } else {
                 ContentUnavailableView(
                     "Connect a device to mirror",
@@ -90,7 +95,7 @@ struct ScreenMirrorView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .recordingDecision(url: pendingRecording) { url in model?.finishedRecording = url }
+        .recordingDecision(url: pendingRecording) { videoEditor.open(.recording($0)) }
         .imageDecision(image: pendingScreenshot) { editor.open($0) }
         .task {
             // Connect if the mirror is the tab on screen when it's first
@@ -176,9 +181,10 @@ struct ScreenMirrorView: View {
             state.clearExitGuard(exitGuardID)
             if tabFeatureID == MirrorWindow.featureID {
                 // A pop-out window is not a tab, so this teardown is final:
-                // an unsaved annotation in it goes with the window, and its
-                // guard has to go with it or nothing would ever clear it.
+                // an unsaved annotation or edit in it goes with the window, and
+                // its guards have to go too or nothing would ever clear them.
                 state.clearExitGuard(editor.exitGuardID)
+                state.clearExitGuard(videoEditor.exitGuardID)
             } else {
                 state.noteMirrorClaims([], featureID: tabFeatureID)
             }

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -35,17 +35,33 @@ struct ScreenMirrorView: View {
     @Environment(\.openWindow) private var openWindow
     @AppStorage(mirrorIncludeAudioKey) private var includeAudio = false
     @AppStorage(mirrorShowTouchesKey) private var showTouches = false
-    @State private var model: MirrorViewModel?
-    /// The in-flight (re)connect, so a newer one can cancel and supersede it.
-    @State private var connectTask: Task<Void, Never>?
-    /// Identifies this view's leave guard so a stale clear can't wipe another's.
-    @State private var exitGuardID = UUID()
     /// Delayed teardown for a hidden tab; cancelled if the tab returns in time.
+    /// The one piece of this that really is the view's: it is about the tab
+    /// being hidden *here*, and a tab that moves is not hidden any more.
     @State private var teardownTask: Task<Void, Never>?
-    /// The two editors' state when this mirror is a *window* rather than a tab
-    /// — see `editor`.
+    /// The session and the two editors' state when this mirror is a *window*
+    /// rather than a tab — see `editor`.
+    @State private var windowMirror = MirrorTabModel()
     @State private var windowEditor = ScreenshotEditorModel()
     @State private var windowVideoEditor = VideoEditorModel()
+
+    /// The live session, held by the window rather than by this view so a tab
+    /// moving keeps the stream it already has. See `MirrorTabModel`.
+    private var mirrorTab: MirrorTabModel {
+        tabFeatureID == MirrorWindow.featureID
+            ? windowMirror
+            : state.featureState(MirrorTabModel.self, for: tabFeatureID) { MirrorTabModel() }
+    }
+
+    private var model: MirrorViewModel? {
+        get { mirrorTab.session }
+        nonmutating set { mirrorTab.session = newValue }
+    }
+    private var connectTask: Task<Void, Never>? {
+        get { mirrorTab.connectTask }
+        nonmutating set { mirrorTab.connectTask = newValue }
+    }
+    private var exitGuardID: UUID { mirrorTab.exitGuardID }
 
     /// Where the screenshot editor keeps the capture and its markup.
     ///
@@ -101,7 +117,15 @@ struct ScreenMirrorView: View {
             // Connect if the mirror is the tab on screen when it's first
             // mounted; a hidden tab connects lazily once it becomes active
             // (below). A hidden mirror is heavy video encode for nothing.
+            // A tab that just moved here arrives with its session already
+            // streaming, and takes neither branch.
             if tabIsActive, model == nil { scheduleReconnect(to: targetSerial) }
+            // Re-publish what this window is mirroring, and re-arm a recording
+            // that crossed with the tab. Neither can ride `onChange`: the new
+            // window inherits nothing, and from its point of view nothing has
+            // changed — only which window is asking.
+            publishClaims(model?.serial)
+            armRecordingGuard(model?.isRecording == true)
         }
         .onChange(of: state.targetSerials.first) { _, serial in
             // Follow the selected device: switching it re-targets the live
@@ -148,14 +172,7 @@ struct ScreenMirrorView: View {
             Task { await CommandLog.userInitiated { await model.setShowTouches(show) } }
         }
         .onChange(of: model?.serial) { _, serial in
-            // Publish what this mirror is actually streaming, so the Mirror Wall
-            // doesn't put a second encoder on the same device (a split pane can
-            // show both at once). Claims come from *live* sessions, which is why
-            // a merely-open tab isn't enough. The pop-out windows are registered
-            // by `AppCore` instead — it holds all of them, and one write here
-            // would clobber its siblings.
-            guard tabFeatureID != MirrorWindow.featureID else { return }
-            state.noteMirrorClaims(serial.map { [$0] } ?? [], featureID: tabFeatureID)
+            publishClaims(serial)
         }
         .onChange(of: model?.recordingError) { _, message in
             guard let message else { return }
@@ -163,14 +180,7 @@ struct ScreenMirrorView: View {
             model?.recordingError = nil
         }
         .onChange(of: model?.isRecording) { _, recording in
-            if recording == true {
-                state.setExitGuard(.init(
-                    id: exitGuardID, featureID: tabFeatureID, style: .recording,
-                    title: "Recording in progress",
-                    message: "Leaving will stop the screen recording. Save it first, or discard it."))
-            } else {
-                state.clearExitGuard(exitGuardID)
-            }
+            armRecordingGuard(recording == true)
         }
         .onChange(of: state.pendingExit?.saving) { _, saving in
             if saving == true, model?.isRecording == true, state.pendingExitConcerns(tabFeatureID) {
@@ -178,22 +188,48 @@ struct ScreenMirrorView: View {
             }
         }
         .onDisappear {
-            state.clearExitGuard(exitGuardID)
+            // Only this window's grace timer is cancelled. The session itself
+            // stays: this also runs when the tab is merely moving, and
+            // `stopBackgroundWork` is where a close and a move are told apart.
+            teardownTask?.cancel()
             if tabFeatureID == MirrorWindow.featureID {
-                // A pop-out window is not a tab, so this teardown is final:
-                // an unsaved annotation or edit in it goes with the window, and
-                // its guards have to go too or nothing would ever clear them.
+                // A pop-out window is not a tab, so this teardown is final: an
+                // unsaved annotation or edit in it goes with the window, its
+                // guards have to go too or nothing would ever clear them, and
+                // the session has nothing left to come back to.
                 state.clearExitGuard(editor.exitGuardID)
                 state.clearExitGuard(videoEditor.exitGuardID)
-            } else {
-                state.noteMirrorClaims([], featureID: tabFeatureID)
+                state.clearExitGuard(exitGuardID)
+                mirrorTab.shutDown()
             }
-            teardownTask?.cancel()
-            connectTask?.cancel()
-            let leaving = model
-            model = nil
-            Task { await leaving?.stop() }
         }
+    }
+
+    /// Publish what this mirror is actually streaming, so the Mirror Wall
+    /// doesn't put a second encoder on the same device (a split pane can show
+    /// both at once). Claims come from *live* sessions, which is why a merely
+    /// open tab isn't enough. The pop-out windows are registered by `AppCore`
+    /// instead — it holds all of them, and one write here would clobber its
+    /// siblings.
+    private func publishClaims(_ serial: String?) {
+        guard tabFeatureID != MirrorWindow.featureID else { return }
+        state.noteMirrorClaims(serial.map { [$0] } ?? [], featureID: tabFeatureID)
+    }
+
+    /// Register (or withdraw) the guard for a recording running through this
+    /// mirror. It survives a move because the recording does — the session
+    /// crosses with the tab and keeps writing — while closing the tab still
+    /// asks, because that really does stop it.
+    private func armRecordingGuard(_ recording: Bool) {
+        guard recording else {
+            state.clearExitGuard(exitGuardID)
+            return
+        }
+        state.setExitGuard(.init(
+            id: exitGuardID, featureID: tabFeatureID, style: .recording,
+            title: "Recording in progress",
+            message: "Leaving will stop the screen recording. Save it first, or discard it.",
+            survivesAMove: true))
     }
 
     /// Stop the hidden mirror after the grace window elapses, unless the tab

--- a/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenMirrorView.swift
@@ -42,10 +42,31 @@ struct ScreenMirrorView: View {
     @State private var exitGuardID = UUID()
     /// Delayed teardown for a hidden tab; cancelled if the tab returns in time.
     @State private var teardownTask: Task<Void, Never>?
+    /// The screenshot editor's state when this mirror is a *window* rather than
+    /// a tab — see `editor`.
+    @State private var windowEditor = ScreenshotEditorModel()
+
+    /// Where the screenshot editor keeps the capture and its markup.
+    ///
+    /// A tab's editor lives in the window's `FeatureStateStore`, so annotations
+    /// survive the tab moving to another window. A pop-out mirror window is not
+    /// a tab: it cannot move, and it reads whichever workspace is frontmost, so
+    /// a store entry would be shared with the other pop-outs and would follow
+    /// the user between windows. It keeps its own instead.
+    private var editor: ScreenshotEditorModel {
+        tabFeatureID == MirrorWindow.featureID
+            ? windowEditor
+            : state.featureState(ScreenshotEditorModel.self, for: tabFeatureID) { ScreenshotEditorModel() }
+    }
 
     var body: some View {
         ZStack {
-            if let model {
+            // The editor takes the whole pane ahead of the mirror: an
+            // annotation in progress is unsaved work, and a device that
+            // disconnects (which drops `model`) must not take it down with it.
+            if editor.image != nil {
+                ScreenshotEditorView(model: editor)
+            } else if let model {
                 // After Edit, take over the whole pane with the editor (full
                 // screen, not a sheet) so its tools are fully usable; closing it
                 // returns to the live mirror.
@@ -55,8 +76,6 @@ struct ScreenMirrorView: View {
                         model.finishedRecording = nil
                     }
                     .id(url)
-                } else if let image = model.editingScreenshot {
-                    ScreenshotEditorView(image: image) { model.editingScreenshot = nil }
                 } else {
                     MirrorStage(
                         model: model,
@@ -72,7 +91,7 @@ struct ScreenMirrorView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .recordingDecision(url: pendingRecording) { url in model?.finishedRecording = url }
-        .imageDecision(image: pendingScreenshot) { image in model?.editingScreenshot = image }
+        .imageDecision(image: pendingScreenshot) { editor.open($0) }
         .task {
             // Connect if the mirror is the tab on screen when it's first
             // mounted; a hidden tab connects lazily once it becomes active
@@ -155,7 +174,12 @@ struct ScreenMirrorView: View {
         }
         .onDisappear {
             state.clearExitGuard(exitGuardID)
-            if tabFeatureID != MirrorWindow.featureID {
+            if tabFeatureID == MirrorWindow.featureID {
+                // A pop-out window is not a tab, so this teardown is final:
+                // an unsaved annotation in it goes with the window, and its
+                // guard has to go with it or nothing would ever clear it.
+                state.clearExitGuard(editor.exitGuardID)
+            } else {
                 state.noteMirrorClaims([], featureID: tabFeatureID)
             }
             teardownTask?.cancel()

--- a/App/Sources/FeatureDetail/Views/ScreenRecordModel.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordModel.swift
@@ -1,0 +1,62 @@
+import ADBKit
+import Foundation
+
+/// A screen recording in progress, kept per window by `FeatureStateStore`
+/// rather than as view `@State`.
+///
+/// The recorder writes to its file through a headless scrcpy session that owes
+/// nothing to the view — the view only polls it for a preview frame. So a tab
+/// moving to another window need not interrupt a take: the recorder crosses
+/// with the tab and the receiving window re-arms the preview, the device lock
+/// and the leave guard. Aborting one because a window changed would be
+/// destroying the user's recording to satisfy a view lifecycle.
+///
+/// A *finished* take waiting on Save/Discard/Edit (`decisionURL`) matters just
+/// as much: it is a file the user has not decided about yet.
+@MainActor
+@Observable
+final class ScreenRecordModel {
+    /// The live recorder, nil when nothing is being captured.
+    var recorder: ScreenRecorder?
+    var isRecording = false
+    var isPaused = false
+    /// Reference date for the elapsed timer, shifted forward on each resume so
+    /// the displayed time counts only *active* recording (paused excluded).
+    var startedAt: Date?
+    /// When the current pause began; nil while actively recording.
+    var pausedAt: Date?
+    /// The file being written, before the user has decided what to do with it.
+    var recordedURL: URL?
+    /// A finished recording awaiting the Discard/Save/Edit choice.
+    var decisionURL: URL?
+    /// The serial the active recording targets, watched for disconnects.
+    var recordingSerial: String?
+    /// The recording device vanished mid-capture: the captured segments are
+    /// kept and only Stop (save/edit/discard) remains.
+    var deviceLost = false
+    /// Stops the recording at the chosen duration. A plain `Task`, so it keeps
+    /// counting across a move — the limit is about the recording, not the view.
+    var limitTask: Task<Void, Never>?
+    /// Identifies the leave guard, so a stale clear can't wipe another's — and
+    /// so the window this tab moves to re-registers the same one.
+    let exitGuardID = UUID()
+
+    /// Whether there is anything a close would destroy.
+    var hasUndecidedWork: Bool { isRecording || recordedURL != nil || decisionURL != nil }
+
+    /// Give up the recording and its file — the tab is closing for good.
+    func abortAndDiscard() {
+        limitTask?.cancel()
+        limitTask = nil
+        if isRecording, let recorder {
+            Task { await recorder.abort() }
+        }
+        for url in [recordedURL, decisionURL].compactMap({ $0 }) {
+            try? FileManager.default.removeItem(at: url)
+        }
+        recorder = nil
+        isRecording = false
+        recordedURL = nil
+        decisionURL = nil
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -40,6 +40,12 @@ struct ScreenRecordView: View {
         get { model.pausedAt }
         nonmutating set { model.pausedAt = newValue }
     }
+    /// The editor's own state, resolved here only so closing it can hand back
+    /// the proxy and the edits along with the recording.
+    private var videoEditor: VideoEditorModel {
+        state.featureState(VideoEditorModel.self, for: tabFeatureID) { VideoEditorModel() }
+    }
+
     private var recordedURL: URL? {
         get { model.recordedURL }
         nonmutating set { model.recordedURL = newValue }
@@ -114,15 +120,18 @@ struct ScreenRecordView: View {
                 VideoEditorPane(source: .recording(url)) {
                     try? FileManager.default.removeItem(at: url)
                     recordedURL = nil
+                    videoEditor.close()
                 }
-                .id(url)
             } else {
                 recordControls
             }
         }
         .recordingDecision(url: Binding(
             get: { model.decisionURL }, set: { model.decisionURL = $0 }
-        )) { recordedURL = $0 }
+        )) { url in
+            recordedURL = url
+            videoEditor.open(.recording(url))
+        }
         .onAppear { RecordAudioPreference.migrate(.standard) }
         .onChange(of: state.devices) {
             guard isRecording, !isStopping, !deviceLost, let recordingSerial,

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -421,7 +421,8 @@ struct ScreenRecordView: View {
             state.setExitGuard(.init(
                 id: exitGuardID, featureID: tabFeatureID, style: .recording,
                 title: "Recording in progress",
-                message: "Leaving will stop the screen recording. Save it first, or discard it."))
+                message: "Leaving will stop the screen recording. Save it first, or discard it.",
+                survivesAMove: true))
             scheduleTimeLimit(remaining: TimeInterval(options.timeLimitSeconds))
         } catch {
             state.showToast(Toast(message: error.localizedDescription, ok: false))
@@ -536,7 +537,8 @@ struct ScreenRecordView: View {
         state.setExitGuard(.init(
             id: exitGuardID, featureID: tabFeatureID, style: .recording,
             title: "Recording in progress",
-            message: "Leaving will stop the screen recording. Save it first, or discard it."))
+            message: "Leaving will stop the screen recording. Save it first, or discard it.",
+            survivesAMove: true))
     }
 
     private func stopPreviewPolling() {

--- a/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenRecordView.swift
@@ -10,30 +10,67 @@ import SwiftUI
 struct ScreenRecordView: View {
     @Environment(AppState.self) private var state
     @Environment(\.tabFeatureID) private var tabFeatureID
-    @State private var recorder: ScreenRecorder?
-    @State private var isRecording = false
-    @State private var isPaused = false
+    /// The recording itself, kept per window so a tab moving to another window
+    /// does not abort a take (see `ScreenRecordModel`). Only the preview — a
+    /// polled image — stays view-local, because it is rebuilt in a frame.
+    private var model: ScreenRecordModel {
+        state.featureState(ScreenRecordModel.self, for: "screen-record") { ScreenRecordModel() }
+    }
+    private var recorder: ScreenRecorder? {
+        get { model.recorder }
+        nonmutating set { model.recorder = newValue }
+    }
+    private var isRecording: Bool {
+        get { model.isRecording }
+        nonmutating set { model.isRecording = newValue }
+    }
+    private var isPaused: Bool {
+        get { model.isPaused }
+        nonmutating set { model.isPaused = newValue }
+    }
+    /// Reference date for the elapsed timer, shifted forward on each resume so
+    /// the displayed time counts only *active* recording (paused time excluded).
+    private var startedAt: Date? {
+        get { model.startedAt }
+        nonmutating set { model.startedAt = newValue }
+    }
+    /// When the current pause began; drives the frozen timer and the time-limit
+    /// reschedule. `nil` while actively recording.
+    private var pausedAt: Date? {
+        get { model.pausedAt }
+        nonmutating set { model.pausedAt = newValue }
+    }
+    private var recordedURL: URL? {
+        get { model.recordedURL }
+        nonmutating set { model.recordedURL = newValue }
+    }
+    /// A finished recording awaiting the Discard/Save/Edit choice.
+    private var decisionURL: URL? {
+        get { model.decisionURL }
+        nonmutating set { model.decisionURL = newValue }
+    }
+    /// The serial the active recording targets, watched for disconnects.
+    private var recordingSerial: String? {
+        get { model.recordingSerial }
+        nonmutating set { model.recordingSerial = newValue }
+    }
+    /// The recording device vanished mid-capture: the captured segments are
+    /// kept and only Stop (save/edit/discard) remains.
+    private var deviceLost: Bool {
+        get { model.deviceLost }
+        nonmutating set { model.deviceLost = newValue }
+    }
+    private var limitTask: Task<Void, Never>? {
+        get { model.limitTask }
+        nonmutating set { model.limitTask = newValue }
+    }
+    /// Identifies this view's leave guard so a stale clear can't wipe another's.
+    private var exitGuardID: UUID { model.exitGuardID }
+
     @State private var isStarting = false
     @State private var isStopping = false
     @State private var isBusy = false
-    /// Reference date for the elapsed timer, shifted forward on each resume so
-    /// the displayed time counts only *active* recording (paused time excluded).
-    @State private var startedAt: Date?
-    /// When the current pause began; drives the frozen timer and the time-limit
-    /// reschedule. `nil` while actively recording.
-    @State private var pausedAt: Date?
-    @State private var recordedURL: URL?
-    /// A finished recording awaiting the Discard/Save/Edit choice.
-    @State private var decisionURL: URL?
-    /// The serial the active recording targets, watched for disconnects.
-    @State private var recordingSerial: String?
-    /// The recording device vanished mid-capture: the captured segments are
-    /// kept and only Stop (save/edit/discard) remains.
-    @State private var deviceLost = false
     @State private var showAdvanced = false
-    @State private var limitTask: Task<Void, Never>?
-    /// Identifies this view's leave guard so a stale clear can't wipe another's.
-    @State private var exitGuardID = UUID()
     /// Live preview of the frames being captured, polled from the recorder's
     /// session while recording so the user sees what's going into the file.
     @State private var previewImage: NSImage?
@@ -83,7 +120,9 @@ struct ScreenRecordView: View {
                 recordControls
             }
         }
-        .recordingDecision(url: $decisionURL) { recordedURL = $0 }
+        .recordingDecision(url: Binding(
+            get: { model.decisionURL }, set: { model.decisionURL = $0 }
+        )) { recordedURL = $0 }
         .onAppear { RecordAudioPreference.migrate(.standard) }
         .onChange(of: state.devices) {
             guard isRecording, !isStopping, !deviceLost, let recordingSerial,
@@ -96,13 +135,18 @@ struct ScreenRecordView: View {
                 Task { await saveRecordingForLeave() }
             }
         }
+        // Re-arm what a live recording needs from *this* window. The tab may
+        // have just arrived here carrying a recording that never stopped, in
+        // which case the preview, the device lock and the leave guard all have
+        // to be set up again — they belong to the window, not to the take.
+        .task { adoptRunningRecording() }
         .onDisappear {
-            limitTask?.cancel()
+            // View-local only. Aborting the take, clearing the guard and
+            // deleting the file belong to the tab *closing*, which
+            // `AppState.stopBackgroundWork` handles — this also runs when the
+            // tab is merely moving to another window, and a move must not
+            // destroy a recording.
             stopPreviewPolling()
-            state.setRecording(false, owner: "screen-record")
-            state.clearExitGuard(exitGuardID)
-            if isRecording, let recorder { Task { await recorder.abort() } }
-            if let url = recordedURL { try? FileManager.default.removeItem(at: url) }
         }
     }
 
@@ -481,6 +525,18 @@ struct ScreenRecordView: View {
                 try? await Task.sleep(for: .milliseconds(90))
             }
         }
+    }
+
+    /// Take up a recording that is already running — either started in this
+    /// window, or carried in by a tab that moved here.
+    private func adoptRunningRecording() {
+        guard isRecording else { return }
+        if previewTask == nil { startPreviewPolling() }
+        state.setRecording(true, owner: "screen-record")
+        state.setExitGuard(.init(
+            id: exitGuardID, featureID: tabFeatureID, style: .recording,
+            title: "Recording in progress",
+            message: "Leaving will stop the screen recording. Save it first, or discard it."))
     }
 
     private func stopPreviewPolling() {

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorModel.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorModel.swift
@@ -1,0 +1,103 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+/// A screenshot being annotated, kept per window by `FeatureStateStore` rather
+/// than as view `@State`.
+///
+/// The editor writes nothing to disk until the user saves or copies, so
+/// everything in it is unsaved work: the capture itself, the markup drawn on
+/// it, and the undo history that can take any of it back. Rebuilding the view —
+/// which a tab does whenever it moves to the other split pane or to another
+/// window — would throw all three away. That is the one loss in this app the
+/// user cannot recover from by waiting: a log refills, a decompile re-runs, an
+/// annotation is gone.
+///
+/// `image` doubles as "is an editor open in this tab": the three hosts (the
+/// Screenshot tab, the mirror, the Mirror Wall) render `ScreenshotEditorView`
+/// exactly while this holds a capture, so opening and closing the editor is
+/// `open(_:)` and `close()` rather than each host keeping its own flag.
+///
+/// Only state that a *move* should carry lives here. What a drag is doing right
+/// now (the stroke being drawn, the handle being pulled) stays in the view: a
+/// drag cannot be in flight across a move, and giving it a longer life than the
+/// mouse button would only let a stale grab resume against a new gesture.
+@MainActor
+@Observable
+final class ScreenshotEditorModel {
+    /// The capture being edited — the base image, which crop and rotate
+    /// replace. Nil when this tab has no editor open.
+    var image: NSImage?
+    var annotations: [Annotation] = []
+    /// Past / future states for ⌘Z / ⇧⌘Z — each snapshot is the full
+    /// (image, annotations) pair, so undo also reverses a clear or a crop.
+    var undoStack: [EditorSnapshot] = []
+    var redoStack: [EditorSnapshot] = []
+
+    /// The drawing settings new markup is made with. Carried across a move for
+    /// the same reason the markup is: the user chose them.
+    var tool: MarkupTool = .pen
+    var color: Color = .red
+    var width: CGFloat = 6
+    var redactStyle: RedactStyle = .blur
+    /// Redact defaults for new regions (per-annotation values live on `Annotation`).
+    var blurStrength: Double = 0.4
+    var fillOpacity: Double = 1
+
+    /// 1.0 == fit-to-view; the displayed scale is `fit * zoom`. `pinchAnchor`
+    /// is the zoom a pinch scales from, and travels with `zoom` — separating
+    /// them would make the first pinch after a move jump back to the old scale.
+    var zoom: CGFloat = 1
+    var pinchAnchor: CGFloat = 1
+
+    var cropping = false
+    var cropRect: CGRect?
+    /// Crop-box rotation in radians.
+    var cropRotation: Double = 0
+
+    /// Select-mode editing: which annotation is picked, and which text label is
+    /// open for re-editing (nil = placing new text).
+    var selecting = false
+    var selectedID: Annotation.ID?
+    var editingTextID: Annotation.ID?
+    /// Normalized location of the text field being typed into (nil = none), and
+    /// its contents. A half-typed label is markup the user has not committed
+    /// yet, so it moves with the rest of it.
+    var textPoint: CGPoint?
+    var editingText = ""
+
+    var lastSavedURL: URL?
+    /// Unsaved markup/edits exist — drives the leave prompt. Reset on save/copy.
+    var dirty = false
+    /// Identifies the leave guard, so a stale clear can't wipe another's — and
+    /// so the window this tab moves to re-registers the same one.
+    let exitGuardID = UUID()
+
+    /// Open a fresh capture, discarding whatever the editor held. Every host
+    /// reaches this through the Discard/Save/Edit prompt, which is where the
+    /// user has already been asked about the previous one.
+    func open(_ capture: NSImage) {
+        close()
+        image = capture
+    }
+
+    /// Close the editor and forget the capture — "New", or the tab closing.
+    func close() {
+        image = nil
+        annotations = []
+        undoStack = []
+        redoStack = []
+        cropping = false
+        cropRect = nil
+        cropRotation = 0
+        selecting = false
+        selectedID = nil
+        editingTextID = nil
+        textPoint = nil
+        editingText = ""
+        zoom = 1
+        pinchAnchor = 1
+        lastSavedURL = nil
+        dirty = false
+    }
+}

--- a/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotEditorView.swift
@@ -8,67 +8,130 @@ import SwiftUI
 struct ScreenshotEditorView: View {
     @Environment(AppState.self) private var state
     @Environment(\.tabFeatureID) private var tabFeatureID
-    /// Discard the current capture and return to the capture controls.
-    let onClose: () -> Void
+    /// The capture and the markup on it, held by whoever outlives this view —
+    /// the window's `FeatureStateStore` for a tab, the pop-out mirror window
+    /// for its own. See `ScreenshotEditorModel`.
+    let model: ScreenshotEditorModel
 
-    @State private var image: NSImage
-    @State private var annotations: [Annotation] = []
-    /// Past / future states for ⌘Z / ⇧⌘Z — each snapshot is the full
-    /// (image, annotations) pair, so undo also reverses a clear or a crop.
-    @State private var undoStack: [EditorSnapshot] = []
-    @State private var redoStack: [EditorSnapshot] = []
+    /// The stroke or shape being drawn right now. View state, not the model's:
+    /// a drag ends with the mouse button, so there is nothing here for a move
+    /// to carry.
     @State private var draft: Annotation?
-    @State private var tool: MarkupTool = .pen
-    @State private var color: Color = .red
-    @State private var width: CGFloat = 6
-    @State private var redactStyle: RedactStyle = .blur
-    /// 1.0 == fit-to-view; the displayed scale is `fit * zoom`.
-    @State private var zoom: CGFloat = 1
-    @State private var pinchAnchor: CGFloat = 1
-    @State private var cropping = false
-    @State private var cropRect: CGRect?
-    /// Crop-box rotation in radians.
-    @State private var cropRotation: Double = 0
     /// What the current crop-mode drag is doing, and the box when it began.
     @State private var cropDrag: CropDragMode = .none
     @State private var cropDragOrigin: CGRect?
     @State private var cropDragStart: CGPoint = .zero
-    /// Normalized location of the text field currently being typed (nil = none).
-    @State private var textPoint: CGPoint?
-    @State private var editingText = ""
-    @State private var lastSavedURL: URL?
     @FocusState private var textFocused: Bool
-    /// Select-mode editing: tap an existing annotation to select it, drag its
-    /// body to move it, drag a handle to resize it.
-    @State private var selecting = false
-    @State private var selectedID: Annotation.ID?
+    /// Select-mode dragging: which handle was grabbed, and the annotation as it
+    /// was when the drag began, so each frame transforms from the original
+    /// rather than accumulating drift.
     @State private var selectDragActive = false
     @State private var selectDragMode: SelectDragMode = .none
-    /// The selected annotation as it was when the drag began, so each frame
-    /// transforms from the original rather than accumulating drift.
     @State private var selectDragOrigin: Annotation?
     @State private var selectDragStart: CGPoint = .zero
     @State private var selectDidEdit = false
-    /// Redact defaults for new regions (per-annotation values live on `Annotation`).
-    @State private var blurStrength: Double = 0.4
-    @State private var fillOpacity: Double = 1
-    /// The text annotation currently being re-edited (nil = placing new text).
-    @State private var editingTextID: Annotation.ID?
-    /// Identifies this view's leave guard so a stale clear can't wipe another's.
-    @State private var exitGuardID = UUID()
-    /// Unsaved markup/edits exist — drives the leave prompt. Reset on save/copy.
-    @State private var dirty = false
+
+    // The editor's own state, read and written through the model so that
+    // moving the tab it lives in doesn't restart the edit. Accessors rather
+    // than direct `model.` access: this view is a thousand lines of drawing
+    // code that predates the model, and the two must not drift.
+    /// The capture being edited. The hosts render this view exactly while the
+    /// model holds one, so the empty fallback is unreachable — it exists
+    /// because everything downstream of here draws into a real image.
+    private var image: NSImage {
+        get { model.image ?? NSImage() }
+        nonmutating set { model.image = newValue }
+    }
+    private var annotations: [Annotation] {
+        get { model.annotations }
+        nonmutating set { model.annotations = newValue }
+    }
+    private var undoStack: [EditorSnapshot] {
+        get { model.undoStack }
+        nonmutating set { model.undoStack = newValue }
+    }
+    private var redoStack: [EditorSnapshot] {
+        get { model.redoStack }
+        nonmutating set { model.redoStack = newValue }
+    }
+    private var tool: MarkupTool {
+        get { model.tool }
+        nonmutating set { model.tool = newValue }
+    }
+    private var color: Color {
+        get { model.color }
+        nonmutating set { model.color = newValue }
+    }
+    private var width: CGFloat {
+        get { model.width }
+        nonmutating set { model.width = newValue }
+    }
+    private var redactStyle: RedactStyle {
+        get { model.redactStyle }
+        nonmutating set { model.redactStyle = newValue }
+    }
+    private var blurStrength: Double {
+        get { model.blurStrength }
+        nonmutating set { model.blurStrength = newValue }
+    }
+    private var fillOpacity: Double {
+        get { model.fillOpacity }
+        nonmutating set { model.fillOpacity = newValue }
+    }
+    private var zoom: CGFloat {
+        get { model.zoom }
+        nonmutating set { model.zoom = newValue }
+    }
+    private var pinchAnchor: CGFloat {
+        get { model.pinchAnchor }
+        nonmutating set { model.pinchAnchor = newValue }
+    }
+    private var cropping: Bool {
+        get { model.cropping }
+        nonmutating set { model.cropping = newValue }
+    }
+    private var cropRect: CGRect? {
+        get { model.cropRect }
+        nonmutating set { model.cropRect = newValue }
+    }
+    private var cropRotation: Double {
+        get { model.cropRotation }
+        nonmutating set { model.cropRotation = newValue }
+    }
+    private var selecting: Bool {
+        get { model.selecting }
+        nonmutating set { model.selecting = newValue }
+    }
+    private var selectedID: Annotation.ID? {
+        get { model.selectedID }
+        nonmutating set { model.selectedID = newValue }
+    }
+    private var editingTextID: Annotation.ID? {
+        get { model.editingTextID }
+        nonmutating set { model.editingTextID = newValue }
+    }
+    private var textPoint: CGPoint? {
+        get { model.textPoint }
+        nonmutating set { model.textPoint = newValue }
+    }
+    private var editingText: String {
+        get { model.editingText }
+        nonmutating set { model.editingText = newValue }
+    }
+    private var lastSavedURL: URL? {
+        get { model.lastSavedURL }
+        nonmutating set { model.lastSavedURL = newValue }
+    }
+    private var dirty: Bool {
+        get { model.dirty }
+        nonmutating set { model.dirty = newValue }
+    }
 
     private static let palette: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .black, .white]
     private static let widths: [(String, CGFloat)] = [("Thin", 3), ("Medium", 6), ("Thick", 12)]
     /// Cap the undo history so a long session can't grow it without bound. A crop
     /// replaces the base image, so a snapshot can hold a full-resolution copy.
     private static let maxUndo = 50
-
-    init(image: NSImage, onClose: @escaping () -> Void) {
-        _image = State(initialValue: image)
-        self.onClose = onClose
-    }
 
     private var pixelSize: CGSize { ScreenshotMarkup.pixelSize(of: image) }
 
@@ -127,6 +190,19 @@ struct ScreenshotEditorView: View {
             }
         )
     }
+    // The controls the model backs directly. `Bindable` would do for one
+    // property; these read through the accessors above so every write to the
+    // model goes through the same door.
+    private var colorBinding: Binding<Color> {
+        Binding(get: { color }, set: { color = $0 })
+    }
+    private var widthBinding: Binding<CGFloat> {
+        Binding(get: { width }, set: { width = $0 })
+    }
+    private var editingTextBinding: Binding<String> {
+        Binding(get: { editingText }, set: { editingText = $0 })
+    }
+
     private func updateAnnotation(_ id: Annotation.ID, _ mutate: (inout Annotation) -> Void) {
         guard let index = annotations.firstIndex(where: { $0.id == id }) else { return }
         mutate(&annotations[index])
@@ -147,17 +223,38 @@ struct ScreenshotEditorView: View {
         // Delete / Backspace removes the selected annotation. Skipped while a text
         // label is being edited so the field's own deletion keeps working.
         .onDeleteCommand { if editingTextID == nil { deleteSelected() } }
-        .onChange(of: dirty) { _, isDirty in
-            if isDirty {
-                state.setExitGuard(.init(
-                    id: exitGuardID, featureID: tabFeatureID, style: .edits,
-                    title: "Unsaved screenshot",
-                    message: "Your annotations and edits haven’t been saved. Leaving discards them."))
-            } else {
-                state.clearExitGuard(exitGuardID)
-            }
+        // Also on appear, not only on change: unsaved markup crosses with a
+        // moving tab, and the window it lands in inherits none of the guards
+        // the window it left had registered. `dirty` hasn't changed, so
+        // `onChange` alone would leave the new window free to close the tab on
+        // work it never asked about.
+        .task { armGuard() }
+        .onChange(of: dirty) { _, _ in armGuard() }
+    }
+
+    /// Register (or withdraw) this tab's leave guard for the markup on screen.
+    ///
+    /// The guard survives a move (`survivesAMove`) because the markup does:
+    /// asking "leaving discards them" for a move that discards nothing is a
+    /// prompt the user has to read to find out it didn't matter. Closing the
+    /// tab still asks — that is the route which really does throw it away.
+    private func armGuard() {
+        guard dirty else {
+            state.clearExitGuard(model.exitGuardID)
+            return
         }
-        .onDisappear { state.clearExitGuard(exitGuardID) }
+        state.setExitGuard(.init(
+            id: model.exitGuardID, featureID: tabFeatureID, style: .edits,
+            title: "Unsaved screenshot",
+            message: "Your annotations and edits haven’t been saved. Leaving discards them.",
+            survivesAMove: true))
+    }
+
+    /// Discard the capture and return the host to whatever it shows without
+    /// one — the capture controls, the live mirror, the wall.
+    private func close() {
+        state.clearExitGuard(model.exitGuardID)
+        model.close()
     }
 
     /// Undo/redo are unavailable while a text label is being typed, so ⌘Z falls
@@ -177,7 +274,7 @@ struct ScreenshotEditorView: View {
 
     private var toolbar: some View {
         HStack(spacing: 12) {
-            Button { onClose() } label: {
+            Button { close() } label: {
                 Image(systemName: "chevron.backward").frame(width: 26, height: 24).contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -230,7 +327,7 @@ struct ScreenshotEditorView: View {
                 // Native color picker, masked behind a color-wheel "logo" so it
                 // reads as "pick any color" instead of a plain swatch. The wheel
                 // is non-interactive, so taps fall through to the picker.
-                ColorPicker("", selection: $color, supportsOpacity: false)
+                ColorPicker("", selection: colorBinding, supportsOpacity: false)
                     .labelsHidden()
                     .frame(width: 20, height: 20)
                     .clipShape(Circle())
@@ -249,7 +346,7 @@ struct ScreenshotEditorView: View {
 
             Divider().frame(height: 22)
 
-            Picker("", selection: $width) {
+            Picker("", selection: widthBinding) {
                 ForEach(Self.widths, id: \.1) { Text($0.0).tag($0.1) }
             }
             .labelsHidden()
@@ -582,7 +679,7 @@ struct ScreenshotEditorView: View {
             // position the moment it's committed.
             let fontSize = max(11, display.width * 0.03 * (activeTextWidth / 6))
             let fieldWidth = max(120, display.width - point.x - 8)
-            TextField("Type, then ⏎", text: $editingText)
+            TextField("Type, then ⏎", text: editingTextBinding)
                 .textFieldStyle(.plain)
                 .font(.system(size: fontSize, weight: .semibold))
                 .foregroundStyle(activeTextColor)
@@ -851,7 +948,7 @@ struct ScreenshotEditorView: View {
             } else {
                 zoomControls
                 Spacer()
-                Button { onClose() } label: { Label("New", systemImage: "camera") }
+                Button { close() } label: { Label("New", systemImage: "camera") }
                     .help("Discard and take another")
                 if let lastSavedURL {
                     Button { NSWorkspace.shared.activateFileViewerSelecting([lastSavedURL]) } label: {

--- a/App/Sources/FeatureDetail/Views/ScreenshotView.swift
+++ b/App/Sources/FeatureDetail/Views/ScreenshotView.swift
@@ -7,15 +7,20 @@ import SwiftUI
 /// global hotkey, or the menu bar instead save straight to the capture folder.
 struct ScreenshotView: View {
     @Environment(AppState.self) private var state
-    @State private var image: NSImage?
+    @Environment(\.tabFeatureID) private var tabFeatureID
     @State private var capturing = false
     @AppStorage("screenshotDelay") private var captureDelay = 0
 
+    /// The capture and its markup, held by the window rather than by this view,
+    /// so moving the tab doesn't throw away an annotation in progress.
+    private var editor: ScreenshotEditorModel {
+        state.featureState(ScreenshotEditorModel.self, for: tabFeatureID) { ScreenshotEditorModel() }
+    }
+
     var body: some View {
         Group {
-            if let image {
-                ScreenshotEditorView(image: image) { self.image = nil }
-                    .id(ObjectIdentifier(image))
+            if editor.image != nil {
+                ScreenshotEditorView(model: editor)
             } else {
                 captureControls
             }
@@ -72,7 +77,7 @@ struct ScreenshotView: View {
         capturing = true
         Task {
             if let shot = await state.captureForEditor(delaySeconds: captureDelay) {
-                image = shot
+                editor.open(shot)
             }
             capturing = false
         }

--- a/App/Sources/FeatureDetail/Views/SendTextView.swift
+++ b/App/Sources/FeatureDetail/Views/SendTextView.swift
@@ -9,24 +9,54 @@ import SwiftUI
 /// and whose result card landed below the snippet list.
 struct SendTextView: View {
     @Environment(AppState.self) private var state
+    @Environment(\.tabFeatureID) private var tabFeatureID
     let feature: FeatureDef
 
-    @State private var text = ""
     @State private var presets = Presets()
     /// The Mac's LAN IP — the `{ip}` placeholder value and, for the React
     /// Native role, a pinned quick insert (Metro's "Debug server host" is
     /// `<mac-ip>:8081`).
     @State private var macIP: String?
-    @State private var creatingSnippet = false
-    @State private var newSnippetName = ""
-    @State private var newSnippetText = ""
-    @State private var snippetSearch = ""
-    @State private var showAllSnippets = false
     @State private var snippetPendingRemoval: SendTextSnippet?
     @FocusState private var textFocused: Bool
     /// Wipe the field after a successful send, for firing a sequence of
     /// inputs without hand-clearing between them. Persisted choice.
     @AppStorage("sendTextClearAfterSend") private var clearAfterSend = false
+
+    /// What has been typed but not sent or saved, held by the window rather
+    /// than by this view. See `SendTextModel`.
+    private var draft: SendTextModel {
+        state.featureState(SendTextModel.self, for: tabFeatureID) { SendTextModel() }
+    }
+
+    private var text: String {
+        get { draft.text }
+        nonmutating set { draft.text = newValue }
+    }
+    private var creatingSnippet: Bool {
+        get { draft.creatingSnippet }
+        nonmutating set { draft.creatingSnippet = newValue }
+    }
+    private var newSnippetName: String {
+        get { draft.newSnippetName }
+        nonmutating set { draft.newSnippetName = newValue }
+    }
+    private var newSnippetText: String {
+        get { draft.newSnippetText }
+        nonmutating set { draft.newSnippetText = newValue }
+    }
+    private var snippetSearch: String {
+        get { draft.snippetSearch }
+        nonmutating set { draft.snippetSearch = newValue }
+    }
+    private var showAllSnippets: Bool {
+        get { draft.showAllSnippets }
+        nonmutating set { draft.showAllSnippets = newValue }
+    }
+
+    private func bind<T>(_ keyPath: ReferenceWritableKeyPath<SendTextModel, T>) -> Binding<T> {
+        Binding(get: { draft[keyPath: keyPath] }, set: { draft[keyPath: keyPath] = $0 })
+    }
 
     /// Library collapse: this many rows before "Show more". Search appears
     /// once the library outgrows a glance.
@@ -111,7 +141,7 @@ struct SendTextView: View {
 
     private var textField: some View {
         TextField(
-            "", text: $text,
+            "", text: bind(\.text),
             prompt: feature.fields.first { $0.name == "text" }?.placeholder.map(Text.init)
         )
         .brandField()
@@ -178,7 +208,7 @@ struct SendTextView: View {
                     newSnippetButton
                     Spacer(minLength: 12)
                     if presets.sendTextSnippets.count > Self.searchThreshold {
-                        SearchField(prompt: "Search snippets", text: $snippetSearch)
+                        SearchField(prompt: "Search snippets", text: bind(\.snippetSearch))
                             .frame(maxWidth: 240)
                             .help("Find a snippet by its name or its text")
                     }
@@ -281,7 +311,7 @@ struct SendTextView: View {
         .buttonStyle(.bordered)
         .controlSize(.small)
         .help("Save the text you send often as a reusable snippet")
-        .popover(isPresented: $creatingSnippet, arrowEdge: .bottom) {
+        .popover(isPresented: bind(\.creatingSnippet), arrowEdge: .bottom) {
             newSnippetPopover
         }
     }
@@ -291,14 +321,14 @@ struct SendTextView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("New snippet")
                 .font(.app(.headline))
-            TextField("Name", text: $newSnippetName, prompt: Text("Name — shown in the list"))
+            TextField("Name", text: bind(\.newSnippetName), prompt: Text("Name — shown in the list"))
                 .textFieldStyle(.roundedBorder)
                 .onChange(of: newSnippetName) { _, value in
                     if value.count > SendTextSnippet.nameLimit {
                         newSnippetName = String(value.prefix(SendTextSnippet.nameLimit))
                     }
                 }
-            TextField("Text", text: $newSnippetText, prompt: Text("Text to insert…"), axis: .vertical)
+            TextField("Text", text: bind(\.newSnippetText), prompt: Text("Text to insert…"), axis: .vertical)
                 .textFieldStyle(.roundedBorder)
                 .lineLimit(1...4)
                 .onSubmit { saveNewSnippet() }

--- a/App/Sources/FeatureDetail/Views/SimulatorLogsModel.swift
+++ b/App/Sources/FeatureDetail/Views/SimulatorLogsModel.swift
@@ -1,0 +1,25 @@
+import ADBKit
+import Foundation
+
+/// iOS Logs' collected lines and filters — Logcat's twin, kept per window by
+/// `FeatureStateStore` for the same reason: a tab moving to another window
+/// rebuilds its view, and a unified-log feed that starts empty every time it
+/// changes places is a restart, not a move.
+///
+/// As with Logcat, the `simctl spawn … log stream` process itself stays with
+/// the view and reattaches. Only what it accumulated is worth carrying.
+@MainActor
+@Observable
+final class SimulatorLogsModel {
+    var lines: [SimLogLine] = []
+    var paused = false
+    var shownLevels: Set<SimLogLevel> = [.notice, .error, .fault]
+    var processFilter: String?
+    /// What the user is typing, debounced into `search`.
+    var searchInput = ""
+    var search = ""
+    /// The stream query (`SimulatorLogsView.taskKey`) the buffer was collected
+    /// under. A restart with the same query is a remount — the tab moved — and
+    /// keeps what it had; a different one is a different question and clears.
+    var bufferKey: String?
+}

--- a/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
@@ -16,22 +16,45 @@ struct SimulatorLogsView: View {
     @Environment(\.colorScheme) private var colorScheme
     /// The frozen, rendered buffer. Only mutated while following the tail —
     /// scrollback reads a stable list.
-    @State private var lines: [SimLogLine] = []
+    /// The buffer and its filters, kept per window so they survive this view
+    /// being rebuilt — see `SimulatorLogsModel`.
+    private var model: SimulatorLogsModel {
+        state.featureState(SimulatorLogsModel.self, for: "ios-logs") { SimulatorLogsModel() }
+    }
+    private var lines: [SimLogLine] {
+        get { model.lines }
+        nonmutating set { model.lines = newValue }
+    }
     /// Batches received while frozen (scrolled up) wait here.
     @State private var pending: [SimLogLine] = []
     /// True once `pending` overflowed and dropped its oldest lines.
     @State private var pendingOverflowed = false
-    @State private var paused = false
+    private var paused: Bool {
+        get { model.paused }
+        nonmutating set { model.paused = newValue }
+    }
     /// What the simulator emits: installed apps only, or the whole OS.
     @AppStorage("iosLogsScope") private var scopeRaw = SimulatorLogScope.apps.rawValue
     /// Which levels the feed *shows*; checking Info/Debug also widens what
     /// the simulator emits (a stream restart).
-    @State private var shownLevels: Set<SimLogLevel> = [.notice, .error, .fault]
+    private var shownLevels: Set<SimLogLevel> {
+        get { model.shownLevels }
+        nonmutating set { model.shownLevels = newValue }
+    }
     /// Right-click / Process-menu pick; narrows the feed to one process.
-    @State private var processFilter: String?
+    private var processFilter: String? {
+        get { model.processFilter }
+        nonmutating set { model.processFilter = newValue }
+    }
     /// Free-text filter, debounced from `searchInput` into `search`.
-    @State private var searchInput = ""
-    @State private var search = ""
+    private var searchInput: String {
+        get { model.searchInput }
+        nonmutating set { model.searchInput = newValue }
+    }
+    private var search: String {
+        get { model.search }
+        nonmutating set { model.search = newValue }
+    }
     /// Whether this tab is the one on screen. The stream keeps running while
     /// it isn't — only the flushing slows down (`FeedFlushCadence`), because a
     /// mounted hidden tab lays out every row it is handed.
@@ -175,7 +198,7 @@ struct SimulatorLogsView: View {
             levelsMenu
             processMenu
 
-            TextField("Filter…", text: $searchInput)
+            TextField("Filter…", text: Binding(get: { model.searchInput }, set: { model.searchInput = $0 }))
                 .brandField()
                 .frame(maxWidth: 200)
                 .help("Show only lines whose process, subsystem, category, or message contains this text")
@@ -571,7 +594,13 @@ struct SimulatorLogsView: View {
     }
 
     private func streamLoop() async {
-        lines.removeAll()
+        // Only when the *question* changed: `.task(id:)` also restarts this on
+        // a plain rebuild, which is what moving the tab does, and clearing
+        // there would make a move indistinguishable from a restart.
+        if model.bufferKey != taskKey {
+            lines.removeAll()
+            model.bufferKey = taskKey
+        }
         pending.removeAll()
         pendingOverflowed = false
         scrolledID = nil

--- a/App/Sources/FeatureDetail/Views/TerminalView.swift
+++ b/App/Sources/FeatureDetail/Views/TerminalView.swift
@@ -60,6 +60,18 @@ final class TerminalManager {
     var onShellExited: ((UUID) -> Void)?
 
     /// Every open tab in display order (groups top to bottom).
+    /// Whether `session` is still one of this manager's shells.
+    ///
+    /// The question a terminal pane asks before it mounts the live view: when a
+    /// Terminal tab moves to another window the manager crosses with it, and
+    /// the window it left runs one more update pass over a view tree that is on
+    /// its way out. That pass must not re-parent a terminal the receiving
+    /// window has already taken, and "am I still its owner?" is the only thing
+    /// that tells the two apart — both panes are in real, live windows.
+    func owns(_ session: TerminalSession) -> Bool {
+        tabsByID.values.contains { $0.sessions.values.contains { $0 === session } }
+    }
+
     var tabs: [Tab] {
         layout.allTabIDs.compactMap { tabsByID[$0] }
     }
@@ -982,6 +994,9 @@ private struct TerminalSplitNodeView: View {
     let isActiveTab: Bool
     let onClosePane: (UUID) -> Void
     @Environment(\.windowOpacity) private var windowOpacity
+    /// Resolved live, not captured: this is what distinguishes the window that
+    /// owns the shells from one whose Terminal tab has just left for another.
+    @Environment(AppState.self) private var state
 
     var body: some View {
         switch node {
@@ -994,7 +1009,8 @@ private struct TerminalSplitNodeView: View {
                     session: session,
                     serial: serial,
                     isActive: isActiveTab && paneID == tab.activePaneID,
-                    isVisibleTab: isActiveTab
+                    isVisibleTab: isActiveTab,
+                    isOwned: state.terminals.owns(session)
                 )
                 // In a split, the shell sits inside a small gutter so the
                 // focus ring never draws over the first/last row of text.

--- a/App/Sources/FeatureDetail/Views/VideoEditorModel.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorModel.swift
@@ -1,0 +1,140 @@
+import ADBKit
+import AVFoundation
+import Foundation
+
+/// A video open in the editor, kept per window by `FeatureStateStore` rather
+/// than as view `@State`.
+///
+/// Two things here are expensive enough that losing them to a tab moving reads
+/// as a restart. The **edits** — trim, rotate, crop, speed, the undo stack
+/// behind them — are unsaved work: nothing is written until Export. The
+/// **proxy** is an MP4 ffmpeg builds when AVFoundation can't play the source
+/// (an AV1 `.mp4`, most `.mkv`), which for a long recording is a transcode of
+/// the whole file; rebuilding it because a window changed would make the editor
+/// unusable for a minute for no reason.
+///
+/// The player travels too. A fresh `AVPlayer` on the far side would reload,
+/// re-buffer and lose the playhead — and for a proxied source it would have to
+/// be pointed back at the proxy anyway, which is exactly what `builtFor`
+/// records.
+@MainActor
+@Observable
+final class VideoEditorModel {
+    /// What the editor has open, nil when this tab shows no editor. The hosts
+    /// render `VideoEditorPane` exactly while this holds a source.
+    var source: VideoSource?
+    /// The source `player`, `asset` and `proxyURL` were built for. A `.task`
+    /// that finds this unchanged is a remount — the tab moved — not a new
+    /// video, so it keeps what it has instead of starting over.
+    private(set) var builtFor: VideoSource?
+
+    private(set) var player = AVPlayer()
+    private(set) var asset: AVURLAsset?
+    /// Bridges the AVKit trim UI, which lives on the player view.
+    let trimmer = VideoTrimmer()
+
+    var edit = EditState()
+    var undoStack: [EditState] = []
+    var redoStack: [EditState] = []
+    /// The edit state at the last successful export; edits matching it count as
+    /// saved, so the leave prompt doesn't fire after exporting.
+    var lastExportedEdit: EditState?
+    /// An export runs in a task the view doesn't own, so a move must not make
+    /// the button look ready while it is still going.
+    var isExporting = false
+
+    var videoSize: CGSize?
+    var assetDuration: Double = 0
+
+    /// An MP4 stand-in for a source AVFoundation refuses, built by ffmpeg and
+    /// used for playback only — the export always reads `source.url`, so a
+    /// proxy costs the saved file nothing. Deleted when the editor closes.
+    var proxyURL: URL?
+    /// Neither a remux nor a transcode produced something playable: the file
+    /// can't be edited here, and saying so beats a black pane.
+    var proxyFailed = false
+
+    var cropMode = false
+    var cropBeforeEditing: CropRect?
+
+    /// Identifies the leave guard, so a stale clear can't wipe another's — and
+    /// so the window this tab moves to re-registers the same one.
+    let exitGuardID = UUID()
+
+    /// Open `source`, unless it is already open. Hosts call this to put the
+    /// editor up — building the player here rather than in the pane's `.task`
+    /// keeps the first frame from being a black pane — and the pane calls it
+    /// again from that task, where a remount caused by a move must change
+    /// nothing at all.
+    func open(_ source: VideoSource) {
+        guard builtFor != source else { return }
+        discardProxy()
+        let asset = AVURLAsset(url: source.url)
+        self.asset = asset
+        player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
+        builtFor = source
+        self.source = source
+        edit = EditState()
+        undoStack = []
+        redoStack = []
+        lastExportedEdit = nil
+        videoSize = nil
+        assetDuration = 0
+        proxyFailed = false
+        cropMode = false
+        cropBeforeEditing = nil
+    }
+
+    /// Play a proxy instead of the source. A *fresh* `AVPlayer`, not
+    /// `replaceCurrentItem`: a player that already failed on the original is
+    /// permanently `.failed` and can't be recovered by handing it a new item.
+    func playProxy(at url: URL) {
+        proxyURL = url
+        let swapped = AVURLAsset(url: url)
+        asset = swapped
+        player = AVPlayer(playerItem: AVPlayerItem(asset: swapped))
+    }
+
+    /// Close the editor. The source file is the caller's to deal with — a
+    /// recording is a temp file it deletes, an opened file is never touched —
+    /// but the proxy is ours.
+    func close() {
+        player.pause()
+        discardProxy()
+        source = nil
+        builtFor = nil
+        asset = nil
+        player = AVPlayer()
+        edit = EditState()
+        undoStack = []
+        redoStack = []
+        lastExportedEdit = nil
+        videoSize = nil
+        assetDuration = 0
+        proxyFailed = false
+        cropMode = false
+        cropBeforeEditing = nil
+        isExporting = false
+    }
+
+    /// Give up the editor *and* the recording it was opened on — the tab is
+    /// closing, so the temp file nobody chose to keep goes with it. An opened
+    /// file is never deleted, which is the whole difference `VideoSource` draws.
+    func closeAndDiscardRecording() {
+        if case .recording(let url) = source {
+            try? FileManager.default.removeItem(at: url)
+        }
+        close()
+    }
+
+    /// Unsaved edits exist — the ones a leave would discard.
+    var hasUnsavedEdits: Bool { edit != EditState() && edit != lastExportedEdit }
+
+    /// The proxy is scratch: nothing refers to it once the editor is done with
+    /// it, and a transcoded recording is the size of the original.
+    private func discardProxy() {
+        guard let proxyURL else { return }
+        try? FileManager.default.removeItem(at: proxyURL)
+        self.proxyURL = nil
+    }
+}

--- a/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorPane.swift
@@ -89,43 +89,61 @@ struct VideoEditorPane: View {
     let source: VideoSource
     let onClose: () -> Void
 
-    @State private var player: AVPlayer
-    @State private var asset: AVURLAsset
-    @State private var trimmer = VideoTrimmer()
-    @State private var edit = EditState()
-    @State private var undoStack: [EditState] = []
-    @State private var redoStack: [EditState] = []
-
+    /// Work in flight, which a move genuinely interrupts: the proxy build
+    /// belongs to a `.task` SwiftUI cancels on unmount, the trim UI to a modal
+    /// the window it was opened in owns.
     @State private var playerReady = false
-    @State private var cropMode = false
-    @State private var cropBeforeEditing: CropRect?
     @State private var isTrimming = false
-    @State private var isExporting = false
-
-    @State private var videoSize: CGSize?
-    @State private var assetDuration: Double = 0
-
-    /// An MP4 stand-in for a source AVFoundation refuses, built by ffmpeg and
-    /// used for playback only — the export always reads `source.url`, so a
-    /// proxy costs the saved file nothing. Deleted when the editor closes.
-    @State private var proxyURL: URL?
     @State private var preparingProxy = false
-    /// Neither a remux nor a transcode produced something playable: the file
-    /// can't be edited here, and saying so beats a black pane.
-    @State private var proxyFailed = false
 
-    /// Identifies this view's leave guard so a stale clear can't wipe another's.
-    @State private var exitGuardID = UUID()
-    /// The edit state at the last successful export; edits matching it count as
-    /// saved, so the leave prompt doesn't fire after exporting.
-    @State private var lastExportedEdit: EditState?
+    /// The video, the player and every edit made to it, held by the window
+    /// rather than by this view. See `VideoEditorModel`.
+    private var model: VideoEditorModel {
+        state.featureState(VideoEditorModel.self, for: tabFeatureID) { VideoEditorModel() }
+    }
 
-    init(source: VideoSource, onClose: @escaping () -> Void) {
-        self.source = source
-        self.onClose = onClose
-        let asset = AVURLAsset(url: source.url)
-        _asset = State(initialValue: asset)
-        _player = State(initialValue: AVPlayer(playerItem: AVPlayerItem(asset: asset)))
+    private var player: AVPlayer { model.player }
+    private var trimmer: VideoTrimmer { model.trimmer }
+    private var edit: EditState {
+        get { model.edit }
+        nonmutating set { model.edit = newValue }
+    }
+    private var undoStack: [EditState] {
+        get { model.undoStack }
+        nonmutating set { model.undoStack = newValue }
+    }
+    private var redoStack: [EditState] {
+        get { model.redoStack }
+        nonmutating set { model.redoStack = newValue }
+    }
+    private var lastExportedEdit: EditState? {
+        get { model.lastExportedEdit }
+        nonmutating set { model.lastExportedEdit = newValue }
+    }
+    private var isExporting: Bool {
+        get { model.isExporting }
+        nonmutating set { model.isExporting = newValue }
+    }
+    private var cropMode: Bool {
+        get { model.cropMode }
+        nonmutating set { model.cropMode = newValue }
+    }
+    private var cropBeforeEditing: CropRect? {
+        get { model.cropBeforeEditing }
+        nonmutating set { model.cropBeforeEditing = newValue }
+    }
+    private var videoSize: CGSize? {
+        get { model.videoSize }
+        nonmutating set { model.videoSize = newValue }
+    }
+    private var assetDuration: Double {
+        get { model.assetDuration }
+        nonmutating set { model.assetDuration = newValue }
+    }
+    private var proxyURL: URL? { model.proxyURL }
+    private var proxyFailed: Bool {
+        get { model.proxyFailed }
+        nonmutating set { model.proxyFailed = newValue }
     }
 
     /// View transforms apply only while not trimming/cropping, so those UIs stay
@@ -134,7 +152,7 @@ struct VideoEditorPane: View {
 
     /// Edits exist when the state differs from the default and from the state
     /// last exported — these are lost on leave unless exported first.
-    private var hasUnsavedEdits: Bool { edit != EditState() && edit != lastExportedEdit }
+    private var hasUnsavedEdits: Bool { model.hasUnsavedEdits }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -149,26 +167,31 @@ struct VideoEditorPane: View {
         }
         .task(id: source.url) { await loadAsset() }
         .onReceive(player.publisher(for: \.status)) { playerReady = ($0 == .readyToPlay) }
-        .onChange(of: hasUnsavedEdits) { _, dirty in
-            if dirty {
-                state.setExitGuard(.init(
-                    id: exitGuardID, featureID: tabFeatureID, style: .edits,
-                    title: "Unsaved video edits",
-                    message: "Your trim, rotate, crop, and other edits haven’t been exported. Leaving discards them."))
-            } else {
-                state.clearExitGuard(exitGuardID)
-            }
+        // Also on appear, not only on change: the edits cross with a moving
+        // tab, and the window it lands in inherits none of the guards the
+        // window it left had registered.
+        .task { armGuard() }
+        .onChange(of: hasUnsavedEdits) { _, _ in armGuard() }
+        // Only the player is stopped here. The proxy and the edits are kept —
+        // this also runs when the tab is merely moving, and the guard is
+        // withdrawn by `stopBackgroundWork`, which can tell a close from a move.
+        .onDisappear { player.pause() }
+    }
+
+    /// Register (or withdraw) this tab's leave guard for the edits on screen.
+    ///
+    /// The guard survives a move (`survivesAMove`) because the edits do; the
+    /// prompt is for closing the tab, which really does discard them.
+    private func armGuard() {
+        guard hasUnsavedEdits else {
+            state.clearExitGuard(model.exitGuardID)
+            return
         }
-        .onDisappear {
-            player.pause()
-            state.clearExitGuard(exitGuardID)
-            // The proxy is scratch: nothing refers to it once the editor is
-            // gone, and a transcoded recording is the size of the original.
-            if let proxyURL {
-                try? FileManager.default.removeItem(at: proxyURL)
-                self.proxyURL = nil
-            }
-        }
+        state.setExitGuard(.init(
+            id: model.exitGuardID, featureID: tabFeatureID, style: .edits,
+            title: "Unsaved video edits",
+            message: "Your trim, rotate, crop, and other edits haven’t been exported. Leaving discards them.",
+            survivesAMove: true))
     }
 
     // MARK: player + crop overlay
@@ -560,10 +583,13 @@ struct VideoEditorPane: View {
     // MARK: loading + export
 
     private func loadAsset() async {
+        // A remount with the same video — the tab moved — keeps the player,
+        // the proxy and every edit; only a different source starts over.
+        model.open(source)
         proxyFailed = false
         guard let playable = await resolvePlayableURL() else { return }
         let size = await Self.naturalVideoSize(at: playable)
-        let loaded = try? await asset.load(.duration)
+        let loaded = try? await model.asset?.load(.duration)
         // Both probes complete before anything is published, so a re-keyed task
         // (a different video) writes none of this one's metadata.
         guard !Task.isCancelled else { return }
@@ -602,13 +628,7 @@ struct VideoEditorPane: View {
             proxyFailed = true
             return nil
         }
-        proxyURL = built
-        // A fresh AVPlayer, not `replaceCurrentItem`: a player that already
-        // failed on the original is permanently `.failed` and can't be
-        // recovered by handing it a new item.
-        let swapped = AVURLAsset(url: built)
-        asset = swapped
-        player = AVPlayer(playerItem: AVPlayerItem(asset: swapped))
+        model.playProxy(at: built)
         return built
     }
 

--- a/App/Sources/FeatureDetail/Views/VideoEditorView.swift
+++ b/App/Sources/FeatureDetail/Views/VideoEditorView.swift
@@ -7,13 +7,18 @@ import SwiftUI
 /// video opened from Finder arrives through `AppState.pendingVideo`.
 struct VideoEditorView: View {
     @Environment(AppState.self) private var state
-    @State private var openedURL: URL?
+    @Environment(\.tabFeatureID) private var tabFeatureID
+
+    /// The open video and every edit made to it, held by the window rather
+    /// than by this view, so moving the tab doesn't discard them.
+    private var editor: VideoEditorModel {
+        state.featureState(VideoEditorModel.self, for: tabFeatureID) { VideoEditorModel() }
+    }
 
     var body: some View {
         Group {
-            if let url = openedURL {
-                VideoEditorPane(source: .file(url)) { openedURL = nil }
-                    .id(url)
+            if let source = editor.source {
+                VideoEditorPane(source: source) { editor.close() }
             } else {
                 emptyState
             }
@@ -22,7 +27,7 @@ struct VideoEditorView: View {
         // routes the feature here and leaves the URL waiting. Claimed rather
         // than read, so returning to the tab later doesn't reopen it.
         .task(id: state.pendingVideo) {
-            if let url = state.claimPendingVideo() { openedURL = url }
+            if let url = state.claimPendingVideo() { editor.open(.file(url)) }
         }
     }
 
@@ -47,7 +52,7 @@ struct VideoEditorView: View {
         // saying no.
         .featureFileDrop(
             claims: { PlayableVideo.filter($0).first.map { [$0] } ?? [] },
-            perform: { openedURL = $0.first })
+            perform: { if let url = $0.first { editor.open(.file(url)) } })
     }
 
     private func openFile() {
@@ -55,6 +60,6 @@ struct VideoEditorView: View {
         panel.allowedContentTypes = PlayableVideo.contentTypes
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        if panel.runModal() == .OK, let url = panel.url { openedURL = url }
+        if panel.runModal() == .OK, let url = panel.url { editor.open(.file(url)) }
     }
 }

--- a/App/Sources/Root/DragTypes.swift
+++ b/App/Sources/Root/DragTypes.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -32,4 +33,18 @@ func privateDragItem(_ type: UTType, _ payload: String) -> NSItemProvider {
     // Legacy item registration is process-global (equivalent to `.all`
     // visibility), so the drag still survives macOS's system-pasteboard bridge.
     NSItemProvider(item: Data(payload.utf8) as NSData, typeIdentifier: type.identifier)
+}
+
+/// The same marker as `privateDragItem`, written for an AppKit dragging
+/// session (`TabDragSource`) rather than for SwiftUI's `.onDrag`.
+///
+/// `NSItemProvider` is not an `NSPasteboardWriting`, so a session cannot carry
+/// one directly. A pasteboard item holding the identical UTI and payload is
+/// what SwiftUI's drop targets end up reading either way — they see the
+/// provider AppKit synthesises from the drag pasteboard, so the drop half is
+/// unchanged by which of the two started the drag.
+func privateDragPasteboardItem(_ type: UTType, _ payload: String) -> NSPasteboardItem {
+    let item = NSPasteboardItem()
+    item.setData(Data(payload.utf8), forType: NSPasteboard.PasteboardType(type.identifier))
+    return item
 }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -683,7 +683,7 @@ private struct TerminalCloseConfirmation: ViewModifier {
         // Buttons resolve the prompt themselves; the binding's `set` only
         // fires for an outside dismissal (Esc), which counts as Cancel — the
         // resolve guard makes a post-button set(false) a no-op.
-        content.alert(title, isPresented: Binding(
+        content.alert("Close all terminals?", isPresented: Binding(
             get: { state.terminalClosePrompt != nil },
             set: { if !$0 { state.resolveTerminalPrompt(confirmed: false) } }
         )) {
@@ -696,32 +696,15 @@ private struct TerminalCloseConfirmation: ViewModifier {
         }
     }
 
-    private var isHandoff: Bool {
-        if case .handoff = state.terminalClosePrompt { return true }
-        return false
-    }
-
-    private var title: String {
-        isHandoff ? "Move Terminal to another window?" : "Close all terminals?"
-    }
-
     private var confirmLabel: String {
-        if isHandoff { return "Move Terminal" }
-        return state.terminalClosePrompt == .quit ? "Quit" : "Close Terminals"
+        state.terminalClosePrompt == .quit ? "Quit" : "Close Terminals"
     }
 
     private var message: String {
         let count = state.terminals.tabs.count
-        let sessions = count == 1
-            ? "your running shell session"
-            : "\(count) running shell sessions"
-        // A move is the one case with a silver lining worth stating: the tab
-        // comes back in the new window at the same directories.
-        return isHandoff
-            ? "This ends \(sessions) — anything still running will be killed. "
-                + "The new window reopens them in the same directories."
-            : "This ends \(sessions) — anything still running in "
-                + (count == 1 ? "it" : "them") + " will be killed."
+        return count == 1
+            ? "This ends your running shell session — anything still running in it will be killed."
+            : "This ends \(count) running shell sessions — anything still running in them will be killed."
     }
 }
 

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -140,9 +140,30 @@ struct RootView: View {
                 // relaunch instead of being maximized. Each window position has
                 // its own slot, cascaded so a second window doesn't land
                 // exactly on top of the first.
+                //
+                // A window torn off by a drag brings its own frame and skips
+                // all of that: the autosave slot is keyed by window *position*,
+                // so restoring it here would yank the new window to wherever
+                // some earlier window happened to sit rather than to the point
+                // the tab was dropped at. Taking the seed is also what settles
+                // the handoff, so it happens exactly once, here, after `bind`
+                // has restored.
+                let seedFrame = state.core.takeWindowSeed(state.id)?.frame
                 let autosaveName = RootView.frameAutosaveName(
                     ordinal: state.core.registry.ordinal(of: state.id) ?? 1)
-                if !window.setFrameUsingName(autosaveName), let screen = window.screen ?? NSScreen.main {
+                if let seedFrame {
+                    window.setFrame(seedFrame, display: true)
+                    // …and again once this turn is over. `WindowGroup` keeps
+                    // its own frame autosave under one name for the whole
+                    // group (`main-AppWindow-1` — it re-stamps that over the
+                    // name set below, which is why no `droidective-main-N`
+                    // frame is ever written), and it restores that saved frame
+                    // *after* this accessor runs. Without the re-assert a torn
+                    // off window lands wherever the last window happened to
+                    // sit instead of where the tab was dropped.
+                    DispatchQueue.main.async { window.setFrame(seedFrame, display: true) }
+                } else if !window.setFrameUsingName(autosaveName),
+                          let screen = window.screen ?? NSScreen.main {
                     window.setFrame(screen.visibleFrame, display: true)
                     if let ordinal = state.core.registry.ordinal(of: state.id), ordinal > 1 {
                         window.setFrame(
@@ -362,9 +383,9 @@ struct RootView: View {
     /// (drops route to the deepest region by geometry, not type).
     private func installDragJanitor() {
         NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDown]) { event in
-            for state in AppCore.shared.allWorkspaces {
-                if state.draggingTabID != nil { state.draggingTabID = nil }
-                if state.terminals.railDragActive { state.terminals.clearRailDrag() }
+            if AppCore.shared.tabDrag != nil { AppCore.shared.tabDrag = nil }
+            for state in AppCore.shared.allWorkspaces where state.terminals.railDragActive {
+                state.terminals.clearRailDrag()
             }
             return event
         }
@@ -500,8 +521,8 @@ struct RootView: View {
         // clear it. Only a target while a tab drag is in flight; returns false so
         // it never swallows a real drop (inner targets are hit first).
         .onDrop(of: [.workspaceTab], delegate: TabDragCancelCatch(
-            isDragging: state.draggingTabID != nil,
-            clear: { state.draggingTabID = nil }
+            isDragging: state.anyTabDrag != nil,
+            clear: { state.core.tabDrag = nil }
         ))
         // Dock-style auto-hide: the sidebar leaves the layout and rides over
         // the content, revealed by pushing the mouse against the left edge
@@ -662,25 +683,45 @@ private struct TerminalCloseConfirmation: ViewModifier {
         // Buttons resolve the prompt themselves; the binding's `set` only
         // fires for an outside dismissal (Esc), which counts as Cancel — the
         // resolve guard makes a post-button set(false) a no-op.
-        content.alert("Close all terminals?", isPresented: Binding(
+        content.alert(title, isPresented: Binding(
             get: { state.terminalClosePrompt != nil },
             set: { if !$0 { state.resolveTerminalPrompt(confirmed: false) } }
         )) {
-            Button(
-                state.terminalClosePrompt == .quit ? "Quit" : "Close Terminals",
-                role: .destructive
-            ) { state.resolveTerminalPrompt(confirmed: true) }
+            Button(confirmLabel, role: .destructive) {
+                state.resolveTerminalPrompt(confirmed: true)
+            }
             Button("Cancel", role: .cancel) { state.resolveTerminalPrompt(confirmed: false) }
         } message: {
             Text(message)
         }
     }
 
+    private var isHandoff: Bool {
+        if case .handoff = state.terminalClosePrompt { return true }
+        return false
+    }
+
+    private var title: String {
+        isHandoff ? "Move Terminal to another window?" : "Close all terminals?"
+    }
+
+    private var confirmLabel: String {
+        if isHandoff { return "Move Terminal" }
+        return state.terminalClosePrompt == .quit ? "Quit" : "Close Terminals"
+    }
+
     private var message: String {
         let count = state.terminals.tabs.count
-        return count == 1
-            ? "This ends your running shell session — anything still running in it will be killed."
-            : "This ends \(count) running shell sessions — anything still running in them will be killed."
+        let sessions = count == 1
+            ? "your running shell session"
+            : "\(count) running shell sessions"
+        // A move is the one case with a silver lining worth stating: the tab
+        // comes back in the new window at the same directories.
+        return isHandoff
+            ? "This ends \(sessions) — anything still running will be killed. "
+                + "The new window reopens them in the same directories."
+            : "This ends \(sessions) — anything still running in "
+                + (count == 1 ? "it" : "them") + " will be killed."
     }
 }
 
@@ -726,7 +767,7 @@ struct TabHostView: View {
                     // tab is deeper than the pane's own tab target and would
                     // otherwise swallow drop-to-split.
                     .modifier(WindowFileDropModifier(
-                        isActive: id == active && state.draggingTabID == nil))
+                        isActive: id == active && state.anyTabDrag == nil))
                     .environment(\.tabFeatureID, id)
                     .environment(\.tabIsActive, id == active)
                     .opacity(id == active ? 1 : 0)
@@ -769,18 +810,20 @@ private final class PaneMeasure {
 /// highlight.
 struct TabPaneDrop: DropDelegate {
     let state: AppState
-    let onDrop: (String) -> Void
+    let onDrop: (TabDrag) -> Void
     var onTargetedChange: ((Bool) -> Void)?
 
-    private var draggingID: String? { state.draggingTabID }
+    /// The app-wide drag, so a pane accepts a tab dragged out of another
+    /// window, not only its own.
+    private var drag: TabDrag? { state.anyTabDrag }
 
-    func validateDrop(info: DropInfo) -> Bool { draggingID != nil }
-    func dropEntered(info: DropInfo) { if draggingID != nil { onTargetedChange?(true) } }
+    func validateDrop(info: DropInfo) -> Bool { drag != nil }
+    func dropEntered(info: DropInfo) { if drag != nil { onTargetedChange?(true) } }
     func dropExited(info: DropInfo) { onTargetedChange?(false) }
     func performDrop(info: DropInfo) -> Bool {
         onTargetedChange?(false)
-        guard let id = draggingID else { return false }
-        onDrop(id)
+        guard let drag else { return false }
+        onDrop(drag)
         return true
     }
 }
@@ -810,18 +853,19 @@ private struct EditorPane: View {
                     // shield the content with a topmost workspaceTab target;
                     // it vanishes with the drag, so feature drops (APKs from
                     // Finder…) are untouched otherwise.
-                    if state.draggingTabID != nil {
+                    if state.anyTabDrag != nil {
                         Color.clear
                             .contentShape(Rectangle())
                             .onDrop(of: [.workspaceTab], delegate: paneDrop)
                     }
                 }
                 .overlay(alignment: .trailing) {
-                    // Only promise a split the model will honor: `split()`
-                    // requires >1 tab (something must stay behind), so a
-                    // single-tab drag shows no preview instead of a dead one.
-                    if !state.isSplit, contentTargeted,
-                       state.openTabIDs(inGroup: index).count > 1 { splitPreview }
+                    // Only promise a split the router will actually perform —
+                    // it refuses one for a tab arriving from another window,
+                    // and for a pane with nothing to leave behind.
+                    if contentTargeted, state.dropWouldSplit(state.anyTabDrag, inGroup: index) {
+                        splitPreview
+                    }
                 }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -830,13 +874,10 @@ private struct EditorPane: View {
     private var paneDrop: TabPaneDrop {
         TabPaneDrop(
             state: state,
-            onDrop: { id in
-                if state.isSplit {
-                    state.moveTab(id, toGroup: index)
-                } else {
-                    state.splitTab(id)
-                }
-                state.draggingTabID = nil
+            onDrop: { drag in
+                // Move into this pane, split off into a new one, or hand off
+                // from another window — `TabDropRouter` decides which.
+                state.acceptTabDrop(drag, on: .pane(group: index))
             },
             onTargetedChange: { contentTargeted = $0 }
         )

--- a/App/Sources/Root/TabDetachPolicy.swift
+++ b/App/Sources/Root/TabDetachPolicy.swift
@@ -1,0 +1,42 @@
+import CoreGraphics
+import Foundation
+
+/// When a finished tab drag should tear a window off.
+///
+/// Pure, and separate from the AppKit drag source, because the decision has
+/// three inputs that are each easy to get wrong and impossible to unit-test
+/// through a real drag: whether anything accepted the drop, whether the drag
+/// was cancelled, and whether the cursor was over one of our own windows.
+enum TabDetachPolicy {
+    /// Whether a screen point lies inside any of the app's own windows.
+    ///
+    /// A drop the app itself refused — the dead chrome beside the tabs, a pane
+    /// with no target under the cursor — is a *miss*, not a request for a new
+    /// window: it should snap back. Only a release genuinely away from the app
+    /// means "put this somewhere else".
+    static func isInsideApp(point: CGPoint, windowFrames: [CGRect]) -> Bool {
+        windowFrames.contains { $0.contains(point) }
+    }
+
+    /// Whether a drag that has just ended should become a new window.
+    ///
+    /// - Parameters:
+    ///   - accepted: whether any drop target took the tab. A drop that landed
+    ///     on a tab strip or pane — in this window or another — is already
+    ///     handled, and must not also spawn a window.
+    ///   - cancelled: whether the user backed out with Escape. AppKit reports a
+    ///     cancel exactly like a refused drop, at whatever point the cursor
+    ///     happens to sit, so without this an Esc over the desktop would open a
+    ///     window the user was in the middle of *not* asking for.
+    ///   - point: where the drag ended, in screen coordinates.
+    ///   - windowFrames: the app's own visible windows.
+    static func shouldTearOff(
+        accepted: Bool,
+        cancelled: Bool,
+        point: CGPoint,
+        windowFrames: [CGRect]
+    ) -> Bool {
+        guard !accepted, !cancelled else { return false }
+        return !isInsideApp(point: point, windowFrames: windowFrames)
+    }
+}

--- a/App/Sources/Root/TabDragSource.swift
+++ b/App/Sources/Root/TabDragSource.swift
@@ -1,0 +1,252 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// A tab chip's drag, run as a real AppKit dragging session.
+///
+/// SwiftUI's `.onDrag` cannot answer the two questions a tear-off needs — did
+/// anything accept the drop, and *where on screen* did it land — and there is
+/// no callback that reports either. `NSDraggingSource` reports both, once, in
+/// `draggingSession(_:endedAt:operation:)`.
+///
+/// The item on the pasteboard is the same `NSItemProvider` `.onDrag` used to
+/// return (`privateDragItem(.workspaceTab,…)`), so every existing SwiftUI
+/// `.onDrop(of: [.workspaceTab])` target — the strips, the panes, the split
+/// shield — accepts it exactly as before. Only the *source* half changed.
+///
+/// The backing view is deliberately hit-test transparent: the chip's tap,
+/// close button and context menu stay SwiftUI's, and the session is started
+/// from a SwiftUI `DragGesture` instead. A `DragGesture` is safe inside the
+/// strip's `ScrollView` because trackpad scrolling arrives as `scrollWheel`
+/// events, which are not gestures and never compete with it.
+struct TabDragSource: NSViewRepresentable {
+    /// The handle the chip's gesture calls to start a drag.
+    let starter: TabDragStarter
+
+    func makeNSView(context: Context) -> TabDragSourceView {
+        let view = TabDragSourceView()
+        starter.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: TabDragSourceView, context: Context) {
+        // Re-point on every update: SwiftUI can rebuild the representable's
+        // view for the same chip, and a stale handle would silently make the
+        // chip undraggable. Cheap, and writes no observable state (see the
+        // update-loop rule in CLAUDE.md).
+        starter.view = nsView
+    }
+}
+
+/// The chip's side of the drag: a plain reference the view writes itself into,
+/// so a SwiftUI gesture can reach AppKit without any observable state changing.
+@MainActor
+final class TabDragStarter {
+    fileprivate weak var view: TabDragSourceView?
+
+    /// Begin dragging this chip.
+    ///
+    /// - Parameters:
+    ///   - featureID: the tab being dragged.
+    ///   - image: a snapshot of the chip, rendered once, which rides the cursor.
+    ///   - grabOffset: where in the chip the pointer went down, from its
+    ///     top-left, y down — so the torn-off window can put that same point
+    ///     back under the cursor.
+    ///   - canTearOff: whether a release away from the app would open a window.
+    ///   - onEnded: called once when the session finishes.
+    func begin(
+        featureID: String,
+        image: NSImage?,
+        grabOffset: CGSize,
+        canTearOff: Bool,
+        onEnded: @escaping (TabDragOutcome) -> Void
+    ) {
+        view?.begin(
+            featureID: featureID, image: image, grabOffset: grabOffset,
+            canTearOff: canTearOff, onEnded: onEnded)
+    }
+}
+
+/// How a tab drag finished.
+struct TabDragOutcome {
+    /// Whether a drop target took the tab. Those drops are already handled by
+    /// the target itself.
+    let accepted: Bool
+    /// Whether the user backed out with Escape.
+    let cancelled: Bool
+    /// Where the drag ended, in screen coordinates.
+    let screenPoint: CGPoint
+    /// Where in the chip the pointer had grabbed it.
+    let grabOffset: CGSize
+    /// The chip's own position inside its window, from the window's top-left,
+    /// y down — the vertical half of where a torn-off window's strip sits.
+    let chipOriginInWindow: CGPoint
+    /// The window the drag started from, and its size, which a torn-off window
+    /// inherits.
+    let sourceWindowFrame: CGRect
+    /// The app's windows as they were when the drag began — what decides
+    /// whether the release landed away from the app.
+    let windowFrames: [CGRect]
+}
+
+/// The `NSView` that owns the dragging session.
+final class TabDragSourceView: NSView, NSDraggingSource {
+    private var onEnded: ((TabDragOutcome) -> Void)?
+    private var grabOffset: CGSize = .zero
+    /// The chip's place in its window, and the window's frame, as they were
+    /// when the drag started.
+    ///
+    /// Captured up front rather than read back in `endedAt`, because by then
+    /// this view may no longer be in a window at all: a drop that moved the tab
+    /// to another window tears its chip down first, and a `guard let window`
+    /// there silently swallowed the whole callback.
+    private var chipOriginInWindow: CGPoint = .zero
+    private var sourceWindowFrame: CGRect = .zero
+    private var escapeMonitor: Any?
+    private var cancelled = false
+    /// Whether releasing away from the app would actually open a window. A tab
+    /// that cannot (its window's only one) must still animate home on release,
+    /// or the chip vanishes and reappears with nothing having happened.
+    private var canTearOff = false
+    /// The app's window frames, captured once per drag.
+    ///
+    /// `movedTo` runs for every mouse move, and walking `NSApp.windows` there
+    /// would allocate an array per move for an answer that cannot change: a
+    /// window can't be moved or opened while the drag holds the mouse. A window
+    /// closed by something else mid-drag leaves this stale in the safe
+    /// direction — the release reads as a miss and the tab stays put.
+    private var windowFrames: [CGRect] = []
+
+    /// Events belong to SwiftUI. This view exists only to be a dragging source
+    /// and to measure the chip; taking hits would break the chip's tap, its
+    /// close button and its context menu.
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override var isFlipped: Bool { true }
+
+    func begin(
+        featureID: String,
+        image: NSImage?,
+        grabOffset: CGSize,
+        canTearOff: Bool,
+        onEnded: @escaping (TabDragOutcome) -> Void
+    ) {
+        self.canTearOff = canTearOff
+        windowFrames = Self.appWindowFrames()
+        // `beginDraggingSession` needs the mouse event that started the drag.
+        // Inside a `DragGesture` callback that is the live `leftMouseDragged`.
+        guard let event = NSApp.currentEvent, window != nil else {
+            // No session will start, so nothing else will report back — tell
+            // the caller now, as a cancel, or the chip stays latched mid-drag.
+            onEnded(TabDragOutcome(
+                accepted: false, cancelled: true, screenPoint: .zero, grabOffset: .zero,
+                chipOriginInWindow: .zero, sourceWindowFrame: .zero, windowFrames: []))
+            return
+        }
+        self.onEnded = onEnded
+        self.grabOffset = grabOffset
+        cancelled = false
+        if let window {
+            // This view is flipped, so `convert(.zero, to: nil)` is its
+            // *top*-left in window base coordinates, which are y-up from the
+            // window's bottom. The strip metrics this feeds are y-down from the
+            // window's top, so the two only need subtracting from the height.
+            let originInWindow = convert(NSPoint.zero, to: nil)
+            chipOriginInWindow = CGPoint(
+                x: originInWindow.x, y: window.frame.height - originInWindow.y)
+            sourceWindowFrame = window.frame
+        }
+
+        let item = NSDraggingItem(pasteboardWriter: privateDragPasteboardItem(.workspaceTab, featureID))
+        if let image {
+            item.setDraggingFrame(bounds, contents: image)
+        } else {
+            item.setDraggingFrame(bounds, contents: NSImage(size: bounds.size))
+        }
+        let session = beginDraggingSession(with: [item], event: event, source: self)
+        // Snapping back is right for a miss inside the app, and wrong for a
+        // tear-off — the chip should not fly home a beat before its window
+        // appears. Re-decided per move in `draggingSession(_:movedTo:)`.
+        session.animatesToStartingPositionsOnCancelOrFail = true
+        installEscapeMonitor()
+    }
+
+    // MARK: - NSDraggingSource
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        switch context {
+        case .withinApplication:
+            return .move
+        default:
+            // Not `[]`: an empty mask paints the ⊘ "no drop" cursor over the
+            // desktop, which is precisely where dropping *does* something. No
+            // other app registers this private UTI, so advertising an operation
+            // here cannot hand the tab to anyone else.
+            return .generic
+        }
+    }
+
+    func draggingSession(_ session: NSDraggingSession, movedTo screenPoint: NSPoint) {
+        // Outside the app the drop opens a window, so a slide-back would be a
+        // lie; inside it, a miss really should return the chip to the strip.
+        session.animatesToStartingPositionsOnCancelOrFail = !canTearOff
+            || TabDetachPolicy.isInsideApp(point: screenPoint, windowFrames: windowFrames)
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        removeEscapeMonitor()
+        let handler = onEnded
+        onEnded = nil
+        guard let handler else { return }
+        handler(TabDragOutcome(
+            accepted: operation != [],
+            cancelled: cancelled || Self.escapeIsDown(),
+            screenPoint: screenPoint,
+            grabOffset: grabOffset,
+            chipOriginInWindow: chipOriginInWindow,
+            sourceWindowFrame: sourceWindowFrame,
+            windowFrames: windowFrames))
+    }
+
+    // MARK: - Escape
+
+    /// AppKit reports an Escape-cancelled drag exactly like a refused one, at
+    /// wherever the cursor sits — so a cancel out over the desktop would open a
+    /// window the user was busy *not* asking for.
+    ///
+    /// Two detectors, because whether a local monitor is delivered at all
+    /// during AppKit's drag loop is not contractual: the monitor catches it
+    /// when it fires, and `escapeIsDown` catches the (normal) case where the
+    /// key is still held when the session reports back. `CGEventSource.keyState`
+    /// reads hardware key state and needs no accessibility permission.
+    private func installEscapeMonitor() {
+        removeEscapeMonitor()
+        escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { self?.cancelled = true }
+            return event
+        }
+    }
+
+    private func removeEscapeMonitor() {
+        if let escapeMonitor { NSEvent.removeMonitor(escapeMonitor) }
+        escapeMonitor = nil
+    }
+
+    private static func escapeIsDown() -> Bool {
+        CGEventSource.keyState(.combinedSessionState, key: 53)
+    }
+
+    /// Frames of the app's own visible windows, for the inside/outside test.
+    /// Panels count: the Quick Actions panel is somewhere a drop should miss,
+    /// not somewhere it should spawn a window.
+    private static func appWindowFrames() -> [CGRect] {
+        NSApp.windows.filter(\.isVisible).map(\.frame)
+    }
+}

--- a/App/Sources/Root/TabStripView.swift
+++ b/App/Sources/Root/TabStripView.swift
@@ -83,9 +83,8 @@ struct TabStripView: View {
         // so precise before/after placement still wins over this catch-all.
         .onDrop(of: [.workspaceTab], delegate: TabPaneDrop(
             state: state,
-            onDrop: { id in
-                state.dropTab(id, intoGroup: group, before: nil)
-                state.draggingTabID = nil
+            onDrop: { drag in
+                state.acceptTabDrop(drag, on: .strip(group: group, before: nil))
             }
         ))
         // A drop that lands outside this strip's chips (the pane content, dead
@@ -93,8 +92,8 @@ struct TabStripView: View {
         // so their `setSlot(nil)` cleanup can't run and the insertion guideline
         // stayed painted. The drag's single source of truth is `draggingTabID` —
         // clear the slot whenever it resets, wherever the drop landed.
-        .onChange(of: state.draggingTabID) { _, id in
-            if id == nil { dropSlot = nil }
+        .onChange(of: state.anyTabDrag) { _, drag in
+            if drag == nil { dropSlot = nil }
         }
     }
 
@@ -155,20 +154,17 @@ struct TabStripView: View {
         // While this chip rides the cursor as the drag image, fade the
         // stationary original so the tab doesn't read as duplicated.
         .opacity(state.draggingTabID == id ? 0.3 : 1)
-        .onDrag {
-            state.draggingTabID = id
-            // A private type, not an NSString: a plain-text drag is captured at
-            // the AppKit level by any mounted text view (SwiftTerm, logcat)
-            // before SwiftUI's drop targets see it — see `DragTypes.swift`.
-            return privateDragItem(.workspaceTab, id)
-        }
+        .modifier(TabChipDrag(
+            id: id, title: Self.title(id, role: state.selectedRole), icon: Self.icon(id)))
         .onDrop(of: [.workspaceTab], delegate: TabReorderDrop(
             targetID: id,
             width: chipWidths[id] ?? 0,
             order: tabIDs,
             state: state,
             setSlot: { dropSlot = $0 },
-            move: { dragged, before in state.dropTab(dragged, intoGroup: group, before: before) }
+            move: { drag, before in
+                state.acceptTabDrop(drag, on: .strip(group: group, before: before))
+            }
         ))
         .contextMenu { tabMenu(for: id) }
     }
@@ -190,10 +186,26 @@ struct TabStripView: View {
         }
     }
 
-    /// Right-click menu for a tab: move it across the split, or close it (or
-    /// everything else in this pane).
+    /// Right-click menu for a tab: move it to a window of its own or to another
+    /// open one, move it across the split, or close it (or everything else in
+    /// this pane).
     @ViewBuilder
     private func tabMenu(for id: String) -> some View {
+        Button("Open in New Window") { state.beginHandoff(id, to: .newWindow(frame: nil)) }
+            // A workspace whose only tab left would not be a move, it would be
+            // the window moving — and the window already moves. Moving it into
+            // an *existing* window is still allowed, so only this item is off.
+            .disabled(!state.canDetachTabToNewWindow(id))
+        let targets = state.handoffTargets
+        if !targets.isEmpty {
+            Menu("Move to Window") {
+                ForEach(targets, id: \.id) { target in
+                    Button(target.label) { state.beginHandoff(id, to: .window(target.id, slot: nil)) }
+                }
+            }
+            .disabled(!state.canDetachTab(id))
+        }
+        Divider()
         if state.isSplit {
             Button("Move to Other Pane") { state.moveTab(id, toGroup: group == 0 ? 1 : 0) }
         } else {
@@ -365,11 +377,13 @@ private struct TabReorderDrop: DropDelegate {
     let order: [String]
     let state: AppState
     let setSlot: (TabDropSlot?) -> Void
-    let move: (_ dragged: String, _ beforeTargetID: String?) -> Void
+    let move: (_ drag: TabDrag, _ beforeTargetID: String?) -> Void
 
-    private var draggingID: String? { state.draggingTabID }
+    /// The app-wide drag, so a tab dragged from *another* window is accepted
+    /// here too — not just this window's own reorders.
+    private var drag: TabDrag? { state.anyTabDrag }
 
-    func validateDrop(info: DropInfo) -> Bool { draggingID != nil }
+    func validateDrop(info: DropInfo) -> Bool { drag != nil }
     func dropEntered(info: DropInfo) { setSlot(slot(info)) }
     func dropUpdated(info: DropInfo) -> DropProposal? {
         setSlot(slot(info))
@@ -379,15 +393,20 @@ private struct TabReorderDrop: DropDelegate {
 
     func performDrop(info: DropInfo) -> Bool {
         setSlot(nil)
-        let dragged = draggingID
-        state.draggingTabID = nil
-        guard let dragged, dragged != targetID else { return false }
+        guard let drag else { return false }
+        // Dropping a tab on itself is a no-op — but only when it really is the
+        // same tab in the same window. Two windows can each have a tab with
+        // this id; moving one onto the other is a merge, not a no-op.
+        guard drag.featureID != targetID || drag.source != state.id else {
+            state.core.tabDrag = nil
+            return false
+        }
         let dropAfter = width > 0 && info.location.x > width / 2
         if dropAfter, let index = order.firstIndex(of: targetID) {
             // After the target = before the tab that follows it (or to the end).
-            move(dragged, order.indices.contains(index + 1) ? order[index + 1] : nil)
+            move(drag, order.indices.contains(index + 1) ? order[index + 1] : nil)
         } else {
-            move(dragged, targetID)
+            move(drag, targetID)
         }
         return true
     }
@@ -395,7 +414,152 @@ private struct TabReorderDrop: DropDelegate {
     /// The slot under the cursor — nil while over the dragged chip itself,
     /// and nil once the drag has ended (a trailing enter/update after the drop).
     private func slot(_ info: DropInfo) -> TabDropSlot? {
-        guard let dragging = draggingID, dragging != targetID else { return nil }
+        guard let drag else { return nil }
+        guard drag.featureID != targetID || drag.source != state.id else { return nil }
         return TabDropSlot(targetID: targetID, after: width > 0 && info.location.x > width / 2)
     }
 }
+
+/// Starts a chip's drag as an AppKit session (see `TabDragSource`) and, when it
+/// is released away from every Droidective window, tears the tab off into a new
+/// one at that point.
+///
+/// A `DragGesture` rather than `.onDrag`, because only an `NSDraggingSource`
+/// reports whether a drop was accepted and where it landed. The item on the
+/// pasteboard is unchanged, so every drop target still works exactly as before.
+private struct TabChipDrag: ViewModifier {
+    @Environment(AppState.self) private var state
+    @Environment(\.displayScale) private var displayScale
+    let id: String
+    let title: String
+    let icon: String
+    @State private var starter = TabDragStarter()
+
+    func body(content: Content) -> some View {
+        content
+            .background(TabDragSource(starter: starter))
+            .gesture(
+                DragGesture(minimumDistance: 6, coordinateSpace: .local)
+                    // `onChanged` fires continuously, so only the first one may
+                    // start a session. The guard is the live drag itself rather
+                    // than a local "already started" flag: SwiftUI's gesture is
+                    // cancelled the moment AppKit's drag loop takes the mouse,
+                    // so its `onEnded` cannot be relied on to re-arm anything —
+                    // a flag latched on and the just-dragged chip became
+                    // undraggable until its view was rebuilt. `tabDrag` is
+                    // cleared by whichever drop took the tab, by the session
+                    // reporting back, and failing both by `installDragJanitor`
+                    // on the next mouse event, so it always re-arms.
+                    .onChanged { value in
+                        guard state.anyTabDrag == nil else { return }
+                        begin(grabbedAt: value.startLocation)
+                    }
+            )
+    }
+
+    private func begin(grabbedAt point: CGPoint) {
+        state.draggingTabID = id
+        starter.begin(
+            featureID: id,
+            image: dragImage(),
+            grabOffset: CGSize(width: point.x, height: point.y),
+            canTearOff: state.canDetachTabToNewWindow(id),
+            onEnded: { outcome in
+                // Whatever happened, the drag is over: a drop target that took
+                // it has already cleared this, and one that did not never will.
+                state.core.tabDrag = nil
+                guard state.canDetachTabToNewWindow(id),
+                      TabDetachPolicy.shouldTearOff(
+                          accepted: outcome.accepted,
+                          cancelled: outcome.cancelled,
+                          point: outcome.screenPoint,
+                          windowFrames: outcome.windowFrames)
+                else { return }
+                state.beginHandoff(id, to: .newWindow(frame: tornOffFrame(outcome)))
+            })
+    }
+
+    /// The chip itself, rendered once at drag start, so what rides the cursor
+    /// is the tab rather than a system placeholder.
+    private func dragImage() -> NSImage? {
+        let renderer = ImageRenderer(content:
+            TabChipGhost(title: title, icon: icon)
+                .environment(\.colorScheme, state.nsWindow?.effectiveAppearance
+                    .bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light))
+        renderer.scale = displayScale
+        return renderer.nsImage
+    }
+
+    /// Where the new window goes: the same size as the one the tab came from,
+    /// positioned so the chip lands back under the cursor, clamped onto the
+    /// screen the drop happened on.
+    private func tornOffFrame(_ outcome: TabDragOutcome) -> NSRect {
+        let screen = NSScreen.screens.first { $0.frame.contains(outcome.screenPoint) }
+            ?? NSScreen.main
+        let visible = screen?.visibleFrame ?? .zero
+        let rect = TearOffFrame.frame(
+            dropPoint: TearOffFrame.Point(
+                x: outcome.screenPoint.x, y: outcome.screenPoint.y),
+            grabOffset: TearOffFrame.Size(
+                width: outcome.grabOffset.width, height: outcome.grabOffset.height),
+            // The moved tab is the only one in the new window, so it lands in
+            // the strip's *first* slot — not wherever this chip happened to
+            // sit. The vertical inset is measured (the strip is at the same
+            // height in both windows); the horizontal one is the fixed layout
+            // offset of the first chip, and being a few points out is
+            // imperceptible next to the clamp that keeps the window on screen.
+            stripOrigin: TearOffFrame.Point(
+                x: TabStripMetrics.firstChipInset, y: outcome.chipOriginInWindow.y),
+            sourceSize: TearOffFrame.Size(
+                width: outcome.sourceWindowFrame.width,
+                height: outcome.sourceWindowFrame.height),
+            screen: TearOffFrame.Rect(
+                x: visible.minX, y: visible.minY,
+                width: visible.width, height: visible.height),
+            minimum: TearOffFrame.Size(
+                width: TabStripMetrics.minimumWindowWidth,
+                height: TabStripMetrics.minimumWindowHeight))
+        return NSRect(x: rect.x, y: rect.y, width: rect.width, height: rect.height)
+    }
+}
+
+/// Layout constants the tear-off geometry needs, named rather than inlined so
+/// the numbers can be traced back to the views that produce them.
+enum TabStripMetrics {
+    /// Where the first chip's leading edge sits inside the window: the Home
+    /// button (28 pt) with its 6 pt padding either side, the divider, and the
+    /// scroll content's 8 pt leading padding.
+    static let firstChipInset: Double = 6 + 28 + 6 + 1 + 8
+    /// `WorkspaceHost.minWindowWidth`'s floor, and `RootView`'s minimum height.
+    static let minimumWindowWidth: Double = 760
+    static let minimumWindowHeight: Double = 480
+}
+
+/// A chip drawn purely to be rasterised as the drag image — the real one is a
+/// `TabChip`, which is bound to live state a renderer has no business touching.
+private struct TabChipGhost: View {
+    let title: String
+    let icon: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.app(.caption))
+                .foregroundStyle(.brandAccent)
+            Text(title)
+                .font(.app(.callout))
+                .lineLimit(1)
+                .foregroundStyle(.textMain)
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 15)
+        .frame(height: 28)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(.bgSurface)
+                .shadow(color: .black.opacity(0.25), radius: 6, y: 2)
+        )
+        .padding(8)
+    }
+}
+

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -329,6 +329,10 @@ final class AppCore {
             pendingWindowSeeds[state.id] = seed
             freshWorkspaces.insert(state.id)
             state.adoptSeedPreferences(seed)
+            // Before the restore below opens the tab, so the view mounts onto
+            // the session that came with it rather than the empty one this
+            // workspace was born with.
+            state.adoptMovableSessions(seed.sessions)
         }
         if didLoadLayout {
             state.restore(from: wantsFresh ? seed?.state : claimPendingRestore())

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -95,6 +95,10 @@ final class AppCore {
     private(set) var frontmostID: WorkspaceID?
     /// Set by `RootView`: opens another window of the main `WindowGroup`.
     var openWorkspaceWindow: (() -> Void)?
+    /// The tab drag in flight, or nil. App-wide because a tab can be dragged
+    /// into a window that did not start the drag, or out of the app entirely —
+    /// see `TabDrag` for why it is written twice per drag and never per move.
+    var tabDrag: TabDrag?
     /// Persisted windows waiting to be claimed by a workspace as its windows
     /// come up. Claimed in order, so window 2 restores window 2's tabs.
     private var pendingRestores: [WindowState] = []
@@ -142,7 +146,8 @@ final class AppCore {
         // Restore the windows that already came up while this was loading
         // (always at least the first one), then ask for the rest.
         for id in awaitingRestore {
-            let saved = freshWorkspaces.contains(id) ? nil : claimPendingRestore()
+            let saved = freshWorkspaces.contains(id)
+                ? pendingWindowSeeds[id]?.state : claimPendingRestore()
             workspaces[id]?.restore(from: saved)
         }
         freshWorkspaces.removeAll()
@@ -248,13 +253,14 @@ final class AppCore {
     /// Workspaces handed to a view but not yet backed by a window. They own
     /// nothing — no registry entry, no persisted record — until they bind.
     private var provisional: Set<WorkspaceID> = []
-    /// Windows the user explicitly asked for (⇧⌘N, "New Window for Device"),
-    /// oldest first: each starts a *new* workspace instead of adopting a
-    /// windowless one, and carries the device it was opened for. A queue
-    /// rather than a keyed lookup because the window has no identity until it
-    /// exists — `openWindow` creates one synchronously per call, and binds are
-    /// serialised on the main actor, so first-asked is first-bound.
-    private var pendingFreshWindows: [String?] = []
+    /// Windows the user explicitly asked for (⇧⌘N, "New Window for Device", a
+    /// tab moved out of another window), oldest first: each starts a *new*
+    /// workspace instead of adopting a windowless one, and carries what it
+    /// should open as. A queue rather than a keyed lookup because the window
+    /// has no identity until it exists — `openWindow` creates one synchronously
+    /// per call, and binds are serialised on the main actor, so first-asked is
+    /// first-bound.
+    private var pendingFreshWindows: [WindowSeed] = []
     /// Workspaces opened by an explicit request while the layout was still
     /// loading. `bootstrap`'s restore must not hand them a persisted window —
     /// the user asked for a *new* one, on a device they may have named.
@@ -295,12 +301,11 @@ final class AppCore {
             return
         }
         provisional.remove(state.id)
-        var requestedSerial: String?
-        var wantsFresh = false
+        var seed: WindowSeed?
         if !pendingFreshWindows.isEmpty {
-            wantsFresh = true
-            requestedSerial = pendingFreshWindows.removeFirst()
+            seed = pendingFreshWindows.removeFirst()
         }
+        let wantsFresh = seed != nil
         let hostToken = claims.first { $0.value == state.id }?.key
         // Adoption has to be able to repoint the host, or it would keep
         // resolving to the workspace just dropped and mint a new provisional
@@ -315,12 +320,18 @@ final class AppCore {
             return
         }
         registry.register(state.id)
-        if let requestedSerial {
-            pendingWindowTargets[state.id] = requestedSerial
+        if var seed {
+            // The seed was built before this workspace existed, so re-key the
+            // record it restores from: `persistWindowState` writes under the
+            // workspace's own id, and a stale one here would leave the layout
+            // holding a window entry nothing owns.
+            seed.state?.id = state.id
+            pendingWindowSeeds[state.id] = seed
+            freshWorkspaces.insert(state.id)
+            state.adoptSeedPreferences(seed)
         }
-        if wantsFresh { freshWorkspaces.insert(state.id) }
         if didLoadLayout {
-            state.restore(from: wantsFresh ? nil : claimPendingRestore())
+            state.restore(from: wantsFresh ? seed?.state : claimPendingRestore())
         } else {
             // The layout is still loading; `bootstrap` restores this workspace
             // once the persisted entries are known.
@@ -477,16 +488,33 @@ final class AppCore {
     /// explicitly fresh, so it starts a new workspace rather than adopting a
     /// parked one; the new workspace picks the device up in `restore`.
     func openNewWindow(targeting serial: String? = nil) {
-        pendingFreshWindows.append(serial)
-        guard let openWorkspaceWindow else {
-            pendingFreshWindows.removeLast()
-            return
-        }
-        openWorkspaceWindow()
+        openSeededWindow(WindowSeed(serial: serial))
     }
 
-    /// Device a not-yet-created window should open on (see `openNewWindow`).
-    private var pendingWindowTargets: [WorkspaceID: String] = [:]
+    /// Open a window that comes up as `seed` describes. Rolls the seed back if
+    /// SwiftUI has not handed us an opener yet, so a caller that already gave
+    /// something up for this window (a handoff, which detaches the tab first)
+    /// can check `canOpenWindow` and never lose it.
+    @discardableResult
+    func openSeededWindow(_ seed: WindowSeed) -> Bool {
+        pendingFreshWindows.append(seed)
+        guard let openWorkspaceWindow else {
+            pendingFreshWindows.removeLast()
+            return false
+        }
+        openWorkspaceWindow()
+        return true
+    }
+
+    /// Whether another window can be opened at all. False only very early in
+    /// launch, before `RootView` has published its opener.
+    var canOpenWindow: Bool { openWorkspaceWindow != nil }
+
+    /// What a just-bound window should open as, until it has taken it (see
+    /// `openNewWindow`). Consumed in two steps because two different callers
+    /// need it: `AppState.restore` reads the device and tabs, then `RootView`
+    /// takes the whole seed for the frame — which is also what drops it.
+    private var pendingWindowSeeds: [WorkspaceID: WindowSeed] = [:]
 
     /// The workspace the pop-out mirror windows belong to — set when one is
     /// popped out, so they read that window's adb client and toasts. The device
@@ -614,8 +642,23 @@ final class AppCore {
         noteMirrorClaims(serials, featureID: MirrorWindow.featureID, in: owner)
     }
 
-    func takeWindowTarget(_ id: WorkspaceID) -> String? {
-        pendingWindowTargets.removeValue(forKey: id)
+    /// The device a just-bound window was opened for, without consuming the
+    /// seed — `RootView` still needs its frame, and it takes the seed itself.
+    func windowSeedTarget(_ id: WorkspaceID) -> String? {
+        pendingWindowSeeds[id]?.serial
+    }
+
+    /// Take (and drop) a just-bound window's seed. Called once, by `RootView`,
+    /// after `bind` has restored — so this is where the seed's life ends, and
+    /// where a handoff is finally settled.
+    func takeWindowSeed(_ id: WorkspaceID) -> WindowSeed? {
+        let seed = pendingWindowSeeds.removeValue(forKey: id)
+        // Only once the window has actually restored — while the layout is
+        // still loading `bind` defers that to `bootstrap`, so the registry does
+        // not yet know the moved tab is open here and the reconcile would read
+        // it as "nobody has it" and stop the relay it was protecting.
+        if seed?.handoffFeatureID != nil, didLoadLayout { reconcileSharedSessions() }
+        return seed
     }
 
     /// Bring `id`'s window forward — the device picker's "it's open over there"

--- a/App/Sources/State/AppCore.swift
+++ b/App/Sources/State/AppCore.swift
@@ -81,6 +81,11 @@ final class AppCore {
     /// Settings ▸ MCP: serves the relay's data to AI agents over localhost.
     let mcp = McpCoordinator()
 
+    /// Per-window feature state that outlives its view — log buffers and the
+    /// like, so a tab moving between windows keeps what it had accumulated.
+    /// Not `@Observable`, on purpose: see `FeatureStateStore`.
+    let featureStates = FeatureStateStore()
+
     // MARK: - Windows
 
     /// Who owns which device and which exclusive feature is live where — the
@@ -471,6 +476,7 @@ final class AppCore {
             return
         }
         workspaces[id] = nil
+        featureStates.discardAll(in: id)
         registry.remove(id)
         layout.removeWindow(id)
         persistLayout()

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1269,6 +1269,14 @@ final class AppState {
             ScreenshotEditorModel.self, feature: id, in: self.id) {
             clearExitGuard(editor.exitGuardID)
         }
+        // The video editor's edits and its playback proxy cross with a moving
+        // tab the same way. A close gives up both, and the recording the editor
+        // was opened on: a temp file nobody chose to keep.
+        if let video = core.featureStates.existing(
+            VideoEditorModel.self, feature: id, in: self.id) {
+            clearExitGuard(video.exitGuardID)
+            if reason == .closing { video.closeAndDiscardRecording() }
+        }
         if id == "terminal", reason == .closing {
             // Implicit teardown (feature tab closed, background window close,
             // role reset) — remember the shells' directories before killing

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1177,11 +1177,13 @@ final class AppState {
     /// snapshots its shells' directories.
     func detachTab(_ featureID: String) -> TabHandoff.Carry {
         guard workspace.detach(featureID) != nil else { return .none }
-        // Taken before anything is stopped: these keep running and cross to the
-        // receiving window, which is what makes a move a move rather than a
-        // restart. `stopBackgroundWork` skips exactly these on `.handoff`.
-        pendingMovedSessions = takeMovableSessions(for: featureID)
+        // Stopped first, then taken: on a `.handoff` the stop only releases what
+        // belongs to *this window* (the device lock, the leave guard) and leaves
+        // the work itself running, and it needs the feature's model still in
+        // place to do that. Taking first would hand it over before this window
+        // had let go of it.
         stopBackgroundWork(for: featureID, reason: .handoff)
+        pendingMovedSessions = takeMovableSessions(for: featureID)
         let carry = TabHandoff.Carry(
             terminalResumeDirs: featureID == TabHandoff.terminalFeatureID
                 ? terminalResumeDirs : nil,
@@ -1238,6 +1240,17 @@ final class AppState {
         if id == "js-console", reason == .closing {
             jsConsoleSession.stop()
             Task { await jsConsoleSession.removeReverseTunnels() }
+        }
+        // A screen recording outlives its view — the recorder writes through a
+        // headless scrcpy session — so a *move* keeps the take and only hands
+        // back this window's device lock and leave guard. A close is the one
+        // that gives up the recording and its file.
+        if id == "screen-record",
+           let recording = core.featureStates.existing(
+               ScreenRecordModel.self, feature: id, in: self.id) {
+            setRecording(false, owner: "screen-record")
+            clearExitGuard(recording.exitGuardID)
+            if reason == .closing { recording.abortAndDiscard() }
         }
         if id == "terminal", reason == .closing {
             // Implicit teardown (feature tab closed, background window close,

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -106,7 +106,9 @@ final class AppState {
     /// APK Studio's loaded-APK session. In-memory, so it resumes across
     /// navigation within a run and is cleared when the app quits (the decompiled
     /// cache is wiped alongside it — see `AppDelegate.applicationWillTerminate`).
-    let apkStudio = ApkStudioSession()
+    /// APK Studio's loaded APK and its tab. `var` so it travels with the tab
+    /// rather than being rebuilt empty in the receiving window (`MovedSessions`).
+    private(set) var apkStudio = ApkStudioSession()
 
     /// The Finder-opened-APK screen's files (the `apk-open` workspace tab —
     /// deliberately not a registry feature; it exists only when a file
@@ -628,13 +630,17 @@ final class AppState {
     struct MovedSessions {
         var terminals: TerminalManager?
         var jsConsole: JSConsoleSession?
+        /// The APK loaded into APK Studio, and which of its tabs was open.
+        var apkStudio: ApkStudioSession?
         /// The moving tab's `FeatureStateStore` model, if it keeps one — the
         /// buffer or loaded work a rebuilt view would otherwise start without.
         var featureState: AnyObject?
         /// Which feature `featureState` belongs to.
         var featureID: String?
 
-        var isEmpty: Bool { terminals == nil && jsConsole == nil && featureState == nil }
+        var isEmpty: Bool {
+            terminals == nil && jsConsole == nil && apkStudio == nil && featureState == nil
+        }
     }
 
     /// Hand `featureID`'s live session over, leaving a fresh one behind.
@@ -647,6 +653,9 @@ final class AppState {
         case "js-console":
             moved.jsConsole = jsConsoleSession
             jsConsoleSession = JSConsoleSession(adb: core.env.client)
+        case "apk-studio":
+            moved.apkStudio = apkStudio
+            apkStudio = ApkStudioSession()
         default:
             break
         }
@@ -668,6 +677,7 @@ final class AppState {
         if let featureID = moved.featureID {
             core.featureStates.put(moved.featureState, feature: featureID, in: id)
         }
+        if let apkStudio = moved.apkStudio { self.apkStudio = apkStudio }
         guard moved.terminals != nil || moved.jsConsole != nil else { return }
         if let terminals = moved.terminals { self.terminals = terminals }
         if let jsConsole = moved.jsConsole { jsConsoleSession = jsConsole }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -1277,6 +1277,27 @@ final class AppState {
             clearExitGuard(video.exitGuardID)
             if reason == .closing { video.closeAndDiscardRecording() }
         }
+        // A live mirror crosses with a moving tab: the scrcpy server, the
+        // encoder, the adb tunnel and the decoder all keep running, and the
+        // window it lands in adopts the same display layer. Only a real close —
+        // or the window going away, which comes through here too — gives the
+        // device back and tears the session down. The same for the wall, which
+        // is up to six of them at once.
+        if let mirror = core.featureStates.existing(
+            MirrorTabModel.self, feature: id, in: self.id) {
+            clearExitGuard(mirror.exitGuardID)
+            // The tab is leaving *this* window either way, so this window stops
+            // claiming the device — before the window it lands in asks for it,
+            // which is the ordering a handoff already promises. A cross-pane
+            // move never reaches here, and shouldn't: the claim stays put.
+            noteMirrorClaims([], featureID: id)
+            if reason == .closing { mirror.shutDown() }
+        }
+        if let wall = core.featureStates.existing(
+            MirrorWallTabModel.self, feature: id, in: self.id) {
+            noteMirrorClaims([], featureID: id)
+            if reason == .closing { wall.shutDown() }
+        }
         if id == "terminal", reason == .closing {
             // Implicit teardown (feature tab closed, background window close,
             // role reset) — remember the shells' directories before killing

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -134,9 +134,20 @@ final class AppState {
     /// (or quitting), not on switching.
     private(set) var workspace = Workspace(fallback: "home")
 
-    /// The tab id being dragged in a strip, or nil when no drag is in flight —
-    /// shared so a pane can offer a drop target for moving/splitting tabs.
-    var draggingTabID: String?
+    /// The tab *this* window is dragging, or nil — which is the question every
+    /// existing caller asks (fade the original chip, suppress its own
+    /// guideline). The drag itself lives on `AppCore` because it can end in
+    /// another window; `anyTabDrag` is the app-wide view of it.
+    var draggingTabID: String? {
+        get { core.tabDrag.flatMap { $0.source == id ? $0.featureID : nil } }
+        set {
+            if let newValue {
+                core.tabDrag = TabDrag(featureID: newValue, source: id)
+            } else if core.tabDrag?.source == id {
+                core.tabDrag = nil
+            }
+        }
+    }
 
     /// The focused pane's active tab: drives the device bar, sidebar highlight,
     /// and window title.
@@ -609,7 +620,7 @@ final class AppState {
             // A new window: target the device it was opened for (or the first
             // one no other window is showing) and inherit the last app bundle.
             selectedBundleId = core.lastSelectedBundleId
-            selectedSerial = core.takeWindowTarget(id) ?? firstFreeSerial()
+            selectedSerial = core.windowSeedTarget(id) ?? firstFreeSerial()
         }
         // Replay feature opens that raced the load (e.g. openAPKs from Finder).
         for pending in pendingFeatureOpens {
@@ -793,7 +804,12 @@ final class AppState {
 
     /// A navigation held back until the user resolves the active `ExitGuard`.
     struct PendingExit: Equatable {
-        enum Target: Equatable { case closeTab(String), device(String), quit }
+        /// `handoff` moves a tab to another window, which unmounts its view
+        /// exactly as closing it does — so it is held behind the same guard.
+        enum Target: Equatable {
+            case closeTab(String), device(String), quit
+            case handoff(String, HandoffDestination)
+        }
         var target: Target
         /// Flips true when the user chooses "Stop & save": the active view runs
         /// its own save, then calls `finishExitSave()`. The dialog hides while
@@ -805,6 +821,12 @@ final class AppState {
     /// this when losable work begins, and `clearExitGuard` when it ends.
     func setExitGuard(_ value: ExitGuard) { exitGuards[value.featureID] = value }
 
+    /// Hold a navigation behind the active leave confirmation. `pendingExit` is
+    /// `private(set)` so only the paths that know how to resolve it can arm it.
+    func holdBehindGuard(_ target: PendingExit.Target) {
+        pendingExit = PendingExit(target: target)
+    }
+
     /// Clear the guard identified by `id`, wherever it's keyed — so a torn-down
     /// view can't wipe a guard a newer view just registered (ids are unique).
     func clearExitGuard(_ id: UUID) {
@@ -815,7 +837,7 @@ final class AppState {
     /// guard, or any active guard when switching device / quitting.
     var pendingGuard: ExitGuard? {
         switch pendingExit?.target {
-        case .closeTab(let id): return exitGuards[id]
+        case .closeTab(let id), .handoff(let id, _): return exitGuards[id]
         case .device, .quit: return exitGuards.values.first
         case nil: return nil
         }
@@ -827,7 +849,7 @@ final class AppState {
     /// can't make a different tab save.
     func pendingExitConcerns(_ featureID: String) -> Bool {
         switch pendingExit?.target {
-        case .closeTab(let id): return id == featureID
+        case .closeTab(let id), .handoff(let id, _): return id == featureID
         case .device, .quit: return true
         case nil: return false
         }
@@ -868,7 +890,12 @@ final class AppState {
     /// Terminal feature tab, or quitting the app — both kill every live shell,
     /// so both are held until the user confirms losing them (RootView shows
     /// the alert).
-    enum TerminalClosePrompt { case closeTab, quit }
+    enum TerminalClosePrompt: Equatable {
+        case closeTab, quit
+        /// Moving the Terminal tab to another window: the shells die here and
+        /// their directories travel with the tab, so it reopens where it was.
+        case handoff(HandoffDestination)
+    }
 
     /// Set while the terminal close/quit confirmation is on screen.
     var terminalClosePrompt: TerminalClosePrompt?
@@ -902,6 +929,11 @@ final class AppState {
         switch prompt {
         case .closeTab:
             if confirmed { performClose("terminal") }
+        case .handoff(let destination):
+            // Deliberately not snapshotting here: `detachTab` does it as part
+            // of stopping the tab's work, and a second `rememberTerminalDirectories`
+            // on the by-then-empty rail would overwrite the snapshot with nothing.
+            if confirmed { core.completeHandoff("terminal", from: id, to: destination) }
         case .quit:
             if confirmed {
                 rememberTerminalDirectories()
@@ -980,6 +1012,58 @@ final class AppState {
         persistTabs()
     }
 
+    /// Resolve a tab drop into *this* window, wherever the tab came from.
+    ///
+    /// One funnel for every strip and pane target, so the cross-window case
+    /// can't be handled in one place and forgotten in another; `TabDropRouter`
+    /// (pure, in ADBKit) makes the actual decision. A tab from another window
+    /// is a handoff routed through `beginHandoff` on its *source*, so a live
+    /// recording or open shells still get their confirmation rather than being
+    /// dropped silently — and the slot rides along, so a move held behind that
+    /// confirmation still lands where it was dropped.
+    func acceptTabDrop(_ drag: TabDrag, on target: TabDropRouter.Target) {
+        core.tabDrag = nil
+        let outcome = TabDropRouter.outcome(
+            drag: TabDropRouter.Drag(featureID: drag.featureID, source: drag.source),
+            window: id,
+            target: target,
+            shape: dropShape(for: target))
+        switch outcome {
+        case .ignore:
+            break
+        case .place(let group, let before):
+            dropTab(drag.featureID, intoGroup: group, before: before)
+        case .split:
+            splitTab(drag.featureID)
+        case .handoff(let source, let group, let before):
+            core.workspace(id: source)?.beginHandoff(
+                drag.featureID,
+                to: .window(id, slot: HandoffSlot(group: group, before: before)))
+        }
+    }
+
+    /// This window's panes as the drop router sees them.
+    private func dropShape(for target: TabDropRouter.Target) -> TabDropRouter.Shape {
+        let group = switch target {
+        case .strip(let group, _): group
+        case .pane(let group): group
+        }
+        return TabDropRouter.Shape(
+            isSplit: isSplit, paneTabCount: openTabIDs(inGroup: group).count)
+    }
+
+    /// Whether dropping the tab in flight on `group`'s content would split this
+    /// window — what the pane's "Drop to split" preview asks before promising.
+    func dropWouldSplit(_ drag: TabDrag?, inGroup group: Int) -> Bool {
+        guard let drag else { return false }
+        let target = TabDropRouter.Target.pane(group: group)
+        return TabDropRouter.outcome(
+            drag: TabDropRouter.Drag(featureID: drag.featureID, source: drag.source),
+            window: id,
+            target: target,
+            shape: dropShape(for: target)) == .split
+    }
+
     /// Split the workspace: move `id` into a new second pane.
     func splitTab(_ id: String) {
         workspace.split(id)
@@ -988,22 +1072,76 @@ final class AppState {
 
     private func performClose(_ id: String) {
         workspace.close(id)
-        stopBackgroundWork(for: id)
+        stopBackgroundWork(for: id, reason: .closing)
         persistTabs()
     }
+
+    /// Whether `featureID`'s tab can leave this window for another *open* one.
+    func canDetachTab(_ featureID: String) -> Bool { workspace.canDetach(featureID) }
+
+    /// Whether it can leave for a window of its own — stricter, because
+    /// something has to stay behind (see `Workspace.canDetachToNewWindow`).
+    func canDetachTabToNewWindow(_ featureID: String) -> Bool {
+        workspace.canDetachToNewWindow(featureID)
+    }
+
+    /// Remove `featureID`'s tab and stop the work this window was doing on its
+    /// behalf, returning the state that has to travel with it.
+    ///
+    /// The order matters twice over. The tab leaves the workspace *before* the
+    /// registry is told, so an exclusive feature (scrcpy, the JS console) is
+    /// released here before the receiving window asks for it — otherwise it
+    /// comes up on the collision banner instead of running. And the carry is
+    /// read *after* the work is stopped, because stopping the Terminal is what
+    /// snapshots its shells' directories.
+    func detachTab(_ featureID: String) -> TabHandoff.Carry {
+        guard workspace.detach(featureID) != nil else { return .none }
+        stopBackgroundWork(for: featureID, reason: .handoff)
+        let carry = TabHandoff.Carry(
+            terminalResumeDirs: featureID == TabHandoff.terminalFeatureID
+                ? terminalResumeDirs : nil,
+            mirrorWallSerials: featureID == TabHandoff.mirrorWallFeatureID
+                ? mirrorWallSerials : nil)
+        persistTabs()
+        return carry
+    }
+
+    /// Take a tab moved in from another window, with the state it carried and
+    /// (for a drag) the slot it was dropped on.
+    ///
+    /// A feature is open in at most one tab per window, so arriving at a window
+    /// that already shows it *merges*: `requestFeature` refocuses the existing
+    /// tab and the moved one's view state is discarded. That is the honest read
+    /// of the invariant — there is nowhere for a second copy to go.
+    func adoptHandoff(_ featureID: String, carrying carry: TabHandoff.Carry, at slot: HandoffSlot?) {
+        if let dirs = carry.terminalResumeDirs { terminalResumeDirs = dirs }
+        if let serials = carry.mirrorWallSerials { mirrorWallSerials = serials }
+        requestFeature(featureID)
+        if let slot { dropTab(featureID, intoGroup: slot.group, before: slot.before) }
+    }
+
+    /// Why a tab's work is being stopped. A tab that is *moving* keeps the
+    /// app-wide sessions it shares with other windows alive across the move.
+    enum StopReason { case closing, handoff }
 
     /// Closing a tab fully stops that feature's background work. Most features
     /// stop when their view unmounts (their `.task` is cancelled on close), but a
     /// few sessions are owned here and kept alive across tab *switches* — so
     /// closing their tab has to tear them down explicitly. A feature is open in at
     /// most one tab, so once it's closed no other tab still needs it.
-    private func stopBackgroundWork(for id: String) {
+    private func stopBackgroundWork(for id: String, reason: StopReason) {
         // With MCP on, the relay must survive tab/window close — agents keep
         // querying while the user isn't looking (Settings ▸ MCP turns it off).
         // The relay is app-wide, so another window still showing it keeps it
         // up too: this window's close must not pull the timeline out from
         // under the other one.
-        if id == "reactotron", reactotronSession.isRunning, !mcp.keepsRelayAlive,
+        // A *moving* tab is about to reopen in another window, so the relay it
+        // shares with every window must survive the gap — stopping it would
+        // drop every connected RN client for the sake of a tab that never
+        // really closed. `AppCore.reconcileSharedSessions` catches the case
+        // where the move somehow didn't land.
+        if id == "reactotron", reason == .closing, reactotronSession.isRunning,
+           !mcp.keepsRelayAlive,
            !core.featureIsOpenElsewhere("reactotron", excluding: self.id) {
             Task { await reactotronSession.stop() }
         }
@@ -1031,7 +1169,15 @@ final class AppState {
     /// window has restored, so an empty default can't clobber the saved file.
     func persistWindowState() {
         guard didRestore, didBind else { return }
-        core.layout.upsertWindow(WindowState(
+        core.layout.upsertWindow(windowRecord)
+        core.persistLayout()
+    }
+
+    /// This window as a persisted record. Also what a tab moved out of here
+    /// inherits its device and app bundle from (`TabHandoff.seed`), so the two
+    /// can't describe a window differently.
+    var windowRecord: WindowState {
+        WindowState(
             id: id,
             serial: selectedSerial,
             bundleId: selectedBundleId,
@@ -1041,8 +1187,7 @@ final class AppState {
             focusedGroup: workspace.focusedGroup,
             terminalResumeDirs: terminalResumeDirs,
             mirrorWallSerials: mirrorWallSerials
-        ))
-        core.persistLayout()
+        )
     }
 
     /// Working directories of this window's terminal tabs at the last implicit
@@ -1081,7 +1226,7 @@ final class AppState {
     /// idle.
     func enterBackground() {
         for featureID in openFeatureIDs {
-            stopBackgroundWork(for: featureID)
+            stopBackgroundWork(for: featureID, reason: .closing)
         }
     }
 
@@ -1098,7 +1243,7 @@ final class AppState {
     /// Reactotron server) leak with no UI left to reach them.
     func resetForRoleChange() {
         for featureID in workspace.groups.flatMap(\.openTabs) {
-            stopBackgroundWork(for: featureID)
+            stopBackgroundWork(for: featureID, reason: .closing)
         }
         workspace.reset()
         persistTabs()
@@ -1155,7 +1300,7 @@ final class AppState {
     /// tab, so clear them all and let each view abort.
     func discardAndExit() {
         switch pendingExit?.target {
-        case .closeTab(let id): exitGuards[id] = nil
+        case .closeTab(let id), .handoff(let id, _): exitGuards[id] = nil
         case .device, .quit: exitGuards.removeAll()
         case nil: break
         }
@@ -1181,6 +1326,8 @@ final class AppState {
         pendingExit = nil
         switch pending.target {
         case .closeTab(let id): performClose(id)
+        case .handoff(let id, let destination):
+            core.completeHandoff(id, from: self.id, to: destination)
         case .device(let serial): applySelection(serial)
         // This window is clear; the next one with work at stake gets its turn.
         case .quit: core.resumeQuit()

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -605,6 +605,15 @@ final class AppState {
         }
     }
 
+    /// This window's model for `feature`, built on first use and kept until
+    /// the tab closes — the state a feature wants to survive its view being
+    /// rebuilt (a log buffer, a fetched list). See `FeatureStateStore`.
+    func featureState<T: AnyObject>(
+        _ type: T.Type, for feature: String, make: () -> T
+    ) -> T {
+        core.featureStates.model(type, feature: feature, in: id, make: make)
+    }
+
     /// The live per-window work a moving tab takes with it.
     ///
     /// A feature whose state lives in an object owned by the *window* — the
@@ -619,8 +628,13 @@ final class AppState {
     struct MovedSessions {
         var terminals: TerminalManager?
         var jsConsole: JSConsoleSession?
+        /// The moving tab's `FeatureStateStore` model, if it keeps one — the
+        /// buffer or loaded work a rebuilt view would otherwise start without.
+        var featureState: AnyObject?
+        /// Which feature `featureState` belongs to.
+        var featureID: String?
 
-        var isEmpty: Bool { terminals == nil && jsConsole == nil }
+        var isEmpty: Bool { terminals == nil && jsConsole == nil && featureState == nil }
     }
 
     /// Hand `featureID`'s live session over, leaving a fresh one behind.
@@ -636,7 +650,11 @@ final class AppState {
         default:
             break
         }
-        if !moved.isEmpty { wireSessions() }
+        // Every feature may have one, so this is not part of the switch: the
+        // store answers nil for the ones that keep nothing.
+        moved.featureID = featureID
+        moved.featureState = core.featureStates.take(feature: featureID, in: id)
+        if moved.terminals != nil || moved.jsConsole != nil { wireSessions() }
         return moved
     }
 
@@ -647,6 +665,10 @@ final class AppState {
     /// Take live sessions arriving with a tab from another window.
     func adoptMovableSessions(_ moved: MovedSessions) {
         guard !moved.isEmpty else { return }
+        if let featureID = moved.featureID {
+            core.featureStates.put(moved.featureState, feature: featureID, in: id)
+        }
+        guard moved.terminals != nil || moved.jsConsole != nil else { return }
         if let terminals = moved.terminals { self.terminals = terminals }
         if let jsConsole = moved.jsConsole { jsConsoleSession = jsConsole }
         wireSessions()
@@ -1119,6 +1141,9 @@ final class AppState {
     private func performClose(_ id: String) {
         workspace.close(id)
         stopBackgroundWork(for: id, reason: .closing)
+        // Closing a tab means done with it: its buffer goes too, rather than
+        // reappearing the next time the feature is opened.
+        core.featureStates.discard(feature: id, in: self.id)
         persistTabs()
     }
 

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -632,14 +632,14 @@ final class AppState {
         var jsConsole: JSConsoleSession?
         /// The APK loaded into APK Studio, and which of its tabs was open.
         var apkStudio: ApkStudioSession?
-        /// The moving tab's `FeatureStateStore` model, if it keeps one — the
-        /// buffer or loaded work a rebuilt view would otherwise start without.
-        var featureState: AnyObject?
+        /// Whatever the moving tab kept in `FeatureStateStore` — the buffer or
+        /// loaded work a rebuilt view would otherwise start without.
+        var featureState: [ObjectIdentifier: AnyObject] = [:]
         /// Which feature `featureState` belongs to.
         var featureID: String?
 
         var isEmpty: Bool {
-            terminals == nil && jsConsole == nil && apkStudio == nil && featureState == nil
+            terminals == nil && jsConsole == nil && apkStudio == nil && featureState.isEmpty
         }
     }
 
@@ -888,6 +888,14 @@ final class AppState {
         var style: Style
         var title: String
         var message: String
+        /// Whether the work this guards travels with a moving tab. A guard says
+        /// "leaving destroys this" — true of closing the tab either way, but a
+        /// *move* destroys nothing for a recording that writes through a
+        /// headless session or markup held in the window's `FeatureStateStore`,
+        /// so those move without asking. Per guard rather than per feature: one
+        /// feature id can carry either kind (the mirror's recording guard and
+        /// its screenshot editor's both key on `scrcpy`).
+        var survivesAMove = false
     }
 
     /// A navigation held back until the user resolves the active `ExitGuard`.
@@ -1251,6 +1259,15 @@ final class AppState {
             setRecording(false, owner: "screen-record")
             clearExitGuard(recording.exitGuardID)
             if reason == .closing { recording.abortAndDiscard() }
+        }
+        // Unsaved screenshot markup crosses with a moving tab — its model
+        // travels in `MovedSessions` — so a move only hands back the leave
+        // guard this window registered, and the window it lands in re-arms the
+        // same one. A close gives up the markup with the tab, which is exactly
+        // what the guard just asked about.
+        if let editor = core.featureStates.existing(
+            ScreenshotEditorModel.self, feature: id, in: self.id) {
+            clearExitGuard(editor.exitGuardID)
         }
         if id == "terminal", reason == .closing {
             // Implicit teardown (feature tab closed, background window close,

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -249,11 +249,13 @@ final class AppState {
 
     /// The JS Console (Hermes CDP) session — owned here so its log buffer and
     /// connection survive leaving the feature, like the Reactotron session.
-    let jsConsoleSession: JSConsoleSession
+    /// `var`, not `let`, because it travels with its tab: see `MovedSessions`.
+    private(set) var jsConsoleSession: JSConsoleSession
 
     /// The Terminal feature's shells — owned here so every tab's PTY session
-    /// and scrollback survive leaving the feature.
-    let terminals = TerminalManager()
+    /// and scrollback survive leaving the feature, and replaceable so they
+    /// survive the tab moving to another window too (`MovedSessions`).
+    private(set) var terminals = TerminalManager()
 
     /// With auto-hide on (Settings ▸ Appearance), the sidebar rides over the
     /// content instead of sitting in the layout; this is that overlay's
@@ -587,6 +589,13 @@ final class AppState {
         let savedStep = UserDefaults.standard.object(forKey: "fontScaleStep") as? Int ?? Self.defaultScaleIndex
         fontScaleStep = min(max(savedStep, 0), Self.scales.count - 1)
         jsConsoleSession = JSConsoleSession(adb: core.env.client)
+        wireSessions()
+    }
+
+    /// Point the per-window sessions back at this window. Called at init and
+    /// again whenever one is replaced — either by a session arriving from
+    /// another window, or by the fresh one left behind when it leaves.
+    private func wireSessions() {
         jsConsoleSession.app = self
         // Typing `exit` (or a shell crash) closes that tab like the × does.
         // The contains-check drops late callbacks racing a killAll teardown.
@@ -594,6 +603,53 @@ final class AppState {
             guard let self, self.terminals.tabs.contains(where: { $0.id == id }) else { return }
             self.closeTerminalShell(id)
         }
+    }
+
+    /// The live per-window work a moving tab takes with it.
+    ///
+    /// A feature whose state lives in an object owned by the *window* — the
+    /// terminal's PTYs and scrollback, the JS console's CDP connection and
+    /// console history — would otherwise be torn down here and rebuilt there,
+    /// which is a restart wearing a move's clothes. The object crosses instead,
+    /// and the window it left gets a fresh one so it keeps working.
+    ///
+    /// Only features whose work outlives their view need an entry: everything
+    /// else either rebuilds cheaply or is already app-wide (the Reactotron
+    /// relay, which no window owns).
+    struct MovedSessions {
+        var terminals: TerminalManager?
+        var jsConsole: JSConsoleSession?
+
+        var isEmpty: Bool { terminals == nil && jsConsole == nil }
+    }
+
+    /// Hand `featureID`'s live session over, leaving a fresh one behind.
+    func takeMovableSessions(for featureID: String) -> MovedSessions {
+        var moved = MovedSessions()
+        switch featureID {
+        case TabHandoff.terminalFeatureID:
+            moved.terminals = terminals
+            terminals = TerminalManager()
+        case "js-console":
+            moved.jsConsole = jsConsoleSession
+            jsConsoleSession = JSConsoleSession(adb: core.env.client)
+        default:
+            break
+        }
+        if !moved.isEmpty { wireSessions() }
+        return moved
+    }
+
+    /// Sessions taken by `detachTab`, waiting for the receiving window. Held
+    /// for the length of one handoff only; `AppCore` collects it immediately.
+    var pendingMovedSessions = MovedSessions()
+
+    /// Take live sessions arriving with a tab from another window.
+    func adoptMovableSessions(_ moved: MovedSessions) {
+        guard !moved.isEmpty else { return }
+        if let terminals = moved.terminals { self.terminals = terminals }
+        if let jsConsole = moved.jsConsole { jsConsoleSession = jsConsole }
+        wireSessions()
     }
 
     /// Adopt this window's persisted state, or start fresh when `saved` is nil
@@ -890,12 +946,7 @@ final class AppState {
     /// Terminal feature tab, or quitting the app — both kill every live shell,
     /// so both are held until the user confirms losing them (RootView shows
     /// the alert).
-    enum TerminalClosePrompt: Equatable {
-        case closeTab, quit
-        /// Moving the Terminal tab to another window: the shells die here and
-        /// their directories travel with the tab, so it reopens where it was.
-        case handoff(HandoffDestination)
-    }
+    enum TerminalClosePrompt { case closeTab, quit }
 
     /// Set while the terminal close/quit confirmation is on screen.
     var terminalClosePrompt: TerminalClosePrompt?
@@ -929,11 +980,6 @@ final class AppState {
         switch prompt {
         case .closeTab:
             if confirmed { performClose("terminal") }
-        case .handoff(let destination):
-            // Deliberately not snapshotting here: `detachTab` does it as part
-            // of stopping the tab's work, and a second `rememberTerminalDirectories`
-            // on the by-then-empty rail would overwrite the snapshot with nothing.
-            if confirmed { core.completeHandoff("terminal", from: id, to: destination) }
         case .quit:
             if confirmed {
                 rememberTerminalDirectories()
@@ -1096,6 +1142,10 @@ final class AppState {
     /// snapshots its shells' directories.
     func detachTab(_ featureID: String) -> TabHandoff.Carry {
         guard workspace.detach(featureID) != nil else { return .none }
+        // Taken before anything is stopped: these keep running and cross to the
+        // receiving window, which is what makes a move a move rather than a
+        // restart. `stopBackgroundWork` skips exactly these on `.handoff`.
+        pendingMovedSessions = takeMovableSessions(for: featureID)
         stopBackgroundWork(for: featureID, reason: .handoff)
         let carry = TabHandoff.Carry(
             terminalResumeDirs: featureID == TabHandoff.terminalFeatureID
@@ -1145,11 +1195,16 @@ final class AppState {
            !core.featureIsOpenElsewhere("reactotron", excluding: self.id) {
             Task { await reactotronSession.stop() }
         }
-        if id == "js-console" {
+        // Both of these travel with a moving tab (`MovedSessions`), so on a
+        // handoff the session that is about to keep running in another window
+        // has already been handed over and this window holds a fresh one —
+        // stopping it here would tear down the wrong thing, and stopping the
+        // moved one would undo the move.
+        if id == "js-console", reason == .closing {
             jsConsoleSession.stop()
             Task { await jsConsoleSession.removeReverseTunnels() }
         }
-        if id == "terminal" {
+        if id == "terminal", reason == .closing {
             // Implicit teardown (feature tab closed, background window close,
             // role reset) — remember the shells' directories before killing
             // them, so the next Terminal open resumes where they were.

--- a/App/Sources/State/FeatureStateStore.swift
+++ b/App/Sources/State/FeatureStateStore.swift
@@ -40,6 +40,14 @@ final class FeatureStateStore {
         return created
     }
 
+    /// This window's model for `feature`, or nil when it has never built one.
+    /// Unlike `model(_:feature:in:make:)` this creates nothing, so callers
+    /// outside the view — a tab closing, say — can ask about state without
+    /// bringing it into existence.
+    func existing<T: AnyObject>(_ type: T.Type, feature: String, in workspace: WorkspaceID) -> T? {
+        models[workspace]?[feature] as? T
+    }
+
     /// Take `feature`'s model out, for a tab moving to another window. Returns
     /// nil when the feature never built one (it was never opened, or it keeps
     /// nothing worth moving).

--- a/App/Sources/State/FeatureStateStore.swift
+++ b/App/Sources/State/FeatureStateStore.swift
@@ -11,7 +11,7 @@ import Foundation
 /// — it is a restart wearing a move's clothes.
 ///
 /// So those features keep their state in a model object held here instead,
-/// keyed by the window and the feature. The view resolves its model each time
+/// keyed by the window, the feature, and the model's type. The view resolves it each time
 /// it renders and gets the same one back; a tab moving between windows re-keys
 /// the entry rather than dropping it.
 ///
@@ -23,20 +23,22 @@ import Foundation
 /// reason `LogRowFrames` and `MainThreadLoad` are plain reference boxes.)
 @MainActor
 final class FeatureStateStore {
-    private var models: [WorkspaceID: [String: AnyObject]] = [:]
+    /// window → feature → model type → model. Keyed by type as well as
+    /// feature because one tab can keep two unrelated things: the mirror keeps
+    /// its live session *and*, when a capture is open, the screenshot editor's
+    /// markup. They move and are discarded together, which is what makes the
+    /// feature the middle key rather than the last one.
+    private var models: [WorkspaceID: [String: [ObjectIdentifier: AnyObject]]] = [:]
 
     /// This window's model for `feature`, created on first use.
     ///
-    /// `make` runs at most once per (window, feature). A stored object of a
-    /// different type is replaced rather than crashing the app: the only way
-    /// that happens is a feature changing its model type across a build, and a
-    /// lost buffer beats a trap.
+    /// `make` runs at most once per (window, feature, type).
     func model<T: AnyObject>(
         _ type: T.Type, feature: String, in workspace: WorkspaceID, make: () -> T
     ) -> T {
-        if let existing = models[workspace]?[feature] as? T { return existing }
+        if let existing = models[workspace]?[feature]?[ObjectIdentifier(type)] as? T { return existing }
         let created = make()
-        models[workspace, default: [:]][feature] = created
+        models[workspace, default: [:]][feature, default: [:]][ObjectIdentifier(type)] = created
         return created
     }
 
@@ -45,25 +47,25 @@ final class FeatureStateStore {
     /// outside the view — a tab closing, say — can ask about state without
     /// bringing it into existence.
     func existing<T: AnyObject>(_ type: T.Type, feature: String, in workspace: WorkspaceID) -> T? {
-        models[workspace]?[feature] as? T
+        models[workspace]?[feature]?[ObjectIdentifier(type)] as? T
     }
 
-    /// Take `feature`'s model out, for a tab moving to another window. Returns
-    /// nil when the feature never built one (it was never opened, or it keeps
-    /// nothing worth moving).
-    func take(feature: String, in workspace: WorkspaceID) -> AnyObject? {
-        let model = models[workspace]?[feature]
+    /// Take everything `feature` keeps out, for a tab moving to another window.
+    /// Empty when the feature never built anything (it was never opened, or it
+    /// keeps nothing worth moving).
+    func take(feature: String, in workspace: WorkspaceID) -> [ObjectIdentifier: AnyObject] {
+        let taken = models[workspace]?[feature] ?? [:]
         models[workspace]?[feature] = nil
-        return model
+        return taken
     }
 
-    /// Put a model taken from another window under this one.
-    func put(_ model: AnyObject?, feature: String, in workspace: WorkspaceID) {
-        guard let model else { return }
-        models[workspace, default: [:]][feature] = model
+    /// Put models taken from another window under this one.
+    func put(_ taken: [ObjectIdentifier: AnyObject], feature: String, in workspace: WorkspaceID) {
+        guard !taken.isEmpty else { return }
+        models[workspace, default: [:]][feature] = taken
     }
 
-    /// Forget `feature`'s model — its tab closed, so its buffer should not
+    /// Forget what `feature` kept — its tab closed, so its buffer should not
     /// outlive it and reappear when the feature is opened again.
     func discard(feature: String, in workspace: WorkspaceID) {
         models[workspace]?[feature] = nil

--- a/App/Sources/State/FeatureStateStore.swift
+++ b/App/Sources/State/FeatureStateStore.swift
@@ -1,0 +1,75 @@
+import ADBKit
+import Foundation
+
+/// Per-window, per-feature state that outlives the view showing it.
+///
+/// SwiftUI destroys a feature's view whenever its tab moves — to the other
+/// split pane, or (now) to another window — taking every `@State` with it. For
+/// most features that is correct: a form's text field or a hub's disclosure
+/// state should start clean. For the ones that accumulate something the user
+/// would be annoyed to lose — a log buffer, a fetched crash list, a loaded APK
+/// — it is a restart wearing a move's clothes.
+///
+/// So those features keep their state in a model object held here instead,
+/// keyed by the window and the feature. The view resolves its model each time
+/// it renders and gets the same one back; a tab moving between windows re-keys
+/// the entry rather than dropping it.
+///
+/// **Deliberately not `@Observable`.** Views resolve their model from `body`,
+/// and resolving creates one on first use — a write. If this type were
+/// observed, that write would invalidate the view that just read it, and the
+/// re-render would write again: the endless update loop, not a wasted pass.
+/// The *models* are observable; the container holding them must not be. (Same
+/// reason `LogRowFrames` and `MainThreadLoad` are plain reference boxes.)
+@MainActor
+final class FeatureStateStore {
+    private var models: [WorkspaceID: [String: AnyObject]] = [:]
+
+    /// This window's model for `feature`, created on first use.
+    ///
+    /// `make` runs at most once per (window, feature). A stored object of a
+    /// different type is replaced rather than crashing the app: the only way
+    /// that happens is a feature changing its model type across a build, and a
+    /// lost buffer beats a trap.
+    func model<T: AnyObject>(
+        _ type: T.Type, feature: String, in workspace: WorkspaceID, make: () -> T
+    ) -> T {
+        if let existing = models[workspace]?[feature] as? T { return existing }
+        let created = make()
+        models[workspace, default: [:]][feature] = created
+        return created
+    }
+
+    /// Take `feature`'s model out, for a tab moving to another window. Returns
+    /// nil when the feature never built one (it was never opened, or it keeps
+    /// nothing worth moving).
+    func take(feature: String, in workspace: WorkspaceID) -> AnyObject? {
+        let model = models[workspace]?[feature]
+        models[workspace]?[feature] = nil
+        return model
+    }
+
+    /// Put a model taken from another window under this one.
+    func put(_ model: AnyObject?, feature: String, in workspace: WorkspaceID) {
+        guard let model else { return }
+        models[workspace, default: [:]][feature] = model
+    }
+
+    /// Forget `feature`'s model — its tab closed, so its buffer should not
+    /// outlive it and reappear when the feature is opened again.
+    func discard(feature: String, in workspace: WorkspaceID) {
+        models[workspace]?[feature] = nil
+        if models[workspace]?.isEmpty == true { models[workspace] = nil }
+    }
+
+    /// Forget everything a window held — it closed for good.
+    func discardAll(in workspace: WorkspaceID) {
+        models[workspace] = nil
+    }
+
+    /// Feature ids currently holding a model in `workspace`. Test/diagnostic
+    /// visibility only.
+    func features(in workspace: WorkspaceID) -> Set<String> {
+        Set(models[workspace]?.keys ?? [:].keys)
+    }
+}

--- a/App/Sources/State/WindowHandoff.swift
+++ b/App/Sources/State/WindowHandoff.swift
@@ -88,12 +88,24 @@ extension AppState {
         if case .window(let target, _) = destination, target == id { return }
         // No terminal confirmation here, unlike `closeTab`: the shells are not
         // killed by a move, they cross with the tab (`MovedSessions`).
-        if exitGuards[featureID] != nil {
+        // A guard means "leaving destroys this work" — but for a feature whose
+        // work crosses with the tab, a move destroys nothing, so asking would be
+        // asking about a loss that is not going to happen.
+        if exitGuards[featureID] != nil, !Self.workSurvivesAMove.contains(featureID) {
             holdBehindGuard(.handoff(featureID, destination))
             return
         }
         core.completeHandoff(featureID, from: id, to: destination)
     }
+
+    /// Features whose in-flight work travels with the tab, so moving one needs
+    /// no confirmation even though closing it would.
+    ///
+    /// Only the screen recorder qualifies today: it writes through a headless
+    /// session that owes nothing to its view. The performance and network
+    /// captures are fed by a sampler the view owns, so a move really does stop
+    /// them and they keep their prompt.
+    static let workSurvivesAMove: Set<String> = ["screen-record"]
 
     /// Whether this tab can go to that destination. A window of its own needs
     /// something to stay behind here; another *open* window does not, because

--- a/App/Sources/State/WindowHandoff.swift
+++ b/App/Sources/State/WindowHandoff.swift
@@ -1,0 +1,243 @@
+import ADBKit
+import AppKit
+import Foundation
+import SwiftUI
+
+/// Moving a tab out of its window — into another open window, or into a new one
+/// of its own.
+///
+/// Every route funnels through `AppState.beginHandoff`: the tab's context menu,
+/// the Window menu, ⌃⌘N, a drag onto another window and a drag out of the app.
+/// One entry point because the cases that need a confirmation (a live
+/// recording, open shells) are easy to get right once and easy to forget four
+/// times.
+
+/// Where a tab being moved out of a window is going.
+enum HandoffDestination: Equatable {
+    /// A window that does not exist yet. `frame` is set when a drag decided
+    /// where it should land; nil lets the usual cascade place it.
+    case newWindow(frame: NSRect?)
+    /// A window that is already open. `slot` is where in that window's strip
+    /// the drop landed — it rides along rather than being applied at the drop,
+    /// because a handoff can be held behind a confirmation and would otherwise
+    /// lose the position by the time it runs.
+    case window(WorkspaceID, slot: HandoffSlot?)
+}
+
+/// Where in a receiving window's tabs a moved tab should sit.
+struct HandoffSlot: Equatable {
+    /// Which pane. Out of range (dropped on a split the receiver doesn't have)
+    /// is tolerated — the tab lands in the pane it opened in.
+    var group: Int
+    /// The tab it should sit before, or nil for the end of the pane.
+    var before: String?
+}
+
+/// A tab drag in flight, anywhere in the app.
+///
+/// App-wide rather than per window because a tab can be dragged *into* a window
+/// that did not start the drag, and out of the app entirely. Deliberately
+/// written only twice per drag — at the start and at the end — because
+/// `AppCore` is `@Observable` and `RootView.body` reads it, so a write per
+/// mouse-move would re-render every open window on every mouse-move. Where the
+/// insertion guideline goes stays in the strip's own local `@State`.
+struct TabDrag: Equatable {
+    let featureID: String
+    /// The window the tab is being dragged out of.
+    let source: WorkspaceID
+}
+
+/// What a window that has not been created yet should come up as.
+///
+/// The handoff half is deliberately a `WindowState` — the same record a window
+/// persists — so the receiving window restores through the path a relaunch
+/// already uses, and the two can never drift apart.
+struct WindowSeed: Equatable {
+    /// The device a plain new window was opened for (⇧⌘N, "New Window for
+    /// Device"). Unused when `state` is set, which carries its own.
+    var serial: String?
+    /// Full opening state for a moved tab: the source window's device and app
+    /// bundle, and exactly the one tab.
+    var state: WindowState?
+    /// Where a drag decided the window should appear, in screen coordinates.
+    var frame: NSRect?
+    /// Inherited from the source window, so a moved tab keeps running against
+    /// the same set of devices it was.
+    var runOnAll = false
+    /// A torn-off window opens focused on its one feature. Reversible with ⌘B.
+    var sidebarHidden = false
+    /// The tab this window is being opened to receive, if any — the marker that
+    /// lets `AppCore` tell a handoff's window from any other new one.
+    var handoffFeatureID: String?
+}
+
+// MARK: - Starting a handoff
+
+extension AppState {
+    /// Start moving `featureID`'s tab out of this window.
+    ///
+    /// Moving a tab unmounts its view, exactly as closing it does, so the same
+    /// two confirmations apply — and they are checked in the same order
+    /// `closeTab` checks them.
+    func beginHandoff(_ featureID: String, to destination: HandoffDestination) {
+        guard canDetach(featureID, to: destination) else { return }
+        if case .window(let target, _) = destination, target == id { return }
+        if featureID == TabHandoff.terminalFeatureID, !terminals.tabs.isEmpty {
+            terminalClosePrompt = .handoff(destination)
+            return
+        }
+        if exitGuards[featureID] != nil {
+            holdBehindGuard(.handoff(featureID, destination))
+            return
+        }
+        core.completeHandoff(featureID, from: id, to: destination)
+    }
+
+    /// Whether this tab can go to that destination. A window of its own needs
+    /// something to stay behind here; another *open* window does not, because
+    /// consolidating two windows into one is a reasonable thing to want.
+    func canDetach(_ featureID: String, to destination: HandoffDestination) -> Bool {
+        switch destination {
+        case .newWindow: canDetachTabToNewWindow(featureID)
+        case .window: canDetachTab(featureID)
+        }
+    }
+
+    /// Apply the parts of a seed that are window *preferences* rather than
+    /// persisted state. Called by `AppCore.bind` before the restore, neither of
+    /// which touches these.
+    func adoptSeedPreferences(_ seed: WindowSeed) {
+        runOnAll = seed.runOnAll
+        // The pinned sidebar only; auto-hide mode already rests hidden, and
+        // `SidebarVisibility.afterButtonPress` treats "fixed mode, hidden" as
+        // the one state where the button just brings it back — so ⌘B is never
+        // a dead click here.
+        if seed.sidebarHidden { sidebarVisible = false }
+    }
+
+    /// A tab drag in flight anywhere in the app, or nil. Every drop target
+    /// validates on this rather than on `draggingTabID`, so a window that did
+    /// not start the drag still accepts the tab.
+    var anyTabDrag: TabDrag? { core.tabDrag }
+
+    /// Windows this one's tabs can be moved into, in window order — the tab
+    /// menu's "Move to Window" list.
+    var handoffTargets: [(id: WorkspaceID, label: String)] {
+        core.registry.entries.filter { $0.id != id }.map { entry in
+            let device = entry.serial
+                .flatMap { serial in core.devices.first { $0.serial == serial } }
+                .map(core.deviceDisplayName)
+            let label = core.registry.label(of: entry.id)
+            return (id: entry.id, label: device.map { "\(label) — \($0)" } ?? label)
+        }
+    }
+}
+
+// MARK: - Performing it
+
+extension AppCore {
+    /// Move `featureID`'s tab out of `from`.
+    ///
+    /// The ordering is the whole correctness story: the source releases the tab
+    /// **before** the destination asks for it. Both writes land on the same
+    /// main-actor turn through `persistTabs` → `noteOpenFeatures`, so an
+    /// exclusive feature is never registered in two windows at once and the
+    /// destination never comes up on the collision banner for a session that is
+    /// already gone.
+    func completeHandoff(_ featureID: String, from: WorkspaceID, to destination: HandoffDestination) {
+        guard let source = workspace(id: from),
+              source.canDetach(featureID, to: destination) else { return }
+        if case .window(let target, _) = destination, target == from { return }
+        // Asking for a window we cannot open would detach the tab into nowhere.
+        // Checked before anything is given up, never after.
+        if case .newWindow = destination, !canOpenWindow { return }
+
+        let record = source.windowRecord
+        let carry = source.detachTab(featureID)
+
+        switch destination {
+        case .window(let target, let slot):
+            guard let receiver = workspace(id: target) else {
+                // The window went away between the drop and here (⌘Q, a script).
+                // Put the tab back rather than dropping it on the floor.
+                source.adoptHandoff(featureID, carrying: carry, at: nil)
+                return
+            }
+            receiver.adoptHandoff(featureID, carrying: carry, at: slot)
+            reconcileSharedSessions()
+            focusWindow(target)
+
+        case .newWindow(let frame):
+            let seeded = openSeededWindow(WindowSeed(
+                state: TabHandoff.seed(
+                    featureID: featureID,
+                    from: record,
+                    newID: .generate(),
+                    carrying: carry),
+                frame: frame,
+                runOnAll: source.runOnAll,
+                sidebarHidden: true,
+                handoffFeatureID: featureID))
+            if !seeded { source.adoptHandoff(featureID, carrying: carry, at: nil) }
+        }
+    }
+
+    /// Stop an app-wide session that a handoff left with no window showing it.
+    ///
+    /// `stopBackgroundWork` deliberately skips the Reactotron relay for a
+    /// *moving* tab, because the tab is about to reopen and stopping the relay
+    /// would drop every connected client for nothing. This is the other half of
+    /// that bargain: once the move has landed, if no window has the tab after
+    /// all, the relay stops here instead of running on with no way to reach it.
+    func reconcileSharedSessions() {
+        guard reactotronSession.isRunning, !mcp.keepsRelayAlive else { return }
+        let openAnywhere = registry.entries.contains { $0.openFeatureIDs.contains("reactotron") }
+        guard !openAnywhere else { return }
+        Task { await reactotronSession.stop() }
+    }
+}
+
+// MARK: - Menu
+
+/// Tab ▸ Move Tab to New Window / Move Tab to Window.
+///
+/// Its own `View` rather than inline in the scene for the reason
+/// `MirrorWindowCommands` is: the app's `body` is one large `some Scene`
+/// expression, and CI's type-checker is already close to its limit on it.
+struct TabHandoffCommands: View {
+    let core: AppCore
+
+    private var state: AppState? { core.frontmost }
+    private var activeTab: String? { state?.activeTabID }
+    private var canMoveOut: Bool {
+        guard let state, let activeTab else { return false }
+        return state.canDetachTabToNewWindow(activeTab)
+    }
+
+    private var canMoveToWindow: Bool {
+        guard let state, let activeTab else { return false }
+        return state.canDetachTab(activeTab)
+    }
+
+    var body: some View {
+        Button("Move Tab to New Window") {
+            guard let state, let activeTab else { return }
+            state.beginHandoff(activeTab, to: .newWindow(frame: nil))
+        }
+        .keyboardShortcut("n", modifiers: [.command, .control])
+        .disabled(!canMoveOut)
+
+        let targets = state?.handoffTargets ?? []
+        if !targets.isEmpty {
+            Menu("Move Tab to Window") {
+                ForEach(targets, id: \.id) { target in
+                    Button(target.label) {
+                        guard let state, let activeTab else { return }
+                        state.beginHandoff(activeTab, to: .window(target.id, slot: nil))
+                    }
+                }
+            }
+            .disabled(!canMoveToWindow)
+        }
+    }
+}

--- a/App/Sources/State/WindowHandoff.swift
+++ b/App/Sources/State/WindowHandoff.swift
@@ -52,7 +52,7 @@ struct TabDrag: Equatable {
 /// The handoff half is deliberately a `WindowState` — the same record a window
 /// persists — so the receiving window restores through the path a relaunch
 /// already uses, and the two can never drift apart.
-struct WindowSeed: Equatable {
+struct WindowSeed {
     /// The device a plain new window was opened for (⇧⌘N, "New Window for
     /// Device"). Unused when `state` is set, which carries its own.
     var serial: String?
@@ -66,6 +66,10 @@ struct WindowSeed: Equatable {
     var runOnAll = false
     /// A torn-off window opens focused on its one feature. Reversible with ⌘B.
     var sidebarHidden = false
+    /// Live sessions travelling with the moved tab, adopted when the window
+    /// binds. Reference-typed, which is the point — this is the running work
+    /// itself, not a description of it.
+    var sessions = AppState.MovedSessions()
     /// The tab this window is being opened to receive, if any — the marker that
     /// lets `AppCore` tell a handoff's window from any other new one.
     var handoffFeatureID: String?
@@ -82,10 +86,8 @@ extension AppState {
     func beginHandoff(_ featureID: String, to destination: HandoffDestination) {
         guard canDetach(featureID, to: destination) else { return }
         if case .window(let target, _) = destination, target == id { return }
-        if featureID == TabHandoff.terminalFeatureID, !terminals.tabs.isEmpty {
-            terminalClosePrompt = .handoff(destination)
-            return
-        }
+        // No terminal confirmation here, unlike `closeTab`: the shells are not
+        // killed by a move, they cross with the tab (`MovedSessions`).
         if exitGuards[featureID] != nil {
             holdBehindGuard(.handoff(featureID, destination))
             return
@@ -154,15 +156,23 @@ extension AppCore {
 
         let record = source.windowRecord
         let carry = source.detachTab(featureID)
+        // Collected straight after the detach that took them, so nothing else
+        // can observe the source holding sessions it has already given up.
+        let sessions = source.pendingMovedSessions
+        source.pendingMovedSessions = AppState.MovedSessions()
 
         switch destination {
         case .window(let target, let slot):
             guard let receiver = workspace(id: target) else {
                 // The window went away between the drop and here (⌘Q, a script).
-                // Put the tab back rather than dropping it on the floor.
+                // Put the tab back rather than dropping it on the floor — and
+                // its live sessions with it, or the move would have killed the
+                // very work it was meant to preserve.
+                source.adoptMovableSessions(sessions)
                 source.adoptHandoff(featureID, carrying: carry, at: nil)
                 return
             }
+            receiver.adoptMovableSessions(sessions)
             receiver.adoptHandoff(featureID, carrying: carry, at: slot)
             reconcileSharedSessions()
             focusWindow(target)
@@ -177,8 +187,12 @@ extension AppCore {
                 frame: frame,
                 runOnAll: source.runOnAll,
                 sidebarHidden: true,
+                sessions: sessions,
                 handoffFeatureID: featureID))
-            if !seeded { source.adoptHandoff(featureID, carrying: carry, at: nil) }
+            if !seeded {
+                source.adoptMovableSessions(sessions)
+                source.adoptHandoff(featureID, carrying: carry, at: nil)
+            }
         }
     }
 

--- a/App/Sources/State/WindowHandoff.swift
+++ b/App/Sources/State/WindowHandoff.swift
@@ -91,21 +91,12 @@ extension AppState {
         // A guard means "leaving destroys this work" — but for a feature whose
         // work crosses with the tab, a move destroys nothing, so asking would be
         // asking about a loss that is not going to happen.
-        if exitGuards[featureID] != nil, !Self.workSurvivesAMove.contains(featureID) {
+        if let guarded = exitGuards[featureID], !guarded.survivesAMove {
             holdBehindGuard(.handoff(featureID, destination))
             return
         }
         core.completeHandoff(featureID, from: id, to: destination)
     }
-
-    /// Features whose in-flight work travels with the tab, so moving one needs
-    /// no confirmation even though closing it would.
-    ///
-    /// Only the screen recorder qualifies today: it writes through a headless
-    /// session that owes nothing to its view. The performance and network
-    /// captures are fed by a sampler the view owns, so a move really does stop
-    /// them and they keep their prompt.
-    static let workSurvivesAMove: Set<String> = ["screen-record"]
 
     /// Whether this tab can go to that destination. A window of its own needs
     /// something to stay behind here; another *open* window does not, because

--- a/App/Tests/TabDetachPolicyTests.swift
+++ b/App/Tests/TabDetachPolicyTests.swift
@@ -1,0 +1,80 @@
+import CoreGraphics
+import Foundation
+import Testing
+
+/// When releasing a dragged tab means "give this its own window".
+@Suite struct TabDetachPolicyTests {
+    /// Two windows side by side with a gap of desktop between them.
+    private let windows = [
+        CGRect(x: 0, y: 0, width: 800, height: 600),
+        CGRect(x: 1000, y: 100, width: 600, height: 400),
+    ]
+
+    // MARK: - isInsideApp
+
+    @Test func aPointInsideAWindowIsInsideTheApp() {
+        #expect(TabDetachPolicy.isInsideApp(point: CGPoint(x: 400, y: 300), windowFrames: windows))
+        #expect(TabDetachPolicy.isInsideApp(point: CGPoint(x: 1200, y: 200), windowFrames: windows))
+    }
+
+    @Test func aPointInTheGapBetweenTwoWindowsIsOutside() {
+        #expect(!TabDetachPolicy.isInsideApp(point: CGPoint(x: 900, y: 300), windowFrames: windows))
+    }
+
+    @Test func aPointBeyondEveryWindowIsOutside() {
+        #expect(!TabDetachPolicy.isInsideApp(point: CGPoint(x: 3000, y: 1500), windowFrames: windows))
+    }
+
+    /// The app with every window closed — background mode, where a drag cannot
+    /// be in flight at all, but the arithmetic must not claim the point is
+    /// somehow inside.
+    @Test func noWindowsMeansEveryPointIsOutside() {
+        #expect(!TabDetachPolicy.isInsideApp(point: .zero, windowFrames: []))
+    }
+
+    @Test func aPointOnAWindowsEdgeCountsAsInside() {
+        // `CGRect.contains` excludes the far edges, so check the near ones —
+        // the case that matters is a drop right on the window's own border not
+        // being read as "outside the app".
+        #expect(TabDetachPolicy.isInsideApp(point: CGPoint(x: 0, y: 0), windowFrames: windows))
+    }
+
+    // MARK: - shouldTearOff
+
+    @Test func aRefusedDropAwayFromTheAppTearsOff() {
+        #expect(TabDetachPolicy.shouldTearOff(
+            accepted: false, cancelled: false,
+            point: CGPoint(x: 900, y: 300), windowFrames: windows))
+    }
+
+    /// A drop a strip or pane already handled must not *also* open a window,
+    /// or every cross-window drag would leave a stray one behind.
+    @Test func anAcceptedDropNeverTearsOff() {
+        #expect(!TabDetachPolicy.shouldTearOff(
+            accepted: true, cancelled: false,
+            point: CGPoint(x: 900, y: 300), windowFrames: windows))
+    }
+
+    /// Escape reports exactly like a refused drop, so without the flag this
+    /// point — out over the desktop — would open a window the user was in the
+    /// middle of cancelling.
+    @Test func anEscapeCancelNeverTearsOff() {
+        #expect(!TabDetachPolicy.shouldTearOff(
+            accepted: false, cancelled: true,
+            point: CGPoint(x: 900, y: 300), windowFrames: windows))
+    }
+
+    /// Released on the app's own dead chrome: a miss, not a request. It snaps
+    /// back rather than spawning a window beside the one it came from.
+    @Test func aRefusedDropInsideTheAppSnapsBackInstead() {
+        #expect(!TabDetachPolicy.shouldTearOff(
+            accepted: false, cancelled: false,
+            point: CGPoint(x: 400, y: 300), windowFrames: windows))
+    }
+
+    @Test func aCancelInsideTheAppAlsoDoesNothing() {
+        #expect(!TabDetachPolicy.shouldTearOff(
+            accepted: false, cancelled: true,
+            point: CGPoint(x: 400, y: 300), windowFrames: windows))
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -563,6 +563,15 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     window keeps its editor in the view instead: it is not a tab, cannot move,
     and reads whichever workspace is frontmost, so a store entry would be
     shared with the other pop-outs.
+  - **A live mirror moves with its tab, layer and all.** `MirrorTabModel` /
+    `MirrorWallTabModel` keep the sessions in `FeatureStateStore`, and the
+    receiving view adopts the same display layer. Two rules fall out:
+    `MirrorLayerNSView.syncDisplayLayerFrame` sizes the layer only when
+    `displayLayer.superlayer === layer` (both views are alive for a moment
+    during a move, and the departing one still lays out), and the device claim
+    is released in `stopBackgroundWork` — for a handoff too — rather than in
+    `onDisappear`, because with the session preserved there is no reconnect
+    afterwards to re-publish it. The window it lands in publishes from `.task`.
   - **A live NSView can only be mounted by the window that owns its session.**
     `NativeTerminalView` re-parents one cached terminal view into whatever
     container SwiftUI hands it. During a move the receiving pane *and* the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,18 +526,36 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     skips them on `.handoff`; per-window session objects (`TerminalManager`,
     `JSConsoleSession`, `ApkStudioSession`) cross in `MovedSessions`, leaving a
     fresh one behind; everything else keeps its state in a model held per
-    (window, feature) by **`FeatureStateStore`**, which is *not* `@Observable`
-    on purpose — views resolve their model from `body` and resolving creates
-    one, so an observed container would loop. A feed must also clear its buffer
+    (window, feature, model type) by **`FeatureStateStore`**, which is *not*
+    `@Observable` on purpose — views resolve their model from `body` and
+    resolving creates one, so an observed container would loop. The type is
+    part of the key because one tab can keep two unrelated things (the mirror's
+    session and, while a capture is open, the screenshot editor's markup); they
+    move and are discarded together. A feed must also clear its buffer
     only when the *question* changed (`bufferKey`), not on every `.task(id:)`
     restart, and must not replay into a buffer that already holds those lines
     (`-T 0` on a keeping restart). A *screen recording* moves too — it
     writes through a headless session and the view only polls it for a preview
     — so its abort and file deletion had to leave `onDisappear` (which also
-    runs on a move) for `stopBackgroundWork`, and `workSurvivesAMove` stops the
-    leave guard asking about a loss that will not happen. Performance and
+    runs on a move) for `stopBackgroundWork`. Performance and
     Network Speed do *not* move: their sampler dies with the view, so a
     preserved buffer would have a silent gap.
+  - **A leave guard whose work travels says so, per guard.**
+    `ExitGuard.survivesAMove` stops a move asking about a loss that will not
+    happen (the screen recorder's take, the screenshot editor's markup) while
+    closing the tab still asks. It is on the guard rather than the feature id
+    because one id can carry either kind — the mirror's recording guard and its
+    screenshot editor's both key on `scrcpy`. The far side has to *re-arm* it
+    from `.task`: the new window inherits none of the old one's guards, and
+    `onChange` won't fire because nothing about the work changed.
+  - **A view that embeds in several tabs keys its state by `tabFeatureID`.**
+    The screenshot editor opens inside the Screenshot tab, the mirror and the
+    Mirror Wall, so `ScreenshotEditorModel` is resolved per tab id and its
+    `image` doubles as "is an editor open here" — the hosts ask the model
+    instead of each keeping a flag that a move would lose. The pop-out mirror
+    window keeps its editor in the view instead: it is not a tab, cannot move,
+    and reads whichever workspace is frontmost, so a store entry would be
+    shared with the other pop-outs.
   - **A live NSView can only be mounted by the window that owns its session.**
     `NativeTerminalView` re-parents one cached terminal view into whatever
     container SwiftUI hands it. During a move the receiving pane *and* the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,6 +519,29 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     an exclusive feature comes up on its own collision banner. Two windows on
     one device is now the normal case, not the unusual one. See
     `docs/multi-window.md`.
+  - **A moved tab keeps its state, and where that state lives decides how.**
+    Moving a tab rebuilds its view, so `@State` is lost — true of a cross-pane
+    move too, not just tear-off. Three routes: app-wide sessions (the
+    Reactotron relay) just carry on, and `stopBackgroundWork(for:reason:)`
+    skips them on `.handoff`; per-window session objects (`TerminalManager`,
+    `JSConsoleSession`, `ApkStudioSession`) cross in `MovedSessions`, leaving a
+    fresh one behind; everything else keeps its state in a model held per
+    (window, feature) by **`FeatureStateStore`**, which is *not* `@Observable`
+    on purpose — views resolve their model from `body` and resolving creates
+    one, so an observed container would loop. A feed must also clear its buffer
+    only when the *question* changed (`bufferKey`), not on every `.task(id:)`
+    restart, and must not replay into a buffer that already holds those lines
+    (`-T 0` on a keeping restart). Captures — Screen Record, Performance,
+    Network Speed — deliberately do *not* move: their sampler dies with the
+    view, so a preserved buffer would have a silent gap.
+  - **A live NSView can only be mounted by the window that owns its session.**
+    `NativeTerminalView` re-parents one cached terminal view into whatever
+    container SwiftUI hands it. During a move the receiving pane *and* the
+    departing window's final update pass both run against real, live windows,
+    so `container.window != nil` cannot tell them apart — the departing one won
+    and re-parented the live terminal into an orphaned tree, leaving an empty
+    black pane over a healthy shell. The pane asks its own window whether it
+    still owns the shell (`TerminalManager.owns`) instead.
   - **Only the windows after the first tint their device icon**
     (`DeviceTint`); the app keeps one accent.
   - **A feature that can't run twice on one device** goes in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,13 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     screenshot editor's both key on `scrcpy`. The far side has to *re-arm* it
     from `.task`: the new window inherits none of the old one's guards, and
     `onChange` won't fire because nothing about the work changed.
+  - **A `.task(id:)` fires on every mount, so anything expensive behind one
+    needs a "same question?" key.** `.task(id: apkURL|mode)` re-ran jadx from
+    the top on a move, because the id had not changed — only the window had.
+    `DecompileModel.treeKey` and `VideoEditorModel.builtFor` record what the
+    kept result was produced for, and the task returns early when it matches.
+    The work *in flight* still dies with the view (SwiftUI cancels the task),
+    which is the honest read: nothing else owns it.
   - **A view that embeds in several tabs keys its state by `tabFeatureID`.**
     The screenshot editor opens inside the Screenshot tab, the mirror and the
     Mirror Wall, so `ScreenshotEditorModel` is resolved per tab id and its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,9 +531,13 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     one, so an observed container would loop. A feed must also clear its buffer
     only when the *question* changed (`bufferKey`), not on every `.task(id:)`
     restart, and must not replay into a buffer that already holds those lines
-    (`-T 0` on a keeping restart). Captures — Screen Record, Performance,
-    Network Speed — deliberately do *not* move: their sampler dies with the
-    view, so a preserved buffer would have a silent gap.
+    (`-T 0` on a keeping restart). A *screen recording* moves too — it
+    writes through a headless session and the view only polls it for a preview
+    — so its abort and file deletion had to leave `onDisappear` (which also
+    runs on a move) for `stopBackgroundWork`, and `workSurvivesAMove` stops the
+    leave guard asking about a loss that will not happen. Performance and
+    Network Speed do *not* move: their sampler dies with the view, so a
+    preserved buffer would have a silent gap.
   - **A live NSView can only be mounted by the window that owns its session.**
     `NativeTerminalView` re-parents one cached terminal view into whatever
     container SwiftUI hands it. During a move the receiving pane *and* the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,15 @@ Node 22 in CI; scroll reveals and the hero palette demo must keep their
   `FeatureEngine` (runner dispatch +
   `implementedIDs` + every sub-service), `SidebarOrdering`
   (pure `reorder`/`move`/`moveToEnd` helpers for the sidebar, unit-tested
-  without UI), `WorkspaceRegistry` (the multi-window model: `WorkspaceID`,
+  without UI), `Workspace` (the tab/pane model — `canDetach` vs
+  `canDetachToNewWindow`: a window's *last* tab may move to another open window,
+  consolidating two windows, but not to one of its own), `TabHandoff` (what a
+  moved tab takes with it — its source's device and bundle, and the terminal
+  directories or wall devices only the feature that owns them),
+  `TabDropRouter` (the one table deciding what a dropped tab does — the
+  tab-drag twin of `FileDropRouter`) and `TearOffFrame` (where a dragged-out
+  window lands; screen coordinates are y-up and strip insets y-down, which is
+  the whole reason it is tested rather than inlined), `WorkspaceRegistry` (the multi-window model: `WorkspaceID`,
   which window owns which device, `exclusiveFeatureIDs` + the conflict
   queries behind the Focus / Take Over banner, and the window tint slot —
   nil for the first window, which keeps the app accent), `WindowEffects` (pure math for the translucent-window
@@ -498,6 +506,19 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     controls stay — the wall keeps its header row, which is where the exit
     button lives. The menu key equivalent is the exit that always works: a
     mirror view swallows key events that reach it, but NSMenu sees them first.
+  - **A torn-off window inherits its source's device — it must never re-pick.**
+    Any tab can leave its window (right-click ▸ Open in New Window, ⌃⌘N, Move
+    to Window ▸, or dragging the chip out of the app), and it becomes an
+    *ordinary* workspace window rather than a bespoke host — the pop-out mirror
+    is what the alternative costs. Every other route to a new window
+    deliberately lands on a device no other window holds (`firstFreeSerial`);
+    for a moved tab that silently swaps the device out from under it. The seed
+    is a `WindowState` (`TabHandoff.seed`), so the receiver restores through the
+    path a relaunch already uses. Ordering is load-bearing: the source releases
+    the tab **before** the destination asks for it, on one main-actor turn, or
+    an exclusive feature comes up on its own collision banner. Two windows on
+    one device is now the normal case, not the unusual one. See
+    `docs/multi-window.md`.
   - **Only the windows after the first tint their device icon**
     (`DeviceTint`); the app keeps one accent.
   - **A feature that can't run twice on one device** goes in
@@ -618,6 +639,34 @@ table) is in `docs/reactotron-mcp-analysis.md`.
     the subset a feature claims and hands the rest to `FileDropRouter`; every
     full-pane URL zone (APK Studio, Install App, the package screen, AAB, the
     video editor, inspector, signer, decompiler) goes through it.
+  - **A tab drag is app-wide, and every window has to know.** A tab can be
+    dragged into a window that did not start the drag, or out of the app
+    entirely, so the drag lives on `AppCore.tabDrag`;
+    `AppState.draggingTabID` narrows it to "a tab from *this* window", which is
+    what the existing callers ask. Three places must read the app-wide one or
+    a cross-window drag breaks silently: every window's drop targets, every
+    window's `EditorPane` shield overlay (without it, dragging into a window
+    whose active tab is APK Studio does nothing), and the hidden-tab
+    file-drop gate. Write it **twice per drag, never per move** — `AppCore` is
+    `@Observable` and `RootView.body` reads it, so a per-move write re-renders
+    every open window on every mouse move; the insertion guideline stays in the
+    strip's own `@State`, and the window frames the release decision needs are
+    captured once per session.
+  - **Only an `NSDraggingSource` can answer "was it accepted, and where?"**
+    SwiftUI's `.onDrag` reports neither, which is why the tab chip's drag is an
+    AppKit session started from a `DragGesture` (the pasteboard item is
+    unchanged, so every `.onDrop(of: [.workspaceTab])` target still accepts it).
+    Consequences worth knowing: SwiftUI's gesture is cancelled the moment the
+    drag loop takes the mouse, so **its `onEnded` cannot re-arm anything** — a
+    local "already started" flag latches on and the just-dragged chip becomes
+    undraggable; guard on the live drag instead. The chip's view is gone by the
+    time an *accepted* drop reports back, so the geometry it needs is captured
+    at drag start. Escape reads exactly like a refused drop, at wherever the
+    cursor sits. And `WindowGroup` keeps one frame autosave for the whole group
+    (`main-AppWindow-1`, re-stamped over the `droidective-main-N` name RootView
+    sets — which is why no such frame is ever written) and restores it *after*
+    the window accessor runs, so an explicitly placed window re-asserts its
+    frame a runloop turn later.
   - **`isTargeted` says *that* something is over the view, never *what*.** The
     hover announcement reads the in-flight drag pasteboard
     (`DragPasteboard.droppedPaths()`), which AppKit keeps populated for the

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -218,6 +218,31 @@ survives a move, and is re-armed on the far side from `.task` rather than
 `onChange`, because `dirty` has not changed by the time the new window builds
 the view — only the window it is being read in has.
 
+**A decompiled APK moves with its tab.** jadx and apktool take *minutes* on a
+real APK and produce tens of thousands of files, and the browser used to re-run
+the decompiler from the top on every remount, because `.task(id:)` fires on
+mount and its id — the APK and the decompiler — had not changed. `DecompileModel`
+keeps the tree, the open file and the search, and records in `treeKey` which
+question produced the tree: a remount asking the same one keeps its answer, a
+different APK or decompiler still re-runs. The tools check is skipped the same
+way, so a move doesn't flash the setup gate on its way back to the browser. The
+decompile *in flight* does not survive — it belongs to the view's `.task`, which
+SwiftUI cancels on unmount — and neither does the file tree's expansion, which
+`OutlineGroup` keeps to itself.
+
+**A video and its edits move with their tab.** Two expensive things live in the
+video editor. The **edits** — trim, rotate, crop, speed, and the undo stack
+behind them — are unsaved work: nothing is written until Export. The **proxy**
+is an MP4 ffmpeg builds when AVFoundation can't play the source (an AV1 `.mp4`,
+most `.mkv`), which for a long recording is a transcode of the whole file.
+`VideoEditorModel` holds both, plus the `AVPlayer` itself, so a move doesn't
+reload, re-buffer or lose the playhead; `builtFor` records which source the
+player was built for, so `.task(id:)` can tell a remount from a new video.
+Verified against an AV1 `.mkv`: after the move the video played immediately and
+`droidective-proxy-*` in the temp directory was still the same single file, with
+its original timestamp — and closing the tab deleted it while leaving the
+user-opened source alone.
+
 **Performance and Network Speed deliberately do not move.** Unlike the
 recorder, they are fed by a sampler the view owns, so a preserved buffer with
 the sampler stopped mid-move would have a silent gap in it — worse than being

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -161,8 +161,12 @@ Two consequences fall out of a moved tab keeping its device:
 Moving a tab unmounts its view exactly as closing it does, so the same two
 confirmations apply, checked in the order `closeTab` checks them:
 
-- a live recording or unsaved edit → `PendingExit.handoff`, reworded ("Moving
-  Screen Record to a new window stops the recording.");
+- a live recording or unsaved edit → `PendingExit.handoff`, which reuses the
+  guard the feature registered ("Recording in progress — leaving will stop the
+  screen recording. Save it first, or discard it.") with its usual Stop & Save /
+  Discard / Keep Recording. The wording is the *guard's*, not the destination's,
+  and stays accurate because a move is a kind of leaving — the guard describes
+  the work at risk, which is the same whichever way the tab goes;
 - open terminal shells → `TerminalClosePrompt.handoff` ("…closes 3 shells. They
   reopen in the same directories."). Not silent, because killing someone's
   running `npm start` should not be — and the directories ride into the seed via

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -190,10 +190,24 @@ Two details decide whether a preserved buffer actually *looks* right:
   live edge instead: measured over the same 5 s move, +342 lines before, +39
   after — the live rate.
 
-**Captures deliberately do not move.** Screen Record, Performance and Network
-Speed are fed by a sampler the view owns; a preserved buffer with the sampler
-stopped mid-move would have a silent gap in it, which is worse than being told.
-They keep their leave guard, and a move asks the same question a close does.
+**A screen recording moves with its tab.** The recorder writes through a
+headless scrcpy session that owes nothing to the view — the view only polls it
+for a preview frame — so a move re-arms the preview, the device lock and the
+leave guard in the receiving window and the take never stops. Moving therefore
+asks nothing (`workSurvivesAMove`), while *closing* still does: the abort and
+the file deletion moved out of `onDisappear`, which also runs on a move, into
+`stopBackgroundWork(for:reason:)` where close and move are told apart. A
+finished take awaiting Save/Discard/Edit travels too — it is a file the user has
+not decided about yet. Verified end to end: recording started, tab moved
+mid-take, stopped in the new window, one continuous 48.02 s file whose duration
+matches wall-clock start to stop; and closing still prompts, discards, and
+leaves no scrcpy process behind.
+
+**Performance and Network Speed deliberately do not move.** Unlike the
+recorder, they are fed by a sampler the view owns, so a preserved buffer with
+the sampler stopped mid-move would have a silent gap in it — worse than being
+told. They keep their leave guard, and a move asks the same question a close
+does.
 
 ### Guards
 

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -243,6 +243,34 @@ Verified against an AV1 `.mkv`: after the move the video played immediately and
 its original timestamp — and closing the tab deleted it while leaving the
 user-opened source alone.
 
+**A live mirror moves with its tab.** A mirror is the most expensive thing a
+tab can hold — a scrcpy server on the device, a video encoder, an `adb forward`
+tunnel and a decoder on this side — and the Mirror Wall holds up to six at once.
+Moving used to stop all of it and start again: a "Connecting…" flash, a second
+of black while the device re-primed, and a recording lost. `MirrorTabModel` and
+`MirrorWallTabModel` keep the sessions, and the receiving window's view adopts
+the same `AVSampleBufferDisplayLayer` (`MirrorLayerNSView.adopt(displayLayer:)`,
+which existed for the reconnect case and now earns its keep twice). Two rules
+came out of it:
+
+- **Only the view the layer currently belongs to may size it.** During a move
+  both views are alive for a moment and the one being torn down still lays out;
+  `syncDisplayLayerFrame` checks `displayLayer.superlayer === layer` first. This
+  is the mirror's version of the terminal's `owns` rule.
+- **A window stops claiming the device when the tab leaves it, whichever way it
+  leaves.** The claim used to be released in `onDisappear`, which also runs on a
+  move — and with the session preserved there was no later reconnect to
+  re-publish it. It is released in `stopBackgroundWork` for both reasons now,
+  and the receiving window publishes from `.task`; a cross-pane move reaches
+  neither, which is right, because the claim never changed windows.
+
+Verified against a live emulator: `adb forward --list` showed the *same* port
+and abstract socket name before and after a move to a new window, after a
+cross-pane drop-to-split, and after moving the wall; touch and keyboard still
+reached the device; and a recording started before the move and stopped after it
+came out as one continuous 67.66 s file. Closing the tab, closing the window and
+quitting each left the list empty.
+
 **Performance and Network Speed deliberately do not move.** Unlike the
 recorder, they are fed by a sampler the view owns, so a preserved buffer with
 the sampler stopped mid-move would have a silent gap in it — worse than being

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -156,6 +156,45 @@ Two consequences fall out of a moved tab keeping its device:
   `tintIndex(ofWindow:paletteSize:)` guarantees no two collide. The title
   carries the device name.
 
+### A moved tab keeps its state
+
+Moving a tab destroys and recreates its view, so anything in `@State` goes with
+it. That was already true of moving a tab across a split; tear-off just made it
+something you would actually do. A move that throws away a log buffer is a
+restart wearing a move's clothes, so state worth keeping lives outside the view.
+
+Three mechanisms, by where the state already lived:
+
+| | How it travels |
+| --- | --- |
+| **Reactotron** | Nothing to do — its relay is app-wide, owned by `AppCore`, and `stopBackgroundWork` skips it on a handoff so clients are not dropped for a tab that is about to reopen. |
+| **Terminal, JS Console, APK Studio** | Their state is an object owned by the *window* (`TerminalManager`, `JSConsoleSession`, `ApkStudioSession`). The object crosses in `MovedSessions` and the window it left gets a fresh one. Live shells keep running: verified with a background loop still printing in the new window, and an unchanged shell pid list across the move. |
+| **Logcat, iOS Logs, Crash Catcher, API Testing, File Explorer** | Their state was view `@State`. It moved into a model object held per (window, feature) by **`FeatureStateStore`**, which re-keys the entry on a handoff and drops it when the tab closes. |
+
+`FeatureStateStore` is **deliberately not `@Observable`.** Views resolve their
+model from `body`, and resolving creates one on first use — a write. An observed
+container would invalidate the view that just read it, whose re-render would
+write again: the endless update loop, not a wasted pass. The models are
+observable; the container holding them must not be. (Same reason `LogRowFrames`
+and `MainThreadLoad` are plain reference boxes.)
+
+Two details decide whether a preserved buffer actually *looks* right:
+
+- **Clear on a changed question, not on every restart.** A feed's `.task(id:)`
+  restarts when the view is merely rebuilt, so the buffer is dropped only when
+  the device, level or app filter changed — `bufferKey` records what the buffer
+  was collected under.
+- **Don't replay into a buffer that already holds it.** `adb logcat -T n` opens
+  by reprinting the device's last n lines, so a restart over a kept buffer
+  showed its recent history twice. A restart that keeps its buffer starts at the
+  live edge instead: measured over the same 5 s move, +342 lines before, +39
+  after — the live rate.
+
+**Captures deliberately do not move.** Screen Record, Performance and Network
+Speed are fed by a sampler the view owns; a preserved buffer with the sampler
+stopped mid-move would have a silent gap in it, which is worse than being told.
+They keep their leave guard, and a move asks the same question a close does.
+
 ### Guards
 
 Moving a tab unmounts its view exactly as closing it does, so the same two

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -271,6 +271,28 @@ reached the device; and a recording started before the move and stopped after it
 came out as one continuous 67.66 s file. Closing the tab, closing the window and
 quitting each left the list empty.
 
+**The Apps list and every typed draft move with their tab.** Reading every
+installed app is a couple of seconds and a handful of `adb shell` round trips,
+and the view used to do it again on each mount, so a move dropped the list, the
+search, the scope and the selected app and made the user wait for something they
+were already looking at; `AppsExplorerModel.loadedSerial` records which device
+the list came from, so only a device switch re-reads. `SendTextModel`,
+`DeepLinkDraftModel` and `CustomCommandDraftModel` carry the app's three typing
+surfaces — a message not yet sent, a deep link half typed, a shell command being
+composed. Nothing in them is expensive to produce again except by hand, which is
+the kind that annoys most. The deep-link draft is keyed by tab because its
+section appears both on its own screen and inside the React Native hub, and a
+sheet left open (the command editor) re-presents itself in the receiving window
+with its fields intact.
+
+**Scroll position is not preserved, and that is a limitation rather than a
+decision.** The list, the tree and the buffer all cross, but a moved tab starts
+at the top of them. `scrollPosition(id:)` does not report a `List`'s position
+here — the binding is never written, so there is nothing to put back either —
+which is the same unreliability the JS-console feed ran into. Restoring it
+properly means tracking row frames the way `LogRowFrames` does, which is more
+machinery than the gain justifies for now.
+
 **Performance and Network Speed deliberately do not move.** Unlike the
 recorder, they are fed by a sampler the view owns, so a preserved buffer with
 the sampler stopped mid-move would have a silent gap in it — worse than being

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -194,7 +194,7 @@ Two details decide whether a preserved buffer actually *looks* right:
 headless scrcpy session that owes nothing to the view — the view only polls it
 for a preview frame — so a move re-arms the preview, the device lock and the
 leave guard in the receiving window and the take never stops. Moving therefore
-asks nothing (`workSurvivesAMove`), while *closing* still does: the abort and
+asks nothing (`ExitGuard.survivesAMove`), while *closing* still does: the abort and
 the file deletion moved out of `onDisappear`, which also runs on a move, into
 `stopBackgroundWork(for:reason:)` where close and move are told apart. A
 finished take awaiting Save/Discard/Edit travels too — it is a file the user has
@@ -202,6 +202,21 @@ not decided about yet. Verified end to end: recording started, tab moved
 mid-take, stopped in the new window, one continuous 48.02 s file whose duration
 matches wall-clock start to stop; and closing still prompts, discards, and
 leaves no scrcpy process behind.
+
+**An unsaved screenshot moves with its tab.** The annotation editor writes
+nothing to disk until Save or Copy, so everything in it — the capture, the
+markup, the undo history that can take any of it back — is work that exists
+only in the app. `ScreenshotEditorModel` holds all of it, including the capture
+itself: `image` doubles as "is an editor open in this tab", so the three hosts
+(the Screenshot tab, the mirror, the Mirror Wall) ask the model rather than each
+keeping a flag of their own, and none of them can lose the editor by losing
+their own state. The pop-out mirror window is the one exception and keeps its
+editor in the view: it is not a tab, so it cannot move, and it reads whichever
+workspace is frontmost — a `FeatureStateStore` entry would be shared with the
+other pop-outs and would follow the user between windows. Its leave guard also
+survives a move, and is re-armed on the far side from `.task` rather than
+`onChange`, because `dirty` has not changed by the time the new window builds
+the view — only the window it is being read in has.
 
 **Performance and Network Speed deliberately do not move.** Unlike the
 recorder, they are fed by a sampler the view owns, so a preserved buffer with
@@ -214,12 +229,17 @@ does.
 Moving a tab unmounts its view exactly as closing it does, so the same two
 confirmations apply, checked in the order `closeTab` checks them:
 
-- a live recording or unsaved edit → `PendingExit.handoff`, which reuses the
+- a live recording or unsaved edit *that a move would destroy* →
+  `PendingExit.handoff`, which reuses the
   guard the feature registered ("Recording in progress — leaving will stop the
   screen recording. Save it first, or discard it.") with its usual Stop & Save /
   Discard / Keep Recording. The wording is the *guard's*, not the destination's,
   and stays accurate because a move is a kind of leaving — the guard describes
-  the work at risk, which is the same whichever way the tab goes;
+  the work at risk, which is the same whichever way the tab goes. A guard whose
+  work travels (`survivesAMove` — the screen recorder's, the screenshot
+  editor's) skips this and moves silently; the flag is on the *guard* rather
+  than the feature because one feature id can carry either kind, the mirror's
+  recording guard and its screenshot editor's both keying on `scrcpy`;
 - open terminal shells → `TerminalClosePrompt.handoff` ("…closes 3 shells. They
   reopen in the same directories."). Not silent, because killing someone's
   running `npm start` should not be — and the directories ride into the seed via

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -101,6 +101,122 @@ can't grow by one window per launch.
 Everything app-wide (enabled set, sidebar order, role, favorites) stays on
 `LayoutState` itself and is shared by every window.
 
+## Tear-off — a tab into a window of its own
+
+Any tab can leave its window: right-click ▸ **Open in New Window**, Tab ▸ **Move
+Tab to New Window** (⌃⌘N), **Move to Window ▸** for one that is already open, or
+by dragging the chip out of the app and letting go — the window appears where it
+was dropped.
+
+**A torn-off tab becomes an ordinary workspace window.** Not a bespoke host: the
+pop-out mirror is what that costs — ~200 lines of window plumbing for one
+feature that can still only mirror. Because no feature view knows what a device
+is, a real workspace window gives all 32 of them tear-off for free, along with
+persistence, restore, the quit walk, background parking and the ⌘W monitor.
+
+What the new window inherits, and why:
+
+| | |
+| --- | --- |
+| Device + app bundle | **inherited from the source.** Every other route to a new window deliberately picks a device *no other window holds* (`firstFreeSerial`); for a moved tab that would swap the device out from under it — you tore off one phone's logcat and got another's. |
+| `runOnAll` | inherited, so the tab keeps running against the same set |
+| Tabs | exactly the moved one. Home is not seeded — the strip's house button is one click away |
+| Sidebar | hidden, and not persisted: a tear-off means "watch this one thing". ⌘B brings it back |
+| Frame | the source window's size, positioned so the chip lands back under the cursor, clamped onto the drop screen (`TearOffFrame`) |
+| Full View | **not** inherited — it is per window and transient |
+
+### The pieces
+
+| | |
+| --- | --- |
+| `Workspace.canDetach` / `canDetachToNewWindow` / `detach` | ADBKit. Two rules, differing on one case: a window's *last* tab may move to another open window (consolidating two windows, leaving Home behind) but not to a window of its own, which would just be this window moving. |
+| `TabHandoff.seed` | ADBKit. The receiving window's opening state — and it is a `WindowState`, the same record a window persists, so the receiver restores through the path a relaunch already uses. No second restore path to drift. |
+| `TabDropRouter` | ADBKit. The one table deciding what a dropped tab does, the tab-drag twin of `FileDropRouter`. |
+| `TearOffFrame` | ADBKit, pure geometry. Screen coordinates are y-up, strip insets y-down; the two conventions meeting is why it is worth testing rather than inlining. |
+| `AppState.beginHandoff` | The single entry point for every route, so the confirmations are handled once. |
+| `AppCore.completeHandoff` | Performs it. |
+| `TabDragSource` / `TabDetachPolicy` | App. The AppKit dragging session and the release decision. |
+
+### Ordering is the whole correctness story
+
+The source releases the tab **before** the destination asks for it. Both writes
+land on one main-actor turn through `persistTabs` → `noteOpenFeatures`, so an
+exclusive feature (`scrcpy`, `js-console`) is never registered in two windows at
+once and the destination never comes up on the collision banner for a session
+that has already gone. Verified live: moving a live mirror between windows keeps
+`adb forward --list` at exactly one `scrcpy_*` entry — the old tunnel removed,
+one new one added.
+
+Two consequences fall out of a moved tab keeping its device:
+
+- **Two windows on one device is now the normal case**, not the unusual one.
+  The registry already tolerated it; `owner(ofDevice:)` answers with the first,
+  and `unclaimed(from:)` still treats it as taken so ⇧⌘N prefers a free device.
+- **They tint differently.** The tint tells *windows* apart, not devices, and
+  `tintIndex(ofWindow:paletteSize:)` guarantees no two collide. The title
+  carries the device name.
+
+### Guards
+
+Moving a tab unmounts its view exactly as closing it does, so the same two
+confirmations apply, checked in the order `closeTab` checks them:
+
+- a live recording or unsaved edit → `PendingExit.handoff`, reworded ("Moving
+  Screen Record to a new window stops the recording.");
+- open terminal shells → `TerminalClosePrompt.handoff` ("…closes 3 shells. They
+  reopen in the same directories."). Not silent, because killing someone's
+  running `npm start` should not be — and the directories ride into the seed via
+  `TabHandoff.Carry`, so the new window comes back where it was.
+
+The **Reactotron relay is deliberately not stopped** for a moving tab. It is one
+app-wide listener; stopping it would drop every connected client for a tab that
+is about to reopen. `stopBackgroundWork(for:reason:)` skips it on `.handoff`,
+and `AppCore.reconcileSharedSessions` is the other half of the bargain — if the
+move somehow did not land, the relay stops there rather than running on with no
+window to reach it.
+
+### The drag
+
+SwiftUI's `.onDrag` cannot answer either question a tear-off needs — was the
+drop accepted, and where did it land — and there is no callback that reports
+them. So the chip's drag is a real `NSDraggingSource`, started from a SwiftUI
+`DragGesture`. The item on the pasteboard is unchanged, so every existing
+`.onDrop(of: [.workspaceTab])` target accepts it exactly as before; only the
+source half changed. A `DragGesture` is safe inside the strip's `ScrollView`
+because trackpad scrolling arrives as `scrollWheel` events, which are not
+gestures.
+
+Four things that are easy to get wrong, and are not:
+
+1. **Escape reads exactly like a refused drop**, at wherever the cursor sits —
+   so a cancel out over the desktop would open a window the user was busy *not*
+   asking for. Detected twice over: a local key monitor, and
+   `CGEventSource.keyState` for the key still being held when the session
+   reports back.
+2. **A refused drop *inside* the app is a miss, not a request.** Released on the
+   dead chrome beside the tabs, the tab snaps back.
+3. **`WindowGroup` keeps one frame autosave for the whole group**
+   (`main-AppWindow-1`, re-stamped over the `droidective-main-N` name `RootView`
+   sets — which is why no such frame is ever written), and restores it *after*
+   the accessor runs. A torn-off window's frame is therefore re-asserted on the
+   next runloop turn, or it lands wherever the last window sat.
+4. **The chip's view is gone by the time an accepted drop reports back** — the
+   tab moved to another window and its chip was torn down. The source window's
+   frame and the chip's position are captured at drag *start*; reading them in
+   `endedAt` behind a `guard let window` swallowed the callback entirely.
+
+A tab drag is **app-wide** (`AppCore.tabDrag`), because it can end in another
+window. `AppState.draggingTabID` still means "a tab from *this* window", which
+is what every existing caller asks. Three places had to widen, and they are the
+drop-routing traps CLAUDE.md already documents: every window's drop targets
+validate on the app-wide drag, every window's `EditorPane` shield overlay is
+live during any tab drag (or dragging into a window whose active tab is APK
+Studio silently does nothing), and the hidden-tab file-drop gate reads it too.
+`tabDrag` is written twice per drag and never per move — `AppCore` is
+`@Observable` and `RootView.body` reads it, so a per-move write would re-render
+every open window on every mouse move. The window frames the release decision
+needs are captured once per session for the same reason.
+
 ## Conflict rules
 
 `WorkspaceRegistry` (ADBKit, pure, 24 tests) mirrors each window's device and

--- a/project.yml
+++ b/project.yml
@@ -304,6 +304,10 @@ targets:
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/Root/PaneFreezePolicy.swift
+      # Whether a released tab drag becomes a new window: the three inputs
+      # (accepted / cancelled / over one of our own windows) can't be exercised
+      # through a real drag, so the decision is pulled out and tested here.
+      - App/Sources/Root/TabDetachPolicy.swift
       # FontCatalog.derive — the picker's filter/collation/curated split.
       - App/Sources/AppFont.swift
       # The id → detail-pane table FeatureDetailView switches over, so the


### PR DESCRIPTION
Any tab can now leave its window — and it takes its work with it.

## Tearing a tab off

A feature tab becomes its own window four ways: the chip's context menu
("Open in New Window"), Tab ▸ Move Tab to New Window (⌃⌘N), "Move to
Window ▸" for an already-open window, and dragging the chip out of the
app. A torn-off window is an ordinary workspace window, and it **inherits
its source's device** rather than picking a free one — every other route
to a new window deliberately lands on a device no other window holds,
which for a moved tab would swap the device out from under it.

The pure parts are in ADBKit and tested there: `Workspace.canDetach` vs
`canDetachToNewWindow` (a window's last tab may join another window but
not spawn one), `TabHandoff.seed` (what a moved tab carries — the seed is
a `WindowState`, so the receiving window restores through the path a
relaunch already uses), `TabDropRouter` (the one table deciding what a
dropped tab does) and `TearOffFrame` (where a dragged-out window lands;
screen coordinates are y-up and strip insets y-down, which is why it is
tested rather than inlined).

The drag is a real `NSDraggingSource` started from a SwiftUI
`DragGesture`, because `.onDrag` cannot answer either question a tear-off
needs — was the drop accepted, and where did it land. The pasteboard item
is unchanged, so every existing `.onDrop(of: [.workspaceTab])` target
accepts it exactly as before.

## A moved tab keeps its state

Moving a tab rebuilds its view, so `@State` is lost — true of a cross-pane
move too, not just a tear-off. Three routes, depending on where the state
lives: app-wide sessions (the Reactotron relay) carry on untouched;
per-window session objects (`TerminalManager`, `JSConsoleSession`,
`ApkStudioSession`) cross in `MovedSessions`; everything else lives in a
model held per (window, feature, type) by `FeatureStateStore`.

Preserved now: Reactotron, Terminal (live shells), JS Console, APK Studio,
logcat, iOS logs, Crash Catcher, API Testing, File Explorer, screen
recording, the screenshot annotation editor, the decompiled APK tree, the
video editor, the live mirror and Mirror Wall, the Apps list, and the
typed drafts in Send Text, Deep Links and Custom Commands.

Two mechanisms came out of it. `ExitGuard.survivesAMove` replaces a
feature-id list: a guard says "leaving destroys this work", and for work
that travels a move destroys nothing — but the flag has to be on the
*guard*, because one feature id can carry either kind (the mirror's
recording guard and its screenshot editor's both key on `scrcpy`). And
`FeatureStateStore` keys by model type as well as window and feature,
because one tab can keep two unrelated things — the mirror's session and,
while a capture is open, the editor's markup.

Performance and Network Speed deliberately do **not** move: their sampler
dies with the view, so a preserved buffer would have a silent gap in it,
which is worse than being told.

## Verified live

Against an Android emulator, with before/after captures for each:

- **Screenshot editor** — annotation, tool mode, undo *and* redo stacks
  survived a move; the move asked nothing; closing in the destination
  still prompted "Unsaved screenshot"; Discard left a clean editor.
- **Decompile browser** — the jadx tree and the open `a.java` were there
  immediately after the move, no re-run.
- **Video editor** — with an AV1 `.mkv`, `droidective-proxy-*` was still
  the same single file with its original timestamp after the move; the
  video played at once; closing deleted the proxy and left the source.
- **Mirror and Mirror Wall** — `adb forward --list` showed the *same* port
  and socket name across a move to a new window, a cross-pane
  drop-to-split, and a wall move; touch and keyboard still reached the
  device; a recording started before a move and stopped after came out as
  one continuous **67.66 s** file. Tab close, window close and quit each
  left the list empty.
- **Terminal** — a background loop kept printing across a move and the
  shell PID list was byte-identical.
- **Apps and drafts** — list, scope and selected app survived with no
  re-read; a typed message survived; a command-editor sheet re-presented
  itself in the receiving window with its fields intact.

`make verify` green: ADBKit 2068 (was 2014) · ReactotronMCP 99 ·
droidectived 408 · AppTests 128 (was 118). `make build` zero warnings.
Idle CPU 2–3% with several windows open, RSS flat.

## Known gaps

- **Scroll position is not preserved.** The list, tree or buffer crosses,
  but a moved tab starts at the top of it. `scrollPosition(id:)` does not
  report a `List`'s position here — the binding is never written, so there
  is nothing to restore either, the same unreliability the JS-console feed
  ran into. Doing it properly means tracking row frames the way
  `LogRowFrames` does; that is not in this PR.
- **One unreproduced handoff failure.** Early in testing, one move
  detached the tab and brought up a plain window without it (no device, no
  tab) — consistent with the window binding without consuming its queued
  seed. Instrumented `completeHandoff`/`bind` and re-ran the same sequence
  four times; every run consumed the seed correctly, so there is no fix
  here, only a note that it was seen once.
- The decompile and proxy runs *in flight* still die with the view: they
  belong to a `.task` SwiftUI cancels on unmount, and nothing else owns
  them.
- The file tree's expansion state is `OutlineGroup`'s own and is lost; the
  tree and the selected file are not.
