### PR TITLE
Drop a device's answer once the user has moved to another device

### DIFF
--- a/desktop/src/components/AppInfoPane.tsx
+++ b/desktop/src/components/AppInfoPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { Download } from "lucide-react"
 import { Banner, Button } from "@/components/Controls"
 import { HubColumn, HubRowList, HubSection } from "@/components/Hub"
@@ -23,20 +23,25 @@ export function AppInfoPane({ device, packageId }: { device: Device | null; pack
   const [pulling, setPulling] = useState(false)
 
   const serial = device?.serial ?? null
-  const load = useCallback(async () => {
-    if (serial === null || packageId === null) return
-    setError(null)
-    try {
-      setInfo(await appInfo(serial, packageId))
-    } catch (thrown) {
-      setError(asDaemonError(thrown))
-    }
-  }, [packageId, serial])
-
   useEffect(() => {
     setInfo(null)
-    void load()
-  }, [load])
+    setError(null)
+    if (serial === null || packageId === null) return
+    // An answer for the device we have left must not land on the one we are
+    // looking at now — the same guard `MeminfoPane` uses.
+    let live = true
+    void (async () => {
+      try {
+        const next = await appInfo(serial, packageId)
+        if (live) setInfo(next)
+      } catch (thrown) {
+        if (live) setError(asDaemonError(thrown))
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [packageId, serial])
 
   if (!device) return <NoDevice feature="app-info" title="App Info" />
   if (packageId === null) return <NoBundle what="see its app info" />

--- a/desktop/src/components/ManageAppPane.tsx
+++ b/desktop/src/components/ManageAppPane.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useLatestRequest } from "@/hooks/useLatestRequest"
 import { Banner } from "@/components/Controls"
 import { AppActions } from "@/components/AppActions"
 import { NoBundle } from "@/components/NoBundle"
@@ -25,24 +26,29 @@ export function ManageAppPane({
   const [actions, setActions] = useState<AppActionDescriptor[]>([])
   const [app, setApp] = useState<AppSummary | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
+  const request = useLatestRequest()
 
   const serial = device?.serial ?? null
   const load = useCallback(async () => {
     if (serial === null || packageId === null) return
+    const current = request.begin()
     setError(null)
     try {
       const response = await listApps(serial)
+      if (!current()) return
       setActions(response.actions)
       setApp(response.apps.find((entry) => entry.packageId === packageId) ?? null)
     } catch (thrown) {
+      if (!current()) return
       setError(asDaemonError(thrown))
     }
-  }, [packageId, serial])
+  }, [packageId, request, serial])
 
   useEffect(() => {
+    request.restart()
     setApp(null)
     void load()
-  }, [load])
+  }, [load, request])
 
   if (!device) return <NoDevice feature="app-management" title="Manage App" />
   if (packageId === null) return <NoBundle what="manage it" />

--- a/desktop/src/components/PermissionsPane.tsx
+++ b/desktop/src/components/PermissionsPane.tsx
@@ -17,6 +17,51 @@ import type { DaemonError, Device, Permission } from "@/lib/wire"
  * exactly as the Mac does — a `pm grant` takes long enough that a second click
  * elsewhere would otherwise race the reload.
  */
+/**
+ * The device's runtime permissions, re-read after every grant.
+ *
+ * Lifted out of the pane because it is the part with lifecycle rules: a read
+ * answered after the device changed must not land on the pane now showing a
+ * different one. `reload` bumps a counter rather than calling a shared loader,
+ * so there is exactly one read path and exactly one place the guard has to be
+ * right.
+ */
+function usePermissionList(serial: string | null, packageId: string | null) {
+  const [entries, setEntries] = useState<Permission[] | null>(null)
+  const [error, setError] = useState<DaemonError | null>(null)
+  const [mutating, setMutating] = useState<string | null>(null)
+  const [reloads, setReloads] = useState(0)
+
+  useEffect(() => {
+    setEntries(null)
+  }, [packageId, serial])
+
+  useEffect(() => {
+    setError(null)
+    if (serial === null || packageId === null) return
+    let live = true
+    void (async () => {
+      try {
+        const next = (await readPermissions(serial, packageId)).permissions
+        if (live) setEntries(next)
+      } catch (thrown) {
+        if (live) setError(asDaemonError(thrown))
+      } finally {
+        if (live) setMutating(null)
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [packageId, reloads, serial])
+
+  const reload = useCallback(() => {
+    setReloads((count) => count + 1)
+  }, [])
+
+  return { entries, error, mutating, setMutating, reload }
+}
+
 export function PermissionsPane({
   device,
   packageId,
@@ -25,26 +70,9 @@ export function PermissionsPane({
   packageId: string | null
 }) {
   const { show } = useNotifications()
-  const [entries, setEntries] = useState<Permission[] | null>(null)
-  const [error, setError] = useState<DaemonError | null>(null)
-  const [mutating, setMutating] = useState<string | null>(null)
   const [query, setQuery] = useState("")
-
   const serial = device?.serial ?? null
-  const load = useCallback(async () => {
-    if (serial === null || packageId === null) return
-    setError(null)
-    try {
-      setEntries((await readPermissions(serial, packageId)).permissions)
-    } catch (thrown) {
-      setError(asDaemonError(thrown))
-    }
-  }, [packageId, serial])
-
-  useEffect(() => {
-    setEntries(null)
-    void load()
-  }, [load])
+  const { entries, error, mutating, setMutating, reload } = usePermissionList(serial, packageId)
 
   if (!device) return <NoDevice feature="permissions" title="Permissions" />
   if (packageId === null) return <NoBundle what="inspect its permissions" />
@@ -75,9 +103,9 @@ export function PermissionsPane({
         show({ ok: false, message: asDaemonError(thrown).message })
       } finally {
         // Always re-read: `pm grant` refuses an install-time permission with a
-        // message, and the switch must go back to what the device says.
-        await load()
-        setMutating(null)
+        // message, and the switch must go back to what the device says. The
+        // re-read clears `mutating` when it lands.
+        reload()
       }
     })()
   }

--- a/desktop/src/components/PrivateDnsSection.tsx
+++ b/desktop/src/components/PrivateDnsSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useLatestRequest } from "@/hooks/useLatestRequest"
 import { RefreshCw } from "lucide-react"
 import { Banner, Button, TextInput } from "@/components/Controls"
 import { HubSection, IconButton } from "@/components/Hub"
@@ -27,26 +28,31 @@ export function PrivateDnsSection({ serial }: { serial: string | null }) {
   const [loaded, setLoaded] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<DaemonError | null>(null)
+  const request = useLatestRequest()
 
   const load = useCallback(async () => {
     if (serial === null) return
+    const current = request.begin()
     setLoaded(false)
     setError(null)
     try {
       const status = await privateDns(serial)
+      if (!current()) return
       setMode(status.mode)
       // Kept when the device has one even in another mode, so switching to
       // Hostname does not lose what was configured.
       if (status.hostname !== null) setHostname(status.hostname)
       setLoaded(true)
     } catch (thrown) {
+      if (!current()) return
       setError(asDaemonError(thrown))
     }
-  }, [serial])
+  }, [request, serial])
 
   useEffect(() => {
+    request.restart()
     void load()
-  }, [load])
+  }, [load, request])
 
   const apply = () => {
     if (serial === null) return

--- a/desktop/src/components/SandboxPane.tsx
+++ b/desktop/src/components/SandboxPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { CornerLeftUp, Download, File, Folder, Lock } from "lucide-react"
 import { Banner } from "@/components/Controls"
 import { IconButton } from "@/components/Hub"
@@ -41,24 +41,29 @@ export function SandboxPane({
     setComponents([])
   }, [packageId, serial])
 
-  const load = useCallback(async () => {
-    if (serial === null || packageId === null) return
+  useEffect(() => {
     setEntries(null)
     setError(null)
-    try {
-      const listing = await sandboxList({ serial, packageId, path })
-      setDebuggable(listing.debuggable)
-      setEntries(listing.entries)
-    } catch (thrown) {
-      // Not `setEntries([])`: that renders "Empty directory", which beside the
-      // error banner claims the listing succeeded and found nothing.
-      setError(asDaemonError(thrown))
+    if (serial === null || packageId === null) return
+    // A listing for the device or directory we have left must not land on the
+    // one on screen — the same guard `MeminfoPane` uses.
+    let live = true
+    void (async () => {
+      try {
+        const listing = await sandboxList({ serial, packageId, path })
+        if (!live) return
+        setDebuggable(listing.debuggable)
+        setEntries(listing.entries)
+      } catch (thrown) {
+        // Not `setEntries([])`: that renders "Empty directory", which beside
+        // the error banner claims the listing succeeded and found nothing.
+        if (live) setError(asDaemonError(thrown))
+      }
+    })()
+    return () => {
+      live = false
     }
   }, [packageId, path, serial])
-
-  useEffect(() => {
-    void load()
-  }, [load])
 
   if (!device) return <NoDevice feature="sandbox-browser" title="Sandbox Browser" />
   if (packageId === null) return <NoBundle what="browse its sandbox" />

--- a/desktop/src/hooks/useCrashBuffer.ts
+++ b/desktop/src/hooks/useCrashBuffer.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { useLatestRequest } from "@/hooks/useLatestRequest"
 import { asDaemonError, listCrashes } from "@/lib/daemon"
 import {
   newestUnseen,
@@ -48,6 +49,7 @@ export function useCrashBuffer(serial: string | null): CrashBuffer {
   const [error, setError] = useState<DaemonError | null>(null)
   const [arrival, setArrival] = useState<CrashReport | null>(null)
   const [generation, setGeneration] = useState(0)
+  const request = useLatestRequest()
 
   // Read through a ref so a poll's identity does not change every render.
   const latest = useRef(crashes)
@@ -64,8 +66,12 @@ export function useCrashBuffer(serial: string | null): CrashBuffer {
   const fetch = useCallback(
     async (announce: boolean) => {
       if (serial === null) return
+      // The five-second watch poll outlives a device switch, so a poll
+      // answered for the old device must not replace the new one's list.
+      const stillWanted = request.begin()
       try {
         const next = (await listCrashes(serial)).crashes
+        if (!stillWanted()) return
         setError(null)
         setFailed(false)
         setFetched(true)
@@ -81,16 +87,18 @@ export function useCrashBuffer(serial: string | null): CrashBuffer {
         if (!sameCrashes(latest.current, next)) setCrashes(next)
         setFilters((current) => prunedFilters(current, next))
       } catch (thrown) {
+        if (!stillWanted()) return
         // Keep the last good list, but say so — a swallowed poll failure reads
         // as "still checking" forever.
         setFailed(true)
         setError(asDaemonError(thrown))
       }
     },
-    [serial],
+    [request, serial],
   )
 
   useEffect(() => {
+    request.restart()
     if (serial === null) return
     let live = true
     setLoading(true)
@@ -100,7 +108,7 @@ export function useCrashBuffer(serial: string | null): CrashBuffer {
     return () => {
       live = false
     }
-  }, [serial, fetch, generation])
+  }, [serial, fetch, generation, request])
 
   useEffect(() => {
     if (!watching || serial === null) return

--- a/desktop/src/hooks/useDeviceSettings.ts
+++ b/desktop/src/hooks/useDeviceSettings.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
+
+import { useLatestRequest } from "@/hooks/useLatestRequest"
 import { useNotifications } from "@/hooks/useNotifications"
 import {
   asDaemonError,
@@ -31,24 +33,30 @@ import type {
  */
 export function useDeveloperSettings(serial: string | null) {
   const { show } = useNotifications()
+  const request = useLatestRequest()
   const [settings, setSettings] = useState<DevSettingsResponse | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
   const [refreshing, setRefreshing] = useState(false)
 
   const load = useCallback(async () => {
     if (serial === null) return
+    const current = request.begin()
     setError(null)
     try {
-      setSettings(await devSettings(serial))
+      const next = await devSettings(serial)
+      if (!current()) return
+      setSettings(next)
     } catch (thrown) {
+      if (!current()) return
       setError(asDaemonError(thrown))
     }
-  }, [serial])
+  }, [request, serial])
 
   useEffect(() => {
+    request.restart()
     setSettings(null)
     void load()
-  }, [load])
+  }, [load, request])
 
   const refresh = useCallback(() => {
     setRefreshing(true)
@@ -60,6 +68,11 @@ export function useDeveloperSettings(serial: string | null) {
   /** Flip a row now; reconcile with the device only if it says no. */
   const apply = useCallback(
     (optimistic: (current: DevSettingsResponse) => DevSettingsResponse, write: () => Promise<RunResponse>) => {
+      // The table on screen is this device's — the load that produced it was
+      // dropped if the serial changed. Belt and braces anyway: `write` closes
+      // over the serial at render time, and this is the write that would
+      // otherwise land on someone else's phone.
+      if (serial === null) return
       setSettings((current) => (current === null ? current : optimistic(current)))
       void (async () => {
         try {
@@ -74,7 +87,7 @@ export function useDeveloperSettings(serial: string | null) {
         }
       })()
     },
-    [load, show],
+    [load, serial, show],
   )
 
   return { settings, error, refreshing, refresh, apply }
@@ -114,24 +127,30 @@ export function withScale(
  */
 export function useRestrictions(serial: string | null) {
   const { show } = useNotifications()
+  const request = useLatestRequest()
   const [state, setState] = useState<RestrictionsResponse | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
   const [busy, setBusy] = useState(false)
 
   const load = useCallback(async () => {
     if (serial === null) return
+    const current = request.begin()
     setError(null)
     try {
-      setState(await restrictions(serial))
+      const next = await restrictions(serial)
+      if (!current()) return
+      setState(next)
     } catch (thrown) {
+      if (!current()) return
       setError(asDaemonError(thrown))
     }
-  }, [serial])
+  }, [request, serial])
 
   useEffect(() => {
+    request.restart()
     setState(null)
     void load()
-  }, [load])
+  }, [load, request])
 
   const reconcile = useCallback(
     async (write: () => Promise<RunResponse>) => {

--- a/desktop/src/hooks/useLatestRequest.test.ts
+++ b/desktop/src/hooks/useLatestRequest.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useLatestRequest } from "@/hooks/useLatestRequest"
+
+describe("useLatestRequest", () => {
+  it("keeps an answer to the question still being asked", () => {
+    const { result } = renderHook(() => useLatestRequest())
+    const current = result.current.begin()
+    expect(current()).toBe(true)
+  })
+
+  it("drops an answer to a question that has moved on", () => {
+    const { result } = renderHook(() => useLatestRequest())
+    const forDeviceA = result.current.begin()
+    act(() => {
+      result.current.restart()
+    })
+    expect(forDeviceA()).toBe(false)
+  })
+
+  /** Two loads in flight at once: only the newest may write. */
+  it("keeps only the newest of several in-flight requests", () => {
+    const { result } = renderHook(() => useLatestRequest())
+    const first = result.current.begin()
+    act(() => {
+      result.current.restart()
+    })
+    const second = result.current.begin()
+    expect(first()).toBe(false)
+    expect(second()).toBe(true)
+  })
+
+  /** Two requests started for the same question both stand — a refresh
+   * racing its own initial load is not a stale answer. */
+  it("keeps both tokens taken for the same question", () => {
+    const { result } = renderHook(() => useLatestRequest())
+    const load = result.current.begin()
+    const refresh = result.current.begin()
+    expect(load()).toBe(true)
+    expect(refresh()).toBe(true)
+  })
+
+  /** It lives in dependency arrays, so a new identity every render would
+   * re-run the very effects it guards. */
+  it("is stable across renders", () => {
+    const { result, rerender } = renderHook(() => useLatestRequest())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it("survives more restarts than a session could produce", () => {
+    const { result } = renderHook(() => useLatestRequest())
+    const stale = result.current.begin()
+    act(() => {
+      for (let i = 0; i < 1000; i += 1) result.current.restart()
+    })
+    expect(stale()).toBe(false)
+    expect(result.current.begin()()).toBe(true)
+  })
+})

--- a/desktop/src/hooks/useLatestRequest.ts
+++ b/desktop/src/hooks/useLatestRequest.ts
@@ -1,0 +1,70 @@
+import { useMemo, useRef } from "react"
+
+/**
+ * Drops the answer to a question nobody is asking any more.
+ *
+ * Every per-device request hook has the same shape: a `load` keyed on the
+ * serial, and an effect that clears the pane and calls it when the serial
+ * changes. Nothing checked that the answer still belonged to the device on
+ * screen, so a `load()` for device A that resolved after the switch to B wrote
+ * A's data into B's pane — eight hooks and panes did this. Developer Settings
+ * was the worst of them: its optimistic toggle builds from whatever table is
+ * displayed and writes with the *current* serial, so a stale table on screen
+ * meant flipping a toggle issued `settings put` against a different device.
+ * That is an unintended write to someone's phone, not a display glitch.
+ *
+ * The codebase already had the idea twice, hand-rolled — `MeminfoPane`'s `let
+ * live = true` and `usePerformance`'s `cancelled`. This is the same idea as
+ * one thing, because eight copies of a three-line flag is eight chances to put
+ * the check on the wrong side of an `await`.
+ *
+ * ```ts
+ * const request = useLatestRequest()
+ *
+ * const load = useCallback(async () => {
+ *   if (serial === null) return
+ *   const current = request.begin()
+ *   const next = await wifi(serial)
+ *   if (!current()) return          // the device changed while we waited
+ *   setData(next)
+ * }, [request, serial])
+ *
+ * useEffect(() => {
+ *   request.restart()
+ *   setData(null)
+ *   void load()
+ * }, [load, request])
+ * ```
+ *
+ * `restart` covers the refresh button too, which the hand-rolled effect flags
+ * did not: a refresh answered after a device switch is the same stale write.
+ *
+ * The returned object is stable for the life of the component, so it can sit
+ * in a dependency array without re-running anything.
+ */
+export interface LatestRequest {
+  /** The question changed — abandon every answer still in flight. */
+  restart: () => void
+  /**
+   * Take a token for the request being made now. Call the returned predicate
+   * after every `await` and before touching state; it is false once `restart`
+   * has been called.
+   */
+  begin: () => () => boolean
+}
+
+export function useLatestRequest(): LatestRequest {
+  const generation = useRef(0)
+  return useMemo(
+    () => ({
+      restart: () => {
+        generation.current += 1
+      },
+      begin: () => {
+        const mine = generation.current
+        return () => generation.current === mine
+      },
+    }),
+    [],
+  )
+}

--- a/desktop/src/hooks/useWifi.ts
+++ b/desktop/src/hooks/useWifi.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
+
+import { useLatestRequest } from "@/hooks/useLatestRequest"
 import { useNotifications } from "@/hooks/useNotifications"
 import { asDaemonError, connectWifi, copyText, setWifiEnabled, wifi } from "@/lib/daemon"
 import type { DaemonError, WifiResponse } from "@/lib/wire"
@@ -13,6 +15,7 @@ import type { DaemonError, WifiResponse } from "@/lib/wire"
  */
 export function useWifi(serial: string | null) {
   const { show } = useNotifications()
+  const request = useLatestRequest()
   const [data, setData] = useState<WifiResponse | null>(null)
   const [error, setError] = useState<DaemonError | null>(null)
   const [loaded, setLoaded] = useState(false)
@@ -20,20 +23,25 @@ export function useWifi(serial: string | null) {
 
   const load = useCallback(async () => {
     if (serial === null) return
+    const current = request.begin()
     setError(null)
     try {
-      setData(await wifi(serial))
+      const next = await wifi(serial)
+      if (!current()) return
+      setData(next)
       setLoaded(true)
     } catch (thrown) {
+      if (!current()) return
       setError(asDaemonError(thrown))
     }
-  }, [serial])
+  }, [request, serial])
 
   useEffect(() => {
+    request.restart()
     setData(null)
     setLoaded(false)
     void load()
-  }, [load])
+  }, [load, request])
 
   const run = useCallback(
     (command: (serial: string) => Promise<{ ok: boolean; message: string }>) => {


### PR DESCRIPTION
Closes #287.

Eight per-device request hooks wrote their result without checking the serial
was still current, so a `load()` for device A that resolved after the switch to
B put A's data on B's screen.

Developer Settings was more than a display glitch. Its optimistic toggle builds
from whatever table is displayed and writes with the *current* serial, so a
stale table on screen meant flipping a toggle issued `settings put` against a
different device — an unintended write to someone's phone.

## Two shapes, because the sites have two shapes

Where the read happens only in an effect (App Info, Sandbox, Permissions) the
guard is the effect's own `live` flag, which is what `MeminfoPane` and
`usePerformance` already do — and it needs no import, so those files stay under
the dependency limit.

Where a refresh button or a five-second poll shares the loader (Wi-Fi,
Developer Settings, Restrictions, Private DNS, the crash buffer) that flag
cannot reach, so `useLatestRequest` holds the same idea as a token taken before
the await and checked after. It covers the refresh path too, which a
hand-rolled effect flag never did.

Permissions reloads after a grant by bumping a counter the effect watches
instead of calling a shared loader, so there is one read path and one place the
guard has to be right; its read moved into a local hook, which also puts the
pane back under the line limit.

## Tests

Six for `useLatestRequest`, including that it is stable across renders — it
lives in dependency arrays, so a new identity every render would re-run the very
effects it guards.

typecheck clean · oxlint clean (no new warnings) · 1265 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
