### PR TITLE
Size feed buffers to the machine, and stop publishing to feeds nobody can see

### DIFF
--- a/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeedFlushCadence.swift
@@ -17,11 +17,25 @@ import Foundation
 /// (DROIDECTIVE-MAC-B: 5087 hangs, and its top `open_features` rows are
 /// single users with 9 to 18 tabs mounted at once).
 ///
-/// **Inactive is slower, never stopped.** Nobody is reading in real time and a
-/// feed streaming behind an unfocused window used to burn CPU for hours — but
-/// pausing outright is worse than pacing: the buffer grows unbounded, and
-/// reactivation hands SwiftUI one enormous flush, which is the same
-/// mass-mutation stall the pacing exists to avoid.
+/// **Inactive is slower, never stopped — but unwatched *is* stopped now.**
+/// A feed streaming behind an unfocused window used to burn CPU for hours, and
+/// the first fix paced it rather than pausing it, for a good reason: pausing
+/// let the buffer grow unbounded, and reactivation then handed SwiftUI one
+/// enormous flush — the same mass-mutation stall the pacing exists to avoid.
+///
+/// That objection no longer holds, which is why `interval` may now answer
+/// *nil*. Both feeds bound their pending buffer by **bytes** as well as by the
+/// cadence (a quarter of the retained byte budget), so a paused feed cannot
+/// grow without limit and the flush it eventually hands over is capped at that
+/// quarter rather than at the whole buffer. What the pace could not fix is
+/// that a feed nobody can see still published: one user sat with the app
+/// behind another window and a Reactotron tab in front, so `watched` was true,
+/// `appActive` was false, and the feed re-diffed every second for
+/// twenty-four minutes while they were not looking at it — twelve hangs, three
+/// tabs open (DROIDECTIVE-MAC-B). Occlusion is now part of what `watched`
+/// means, so a covered window reports false and the feed stops publishing
+/// until someone can actually see it. It keeps *receiving* throughout; only
+/// the SwiftUI mutation waits.
 ///
 /// Two things the fixed active/inactive pair could not express, both of which
 /// the hang data asked for (5261 hangs in 30 days, 75:1 of them with the app
