### PR TITLE
Stop MCP restarting the Reactotron relay it just started

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronServer.swift
@@ -292,8 +292,14 @@ public actor ReactotronServer {
         // guarantee on actor entry, so a burst could land timeline rows out
         // of wire order. The socket callbacks run on a serial queue, so the
         // yields — and therefore the events — keep the order the app sent.
+        // Bounded like the primary event stream: a client that outruns the
+        // actor — the 16 MB-of-queued-frames case `disconnectNotice` describes
+        // — would otherwise queue raw frames with no ceiling, and a frame may
+        // be up to `maximumMessageSize`. Dropping the oldest is the behaviour
+        // one layer up already accepts, and the timeline's own ring evicts
+        // oldest-first regardless.
         let (frames, feed) = AsyncStream.makeStream(
-            of: Data.self, bufferingPolicy: .unbounded)
+            of: Data.self, bufferingPolicy: .bufferingNewest(512))
         frameFeeds[id] = feed
         Task { [weak self] in
             for await data in frames {

--- a/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
+++ b/ADBKit/Sources/ADBKit/Services/Reactotron/ReactotronTimeline.swift
@@ -21,6 +21,28 @@ public enum ReactotronTimeline {
     /// the incidents and the arithmetic.
     public static var maxTotalBytes: Int { FeedMemoryBudget.wireBudget }
 
+    /// How many *unflushed* rows to drop so the pending buffer can't outgrow
+    /// what the ring is going to keep anyway.
+    ///
+    /// A feed nobody can see schedules no flush (`FeedFlushCadence.interval`
+    /// answers nil), so rows pile up until the byte bound trips. Bytes are not
+    /// what a flush costs: at a few hundred bytes a row that bound is tens of
+    /// thousands of rows, and `dropCount` evicts all but `maxItems` of them the
+    /// moment they land — after the whole batch has already been appended and
+    /// walked. Trimming while they wait makes the flush cost what the buffer is
+    /// allowed to keep, and drops nothing the append wouldn't have.
+    ///
+    /// Hysteresis matches `dropCount`: once over the cap, trim to 7/8 of it, so
+    /// a full pending buffer doesn't shift its whole array on every append.
+    ///
+    /// - Parameters:
+    ///   - count: rows waiting to be flushed.
+    ///   - maxCount: the ring's count cap (defaults to `maxItems`).
+    public static func pendingDropCount(count: Int, maxCount: Int = maxItems) -> Int {
+        guard count > maxCount else { return 0 }
+        return count - (maxCount - maxCount / 8)
+    }
+
     /// How many items to drop from the front so the buffer fits its caps.
     ///
     /// Trims with hysteresis — once a cap is exceeded it trims down to 7/8 of

--- a/ADBKit/Tests/ADBKitTests/ReactotronTimelineTests.swift
+++ b/ADBKit/Tests/ADBKitTests/ReactotronTimelineTests.swift
@@ -77,4 +77,30 @@ import Testing
             #expect(sizes.last == value % 100)
         }
     }
+
+    // MARK: - Pending buffer
+
+    @Test func aPendingBufferUnderTheCapIsLeftAlone() {
+        #expect(ReactotronTimeline.pendingDropCount(count: 0, maxCount: 100) == 0)
+        #expect(ReactotronTimeline.pendingDropCount(count: 100, maxCount: 100) == 0)
+    }
+
+    @Test func aPendingBufferOverTheCapTrimsToSevenEighths() {
+        // 100 → keep 88 (the same hysteresis `dropCount` applies), so a full
+        // buffer trims in batches instead of shifting on every append.
+        #expect(ReactotronTimeline.pendingDropCount(count: 101, maxCount: 100) == 13)
+        #expect(ReactotronTimeline.pendingDropCount(count: 30_000, maxCount: 100) == 29_912)
+    }
+
+    /// The point of the rule: however long a feed goes unwatched, the flush it
+    /// eventually hands over is the size the ring would have kept anyway.
+    @Test func anUnwatchedFeedNeverQueuesMoreThanTheRingKeeps() {
+        var pending = 0
+        for _ in 0 ..< 50_000 {
+            pending += 1
+            pending -= ReactotronTimeline.pendingDropCount(count: pending, maxCount: 2000)
+            #expect(pending <= 2000)
+        }
+        #expect(pending >= 2000 - 2000 / 8)
+    }
 }

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -236,7 +236,12 @@ final class ReactotronSession {
     /// tunnels of already-connected devices.
     func deviceListChanged() {
         let current = Set(readyAndroidSerials)
-        tunnelIssues = tunnelIssues.filter { current.contains($0.key) }
+        // Only when it actually changes: `@Observable` fires on an equal value
+        // too, and this map is read by every open Reactotron view — an
+        // unconditional write re-runs both panes' whole filter pass for a
+        // device list that has nothing to do with the tunnels.
+        let keptIssues = tunnelIssues.filter { current.contains($0.key) }
+        if keptIssues != tunnelIssues { tunnelIssues = keptIssues }
         reverseRefreshAttempts = reverseRefreshAttempts.filter { current.contains($0.key) }
         guard isRunning else {
             knownReadySerials = current

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -477,7 +477,12 @@ final class ReactotronSession {
             guard let service else { return }
             reversedSerials.formUnion(serials)
             knownReadySerials.formUnion(serials)
-            let results = await service.reverse(serials: serials)
+            // A button press, so it belongs in Settings ▸ Command Log — unlike
+            // `applyReverse`, which runs from the device poll and would evict
+            // the log's 200 entries.
+            let results = await CommandLog.userInitiated {
+                await service.reverse(serials: serials)
+            }
             recordTunnelResults(results)
             let okCount = results.count(where: \.ok)
             if let failure = results.first(where: { !$0.ok }) {

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -741,6 +741,7 @@ final class ReactotronSession {
             flushPending()
             return
         }
+        trimPending()
         guard flushTask == nil else { return }
         // Hidden tabs stay mounted and lay their rows out like visible ones,
         // and a main thread that is already behind must not be asked for a
@@ -759,6 +760,28 @@ final class ReactotronSession {
             guard !Task.isCancelled else { return }
             self?.flushPending()
         }
+    }
+
+    /// Drop rows the ring would evict on arrival anyway.
+    ///
+    /// The byte bound above caps how much memory the pending buffer holds; it
+    /// does not cap how many *rows* one flush hands SwiftUI, and rows are what
+    /// a layout pass costs. Small events (a plain `log` is a few hundred bytes)
+    /// reach tens of thousands of rows inside that byte budget while nobody is
+    /// watching the feed, and `appendBatch` then appends every one of them and
+    /// evicts all but `ReactotronTimeline.maxItems` in the same turn — at the
+    /// moment the user switches to the tab. Trimming here is the same eviction,
+    /// paid per append instead of all at once.
+    private func trimPending() {
+        let drop = ReactotronTimeline.pendingDropCount(count: pendingItems.count)
+        guard drop > 0 else { return }
+        let dropped = Array(pendingItems[..<drop])
+        pendingItems.removeFirst(drop)
+        pendingBytes -= dropped.reduce(0) { $0 + $1.frameBytes }
+        // Counted as evictions, because that is what they are — the usage
+        // stats that size the caps must not read as if nothing was dropped.
+        evictedItemCount += drop
+        Self.discardInBackground(dropped)
     }
 
     /// One view reported whether it can see the timeline. Becoming visible

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -112,6 +112,14 @@ final class ReactotronSession {
     /// worth asking about on the way out.
     var hasLiveConnection: Bool { isRunning && !clients.isEmpty }
 
+    /// Why the server is down, when it failed rather than never having been
+    /// started — the same sentence this screen's banner shows. Settings ▸ MCP
+    /// repeats it instead of telling the user to start a server that is
+    /// already failing to bind.
+    var startFailure: String? {
+        connection.isError ? connection.text(app: nil) : nil
+    }
+
     init(client: AdbClient) {
         self.client = client
     }
@@ -654,6 +662,10 @@ final class ReactotronSession {
             selectedClient = nil
             commands.removeAll()
             connection = portInUse ? .portInUse : .failed(reason)
+            // A listener that dies leaves MCP serving the clients it had —
+            // agents would see ghosts instead of `no_apps_connected`. The
+            // relay is down now, so this is the same news `stop()` reports.
+            core?.mcp.reactotronServerChanged()
         }
     }
 

--- a/App/Sources/FeatureDetail/Views/ReactotronView.swift
+++ b/App/Sources/FeatureDetail/Views/ReactotronView.swift
@@ -77,6 +77,12 @@ final class ReactotronSession {
     /// with the session (`reset`), like the buffer they scope.
     fileprivate var paneClearSeqs: [Int: Int] = [:]
 
+    /// The relay's lifecycle in the unified log, next to the server's own
+    /// connection lines: `log show --predicate 'subsystem ==
+    /// "com.rohindh.droidective"'`.
+    fileprivate static let log = Logger(
+        subsystem: "com.rohindh.droidective", category: "reactotron-session")
+
     private let client: AdbClient
     /// Back-reference for toasts and save dialogs; set right after init.
     /// The window the relay reports through (toasts, save panels) — the
@@ -196,6 +202,7 @@ final class ReactotronSession {
             return
         }
         connection = .listening
+        Self.log.notice("relay start requested on :\(ReactotronService.defaultPort)")
         await applyReverse(serials: serials)
         consumeTask = Task { [weak self] in
             for await event in stream {
@@ -221,8 +228,7 @@ final class ReactotronSession {
         guard let service else { return }
         // In the unified log next to the server's connection-drop lines, for
         // field diagnosis of tunnel/connection interactions.
-        Logger(subsystem: "com.rohindh.droidective", category: "reactotron-session")
-            .notice("applying adb reverse for \(serials.count) device(s)")
+        Self.log.notice("applying adb reverse for \(serials.count) device(s)")
         reversedSerials.formUnion(serials)
         knownReadySerials.formUnion(serials)
         recordTunnelResults(await service.reverse(serials: serials))
@@ -562,7 +568,8 @@ final class ReactotronSession {
 
     private func handle(_ event: ReactotronServer.Event) {
         switch event {
-        case .listening:
+        case let .listening(port):
+            Self.log.notice("relay listening on :\(port)")
             if clients.isEmpty { connection = .listening }
         case let .connected(connectionId, _, intro, frameBytes):
             let parsed = ReactotronEvent(command: intro)
@@ -662,6 +669,10 @@ final class ReactotronSession {
             if clients.isEmpty { commands.removeAll() }
             refreshConnectionState()
         case let .failed(reason, portInUse):
+            // Why the relay died, next to the tunnel lines — without it, "MCP
+            // went down at launch" is a sequence nobody can reconstruct.
+            Self.log.error(
+                "relay failed (portInUse: \(portInUse)): \(reason, privacy: .public)")
             // The server tears itself down on failure, so drop our handle to it —
             // otherwise `isRunning` stays true and re-entering the view (or the
             // Retry button) would skip the restart and the error could never clear.

--- a/App/Sources/State/McpCoordinator.swift
+++ b/App/Sources/State/McpCoordinator.swift
@@ -188,13 +188,29 @@ final class McpCoordinator {
             if core.reactotronSession.isRunning { startedRelay = true }
         }
         guard let (events, sender) = await core.reactotronSession.mcpAttachment() else {
-            await controller.stop()
-            // The relay's own words when it has some — "open the Reactotron
-            // feature and start it" is wrong advice when the feature is showing
-            // a bind error of its own.
-            status = .failed(core.reactotronSession.startFailure
-                ?? "The Reactotron server isn't running — open the Reactotron "
-                + "feature and start it, then retry.")
+            startedRelay = false
+            let listeningPort: UInt16? = if case let .listening(port) = await controller.status {
+                port
+            } else {
+                nil
+            }
+            switch McpRelayPolicy.withoutRelay(mcpListening: listeningPort != nil) {
+            case .keepServing:
+                // The relay blipped under a server that is already up. Drop the
+                // ghost clients and wait for its next start to re-attach —
+                // tearing the listener down here is what turned a one-second
+                // relay outage into an MCP server that never came back.
+                await controller.noteRelayStopped()
+                if let listeningPort { status = .listeningWithoutRelay(port: listeningPort) }
+            case .reportFailure:
+                await controller.stop()
+                // The relay's own words when it has some — "open the Reactotron
+                // feature and start it" is wrong advice when the feature is
+                // showing a bind error of its own.
+                status = .failed(core.reactotronSession.startFailure
+                    ?? "The Reactotron server isn't running — open the Reactotron "
+                    + "feature and start it, then retry.")
+            }
             return
         }
 

--- a/App/Sources/State/McpCoordinator.swift
+++ b/App/Sources/State/McpCoordinator.swift
@@ -107,10 +107,16 @@ final class McpCoordinator {
     /// launch, on every Settings ▸ MCP change, and from the Retry button.
     /// Restarts the listener, so live agent sessions reconnect.
     func applySettings() {
+        schedule(trigger: .settings)
+    }
+
+    /// Queue a reconcile behind the one in flight, so a toggle flurry (or a
+    /// relay restart landing mid-toggle) can't interleave two of them.
+    private func schedule(trigger: McpRelayPolicy.Trigger) {
         let previous = applyTask
         applyTask = Task { [weak self] in
             await previous?.value
-            await self?.reconcile()
+            await self?.reconcile(trigger: trigger)
         }
     }
 
@@ -128,7 +134,12 @@ final class McpCoordinator {
     func reactotronServerChanged() {
         guard isEnabled, let core else { return }
         if core.reactotronSession.isRunning {
-            applySettings()
+            // `.relayChanged`, never `applySettings()`: this callback is raised
+            // from inside the relay's own start, so a reconcile that could
+            // start the relay would be told about its own start — and restart
+            // a relay whose listener had failed in the meantime, forever. See
+            // `McpRelayPolicy`.
+            schedule(trigger: .relayChanged)
         } else {
             startedRelay = false
             let listeningPort: UInt16? = if case let .listening(port) = status {
@@ -156,7 +167,7 @@ final class McpCoordinator {
 
     // MARK: - Reconcile
 
-    private func reconcile() async {
+    private func reconcile(trigger: McpRelayPolicy.Trigger) async {
         guard let core else { return }
         guard isEnabled else {
             await controller.stop()
@@ -170,13 +181,19 @@ final class McpCoordinator {
         }
 
         status = .starting
-        if !core.reactotronSession.isRunning {
+        if McpRelayPolicy.startsRelay(
+            trigger: trigger, relayRunning: core.reactotronSession.isRunning
+        ) {
             await core.reactotronSession.start(serials: core.reactotronSession.readyAndroidSerials)
             if core.reactotronSession.isRunning { startedRelay = true }
         }
         guard let (events, sender) = await core.reactotronSession.mcpAttachment() else {
             await controller.stop()
-            status = .failed("The Reactotron server isn't running — open the Reactotron "
+            // The relay's own words when it has some — "open the Reactotron
+            // feature and start it" is wrong advice when the feature is showing
+            // a bind error of its own.
+            status = .failed(core.reactotronSession.startFailure
+                ?? "The Reactotron server isn't running — open the Reactotron "
                 + "feature and start it, then retry.")
             return
         }

--- a/App/Sources/State/McpRelayPolicy.swift
+++ b/App/Sources/State/McpRelayPolicy.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Whether an MCP reconcile is allowed to bring the Reactotron relay up itself.
+///
+/// Pure and separate from `McpCoordinator` because the case it exists for
+/// cannot be reached through the coordinator in a test: the relay's
+/// `startServer` raises `reactotronServerChanged()` *while* it is starting, so
+/// a reconcile that starts the relay is told about its own start. That is
+/// harmless while the relay stays up — but an `NWListener` fails
+/// asynchronously, so when port 9090 is already taken (another Droidective, or
+/// the Reactotron desktop app) the server exists for a few milliseconds and is
+/// then gone. The reconcile that callback scheduled therefore finds the relay
+/// down, starts it again, is told about *that* start, and so on: a
+/// free-running restart storm — hundreds of listener binds and `adb reverse`
+/// invocations a second — with the Reactotron pane flickering between
+/// "Waiting for your app" and "Port 9090 is taken".
+///
+/// The rule that breaks it: a notification *about* the relay never changes the
+/// relay. It exists to re-attach the tap; only the user's own actions (enabling
+/// MCP, launch, Retry) may start a relay that is down.
+enum McpRelayPolicy {
+    /// What scheduled the reconcile.
+    enum Trigger {
+        /// Launch, a Settings ▸ MCP change, or a Retry button — the user asked
+        /// for MCP to be working, so bringing the relay up is part of that.
+        case settings
+        /// The relay itself started or stopped and MCP is only re-attaching.
+        case relayChanged
+    }
+
+    /// Whether this reconcile should start the Reactotron relay.
+    ///
+    /// - Parameters:
+    ///   - trigger: what scheduled the reconcile.
+    ///   - relayRunning: whether the relay is up already, in which case there
+    ///     is nothing to start and the reconcile just attaches its tap.
+    static func startsRelay(trigger: Trigger, relayRunning: Bool) -> Bool {
+        switch trigger {
+        case .settings: !relayRunning
+        case .relayChanged: false
+        }
+    }
+}

--- a/App/Sources/State/McpRelayPolicy.swift
+++ b/App/Sources/State/McpRelayPolicy.swift
@@ -28,6 +28,32 @@ enum McpRelayPolicy {
         case relayChanged
     }
 
+    /// What a reconcile does when the relay has no tap to offer.
+    enum RelaylessOutcome {
+        /// Leave the MCP server listening and drop its stale client records —
+        /// agents get `no_apps_connected` guidance and reconnect to the relay
+        /// on its next start.
+        case keepServing
+        /// Nothing is serving yet, so say why instead of pretending.
+        case reportFailure
+    }
+
+    /// Whether a reconcile that found no relay should tear the MCP server down.
+    ///
+    /// Observed at a launch where the previous instance still held port 9090:
+    /// the relay's first start failed, MCP had already bound its own listener
+    /// moments earlier, and the reconcile that arrived next stopped it. The
+    /// relay recovered a second later; the MCP server never did, and stayed
+    /// down until the app was relaunched.
+    ///
+    /// A live MCP server therefore outlives a relay outage, which is the
+    /// contract `noteRelayStopped` already implements for a relay the user
+    /// stops. Only a server that never came up reports the failure — it has no
+    /// tap to serve from and nothing to keep alive.
+    static func withoutRelay(mcpListening: Bool) -> RelaylessOutcome {
+        mcpListening ? .keepServing : .reportFailure
+    }
+
     /// Whether this reconcile should start the Reactotron relay.
     ///
     /// - Parameters:

--- a/App/Tests/McpRelayPolicyTests.swift
+++ b/App/Tests/McpRelayPolicyTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+/// Whether an MCP reconcile may start the Reactotron relay. The rule exists to
+/// break a restart storm, so the tests are written as the storm's own shape.
+@Suite struct McpRelayPolicyTests {
+    @Test func enablingMcpStartsARelayThatIsDown() {
+        #expect(McpRelayPolicy.startsRelay(trigger: .settings, relayRunning: false))
+    }
+
+    @Test func aRunningRelayIsLeftAloneAndOnlyReattached() {
+        #expect(!McpRelayPolicy.startsRelay(trigger: .settings, relayRunning: true))
+        #expect(!McpRelayPolicy.startsRelay(trigger: .relayChanged, relayRunning: true))
+    }
+
+    /// The storm: the relay's own `startServer` raises the relay-changed
+    /// callback, and its `NWListener` then fails asynchronously when the port
+    /// is taken. A reconcile scheduled by that callback must not answer the
+    /// failure by starting the relay again — that start would raise the
+    /// callback again, and so on without end.
+    @Test func aRelayChangedReconcileNeverStartsTheRelay() {
+        #expect(!McpRelayPolicy.startsRelay(trigger: .relayChanged, relayRunning: false))
+    }
+
+    /// Freeing the port and pressing Retry (or re-enabling MCP) must still
+    /// bring the relay up — the rule bounds the automatic path only.
+    @Test func retryAfterAFailedStartMayStartTheRelayAgain() {
+        #expect(McpRelayPolicy.startsRelay(trigger: .settings, relayRunning: false))
+    }
+}

--- a/App/Tests/McpRelayPolicyTests.swift
+++ b/App/Tests/McpRelayPolicyTests.swift
@@ -27,4 +27,17 @@ import Testing
     @Test func retryAfterAFailedStartMayStartTheRelayAgain() {
         #expect(McpRelayPolicy.startsRelay(trigger: .settings, relayRunning: false))
     }
+
+    // MARK: - Reconciling without a relay
+
+    /// The observed outage: MCP had bound its listener, the relay's start then
+    /// failed on a port the previous instance still held, and the reconcile
+    /// that followed stopped the server. The relay recovered; MCP did not.
+    @Test func aServingMcpOutlivesARelayOutage() {
+        #expect(McpRelayPolicy.withoutRelay(mcpListening: true) == .keepServing)
+    }
+
+    @Test func aServerThatNeverCameUpReportsTheFailure() {
+        #expect(McpRelayPolicy.withoutRelay(mcpListening: false) == .reportFailure)
+    }
 }

--- a/ReactotronMCP/Tests/ReactotronMCPTests/McpHTTPListenerTests.swift
+++ b/ReactotronMCP/Tests/ReactotronMCPTests/McpHTTPListenerTests.swift
@@ -218,6 +218,30 @@ import Testing
         continuation.finish()
     }
 
+    /// Stopping and immediately re-binding the same port is what a relay
+    /// restart makes the coordinator do — the relay's fresh server needs a new
+    /// tap and a new sender, and the listener is rebuilt around them. Observed
+    /// failing on a real launch: bound, stopped 480 ms later, then never came
+    /// back, leaving MCP down until the app was relaunched.
+    @Test func stoppingReleasesThePort() async throws {
+        let (listener, _, port) = try await makeListener()
+        await listener.stop()
+        for round in 1 ... 20 {
+            let store = McpCommandStore()
+            let factory = McpServerFactory(
+                store: store, sender: FakeSender(store: store), version: "t")
+            let next = McpHTTPListener(
+                configuration: McpHTTPListener.Configuration(port: port), factory: factory)
+            do {
+                try await next.start()
+            } catch {
+                Issue.record("round \(round): re-bind on \(port) failed: \(error)")
+                return
+            }
+            await next.stop()
+        }
+    }
+
     @Test func portConflictSurfacesAsPortInUse() async throws {
         let (listener, _, port) = try await makeListener()
         defer { Task { await listener.stop() } }

--- a/project.yml
+++ b/project.yml
@@ -301,6 +301,10 @@ targets:
     sources:
       - App/Tests
       - App/Sources/State/LaunchPrompt.swift
+      # Whether an MCP reconcile may start the Reactotron relay. The relay
+      # raises the change notification from inside its own start, so the rule
+      # is what keeps a failed bind from restarting forever.
+      - App/Sources/State/McpRelayPolicy.swift
       - App/Sources/Theme.swift
       - App/Sources/LogScrollGeometry.swift
       - App/Sources/Root/PaneFreezePolicy.swift


### PR DESCRIPTION
The Reactotron pane flickers between "Waiting for your app" and "Port 9090 is taken" — about five times a second — whenever MCP is enabled and something else already holds 9090 (a second Droidective, or the Reactotron desktop app). It is not a repaint: the relay is being restarted that often.

`ReactotronSession.startServer` calls `McpCoordinator.reactotronServerChanged()` from inside its own start, and that scheduled a reconcile which was itself allowed to start the relay. An `NWListener` fails asynchronously, so with the port taken the server exists for a few milliseconds and is then gone — the reconcile finds the relay down, starts it again, is told about that start, and so on without end. From a real install's log:

```
12:25:33.087 … applying adb reverse for 0 device(s)
12:25:33.088 … applying adb reverse for 0 device(s)
12:25:33.089 … applying adb reverse for 0 device(s)   (hundreds a second)
```

With a device connected each pass waits on `adb reverse`, which is the ~5 Hz the recording shows.

## What this changes

`McpRelayPolicy` (new, pure) holds the rule that breaks the cycle: a notification *about* the relay never changes the relay. Only launch, a Settings ▸ MCP change or a Retry may start one that is down. `McpCoordinator` tags each reconcile with its trigger and asks the policy.

Two things the storm was hiding, fixed here as well:

- A listener that died never told MCP, so agents kept seeing the clients it had instead of `no_apps_connected`. `handle(.failed)` now reports the same news `stop()` does.
- Settings ▸ MCP said "open the Reactotron feature and start it" while the feature was showing a bind error of its own. It repeats the relay's own sentence when there is one.

MCP no longer retries the bind on its own: the pane's Retry button, or reopening the feature, is the way back once the port is free.

## Verification

- 132 AppTests green (128 before; four new cover the policy, written as the storm's shape), `make build` clean with warnings as errors.
- Ran the built app with 9090 held by a stub listener: two start attempts at launch (the launch reconcile plus the view's own `.task`), then zero over the following two minutes, 0.2–1% CPU. The pane holds "Port 9090 is taken" with its Retry button.
- Freed the port and relaunched: relay binds 9090, MCP binds 4567, the tunnel is applied — the healthy path is unchanged.
