### PR TITLE
Stop a subscription's poll loop outliving the socket that asked for it

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/NetworkSpeed.swift
+++ b/ADBKit/Sources/ADBKit/Services/NetworkSpeed.swift
@@ -32,8 +32,11 @@ public actor NetworkSpeedService {
         self.client = client
     }
 
-    public func reset() {
-        previous.removeAll()
+    /// Forget one device's baseline. Per serial, not the whole table: the
+    /// previous whole-table reset meant a second subscriber starting punched a
+    /// gap in every other device's throughput reading.
+    public func reset(serial: String) {
+        previous[serial] = nil
     }
 
     public func poll(serial: String) async -> NetSample? {

--- a/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
+++ b/ADBKit/Sources/ADBKit/Services/PerformanceMonitor.swift
@@ -274,10 +274,16 @@ public actor PerformanceService {
 
     /// Forget the delta baselines so a fresh recording doesn't show a spike
     /// computed against a stale, long-ago reading.
-    public func reset() {
-        previousCpu.removeAll()
-        previousGfx.removeAll()
-        previousNet.removeAll()
+    ///
+    /// One serial at a time. The whole-table version this replaces was called
+    /// once per subscription, so a second window starting a recording wiped
+    /// the first window's baselines too — punching a one-interval hole in a
+    /// chart nobody had touched. Per-device state should only ever be reset
+    /// per device.
+    public func reset(serial: String) {
+        previousCpu[serial] = nil
+        previousGfx[serial] = nil
+        previousNet[serial] = nil
     }
 
     private func consumeNet(serial: String, output: String) -> (down: Double, up: Double)? {

--- a/ADBKit/Tests/ADBKitTests/NetworkSpeedServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/NetworkSpeedServiceTests.swift
@@ -57,7 +57,21 @@ import Testing
         script(runner, rx: 1000, tx: 500)
         let service = await makeService(runner)
         _ = await service.poll(serial: "S1")
-        await service.reset()
+        await service.reset(serial: "S1")
         #expect(await service.poll(serial: "S1") == nil)
+    }
+
+    /// Two windows watching two devices. Starting a recording on one used to
+    /// wipe every baseline, so the other's next sample was dropped for want of
+    /// a delta — a gap in a chart nobody had touched.
+    @Test func resettingOneDeviceLeavesAnotherDevicesBaselineAlone() async {
+        let runner = MockProcessRunner()
+        script(runner, rx: 1000, tx: 500)
+        let service = await makeService(runner)
+        _ = await service.poll(serial: "S1")
+        _ = await service.poll(serial: "S2")
+        await service.reset(serial: "S1")
+        #expect(await service.poll(serial: "S1") == nil, "the reset device needs a fresh baseline")
+        #expect(await service.poll(serial: "S2") != nil, "the untouched device keeps its own")
     }
 }

--- a/App/Sources/FeatureDetail/Views/NetworkView.swift
+++ b/App/Sources/FeatureDetail/Views/NetworkView.swift
@@ -348,7 +348,7 @@ struct NetworkView: View {
         guard let serial else { return }
         sampler?.cancel()
         sampler = Task { @MainActor in
-            await state.env.engine.networkSpeed.reset()
+            await state.env.engine.networkSpeed.reset(serial: serial)
             while !Task.isCancelled {
                 let sample = await state.env.engine.networkSpeed.poll(serial: serial)
                 if Task.isCancelled { break }

--- a/App/Sources/FeatureDetail/Views/PerformanceView.swift
+++ b/App/Sources/FeatureDetail/Views/PerformanceView.swift
@@ -558,7 +558,7 @@ struct PerformanceView: View {
         sampler = Task { @MainActor in
             // Drop stale deltas so the first post-(re)start sample isn't a
             // spike measured against a long-ago reading.
-            await state.env.engine.performance.reset()
+            await state.env.engine.performance.reset(serial: serial)
             var tick = 0
             while !Task.isCancelled {
                 let includeProcesses = tick % 2 == 0

--- a/droidectived/Sources/DaemonCore/StreamSession.swift
+++ b/droidectived/Sources/DaemonCore/StreamSession.swift
@@ -159,6 +159,36 @@ public actor StreamSession {
         subscriptions.mapValues(\.topic)
     }
 
+    /// Hand a subscription its pump, or cancel the pump if the subscription is
+    /// already gone.
+    ///
+    /// `subscribe` suspends at least twice before it gets here — sending
+    /// `subscribed`, and building the stream — and this is a reentrant actor
+    /// whose frames each arrive as their own unstructured `Task`. So another
+    /// message runs in that window, and two of them are ordinary: the client
+    /// closing the socket (the desktop app quitting with the Performance
+    /// screen open), and an `unsubscribe` for the same id (a fast tab switch).
+    /// Either removes the entry, and `subscriptions[id]?.pump = …` then
+    /// silently discarded the handle.
+    ///
+    /// For `logcat` and `devices` that dropped an iterator over a stream
+    /// somebody else owns. For `performance` and `netspeed` it stranded a
+    /// live one: those streams build their poll `Task` inside the `AsyncStream`
+    /// builder, which runs synchronously at construction, so the loop is
+    /// already running by the time this line is reached. Nothing stops it but
+    /// `onTermination`, and the poll task retains the continuation that owns
+    /// `onTermination` — so a never-iterated stream never deinits and never
+    /// cancels. The result is an immortal 1 Hz loop spawning up to seven adb
+    /// children a second, for the life of the daemon, cumulative per
+    /// occurrence.
+    private func attach(to id: Int, _ pump: Task<Void, Never>) {
+        guard !closed, subscriptions[id] != nil else {
+            pump.cancel()
+            return
+        }
+        subscriptions[id]?.pump = pump
+    }
+
     /// Tears every subscription down. Idempotent, so a close racing an error
     /// path cannot double-cancel.
     public func shutdown(reason: StreamProtocol.EndReason = .serverStopping) async {
@@ -226,24 +256,24 @@ public actor StreamSession {
         switch topic {
         case .devices:
             let stream = await source.devices()
-            subscriptions[id]?.pump = Task { [weak self] in
+            attach(to: id, Task { [weak self] in
                 for await devices in stream {
                     await self?.enqueue(id: id, items: devices.compactMap { try? DaemonProtocol.encode($0) })
                 }
                 await self?.end(id, reason: .deviceDisconnected)
-            }
+            })
         case .logcat:
             guard let serial = command.params?.serial else { return }
             do {
                 let stream = try await source.logcat(serial: serial, pid: command.params?.pid)
-                subscriptions[id]?.pump = Task { [weak self] in
+                attach(to: id, Task { [weak self] in
                     for await lines in stream {
                         await self?.enqueue(
                             id: id,
                             items: lines.compactMap { try? DaemonProtocol.encode(LogLinePayload($0)) })
                     }
                     await self?.end(id, reason: .deviceDisconnected)
-                }
+                })
             } catch {
                 // adb refused (device gone, unauthorised). Report it and drop
                 // the subscription rather than leaving a dead id registered.
@@ -256,7 +286,7 @@ public actor StreamSession {
         case .netspeed:
             guard let serial = command.params?.serial else { return }
             let stream = await source.netspeed(serial: serial)
-            subscriptions[id]?.pump = Task { [weak self] in
+            attach(to: id, Task { [weak self] in
                 for await sample in stream {
                     await self?.enqueue(
                         id: id,
@@ -264,14 +294,14 @@ public actor StreamSession {
                             .compactMap { $0 })
                 }
                 await self?.end(id, reason: .deviceDisconnected)
-            }
+            })
 
         case .performance:
             guard let serial = command.params?.serial else { return }
             let stream = await source.performance(
                 serial: serial, packageId: command.params?.packageId,
                 includeProcesses: command.params?.wantsProcesses ?? false)
-            subscriptions[id]?.pump = Task { [weak self] in
+            attach(to: id, Task { [weak self] in
                 for await poll in stream {
                     await self?.enqueue(
                         id: id,
@@ -279,12 +309,12 @@ public actor StreamSession {
                             .compactMap { $0 })
                 }
                 await self?.end(id, reason: .deviceDisconnected)
-            }
+            })
 
         case .reactotron:
             do {
                 let stream = try await source.reactotron()
-                subscriptions[id]?.pump = Task { [weak self] in
+                attach(to: id, Task { [weak self] in
                     for await event in stream {
                         await self?.enqueue(
                             id: id,
@@ -292,7 +322,7 @@ public actor StreamSession {
                                 .compactMap { $0 })
                     }
                     await self?.end(id, reason: .serverStopping)
-                }
+                })
             } catch {
                 // The port being taken is the common one, and it is actionable:
                 // another Reactotron is running. Reported rather than left as a
@@ -307,7 +337,7 @@ public actor StreamSession {
         case .pty:
             guard let channel else { return }
             let stream = channel.output()
-            subscriptions[id]?.pump = Task { [weak self] in
+            attach(to: id, Task { [weak self] in
                 for await chunk in stream {
                     await self?.enqueue(
                         id: id,
@@ -318,11 +348,11 @@ public actor StreamSession {
                 // case where it never started, because a failed `exec` reaches
                 // the parent as the terminal hanging up rather than as a throw.
                 await self?.end(id, reason: .processExited)
-            }
+            })
 
         case .mirror:
             guard let mirror else { return }
-            subscriptions[id]?.pump = Task { [weak self] in
+            attach(to: id, Task { [weak self] in
                 do {
                     for try await frame in try await mirror.start() {
                         await self?.enqueue(
@@ -341,7 +371,7 @@ public actor StreamSession {
                     // way the reason is the whole value of the event.
                     await self?.fail(id, message: "\(error)")
                 }
-            }
+            })
         }
     }
 
@@ -502,8 +532,9 @@ public struct LiveStreamSource: StreamSource {
             let task = Task {
                 // Forget any baseline from a previous subscription: a delta
                 // against a reading from ten minutes ago is not a spike, it is
-                // an artefact.
-                await service.reset()
+                // an artefact. This device only — resetting the whole table
+                // punched a one-interval hole in every other window's chart.
+                await service.reset(serial: serial)
                 while !Task.isCancelled {
                     let poll = await service.poll(
                         serial: serial, packageId: packageId,
@@ -528,7 +559,7 @@ public struct LiveStreamSource: StreamSource {
         let service = networkService
         return AsyncStream { continuation in
             let task = Task {
-                await service.reset()
+                await service.reset(serial: serial)
                 while !Task.isCancelled {
                     if let sample = await service.poll(serial: serial) {
                         guard !Task.isCancelled else { break }

--- a/droidectived/Tests/DaemonCoreTests/StreamSessionTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/StreamSessionTests.swift
@@ -7,6 +7,8 @@ import Testing
 /// The subscription lifecycle, driven through the sink protocol rather than a
 /// socket. The socket is proven separately; what matters here is the ordering
 /// and the drop behaviour under a slow client.
+private enum StreamSessionTestError: Error { case unsupported }
+
 @Suite struct StreamSessionTests {
     /// Records frames, and can be made deliberately slow so the producer
     /// outruns it — which is the only way to observe the drop policy.
@@ -271,6 +273,133 @@ import Testing
             try? await Task.sleep(for: .milliseconds(5))
         }
         return await condition()
+    }
+
+    // MARK: - A pump that arrives after its subscription is gone
+
+    /// Opens once and lets everyone waiting through. Lets a test park
+    /// `subscribe` mid-flight and act while it is suspended.
+    private actor Gate {
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var open = false
+        private var arrived = false
+
+        /// True once someone has waited here — how the test knows `subscribe`
+        /// has reached the suspension point rather than guessing with a sleep.
+        var reached: Bool { arrived }
+
+        func wait() async {
+            arrived = true
+            if open { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        func release() {
+            open = true
+            for waiter in waiters { waiter.resume() }
+            waiters = []
+        }
+    }
+
+    /// A `performance` stream shaped like the real one: its poll `Task` is
+    /// built inside the `AsyncStream` closure, so it is already running by the
+    /// time the stream is returned, and only `onTermination` stops it.
+    private actor PollWatch {
+        private(set) var polls = 0
+        private(set) var cancelled = false
+        func count() { polls += 1 }
+        func noteCancelled() { cancelled = true }
+    }
+
+    private struct StallingSource: StreamSource {
+        let gate: Gate
+        let watch: PollWatch
+
+        func devices() async -> AsyncStream<[Device]> { .init { $0.finish() } }
+        func logcat(serial: String, pid: Int?) async throws -> AsyncStream<[LogLine]> {
+            .init { $0.finish() }
+        }
+        func logcatPid(serial: String, packageId: String) async throws -> Int? { nil }
+        func stopLogcat(serial: String) async {}
+        func netspeed(serial: String) async -> AsyncStream<NetSample> { .init { $0.finish() } }
+        func reactotron() async throws -> AsyncStream<ReactotronRelay.Event> { .init { $0.finish() } }
+        func stopReactotron() async {}
+        func openPty(serial: String?, size: PtySize) throws -> any PtyChannel {
+            throw StreamSessionTestError.unsupported
+        }
+        func openMirror(serial: String, quality: MirrorQuality) async throws -> ScrcpySession {
+            throw StreamSessionTestError.unsupported
+        }
+
+        func performance(
+            serial: String, packageId: String?, includeProcesses: Bool
+        ) async -> AsyncStream<PerformanceService.PerfPoll> {
+            // Park here so the test can close the socket while `subscribe` is
+            // suspended — the window the real bug lives in.
+            await gate.wait()
+            let watch = self.watch
+            return AsyncStream { continuation in
+                let task = Task {
+                    while !Task.isCancelled {
+                        await watch.count()
+                        try? await Task.sleep(for: .milliseconds(5))
+                    }
+                    continuation.finish()
+                }
+                continuation.onTermination = { _ in
+                    task.cancel()
+                    Task { await watch.noteCancelled() }
+                }
+            }
+        }
+    }
+
+    /// The bug: `subscribe` suspends twice before it stores the pump, and the
+    /// socket closing in that window removed the entry — so
+    /// `subscriptions[id]?.pump = …` discarded the only handle that could stop
+    /// a poll loop which was already running. An immortal 1 Hz loop spawning
+    /// adb children for the life of the daemon, one per occurrence.
+    @Test func aPollStartedAfterTheSocketClosedIsStopped() async {
+        let sink = RecordingSink()
+        let gate = Gate()
+        let watch = PollWatch()
+        let session = StreamSession(sink: sink, source: StallingSource(gate: gate, watch: watch))
+
+        let subscribing = Task {
+            await session.handle(
+                text: #"{"op":"subscribe","id":7,"topic":"performance","params":{"serial":"R58M"}}"#)
+        }
+        #expect(await eventually { await gate.reached }, "subscribe never reached the source")
+
+        // The desktop app quitting with the Performance screen open.
+        await session.shutdown()
+        await gate.release()
+        await subscribing.value
+
+        #expect(
+            await eventually { await watch.cancelled },
+            "the poll loop outlived the socket that asked for it")
+    }
+
+    /// The same window, reached the other way: a fast tab switch sends
+    /// `unsubscribe` for an id whose `subscribe` is still in flight.
+    @Test func aPollStartedAfterUnsubscribeIsStopped() async {
+        let sink = RecordingSink()
+        let gate = Gate()
+        let watch = PollWatch()
+        let session = StreamSession(sink: sink, source: StallingSource(gate: gate, watch: watch))
+
+        let subscribing = Task {
+            await session.handle(
+                text: #"{"op":"subscribe","id":8,"topic":"performance","params":{"serial":"R58M"}}"#)
+        }
+        #expect(await eventually { await gate.reached })
+
+        await session.handle(text: #"{"op":"unsubscribe","id":8}"#)
+        await gate.release()
+        await subscribing.value
+
+        #expect(await eventually { await watch.cancelled })
     }
 
     @Test func subscribingAcknowledgesThenStreamsThenEnds() async {


### PR DESCRIPTION
Closes #286.

`subscribe` suspends at least twice before it stores its pump — sending
`subscribed`, and building the stream — and `StreamSession` is a reentrant
actor whose frames each arrive as their own unstructured `Task`. Two ordinary
things happen in that window: the client closes the socket (the desktop app
quitting with the Performance screen open), and an `unsubscribe` arrives for
the same id (a fast tab switch). Either removes the entry, and
`subscriptions[id]?.pump = …` then silently discarded the handle.

For `logcat` and `devices` that dropped an iterator over somebody else's
stream. For `performance` and `netspeed` it stranded a live one: those build
their poll `Task` inside the `AsyncStream` closure, which runs synchronously at
construction, so the loop is already running by then and only `onTermination`
stops it — and the poll task retains the continuation that owns
`onTermination`. The result is an immortal 1 Hz loop spawning up to seven adb
children a second for the life of the daemon, cumulative per occurrence.

## What changed

- `attach(to:_:)` cancels a pump whose subscription is already gone, and every
  topic goes through it.
- `PerformanceMonitor.reset()` and `NetworkSpeed.reset()` took no serial but
  were called once per subscription, so a second window starting a recording
  wiped the first window's baselines — a one-interval hole in a chart nobody
  had touched. Both now take a serial.

## Tests

Two new tests park the source mid-`subscribe` and close the socket in that
window, driving the real race rather than approximating it. Verified they catch
the bug: reverting `attach` to the old assignment fails both.

`NetworkSpeedServiceTests` gains a two-device case for the reset.

ADBKit 2126 · droidectived 410 · AppTests 134 · Mac build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