@@ -58,21 +72,16 @@ public enum FeedFlushCadence {
     /// one.
     public static let inactive: Duration = .seconds(1)
 
-    /// Mounted but not on screen — a tab behind another tab, in either pane of
-    /// any window. Nothing is being read, so this only has to keep the buffer
-    /// draining into the feed's own ring; the eager flush on becoming visible
-    /// is what the user actually sees.
-    public static let hidden: Duration = .seconds(5)
-
     /// Ceiling for the `lateness` widening. Past this the feed has backed off
     /// as far as it usefully can, and a longer wait only delays recovery —
     /// including after a system sleep, where lateness is the length of the
     /// sleep and means nothing about load.
     public static let maxInterval: Duration = .seconds(8)
 
-    /// The unloaded interval for a feed in this state, before any widening.
-    public static func base(appActive: Bool, watched: Bool) -> Duration {
-        guard watched else { return hidden }
+    /// The unloaded interval for a feed in this state, before any widening —
+    /// nil when no timed flush should be scheduled at all.
+    public static func base(appActive: Bool, watched: Bool) -> Duration? {
+        guard watched else { return nil }
         return appActive ? active : inactive
     }
 
@@ -91,18 +100,37 @@ public enum FeedFlushCadence {
         max(.zero, elapsed - requested)
     }
 
+    /// The interval for a feed that must keep draining on a timer even when
+    /// nobody is watching.
+    ///
+    /// The log streams are that kind: they yield buffered lines through an
+    /// `AsyncStream` rather than publishing into observable state, so a paused
+    /// flusher would stall the stream itself rather than merely skip a SwiftUI
+    /// diff. They back all the way off instead — `maxInterval`, the same
+    /// ceiling load widening reaches.
+    public static func drainingInterval(
+        appActive: Bool, watched: Bool, lateness: Duration
+    ) -> Duration {
+        interval(appActive: appActive, watched: watched, lateness: lateness) ?? maxInterval
+    }
+
     /// How long to wait before the next flush.
     ///
     /// - Parameters:
     ///   - appActive: whether this app is frontmost.
     ///   - watched: whether any mounted view can currently see this feed
     ///     (`FeedAudience`), which is not the same as the feed having a view —
-    ///     a hidden tab keeps its view mounted.
+    ///     a hidden tab keeps its view mounted, and neither does a window the
+    ///     window server reports as occluded.
     ///   - lateness: how far past its requested interval the last scheduled
     ///     flush actually ran. Zero when the main thread kept up; negative
     ///     values (a clock reading early) are treated as zero.
-    public static func interval(appActive: Bool, watched: Bool, lateness: Duration) -> Duration {
-        let base = base(appActive: appActive, watched: watched)
+    /// - Returns: how long to wait, or nil to schedule nothing — nobody can see
+    ///   this feed, so publishing would buy a SwiftUI diff no one reads. Rows
+    ///   keep accumulating in the feed's byte-bounded pending buffer, an
+    ///   overflow there still flushes, and becoming visible flushes at once.
+    public static func interval(appActive: Bool, watched: Bool, lateness: Duration) -> Duration? {
+        guard let base = base(appActive: appActive, watched: watched) else { return nil }
         guard lateness > .zero else { return base }
         return min(maxInterval, max(base, base + lateness))
     }

--- a/ADBKit/Sources/ADBKit/Features/FeedMemoryBudget.swift
+++ b/ADBKit/Sources/ADBKit/Features/FeedMemoryBudget.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// How much memory one streaming feed's retained buffer may hold.
+///
+/// The number that matters is *resident* bytes; what the feeds actually cap is
+/// *wire* bytes — the size of the frames as they arrived off the socket. Those
+/// are not the same figure. Each frame is decoded into a Swift object graph
+/// several times its wire size (the parsed payload, the strings each row
+/// caches for search and display, one `RtItem`/`JSEntry` per row), so a wire
+/// cap is a resident cap divided by that multiple. Both feeds shipped a flat
+/// 128 MB wire cap, which is roughly a **gigabyte** resident;
+/// `ReactotronTimeline`'s own comment conceded the multiple without following
+/// it through to the number.
+///
+/// What that cost, measured on one install (a 16 GB M5, `Mac17,2`) with three
+/// tabs open — home, js-console, reactotron — from its `feature_perf` windows:
+///
+///     08:00   363 MB      the session's baseline
+///     10:00  1096 MB
+///     11:00  1578 MB      peak, 102% CPU
+///     …      0.8–1.5 GB   for the next *day*, sawtoothing
+///
+/// The sawtooth is the tell. It is not a leak — the rings do evict, and the
+/// footprint comes back down — it is the buffers' own working range, and with
+/// two feeds at 128 MB of wire each that range is predicted at roughly
+/// 0.3–2 GB. Observed: 0.8–1.5 GB. The cap *was* the bug, which is why looking
+/// for a leak would never have found anything.
+///
+/// Alongside it, sixty-odd 2-second main-thread hangs over two days, nearly all
+/// with the app not even frontmost (Sentry DROIDECTIVE-MAC-B), and CPU peaks of
+/// 56–102% attributed to a feed nobody was looking at.
+///
+/// So the budget is a fraction of the machine rather than a constant. A
+/// debugging tool has no business retaining the same fixed 128 MB of frames on
+/// a machine with 8 GB as on one with 64 — and no business holding a gigabyte
+/// of decoded log rows on any of them.
+public enum FeedMemoryBudget {
+    /// Resident bytes one decoded frame costs per wire byte.
+    ///
+    /// Between 5x and 9x across the two incidents above — 55 MB of wire frames
+    /// sat inside a 566 MB process, and a buffer at the old cap inside 1.47 GB.
+    /// 8 is the conservative end of that range: the budget should err toward
+    /// retaining less, because the failure it prevents is machine-wide.
+    public static let decodedGraphMultiplier = 8
+
+    /// Share of the machine's RAM one feed's decoded buffer may occupy — 1/32,
+    /// about 3%. Two feeds streaming at once (the shape of the incident: a
+    /// Reactotron tab and a JS Console tab) therefore reach ~6%, which leaves
+    /// an 8 GB machine its headroom.
+    static let hostFraction = 32
+    /// Ceiling however much RAM the machine has. A feed holding more decoded
+    /// history than this is holding more than anyone scrolls back through, and
+    /// the count cap (`ReactotronTimeline.maxItems`) bites long before it on
+    /// ordinary traffic.
+    static let maximumDecodedBytes = 192 << 20
+    /// Floor, so a small machine still keeps a useful amount of history rather
+    /// than a feed that evicts what it just received.
+    static let minimumDecodedBytes = 48 << 20
+
+    /// Resident ceiling for one feed's retained buffer.
+    public static func decodedBudget(physicalMemory: UInt64) -> Int {
+        let share = physicalMemory / UInt64(hostFraction)
+        let clamped = min(UInt64(maximumDecodedBytes), max(UInt64(minimumDecodedBytes), share))
+        return Int(clamped)
+    }
+
+    /// The wire-byte cap a feed applies to keep `decodedBudget` within reach.
+    public static func wireBudget(physicalMemory: UInt64) -> Int {
+        decodedBudget(physicalMemory: physicalMemory) / decodedGraphMultiplier
+    }
+
+    /// The wire-byte cap for the machine this is running on — what the feeds
+    /// use.
+    ///
+    /// Resolved once. A feed consults this on the *per-event* ingest path (the
+    /// early-flush bound), and `physicalMemory` is a `sysctl` read: cheap, but
+    /// not free per event on the one path this whole type exists to make
+    /// cheaper. There is nothing to invalidate — a process does not change
+    /// machines.
+    public static let wireBudget = wireBudget(
+        physicalMemory: ProcessInfo.processInfo.physicalMemory)
+}

--- a/ADBKit/Sources/ADBKit/Features/MainThreadStall.swift
+++ b/ADBKit/Sources/ADBKit/Features/MainThreadStall.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// The app's own record of how long the main thread went away for.
+///
+/// This exists because the hang reports the app already sends cannot answer
+/// "how bad was it". Sentry's hang integration fills the duration in from the
+/// *configured threshold* — `durationMs = appHangTimeoutInterval * 1000` — so
+/// every event says "at least 2000 ms" whether the thread was gone for two
+/// seconds or forty. Sixty-odd such reports from one install told us a hang
+/// happened and nothing about its size.
+///
+/// The measurement was already being taken and thrown away: `MainThreadLoad`
+/// asks the main thread for a turn twice a second and records how late the turn
+/// arrives, purely so the feeds can pace against it. A thread that disappeared
+/// for eight seconds shows up there as one ~7.5 s sample. Keeping those samples
+/// is the whole instrument — no new probe, no stopwatch around a mutation
+/// (which the feed convention warns measures the wrong thing, since the
+/// expensive part is the layout the mutation causes in a later runloop pass).
+///
+/// Pure and value-typed, so the summarising is tested without a clock.
+public struct MainThreadStall: Sendable, Equatable {
+    /// Lateness past which a sample is a stall a person would notice rather
+    /// than scheduler noise.
+    ///
+    /// 250 ms, matching the band `PerfLog.backendThresholdMs` already reports
+    /// on: past a few frames the user is watching the app not repaint, and
+    /// Sentry's own detector does not fire until 2000 ms — so this is the
+    /// range that explains a hang *before* it is one.
+    public static let threshold: Duration = .milliseconds(250)
+
+    /// Samples kept before the oldest are dropped. At two samples a second
+    /// this is ten minutes of history, comfortably more than the reporting
+    /// window, and it bounds the memory of a type that exists to diagnose
+    /// memory problems.
+    static let capacity = 1200
+
+    /// One reporting window, in whole milliseconds — the shape that goes to
+    /// the backend, where a float would only be false precision.
+    public struct Window: Sendable, Equatable {
+        /// How many turns were sampled.
+        public let samples: Int
+        /// How many of them were late past `threshold`.
+        public let stalls: Int
+        /// The worst single lateness — the closest thing to "how long did it
+        /// hang for", which is the question the hang events cannot answer.
+        public let worstMilliseconds: Int
+        /// Median lateness across *stalled* samples only. The median over all
+        /// samples is zero on any healthy app and says nothing.
+        public let medianStallMilliseconds: Int
+
+        /// Share of sampled turns that stalled, 0…100. A single 8 s stall in
+        /// ten minutes and a thread late a third of the time are different
+        /// problems, and this is what separates them.
+        public var stalledPercent: Int {
+            samples > 0 ? Int((Double(stalls) / Double(samples) * 100).rounded()) : 0
+        }
+
+        /// Nothing to report: the thread kept up for the whole window.
+        public var isQuiet: Bool { stalls == 0 }
+    }
+
+    private var latenessMilliseconds: [Int] = []
+
+    public init() {}
+
+    public mutating func ingest(_ lateness: Duration) {
+        latenessMilliseconds.append(Self.milliseconds(lateness))
+        if latenessMilliseconds.count > Self.capacity {
+            latenessMilliseconds.removeFirst(latenessMilliseconds.count - Self.capacity)
+        }
+    }
+
+    /// Summarise without resetting.
+    ///
+    /// For a reporter that must not disturb the window another one is
+    /// accumulating: the health report drains on a fixed cadence, while a hang
+    /// report fires whenever the thread misbehaves. If both consumed the
+    /// samples they would each see an arbitrary half of them, and the number
+    /// that matters — how late the thread has been *lately* — would be split
+    /// between two events at random.
+    ///
+    /// Returns nil when nothing was sampled at all, which is distinct from a
+    /// window that sampled a healthy thread: that reports `isQuiet`, so a
+    /// caller can still record the baseline.
+    public func summary() -> Window? {
+        guard !latenessMilliseconds.isEmpty else { return nil }
+        let stalled = latenessMilliseconds
+            .filter { $0 >= Self.milliseconds(Self.threshold) }
+            .sorted()
+        return Window(
+            samples: latenessMilliseconds.count,
+            stalls: stalled.count,
+            worstMilliseconds: latenessMilliseconds.max() ?? 0,
+            medianStallMilliseconds: stalled.isEmpty ? 0 : stalled[stalled.count / 2])
+    }
+
+    /// Summarise and start a fresh window. Exactly one reporter may do this.
+    public mutating func takeWindow() -> Window? {
+        defer { latenessMilliseconds.removeAll(keepingCapacity: true) }
+        return summary()
+    }
+
+    /// Whole milliseconds, rounded down. Negative durations cannot occur —
+    /// `FeedFlushCadence.lateness` clamps at zero — but a floor at zero keeps
+    /// that a property of this type too rather than an assumption about it.
+    static func milliseconds(_ duration: Duration) -> Int {
+        let components = duration.components
+        let millis = components.seconds * 1000 + components.attoseconds / 1_000_000_000_000_000
+        return Int(max(0, millis))
+    }
+}

--- a/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
+++ b/ADBKit/Sources/ADBKit/Services/JSConsole/ConsoleFiltering.swift
@@ -40,7 +40,12 @@ public struct FilteredLogBuffer<Entry: Identifiable> where Entry.ID: Comparable 
     private let cost: (Entry) -> Int
     /// Per-entry costs aligned with `entries`, so eviction never re-measures.
     private var costs: [Int] = []
-    private var totalCost = 0
+    /// Summed `cost` of everything retained — the buffer's wire size.
+    ///
+    /// Readable because the app reports it: a feed's retained bytes are half of
+    /// "why is this process holding a gigabyte", and it was previously visible
+    /// only to the eviction arithmetic inside this type.
+    public private(set) var totalCost = 0
 
     public init(capacity: Int, byteBudget: Int = .max, cost: @escaping (Entry) -> Int = { _ in 0 }) {
         self.capacity = max(1, capacity)

--- a/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/LogcatStream.swift
@@ -122,7 +122,7 @@ public actor LogcatStreamer {
     /// tab is on screen, and a mounted hidden tab lays out every row it is
     /// handed. Defaults to the pace a visible feed in a frontmost app gets, so
     /// a caller that never sets it behaves as before.
-    private var flushInterval = FeedFlushCadence.base(appActive: true, watched: true)
+    private var flushInterval = FeedFlushCadence.active
 
     private let client: AdbClient
     private var process: Process?

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
@@ -11,9 +11,15 @@ import Foundation
 public enum ReactotronTimeline {
     /// Most items the timeline retains.
     public static let maxItems = 2000
-    /// Most cumulative wire bytes the timeline retains. The decoded Swift
-    /// graph is proportional to the wire size (typically a small multiple).
-    public static let maxTotalBytes = 128 * 1024 * 1024
+    /// Most cumulative wire bytes the timeline retains.
+    ///
+    /// Was a flat 128 MB, on the reasoning that the decoded Swift graph is
+    /// "a small multiple" of the wire size. It is — about eight times — and
+    /// that made this a one-gigabyte *resident* cap, which is what put 8 GB
+    /// machines into swap and turned a slow feed into an unresponsive Mac.
+    /// `FeedMemoryBudget` sizes it against the machine instead; see there for
+    /// the incidents and the arithmetic.
+    public static var maxTotalBytes: Int { FeedMemoryBudget.wireBudget }
 
     /// How many items to drop from the front so the buffer fits its caps.
     ///

--- a/ADBKit/Sources/ADBKit/Services/SimulatorLogStream.swift
+++ b/ADBKit/Sources/ADBKit/Services/SimulatorLogStream.swift
@@ -212,7 +212,7 @@ public actor SimulatorLogStreamer {
     /// tab is on screen, and a mounted hidden tab lays out every row it is
     /// handed. Defaults to the pace a visible feed in a frontmost app gets, so
     /// a caller that never sets it behaves as before.
-    private var flushInterval = FeedFlushCadence.base(appActive: true, watched: true)
+    private var flushInterval = FeedFlushCadence.active
 
     private let xcrunPath: String
     private var process: Process?

--- a/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeedFlushCadenceTests.swift
@@ -5,10 +5,12 @@ import Testing
 /// visible feed and every open tab stays mounted, so this interval is a direct
 /// multiplier on main-thread layout across all of them.
 @Suite struct FeedFlushCadenceTests {
-    @Test func inactiveIsSlowerThanActive() {
-        #expect(
-            FeedFlushCadence.interval(appActive: false, watched: true, lateness: .zero)
-                > FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero))
+    @Test func inactiveIsSlowerThanActive() throws {
+        let inactive = try #require(
+            FeedFlushCadence.interval(appActive: false, watched: true, lateness: .zero))
+        let active = try #require(
+            FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero))
+        #expect(inactive > active)
     }
 
     @Test func picksTheIntervalForEachState() {
@@ -28,45 +30,60 @@ import Testing
         #expect(FeedFlushCadence.active >= .milliseconds(100))
     }
 
-    /// Never zero and never stopped: pausing a feed outright grows the buffer
-    /// unbounded and hands SwiftUI one enormous flush on reactivation, which
-    /// is the same mass-mutation stall the pacing avoids.
-    @Test func neitherStateStopsTheFeed() {
+    /// A feed someone can see is never stopped, whether or not the app is
+    /// frontmost: it is being read, and a feed that only flushes every few
+    /// seconds reads as broken when the user looks back at it.
+    @Test func aWatchedFeedIsNeverStopped() {
         #expect(FeedFlushCadence.active > .zero)
         #expect(FeedFlushCadence.inactive > .zero)
-        #expect(FeedFlushCadence.hidden > .zero)
-        // A cap, so "slower while inactive" can't drift into "effectively off"
-        // — a feed that only flushes every few seconds reads as broken when
-        // the user comes back to it.
+        #expect(FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero) != nil)
+        #expect(FeedFlushCadence.interval(appActive: false, watched: true, lateness: .zero) != nil)
+        // A cap, so "slower while inactive" can't drift into "effectively off".
         #expect(FeedFlushCadence.inactive <= .seconds(2))
     }
 
     // MARK: Visibility
 
-    /// A mounted-but-hidden tab lays its rows out exactly like a visible one,
-    /// so the feed nobody can see must be the cheapest of the three states —
-    /// including when the app itself is frontmost, which says nothing about
-    /// whether *this* tab is the one on screen.
-    @Test func hiddenIsTheSlowestState() {
-        let hidden = FeedFlushCadence.interval(appActive: true, watched: false, lateness: .zero)
-        #expect(hidden == FeedFlushCadence.hidden)
-        #expect(hidden > FeedFlushCadence.inactive)
-        #expect(hidden > FeedFlushCadence.active)
+    /// A feed nobody can see schedules nothing at all. A mounted hidden tab
+    /// lays its rows out exactly like a visible one, so publishing to it buys
+    /// a SwiftUI diff no one reads — the twenty-four minutes of once-a-second
+    /// re-diffing behind DROIDECTIVE-MAC-B. Rows keep arriving into the feed's
+    /// byte-bounded pending buffer, which is what makes stopping safe.
+    @Test func anUnwatchedFeedSchedulesNothing() {
+        #expect(FeedFlushCadence.interval(appActive: true, watched: false, lateness: .zero) == nil)
+        #expect(FeedFlushCadence.interval(appActive: false, watched: false, lateness: .zero) == nil)
     }
 
     /// App activation is irrelevant while nothing can see the feed: the cost
-    /// being paced away is this tab's layout, and a hidden tab is hidden
-    /// whether or not the window is frontmost.
-    @Test func activationDoesNotChangeAHiddenFeed() {
+    /// being skipped is this tab's layout, and a hidden tab is hidden whether
+    /// or not the window is frontmost.
+    @Test func activationDoesNotChangeAnUnwatchedFeed() {
         #expect(
             FeedFlushCadence.interval(appActive: true, watched: false, lateness: .zero)
                 == FeedFlushCadence.interval(appActive: false, watched: false, lateness: .zero))
     }
 
-    /// Hidden is a pace, not a pause — but it must stay short enough that the
-    /// buffer keeps draining into the feed's own ring between reveals.
-    @Test func hiddenStaysBounded() {
-        #expect(FeedFlushCadence.hidden <= .seconds(10))
+    /// No amount of lateness turns an unwatched feed back on: the widening is
+    /// a pace, and there is no pace to widen.
+    @Test func latenessCannotReviveAnUnwatchedFeed() {
+        for seconds in [0, 1, 10, 600] {
+            #expect(
+                FeedFlushCadence.interval(
+                    appActive: true, watched: false, lateness: .seconds(seconds)) == nil)
+        }
+    }
+
+    /// A feed that cannot pause — one whose flush yields into an
+    /// `AsyncStream` rather than publishing observable state, so pausing would
+    /// stall the stream — backs off to the ceiling instead of stopping.
+    @Test func aDrainingFeedBacksOffInsteadOfStopping() {
+        let unwatched = FeedFlushCadence.drainingInterval(
+            appActive: true, watched: false, lateness: .zero)
+        #expect(unwatched == FeedFlushCadence.maxInterval)
+        // Watched, it paces exactly like every other feed.
+        #expect(
+            FeedFlushCadence.drainingInterval(appActive: true, watched: true, lateness: .zero)
+                == FeedFlushCadence.active)
     }
 
     // MARK: Backpressure
@@ -81,18 +98,19 @@ import Testing
     /// often when a flush costs 900 ms as when it costs 5 ms, so a big enough
     /// feed saturates the thread and never catches up. Lateness has to widen
     /// the next wait by at least what the thread was already behind.
-    @Test func latenessWidensTheNextInterval() {
-        let late = FeedFlushCadence.interval(
-            appActive: true, watched: true, lateness: .milliseconds(900))
+    @Test func latenessWidensTheNextInterval() throws {
+        let late = try #require(FeedFlushCadence.interval(
+            appActive: true, watched: true, lateness: .milliseconds(900)))
         #expect(late >= FeedFlushCadence.active + .milliseconds(900))
         #expect(late > FeedFlushCadence.active)
     }
 
-    @Test func wideningIsMonotonicInLateness() {
-        var previous = FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero)
+    @Test func wideningIsMonotonicInLateness() throws {
+        var previous = try #require(
+            FeedFlushCadence.interval(appActive: true, watched: true, lateness: .zero))
         for milliseconds in [50, 200, 800, 1500, 3000] {
-            let next = FeedFlushCadence.interval(
-                appActive: true, watched: true, lateness: .milliseconds(milliseconds))
+            let next = try #require(FeedFlushCadence.interval(
+                appActive: true, watched: true, lateness: .milliseconds(milliseconds)))
             #expect(next >= previous)
             previous = next
         }
@@ -108,16 +126,20 @@ import Testing
         #expect(slept == FeedFlushCadence.maxInterval)
     }
 
-    /// Backing off must never overtake the ceiling from any starting state,
-    /// hidden included — the ceiling is the promise that a feed always comes
-    /// back.
+    /// Backing off must never overtake the ceiling from any starting state —
+    /// the ceiling is the promise that a feed someone is watching always comes
+    /// back. The draining form is included, since it is the one that answers
+    /// with the ceiling itself.
     @Test func noStateExceedsTheCeiling() {
         for appActive in [true, false] {
             for watched in [true, false] {
                 for seconds in [0, 1, 10, 600] {
                     let interval = FeedFlushCadence.interval(
                         appActive: appActive, watched: watched, lateness: .seconds(seconds))
-                    #expect(interval <= FeedFlushCadence.maxInterval)
+                    #expect(interval ?? .zero <= FeedFlushCadence.maxInterval)
+                    #expect(FeedFlushCadence.drainingInterval(
+                        appActive: appActive, watched: watched,
+                        lateness: .seconds(seconds)) <= FeedFlushCadence.maxInterval)
                 }
             }
         }
@@ -132,15 +154,16 @@ import Testing
     }
 
     /// The ceiling has to leave room above the slowest base, or the widening
-    /// it bounds could never happen for a hidden feed.
+    /// it bounds could never happen at all.
     @Test func theCeilingLeavesRoomAboveEveryBase() {
-        #expect(FeedFlushCadence.maxInterval > FeedFlushCadence.hidden)
+        #expect(FeedFlushCadence.maxInterval > FeedFlushCadence.inactive)
+        #expect(FeedFlushCadence.maxInterval > FeedFlushCadence.active)
     }
 
     @Test func baseIgnoresLatenessEntirely() {
         #expect(FeedFlushCadence.base(appActive: true, watched: true) == FeedFlushCadence.active)
         #expect(FeedFlushCadence.base(appActive: false, watched: true) == FeedFlushCadence.inactive)
-        #expect(FeedFlushCadence.base(appActive: false, watched: false) == FeedFlushCadence.hidden)
+        #expect(FeedFlushCadence.base(appActive: false, watched: false) == nil)
     }
 
     // MARK: Lateness readings

--- a/ADBKit/Tests/ADBKitTests/FeedMemoryBudgetTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FeedMemoryBudgetTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// The retained-memory budget for a streaming feed. The regression these guard
+/// is a *machine-wide* one: a wire-byte cap that ignored both the decoded cost
+/// and the size of the machine put 8 GB Macs into swap, at which point the
+/// report is "the whole Mac stopped responding" rather than "this app is slow".
+@Suite struct FeedMemoryBudgetTests {
+    private static let gigabyte: UInt64 = 1 << 30
+
+    // MARK: - The regression
+
+    /// The old cap was a flat 128 MB of wire bytes, which at the measured
+    /// decode multiple is about a gigabyte resident. No machine may reach that
+    /// again — not even a very large one, where the count cap bites first
+    /// anyway.
+    @Test func noMachineGetsTheOldGigabyteBudget() {
+        for gigabytes: UInt64 in [2, 4, 8, 16, 32, 64, 128] {
+            let decoded = FeedMemoryBudget.decodedBudget(
+                physicalMemory: gigabytes * Self.gigabyte)
+            #expect(decoded <= FeedMemoryBudget.maximumDecodedBytes)
+            #expect(decoded < 512 << 20, "\(gigabytes) GB machine budgeted \(decoded) bytes")
+        }
+    }
+
+    /// The machine the incidents happened on: 8 GB, with under 200 MB free.
+    /// Two feeds streaming at once is the shape that was reported (a
+    /// Reactotron tab and a JS Console tab), so what matters is that *both*
+    /// together stay a modest share of the machine.
+    @Test func twoFeedsOnAnEightGigMachineStayWellUnderASixth() {
+        let physical = 8 * Self.gigabyte
+        let bothFeeds = 2 * FeedMemoryBudget.decodedBudget(physicalMemory: physical)
+        #expect(Double(bothFeeds) < Double(physical) / 6)
+    }
+
+    // MARK: - Shape
+
+    @Test func theBudgetGrowsWithTheMachineUntilItCaps() {
+        let small = FeedMemoryBudget.decodedBudget(physicalMemory: 4 * Self.gigabyte)
+        let medium = FeedMemoryBudget.decodedBudget(physicalMemory: 8 * Self.gigabyte)
+        #expect(small < medium)
+        #expect(medium == FeedMemoryBudget.maximumDecodedBytes)
+    }
+
+    /// A tiny machine still keeps a usable amount of history: a feed that
+    /// evicted what it had just received would be worse than a slow one.
+    @Test func aTinyMachineGetsTheFloorNotAScrap() {
+        let decoded = FeedMemoryBudget.decodedBudget(physicalMemory: 1 * Self.gigabyte)
+        #expect(decoded == FeedMemoryBudget.minimumDecodedBytes)
+        #expect(FeedMemoryBudget.wireBudget(physicalMemory: 1 * Self.gigabyte) > 0)
+    }
+
+    @Test func zeroPhysicalMemoryStillYieldsTheFloor() {
+        // `physicalMemory` should never be zero, but a budget that came back
+        // as zero would evict every row the moment it arrived.
+        #expect(FeedMemoryBudget.decodedBudget(physicalMemory: 0)
+            == FeedMemoryBudget.minimumDecodedBytes)
+    }
+
+    @Test func theBudgetIsMonotonicInMachineSize() {
+        var previous = 0
+        for gigabytes: UInt64 in [1, 2, 4, 8, 16, 32, 64] {
+            let decoded = FeedMemoryBudget.decodedBudget(
+                physicalMemory: gigabytes * Self.gigabyte)
+            #expect(decoded >= previous)
+            previous = decoded
+        }
+    }
+
+    // MARK: - Wire vs resident
+
+    /// The whole point of the type: what a feed caps is wire bytes, and what
+    /// the machine feels is the decoded graph. The wire budget must be the
+    /// resident one divided by the multiple, never the resident one itself.
+    @Test func theWireBudgetIsTheResidentOneDividedByTheDecodeMultiple() {
+        let physical = 16 * Self.gigabyte
+        let decoded = FeedMemoryBudget.decodedBudget(physicalMemory: physical)
+        let wire = FeedMemoryBudget.wireBudget(physicalMemory: physical)
+        #expect(wire == decoded / FeedMemoryBudget.decodedGraphMultiplier)
+        #expect(wire < decoded)
+    }
+
+    /// Measured between 5x and 9x on the two field incidents; anything at or
+    /// below 1 would mean the type had stopped distinguishing the two costs at
+    /// all, which is exactly the bug.
+    @Test func theDecodeMultipleIsAMultiple() {
+        #expect(FeedMemoryBudget.decodedGraphMultiplier >= 5)
+    }
+
+    // MARK: - The feeds' use of it
+
+    /// `ReactotronTimeline` reads the budget rather than carrying its own
+    /// constant, so the two feeds cannot drift apart again — the JS Console
+    /// copied Reactotron's 128 MB figure by hand, and that is how one of them
+    /// missed the flush pacing for two releases.
+    @Test func theReactotronTimelineTakesItsCapFromTheBudget() {
+        #expect(ReactotronTimeline.maxTotalBytes == FeedMemoryBudget.wireBudget)
+        #expect(ReactotronTimeline.maxTotalBytes > 0)
+    }
+
+    /// The eviction arithmetic has to work at the new size: a buffer over the
+    /// byte cap must still trim, and must still keep the newest row even when
+    /// that row alone is bigger than the whole budget.
+    @Test func evictionStillWorksAtTheNewBudget() {
+        let wire = FeedMemoryBudget.wireBudget
+        let oversized = wire * 2
+        let drop = ReactotronTimeline.dropCount(
+            sizes: [oversized], count: 1, totalBytes: oversized)
+        #expect(drop == 0, "the newest row must survive even when it alone exceeds the budget")
+
+        // Ten rows each a fifth of the budget: over by half, so it trims.
+        let size = wire / 5
+        let sizes = Array(repeating: size, count: 10)
+        let trimmed = ReactotronTimeline.dropCount(
+            sizes: sizes, count: 10, totalBytes: size * 10)
+        #expect(trimmed > 0)
+        #expect(trimmed < 10)
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/MainThreadStallTests.swift
+++ b/ADBKit/Tests/ADBKitTests/MainThreadStallTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import ADBKit
+
+/// The app's own stall record. It exists because the hang events cannot say how
+/// long a hang lasted — Sentry fills the duration in from the configured
+/// threshold — so these summaries are the only answer to "how bad was it".
+@Suite struct MainThreadStallTests {
+    private func stall(_ latenessMs: [Int]) -> MainThreadStall {
+        var stall = MainThreadStall()
+        for ms in latenessMs { stall.ingest(.milliseconds(ms)) }
+        return stall
+    }
+
+    // MARK: - Summarising
+
+    @Test func aHealthyThreadReportsQuietRatherThanNothing() throws {
+        // Every turn arrived on time. That is a fact worth recording as a
+        // baseline, not an absence of data.
+        let subject = stall([0, 0, 0, 0])
+        let window = try #require(subject.summary())
+        #expect(window.samples == 4)
+        #expect(window.stalls == 0)
+        #expect(window.isQuiet)
+        #expect(window.stalledPercent == 0)
+        #expect(window.worstMilliseconds == 0)
+    }
+
+    @Test func nothingSampledIsNil() {
+        let untouched = MainThreadStall()
+        #expect(untouched.summary() == nil)
+        var empty = MainThreadStall()
+        let taken = empty.takeWindow()
+        #expect(taken == nil)
+    }
+
+    /// The number the hang events never carried: one turn that arrived eight
+    /// seconds late is an eight-second hang, however "at least 2000 ms" it was
+    /// reported as.
+    @Test func theWorstSampleIsTheHangDuration() throws {
+        let subject = stall([0, 0, 8_000, 0])
+        let window = try #require(subject.summary())
+        #expect(window.worstMilliseconds == 8_000)
+        #expect(window.stalls == 1)
+    }
+
+    /// One long stall and a thread late a third of the time are different
+    /// problems; the share is what separates them.
+    @Test func theStalledShareSeparatesASpikeFromSaturation() throws {
+        let spiky = stall(Array(repeating: 0, count: 99) + [4_000])
+        let spike = try #require(spiky.summary())
+        #expect(spike.stalledPercent == 1)
+
+        let busy = stall(Array(repeating: 400, count: 100))
+        let saturated = try #require(busy.summary())
+        #expect(saturated.stalledPercent == 100)
+        #expect(saturated.worstMilliseconds == 400)
+    }
+
+    /// The median is taken over stalled samples only. Over *all* samples it
+    /// would read zero on any app that mostly keeps up, which is every app
+    /// worth diagnosing.
+    @Test func theMedianIgnoresTheHealthySamples() throws {
+        let subject = stall(Array(repeating: 0, count: 50) + [300, 900, 1_500])
+        let window = try #require(subject.summary())
+        #expect(window.medianStallMilliseconds == 900)
+        #expect(window.stalls == 3)
+    }
+
+    @Test func latenessAtTheThresholdCounts() throws {
+        let subject = stall([249, 250])
+        let window = try #require(subject.summary())
+        #expect(window.stalls == 1) // 250 is a stall, 249 is not
+    }
+
+    // MARK: - Peek vs drain
+
+    /// Two reporters read this — a hang whenever one happens, and the health
+    /// report on a fixed cadence. Only the second may consume, or each would
+    /// see an arbitrary half of the samples.
+    @Test func summaryLeavesTheWindowInPlace() throws {
+        let subject = stall([0, 500, 0])
+        let first = try #require(subject.summary())
+        let second = try #require(subject.summary())
+        #expect(first == second)
+        #expect(second.samples == 3)
+    }
+
+    @Test func takeWindowStartsAFreshOne() throws {
+        var subject = stall([0, 500])
+        // Outside the macro: `#require` captures its argument immutably, and
+        // this is the mutating half of the pair.
+        let drained = subject.takeWindow()
+        let taken = try #require(drained)
+        #expect(taken.stalls == 1)
+        #expect(subject.summary() == nil)
+        subject.ingest(.milliseconds(0))
+        let reopened = try #require(subject.summary())
+        #expect(reopened.samples == 1)
+    }
+
+    // MARK: - Bounds
+
+    /// This type is instrumentation for memory problems, so it must not be one:
+    /// a long session samples twice a second for hours.
+    @Test func theSampleWindowIsBounded() throws {
+        var subject = MainThreadStall()
+        for _ in 0..<(MainThreadStall.capacity * 3) { subject.ingest(.milliseconds(1)) }
+        let window = try #require(subject.summary())
+        #expect(window.samples == MainThreadStall.capacity)
+    }
+
+    /// The oldest samples are the ones dropped, so a stall stays visible for
+    /// the whole window it happened in rather than being evicted by the newest
+    /// healthy readings.
+    @Test func theOldestSamplesAreTheOnesDropped() throws {
+        var subject = MainThreadStall()
+        subject.ingest(.milliseconds(9_000)) // the oldest
+        for _ in 0..<MainThreadStall.capacity { subject.ingest(.milliseconds(0)) }
+        let window = try #require(subject.summary())
+        #expect(window.worstMilliseconds == 0, "the 9 s sample should have aged out")
+        #expect(window.samples == MainThreadStall.capacity)
+    }
+
+    @Test func aNegativeDurationIsFlooredAtZero() throws {
+        var subject = MainThreadStall()
+        subject.ingest(.milliseconds(-500))
+        let window = try #require(subject.summary())
+        #expect(window.worstMilliseconds == 0)
+    }
+
+    @Test func subSecondDurationsConvertExactly() {
+        #expect(MainThreadStall.milliseconds(.milliseconds(1)) == 1)
+        #expect(MainThreadStall.milliseconds(.seconds(3)) == 3_000)
+        #expect(MainThreadStall.milliseconds(.microseconds(999)) == 0)
+    }
+}

--- a/App/Sources/FeatureDetail/Views/JSConsoleView.swift
+++ b/App/Sources/FeatureDetail/Views/JSConsoleView.swift
@@ -169,7 +169,7 @@ final class JSConsoleSession {
     // count cap: 2000 entries each holding a multi-megabyte logged string
     // would otherwise retain gigabytes. Shared with the pending early-flush
     // bound so the two can't drift apart when retuned.
-    private static let bufferByteBudget = 128 << 20
+    private static var bufferByteBudget: Int { FeedMemoryBudget.wireBudget }
     private var buffer = FilteredLogBuffer<JSEntry>(
         capacity: JSConsoleSession.maxEntries,
         byteBudget: JSConsoleSession.bufferByteBudget,
@@ -446,6 +446,7 @@ final class JSConsoleSession {
         phase = .searching
         // Session over — a later hang must not read as "the console did it".
         Telemetry.shared.setDiagnosticContext("js_console", nil)
+        FeedHealth.shared.forget("js-console")
         Telemetry.shared.breadcrumb(category: "js-console", "session stopped")
         publishedDiagnostics = nil
     }
@@ -485,6 +486,13 @@ final class JSConsoleSession {
             bufferedEntries: (buffer.entries.count / 100) * 100,
             ingestPerMinute: ConsoleRateBucket.decade(perMinute)
         )
+        // Unbucketed, into the shared snapshot the hang and health reports
+        // read — this feed and Reactotron were each visible alone and never
+        // together, which is what hid a combined 1.5 GB.
+        FeedHealth.shared.report("js-console", FeedHealth.Snapshot(
+            rows: buffer.entries.count,
+            wireBytes: buffer.totalCost,
+            watched: audience.isWatched))
         guard snapshot != publishedDiagnostics else { return }
         if ConsoleRateBucket.isBurst(
             from: publishedDiagnostics?.ingestPerMinute, to: snapshot.ingestPerMinute
@@ -1050,7 +1058,8 @@ final class JSConsoleSession {
     /// The intervals moved to `FeedFlushCadence` when the Reactotron timeline
     /// turned out to have missed this fix entirely — the rule is shared so a
     /// feed cannot be added without it.
-    private var flushInterval: Duration {
+    /// nil when nobody can see the feed — see `FeedFlushCadence.interval`.
+    private var flushInterval: Duration? {
         // Visibility and main-thread load both feed the pace: a hidden tab
         // still lays out every row it flushes, and a thread already behind
         // must not be asked for a turn as often (`MainThreadLoad`).
@@ -1062,7 +1071,10 @@ final class JSConsoleSession {
 
     private func scheduleFlush() {
         guard flushTask == nil else { return }
-        let interval = flushInterval
+        // Nothing scheduled while unseen: entries keep arriving into
+        // `pendingEntries`, which is bounded by bytes, and the early flush
+        // above still drains it on volume.
+        guard let interval = flushInterval else { return }
         flushTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: interval)
             guard let self, !Task.isCancelled else { return }

--- a/App/Sources/FeatureDetail/Views/LogcatView.swift
+++ b/App/Sources/FeatureDetail/Views/LogcatView.swift
@@ -556,7 +556,10 @@ struct LogcatView: View {
     /// the streamer is a portable actor that can see neither, so the App layer
     /// has to tell it (`LogcatStreamer.setFlushInterval`).
     private var pacedFlushInterval: Duration {
-        FeedFlushCadence.interval(
+        // `drainingInterval`, not `interval`: this feed's flush yields into an
+        // `AsyncStream` rather than publishing observable state, so pausing it
+        // would stall the stream itself. It backs off to the ceiling instead.
+        FeedFlushCadence.drainingInterval(
             appActive: NSApp.isActive,
             watched: feedVisible,
             lateness: MainThreadLoad.shared.lateness)

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -323,6 +323,8 @@ final class ReactotronSession {
         Self.discardInBackground((items, snapshots, storeState, subscriptionValues))
         items.removeAll()
         itemsBytes = 0
+        FeedHealth.shared.report("reactotron", FeedHealth.Snapshot(
+            rows: 0, wireBytes: 0, watched: audience.isWatched))
         paneClearSeqs.removeAll()
         commands.removeAll()
         subscriptionPaths.removeAll()
@@ -731,10 +733,15 @@ final class ReactotronSession {
         // Hidden tabs stay mounted and lay their rows out like visible ones,
         // and a main thread that is already behind must not be asked for a
         // turn as often — `MainThreadLoad` is the app-wide reading of that.
-        let interval = FeedFlushCadence.interval(
+        // A nil interval means nobody can see the timeline: publishing would
+        // buy a SwiftUI diff no one reads, so nothing is scheduled and the
+        // rows wait in `pendingItems` (byte-bounded above) until either the
+        // early flush or someone looking at it drains them.
+        guard let interval = FeedFlushCadence.interval(
             appActive: NSApp.isActive,
             watched: audience.isWatched,
             lateness: MainThreadLoad.shared.lateness)
+        else { return }
         flushTask = Task { [weak self] in
             try? await Task.sleep(for: interval)
             guard !Task.isCancelled else { return }
@@ -761,7 +768,13 @@ final class ReactotronSession {
         let batch = pendingItems
         pendingItems.removeAll(keepingCapacity: true)
         pendingBytes = 0
-        appendBatch(batch)
+        // The JS Console has measured its drain since v3.7.0 and this feed —
+        // the larger of the two, and the one named in the hang issue — never
+        // did. A breach past `backendThresholdMs` reaches the backend from
+        // inside `PerfLog`, so this is the local half of the same signal.
+        PerfLog.measure(PerfLog.feed, "reactotron flush \(batch.count) rows into \(items.count)") {
+            appendBatch(batch)
+        }
     }
 
     /// Ring-buffer append bounded by count *and* cumulative frame bytes
@@ -803,6 +816,11 @@ final class ReactotronSession {
             clients: clients.count,
             evicted: ConsoleRateBucket.decade(Double(evictedItemCount))
         )
+        // Reported every flush, not only when the bucket changes: the shared
+        // snapshot is read by the hang and health reports, and a bucketed
+        // value is too coarse for "how much is the app holding right now".
+        FeedHealth.shared.report("reactotron", FeedHealth.Snapshot(
+            rows: items.count, wireBytes: itemsBytes, watched: audience.isWatched))
         guard snapshot != publishedDiagnostics else { return }
         publishedDiagnostics = snapshot
         Telemetry.shared.setDiagnosticContext("reactotron", [

--- a/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
+++ b/App/Sources/FeatureDetail/Views/SimulatorLogsView.swift
@@ -587,7 +587,10 @@ struct SimulatorLogsView: View {
     /// rule, given whether anyone can see the tab and how far behind the main
     /// thread already is (`SimulatorLogStreamer.setFlushInterval`).
     private var pacedFlushInterval: Duration {
-        FeedFlushCadence.interval(
+        // `drainingInterval`, not `interval`: this feed's flush yields into an
+        // `AsyncStream` rather than publishing observable state, so pausing it
+        // would stall the stream itself. It backs off to the ceiling instead.
+        FeedFlushCadence.drainingInterval(
             appActive: NSApp.isActive,
             watched: feedVisible,
             lateness: MainThreadLoad.shared.lateness)

--- a/App/Sources/Root/AppVisibility.swift
+++ b/App/Sources/Root/AppVisibility.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Foundation
+
+/// Whether any of the app's windows is actually on screen, as the window
+/// server sees it.
+///
+/// The streaming feeds need this because "watched" was inferred from two things
+/// that both lie about it. `NSApp.isActive` says whether we are frontmost, not
+/// whether we are *visible* — an app behind another window is inactive but may
+/// be fully readable beside it. And a tab being the front tab of its pane
+/// (`tabIsActive`) says nothing about the window that pane is in.
+///
+/// Between them they produced the shape of DROIDECTIVE-MAC-B: a user with the
+/// app behind another window and a Reactotron tab in front, so the feed scored
+/// as watched-but-inactive and re-published every second for twenty-four
+/// minutes while nobody could see a thing. `occlusionState` is the window
+/// server's own answer to the question, so it is the one worth asking.
+///
+/// `@Observable` on purpose, unlike `MainThreadLoad`: this changes when the
+/// user switches app or covers a window — a few times an hour, not twice a
+/// second — so the feed views can simply read it and re-report their
+/// visibility through the path they already use.
+@MainActor
+@Observable
+final class AppVisibility {
+    static let shared = AppVisibility()
+
+    /// True while at least one window that can front the app is unoccluded.
+    ///
+    /// Starts true so a feed mounted before the first notification behaves as
+    /// it always did, and errs that way in general: over-reporting visibility
+    /// pays for layout nobody reads, while under-reporting would stall a feed
+    /// somebody is watching. `FeedAudience` leans the same way, for the same
+    /// reason.
+    private(set) var hasVisibleWindow = true
+
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {}
+
+    /// Begin observing. Idempotent — every window's launch setup may call it.
+    func start() {
+        guard observers.isEmpty else { return }
+        // `object: nil`, and recomputed from `NSApp.windows` rather than
+        // tracked per window: an app-wide singleton that re-points at the
+        // newest window silently drops the others (see the multi-window
+        // convention in CLAUDE.md), and the answer here is a fold over every
+        // window anyway.
+        let center = NotificationCenter.default
+        for name: NSNotification.Name in [
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification,
+            NSApplication.didHideNotification,
+            NSApplication.didUnhideNotification,
+            // Activation is part of the answer (see `recompute`), so a change
+            // in it has to re-ask the question.
+            NSApplication.didBecomeActiveNotification,
+            NSApplication.didResignActiveNotification,
+        ] {
+            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { _ in
+                MainActor.assumeIsolated { AppVisibility.shared.recompute() }
+            })
+        }
+        recompute()
+    }
+
+    private func recompute() {
+        // Frontmost counts as visible without consulting occlusion at all.
+        // `occlusionState` is the window server's answer and it is the right
+        // one, but a wrong answer in the stalling direction would freeze a
+        // feed somebody is reading — the one failure worse than the cost this
+        // saves. If we are the app in front, someone is looking at us.
+        let visible = NSApp.isActive || NSApp.windows.contains { window in
+            // `canBecomeMain` narrows this to the windows that show features —
+            // the workspace windows and the pop-out mirrors — so the Quick
+            // Actions panel being on screen does not make a covered timeline
+            // count as watched.
+            window.canBecomeMain
+                && window.isVisible
+                && !window.isMiniaturized
+                && window.occlusionState.contains(.visible)
+        }
+        // Guarded: this is `@Observable` and the feed views read it, so an
+        // unconditional write would invalidate them on every occlusion
+        // notification — including the ones that changed nothing.
+        guard visible != hasVisibleWindow else { return }
+        hasVisibleWindow = visible
+    }
+}

--- a/App/Sources/Root/FeedHealth.swift
+++ b/App/Sources/Root/FeedHealth.swift
@@ -1,0 +1,86 @@
+import ADBKit
+import Foundation
+
+/// What every streaming feed is holding right now, in one place.
+///
+/// Each feed already publishes its own shape as a Sentry context
+/// (`ReactotronSession.publishDiagnostics` and the JS Console's equivalent),
+/// and that is genuinely useful on a crash — but it is *per feed*, so nothing
+/// could answer "how much is the app holding across all of them", which is the
+/// question that mattered when a session sat at 1.5 GB with two feeds open.
+/// Reconstructing it took joining three event types by hour, after knowing to
+/// look. One snapshot makes it one field.
+///
+/// Deliberately **not** `@Observable`, for the reason `MainThreadLoad` is not:
+/// feeds report on every flush, and anything observing this would re-render the
+/// UI at flush rate — the exact cost these numbers exist to measure.
+@MainActor
+final class FeedHealth {
+    static let shared = FeedHealth()
+
+    /// One feed's current shape. Rows and bytes are what it retains, not what
+    /// it has ever seen.
+    struct Snapshot: Equatable {
+        var rows: Int
+        /// Wire bytes retained. The resident cost is a multiple of this — see
+        /// `FeedMemoryBudget`, which is the whole reason that distinction is
+        /// worth reporting rather than assuming.
+        var wireBytes: Int
+        /// Whether any mounted view could see this feed when it last reported.
+        var watched: Bool
+    }
+
+    private var feeds: [String: Snapshot] = [:]
+
+    private init() {}
+
+    /// Called from a feed's own diagnostics publish, so it costs one
+    /// dictionary write on a path that was already crossing two telemetry
+    /// SDKs.
+    func report(_ feed: String, _ snapshot: Snapshot) {
+        feeds[feed] = snapshot
+    }
+
+    /// A feed that has gone away entirely (its tab closed, its session torn
+    /// down) must stop counting toward the total, or a closed feed's last
+    /// snapshot is reported as live memory for the rest of the session.
+    func forget(_ feed: String) {
+        feeds.removeValue(forKey: feed)
+    }
+
+    var totalWireBytes: Int { feeds.values.reduce(0) { $0 + $1.wireBytes } }
+    var totalRows: Int { feeds.values.reduce(0) { $0 + $1.rows } }
+    /// How many feeds believe someone can see them. Zero alongside a large
+    /// `totalWireBytes` is the state that produced the incident: work being
+    /// done, nobody reading it.
+    var watchedCount: Int { feeds.values.count { $0.watched } }
+    var feedCount: Int { feeds.count }
+
+    /// Flattened for telemetry — numbers and feed ids only, never contents.
+    /// Per-feed rows and megabytes are included because "which feed" is the
+    /// first question after "how much".
+    var properties: [String: Int] {
+        var result: [String: Int] = [
+            "feeds": feedCount,
+            "feeds_watched": watchedCount,
+            "feed_rows": totalRows,
+            "feed_mb": totalWireBytes / 1_048_576,
+        ]
+        for (feed, snapshot) in feeds {
+            // `rt`/`js` rather than the feature id, so the key set is fixed
+            // and a renamed feature cannot silently start a new column.
+            let key = Self.shortName(feed)
+            result["\(key)_rows"] = snapshot.rows
+            result["\(key)_mb"] = snapshot.wireBytes / 1_048_576
+        }
+        return result
+    }
+
+    private static func shortName(_ feed: String) -> String {
+        switch feed {
+        case "reactotron": return "rt"
+        case "js-console": return "js"
+        default: return feed.replacingOccurrences(of: "-", with: "_")
+        }
+    }
+}

--- a/App/Sources/Root/MainThreadLoad.swift
+++ b/App/Sources/Root/MainThreadLoad.swift
@@ -34,9 +34,33 @@ final class MainThreadLoad {
     /// sample after it clears reports zero again, so no decay is needed.
     private(set) var lateness: Duration = .zero
 
+    /// The same samples, kept rather than overwritten (`MainThreadStall`).
+    ///
+    /// Pacing only ever needs the latest reading, so that is all this used to
+    /// keep — and the app therefore measured its own stalls twice a second for
+    /// the life of the process and remembered none of them. The hang reports it
+    /// sends cannot supply a duration (Sentry fills that in from the
+    /// configured threshold), so these samples are the only record of how long
+    /// the thread actually went away for.
+    private var stall = MainThreadStall()
+
     private var sampler: Task<Void, Never>?
 
     private init() {}
+
+    /// The stalls in the current window, left in place. What a hang report
+    /// reads — it fires on its own schedule and must not consume the window
+    /// the health report is accumulating.
+    func stallSummary() -> MainThreadStall.Window? {
+        stall.summary()
+    }
+
+    /// Summarise the stalls since the last call and start a fresh window. The
+    /// health report is the only caller; a second drainer would leave each of
+    /// them an arbitrary half of the samples.
+    func takeStallWindow() -> MainThreadStall.Window? {
+        stall.takeWindow()
+    }
 
     /// Begin sampling. Idempotent — every window's launch setup may call it.
     func start() {
@@ -52,6 +76,7 @@ final class MainThreadLoad {
                 // instead would need a "was the Mac asleep?" guess.
                 self.lateness = FeedFlushCadence.lateness(
                     elapsed: ContinuousClock.now - started, requested: Self.period)
+                self.stall.ingest(self.lateness)
             }
         }
     }

--- a/App/Sources/Root/RootView.swift
+++ b/App/Sources/Root/RootView.swift
@@ -253,6 +253,7 @@ struct RootView: View {
         // once, because main-thread load belongs to the thread rather than to
         // any one feed.
         MainThreadLoad.shared.start()
+        AppVisibility.shared.start()
         // A double-clicked APK — or a split bundle (.apks/.xapk/.apkm) — opens
         // the in-window opened-package screen (install with live status / APK
         // Studio); a double-clicked AAB opens the AAB to APK converter with the

--- a/App/Sources/Root/TabEnvironment.swift
+++ b/App/Sources/Root/TabEnvironment.swift
@@ -17,8 +17,9 @@ extension EnvironmentValues {
     /// tabs stay mounted, so device-heavy *live* views (network/CPU polling, the
     /// screen mirror) read this to pause while hidden. Recordings and log streams
     /// deliberately ignore it and keep *running* — but they pace their flushing
-    /// by it (`reportsFeedVisibility`, `FeedFlushCadence.hidden`), because a
-    /// mounted hidden tab lays its rows out exactly like a visible one.
+    /// by it (`reportsFeedVisibility`), because a mounted hidden tab lays its
+    /// rows out exactly like a visible one — and stop publishing entirely when
+    /// nobody can see them at all.
     /// Defaults to true for views shown outside the tab host (Settings,
     /// sheets), which must never pause.
     var tabIsActive: Bool {
@@ -54,13 +55,20 @@ private struct FeedVisibilityReporter: ViewModifier {
     @State private var viewID = UUID()
     let report: (UUID, Bool) -> Void
 
+    /// Being the front tab is only half of it: the window that tab sits in has
+    /// to be on screen too. `AppVisibility` asks the window server, because
+    /// neither `tabIsActive` nor `NSApp.isActive` answers it — an app behind
+    /// another window can still be perfectly readable, and a front tab in a
+    /// fully covered window cannot.
+    private var canBeSeen: Bool { tabIsActive && AppVisibility.shared.hasVisibleWindow }
+
     func body(content: Content) -> some View {
         content
             // Reported from lifecycle hooks, never from `body`: these writes
             // land on state a feed view reads, and writing observable state
             // during an update is an endless update loop, not a wasted pass.
-            .onAppear { report(viewID, tabIsActive) }
-            .onChange(of: tabIsActive) { _, visible in report(viewID, visible) }
+            .onAppear { report(viewID, canBeSeen) }
+            .onChange(of: canBeSeen) { _, visible in report(viewID, visible) }
             .onDisappear { report(viewID, false) }
     }
 }

--- a/App/Sources/Telemetry/PerformanceMonitor.swift
+++ b/App/Sources/Telemetry/PerformanceMonitor.swift
@@ -40,9 +40,16 @@ final class PerformanceMonitor {
         return context.openFeatures.contains { cpuIntensiveFeatures.contains($0) }
     }
 
+    /// Ticks between health reports. The poller runs every 5 s and this is a
+    /// windowed summary, not a sample, so a five-minute window is both enough
+    /// resolution to see a footprint climbing over an hour and little enough
+    /// event volume to sit inside a free plan.
+    private static let healthReportTicks = 60
+
     private var poller: Task<Void, Never>?
     private var watchdog = ResourceWatchdog()
     private var perFeature = FeaturePerfAggregator()
+    private var ticksUntilHealthReport = healthReportTicks
 
     /// Begin sampling every `interval`. `context` is read on the main actor each
     /// tick, so it can reach into AppState safely. Each sample feeds two things:
@@ -63,6 +70,14 @@ final class PerformanceMonitor {
                 if let record = self.perFeature.ingest(sample, feature: context.activeFeature ?? "none") {
                     Telemetry.shared.reportFeaturePerf(record)
                 }
+                self.ticksUntilHealthReport -= 1
+                guard self.ticksUntilHealthReport <= 0 else { continue }
+                self.ticksUntilHealthReport = Self.healthReportTicks
+                // Drains the stall window, so nothing else may: two callers
+                // would each get half the samples.
+                Telemetry.shared.reportHealth(
+                    footprintBytes: sample.footprintBytes,
+                    stall: MainThreadLoad.shared.takeStallWindow())
             }
         }
     }

--- a/App/Sources/Telemetry/Telemetry.swift
+++ b/App/Sources/Telemetry/Telemetry.swift
@@ -313,6 +313,88 @@ final class Telemetry {
         ])
     }
 
+    // MARK: - Health
+
+    /// Footprint at the first sample of the session — the denominator for
+    /// growth. A number on its own says little: 1.5 GB is alarming for a
+    /// session that started at 363 MB and unremarkable for one that opened a
+    /// 1 GB APK.
+    private var baselineFootprintBytes: UInt64?
+
+    /// One app-hang report, with the facts the bare event never carried.
+    ///
+    /// The hang itself supplies no duration — Sentry fills that in from the
+    /// configured threshold, so every report reads "at least 2000 ms" — so the
+    /// measured stall comes from the app's own sampler (`MainThreadStall`).
+    /// Memory, growth since launch, and what the feeds were holding ride along
+    /// because reconstructing them afterwards meant joining three event types
+    /// by hour, and only after knowing to look.
+    func reportHang() {
+        var properties: [String: Any] = [:]
+        // Peeked, never drained: the health report owns the window.
+        if let window = MainThreadLoad.shared.stallSummary() {
+            properties["stall_worst_ms"] = window.worstMilliseconds
+            properties["stall_median_ms"] = window.medianStallMilliseconds
+            properties["stall_percent"] = window.stalledPercent
+            properties["stall_samples"] = window.samples
+        }
+        if let sample = ProcessStats.sample() {
+            let megabytes = Int(sample.footprintBytes / 1_048_576)
+            properties["memory_mb"] = megabytes
+            if let growth = growthPercent(sample.footprintBytes) { properties["memory_growth_pct"] = growth }
+        }
+        for (key, value) in FeedHealth.shared.properties { properties[key] = value }
+        track("app_hang", properties)
+    }
+
+    /// A periodic picture of the things that go wrong together: how late the
+    /// main thread has been running, how much memory the process holds against
+    /// where it started, and what each streaming feed is retaining.
+    ///
+    /// One event rather than three, because the incident that prompted it was
+    /// only visible as a *shape* — a footprint climbing 363 MB → 1.58 GB over
+    /// three hours while two feeds streamed to a window nobody was looking at.
+    /// No single existing event carried two of those three facts, so seeing the
+    /// shape meant already suspecting it.
+    ///
+    /// Skipped entirely when there is nothing to say: a healthy thread and no
+    /// retained feed rows sends no event, so an idle app costs no quota.
+    func reportHealth(footprintBytes: UInt64, stall: MainThreadStall.Window?) {
+        let feeds = FeedHealth.shared.properties
+        let quiet = stall?.isQuiet ?? true
+        guard !quiet || (feeds["feed_rows"] ?? 0) > 0 else { return }
+        var properties: [String: Any] = [
+            "memory_mb": Int(footprintBytes / 1_048_576),
+        ]
+        if let growth = growthPercent(footprintBytes) { properties["memory_growth_pct"] = growth }
+        if let stall {
+            properties["stall_worst_ms"] = stall.worstMilliseconds
+            properties["stall_median_ms"] = stall.medianStallMilliseconds
+            properties["stall_percent"] = stall.stalledPercent
+            properties["stall_samples"] = stall.samples
+        }
+        for (key, value) in feeds { properties[key] = value }
+        track("app_health", properties)
+        // The same numbers locally, so an incident someone shows you in person
+        // is readable without waiting for the backend:
+        //   log stream --predicate 'subsystem BEGINSWITH "com.rohindh.droidective"'
+        AppLog.write(
+            quiet ? .info : .warn, .feed, "health",
+            properties.compactMapValues { $0 as? Int })
+    }
+
+    /// Footprint against the session's first sample, as a percentage. nil until
+    /// a baseline exists — the first sample *is* the baseline, and reporting it
+    /// as 100% growth would be noise.
+    private func growthPercent(_ footprintBytes: UInt64) -> Int? {
+        guard let baseline = baselineFootprintBytes else {
+            baselineFootprintBytes = footprintBytes
+            return nil
+        }
+        guard baseline > 0 else { return nil }
+        return Int((Double(footprintBytes) / Double(baseline) * 100).rounded())
+    }
+
     // MARK: - Performance incidents
 
     /// Report sustained app resource overuse (or its recovery) from the
@@ -437,7 +519,7 @@ final class Telemetry {
             // (the `active_feature` super-property rides along automatically).
             options.beforeSend = { event in
                 if Self.isAppHang(event) {
-                    Task { @MainActor in Telemetry.shared.track("app_hang") }
+                    Task { @MainActor in Telemetry.shared.reportHang() }
                 }
                 return event
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,7 +607,38 @@ table) is in `docs/reactotron-mcp-analysis.md`.
 - **A streaming feed is paced by who can see it and how busy the main thread
   is** — never by a bare timer. All four feeds (Reactotron, JS Console, logcat,
   iOS logs) go through `FeedFlushCadence`, and adding a fifth means passing all
-  three inputs: `appActive`, `watched`, `lateness`. Traps worth knowing:
+  three inputs: `appActive`, `watched`, `lateness`. `interval` returns
+  **nil** — schedule nothing — when nobody can see the feed; a feed that cannot
+  pause because its flush yields into an `AsyncStream` rather than publishing
+  observable state (the two log streams) calls `drainingInterval` and backs off
+  to the 8 s ceiling instead. Traps worth knowing:
+  - **Visible means the window server says so, not that the app is frontmost.**
+    `NSApp.isActive` answers a different question — an app behind another
+    window can still be perfectly readable, and a front tab in a fully covered
+    window cannot be. `AppVisibility` (App) folds `NSWindow.occlusionState`
+    into what `reportsFeedVisibility` reports, with frontmost short-circuiting
+    to visible so a wrong occlusion answer can never stall a feed someone is
+    reading.
+  - **A feed's byte budget is a *resident* budget, and what it caps is *wire*
+    bytes.** `FeedMemoryBudget` (ADBKit) holds the conversion: a decoded frame
+    costs about 8x its wire size, so the old flat 128 MB wire cap was a
+    gigabyte resident, *per feed* — two streaming feeds put the ceiling near
+    2 GB. It is now a fraction of the machine (1/32 of RAM, floor 48 MB,
+    ceiling 192 MB decoded). The measurement that settled it is one install's
+    `feature_perf` curve with three tabs open (home, js-console, reactotron):
+    363 MB at 08:00, 1096 MB by 10:00, 1578 MB by 11:00, then a *day* spent
+    sawtoothing between 0.8 and 1.5 GB as the rings filled and evicted, with
+    CPU peaks of 56–102% while the app was not even frontmost. The band was
+    the buffers' own working range, which is why no leak was ever found: the
+    cap *was* the bug.
+  - **A hang report cannot tell you how long the hang was.** Sentry fills the
+    duration in from the configured threshold (`durationMs =
+    appHangTimeoutInterval * 1000`), so every event reads "at least 2000 ms".
+    `MainThreadStall` (ADBKit) keeps the lateness samples `MainThreadLoad`
+    already takes and was discarding, and `FeedHealth` (App) is the one
+    snapshot of what every feed retains — per-feed Sentry contexts could never
+    answer "how much across all of them". Both ride the `app_hang` event and a
+    five-minute `app_health` line.
   - **Visibility is an audience, not a flag** (`FeedAudience`). One feed can be
     on screen twice — an app-wide feed in two windows, a per-window feed in
     both panes of a split — and SwiftUI lifecycle hooks are not reliably


### PR DESCRIPTION
Two feeds were each entitled to about a gigabyte of decoded log rows, and kept
publishing to a window nobody could see.

## What the telemetry showed

One install (`Mac17,2`, 16 GB, macOS 26.4.1) with three tabs open — home,
js-console, reactotron — from its `feature_perf` windows:

| time | app memory | peak CPU |
| --- | --- | --- |
| 08:00 | 363 MB (session baseline) | 57% |
| 10:00 | 1096 MB | 96% |
| 11:00 | **1578 MB** | **102%** |
| next day, 04:00–07:00 | 1442 → 1506 MB | 66–80% |
| 12:00 | 794 MB | 5% |

`app_perf_incident metric=memory value=1512` fired and did not recover for four
hours. Alongside it, sixty-odd 2-second main-thread hangs over two days
(DROIDECTIVE-MAC-B), nearly all with `app_active: false`.

Nothing leaked. The rings evicted and the footprint came down — that band was
the buffers' own working range, and with two feeds at 128 MB of wire bytes each
it is exactly the range those caps predict. Looking for a leak would never have
found anything.

## The caps measured the wrong bytes

A decoded frame costs about eight times its wire size. `ReactotronTimeline`'s
own comment conceded the multiple without following it through to the number,
so a 128 MB *wire* cap was roughly a gigabyte *resident* — per feed.

`FeedMemoryBudget` holds the conversion and sizes the budget against the machine
instead: 1/32 of RAM, floor 48 MB, ceiling 192 MB decoded. Both feeds read it,
so the figure cannot be hand-copied and drift again (which is how the JS Console
came to carry Reactotron's 128 MB by hand). On a 16 GB machine: 192 MB decoded /
24 MB wire per feed, down from ~1 GB.

## A feed nobody could see kept publishing

`watched` came from `tabIsActive` and `appActive` from `NSApp.isActive`, and
neither answers whether the window is on screen. This user sat with the app
behind another window and a Reactotron tab in front, so the feed scored as
watched-but-inactive — the 1-second cadence — and re-diffed every second for
twenty-four minutes while nobody was looking at it.

`AppVisibility` asks the window server (`NSWindow.occlusionState`) and folds that
into what `reportsFeedVisibility` reports. Frontmost short-circuits to visible,
so a wrong occlusion answer can never stall a feed someone is reading — the one
failure worse than the cost this saves.

`FeedFlushCadence.interval` therefore returns nil for an unwatched feed:
schedule nothing. That reverses the earlier decision to pace rather than pause,
which was right at the time — pausing grew the buffer unbounded. Both feeds now
bound pending by bytes as well as by the cadence, so a paused feed cannot grow
without limit and the flush it eventually hands over is capped at a quarter of
the budget. The two log streams cannot pause at all (their flush yields into an
`AsyncStream` rather than publishing observable state), so they call
`drainingInterval` and back off to the 8 s ceiling.

## The instrumentation, which is the first commit

A hang report cannot say how long the hang was: Sentry's integration fills the
duration in from the configured threshold (`durationMs = appHangTimeoutInterval
* 1000`), so every event reads "at least 2000 ms". And `app_hang` carried no
properties at all.

The measurement was already being taken and thrown away — `MainThreadLoad` asks
the main thread for a turn twice a second and then overwrote the reading.
`MainThreadStall` keeps the samples: worst lateness (the real hang duration),
median across stalled samples only, and the share of turns that stalled, which
separates one long spike from a thread late a third of the time.

`FeedHealth` is the other half. Each feed published its own Sentry context, so
nothing could answer how much the app held *across* them — the question that
mattered at 1.5 GB with two feeds open. Reconstructing it meant joining three
event types by hour, after knowing to look.

Both ride `app_hang` and a five-minute `app_health` line, skipped entirely when
the thread is healthy and no feed holds rows. The same numbers go to os_log, so
an incident someone shows you in person is readable without the backend.

## Verification

`make verify` green — 2091 ADBKit / 99 ReactotronMCP / 408 droidectived / 128
AppTests — and `make build` warning-free. Each commit was checked out and built
on its own, so the instrumentation commit stands alone.

**Not verified:** the predicted memory band. That is a measurement, not an
argument, and it needs a real RN session — the new `app_health` rows will show
whether the plateau lands near 0.1–0.4 GB as expected. If it does not,
`decodedGraphMultiplier` is the one constant to change.

**Also open:** one of the sixty hangs has `app_active: true`. Everything here
addresses the background case, so if the foreground stall is a separate bug this
does not close it — the instrumentation is what will surface it.
