### PR TITLE
Pin the installers' protocol, and let the parity tracker record finished work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: generate build test test-app test-linux run dmg clean site-dev site-build \
 	verify verify-fast verify-self \
 	test-emulator test-emulator-rooted test-emulator-mirror test-mutation test-smoke \
-	desktop-dev desktop-test desktop-build
+	desktop-dev desktop-test desktop-build desktop-linux desktop-linux-smoke
 
 # Optional telemetry keys for local builds. Create .env.telemetry (gitignored)
 # with SENTRY_DSN=... and POSTHOG_KEY=... to enable crash/analytics locally.
@@ -124,6 +124,18 @@ desktop-test:
 desktop-build:
 	./scripts/build-daemon-sidecar.sh release
 	cd desktop && npm ci && npm run tauri build
+
+# The Linux app, built in a container from a macOS or Linux host — Tauri does
+# not cross-compile. Then the same .deb installed in a bare ubuntu:24.04 and
+# driven under Xvfb, which is what catches a runtime dependency the build
+# container happened to have. Both had no front door here, so the only way to
+# find them was to already know their paths.
+CONFIGURATION ?= release
+desktop-linux:
+	./scripts/build-desktop-linux.sh $(CONFIGURATION)
+
+desktop-linux-smoke:
+	./scripts/smoke-desktop-linux.sh $(DEB)
 
 # Marketing site (website/ — React + Vite; site/ is the static passthrough
 # copied into the build via Vite's publicDir)

--- a/docs/desktop-parity.md
+++ b/docs/desktop-parity.md
@@ -11,15 +11,22 @@ rewriting one when something turns out to be more work than it looked.
 
 | | Count |
 | --- | --- |
+| ✅ Ported | 55 |
+| 🟡 Partial | 2 |
 | ⬜ Not started | 2 |
-| 🟡 Partial | 57 |
 | ⛔ Not applicable off-Apple | 2 |
 | **Total registry features** | **61** |
 
-"Partial" is doing a lot of work in that table: 19 of the 57 are actions that
-run from the palette but have no screen of their own, and the 38 that do have
-screens are each missing something the Mac version offers. Read it as *nothing
-is finished*, not as *most of it is done*.
+These are the generated classifier's own numbers, not a second count kept by
+hand — the two used to disagree (this table said 19 not started and 40 partial
+while the generated half said 35 and 24, because they meant different things by
+"partial"), and a tracker with two answers is a tracker nobody trusts.
+
+**"Ported" means a pane is routed, or the feature is an action with nothing to
+build** — not that the screen has been audited against the Mac's. The
+per-feature checklists below are that audit, and they are still unticked. The
+two **partial** entries are the ones with a gap named in the classifier: the
+mirror's screenshot annotation editor, and the Terminal on Windows.
 
 **The two not started are `video-editor` and `frida-console`.** The video
 editor is the ffmpeg filter graph and a preview scrubber — the toolchain
@@ -39,8 +46,8 @@ covers **29 of the 32 full-screen views** in the catalog; the other seven
 catalog features are actions that render from their registry fields.
 
 That list is not written here twice: `scripts/generate-parity-tracker.py` reads
-it out of the desktop app's pane router, so a screen that lands is partial in
-the checklist below without anyone remembering to say so.
+it out of the desktop app's pane router, so a screen that lands is marked
+ported in the checklist below without anyone remembering to say so.
 
 **Only two features are out of scope**, and only because they drive an Apple
 toolchain rather than a device: `ios-logs` and `push-notification` are `xcrun
@@ -1533,28 +1540,28 @@ job, and the checklist now says which.
 
 ## Per-feature checklists
 ### Input & Clipboard
-#### `send-text` — Send Text  ·  🟡 partial
+#### `send-text` — Send Text  ·  ✅ ported
 > Type text, URLs, or symbols on the device
 - **Kind** `formAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `text` (text)
 
 
 ### Connection
-#### `connection` — Connection  ·  🟡 partial
+#### `connection` — Connection  ·  ✅ ported
 > Copy IP, reverse port, disconnect, DNS & wireless setup
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `NetworkConnectionView` — `App/Sources/FeatureDetail/Views/NetworkConnectionView.swift`
 - **Must replicate**
   - [ ] button: Forward
   - [ ] label: Copy IP
   - [ ] tooltip: Refresh
 
-#### `emulators` — Emulators & Simulators  ·  🟡 partial
+#### `emulators` — Emulators & Simulators  ·  ✅ ported
 > Launch and stop Android emulators & iOS Simulators
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `EmulatorsView` — `App/Sources/FeatureDetail/Views/EmulatorsView.swift`
 - **Must replicate**
   - [ ] button: Wipe Data
@@ -1569,41 +1576,41 @@ job, and the checklist now says which.
   - [ ] label: Refresh
   - [ ] tooltip: Stop the emulator and boot it again
 
-#### `get-ip` — Copy Device IP  ·  🟡 partial
+#### `get-ip` — Copy Device IP  ·  ✅ ported
 > Get the Wi-Fi IP address and copy it
 - **Kind** `instantAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `network-speed` — Network Speed  ·  🟡 partial
+#### `network-speed` — Network Speed  ·  ✅ ported
 > Live download & upload throughput with recording
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `NetworkView` — `App/Sources/FeatureDetail/Views/NetworkView.swift`
 - **Must replicate**
   - [ ] label: Export
   - [ ] label: seconds
   - [ ] tooltip: Export the recording as JSON + CSV
 
-#### `private-dns` — Private DNS  ·  🟡 partial
+#### `private-dns` — Private DNS  ·  ✅ ported
 > Off, automatic, or a DNS-over-TLS provider
 - **Kind** `view` · **hub member**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `PrivateDnsView` — `App/Sources/FeatureDetail/Views/PrivateDnsView.swift`
 - **Must replicate**
   - [ ] button: Apply
   - [ ] picker: Mode
   - [ ] tooltip: Refresh
 
-#### `reverse-port` — Reverse Port  ·  🟡 partial
+#### `reverse-port` — Reverse Port  ·  ✅ ported
 > Forward a device port to your machine (Metro 8081)
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `port` (preset)
 
-#### `wifi` — Wi-Fi  ·  🟡 partial
+#### `wifi` — Wi-Fi  ·  ✅ ported
 > Connection details, toggle, saved networks & passwords
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `WiFiView` — `App/Sources/FeatureDetail/Views/WiFiView.swift`
 - **Must replicate**
   - [ ] button: Connect
@@ -1612,10 +1619,10 @@ job, and the checklist now says which.
   - [ ] tooltip: Refresh
   - [ ] tooltip: Copy password
 
-#### `wireless-adb` — Wireless ADB  ·  🟡 partial
+#### `wireless-adb` — Wireless ADB  ·  ✅ ported
 > Connect over Wi-Fi (tcpip + Android 11 pairing)
 - **Kind** `view` · **hub member**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `WirelessAdbView` — `App/Sources/FeatureDetail/Views/WirelessAdbView.swift`
 - **Must replicate**
   - [ ] button: Enable Wi-Fi & Connect
@@ -1626,10 +1633,10 @@ job, and the checklist now says which.
 
 
 ### React Native
-#### `deep-link` — Deep Links  ·  🟡 partial
+#### `deep-link` — Deep Links  ·  ✅ ported
 > Launch and save deep links per app
 - **Kind** `view` · **hub member** · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `DeepLinksView` — `App/Sources/FeatureDetail/Views/DeepLinksView.swift`
 - **Must replicate**
   - [ ] button: Delete
@@ -1641,10 +1648,10 @@ job, and the checklist now says which.
   - [ ] label: Delete \(link.label)
   - [ ] tooltip: Launch on device
 
-#### `js-console` — JS Console  ·  🟡 partial
+#### `js-console` — JS Console  ·  ✅ ported
 > Hermes REPL + live console over the Metro debugger
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `JSConsoleView` — `App/Sources/FeatureDetail/Views/JSConsoleView.swift`
 - **Must replicate**
   - [ ] button: Clear Data & Restart
@@ -1675,29 +1682,29 @@ job, and the checklist now says which.
   - [ ] shortcut: "c", modifiers: .command
   - [ ] export: save/export to a file
 
-#### `open-dev-menu` — Open Dev Menu  ·  🟡 partial
+#### `open-dev-menu` — Open Dev Menu  ·  ✅ ported
 > Open the React Native developer menu
 - **Kind** `instantAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `process-death` — Simulate Process Death  ·  🟡 partial
+#### `process-death` — Simulate Process Death  ·  ✅ ported
 > Background then kill the app to test restoration
 - **Kind** `instantAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `react-native` — React Native  ·  🟡 partial
+#### `react-native` — React Native  ·  ✅ ported
 > Dev menu, reload, deep links, dev server, process death
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ReactNativeView` — `App/Sources/FeatureDetail/Views/ReactNativeView.swift`
 - **Must replicate**
   - [ ] button: Forward
   - [ ] button: Set
 
-#### `reactotron` — Reactotron  ·  🟡 partial
+#### `reactotron` — Reactotron  ·  ✅ ported
 > Live React Native inspector — logs, network, state, custom display
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ReactotronView` — `App/Sources/FeatureDetail/Views/ReactotronView.swift`
 - **Must replicate**
   - [ ] button: OK
@@ -1756,28 +1763,28 @@ job, and the checklist now says which.
   - [ ] shortcut: "c", modifiers: .command
   - [ ] export: save/export to a file
 
-#### `reload-js` — Reload JS  ·  🟡 partial
+#### `reload-js` — Reload JS  ·  ✅ ported
 > Reload the JS bundle (double-tap R)
 - **Kind** `instantAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `rn-dev-host` — Set Dev Server Host  ·  🟡 partial
+#### `rn-dev-host` — Set Dev Server Host  ·  ✅ ported
 > Point the app at a different Metro host
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `host` (text)
 
 
 ### Screen & Capture
-#### `demo-mode` — Demo Mode  ·  🟡 partial
+#### `demo-mode` — Demo Mode  ·  ✅ ported
 > Clean status bar for store screenshots
 - **Kind** `toggleAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `mirror-wall` — Mirror Wall  ·  🟡 partial
+#### `mirror-wall` — Mirror Wall  ·  ✅ ported
 > Mirror up to six devices side by side
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `MirrorWallView` — `App/Sources/FeatureDetail/Views/MirrorWallView.swift`
 - **Must replicate**
   - [ ] button: Open Each in Its Own Window
@@ -1792,7 +1799,7 @@ job, and the checklist now says which.
 #### `scrcpy` — Mirror Screen  ·  🟡 partial
 > Mirror and control the device with scrcpy
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** The pane mirrors and takes input; the screenshot annotation editor the Mac opens from it is Mac-only so far.
 - **macOS view** `ScreenMirrorView` — `App/Sources/FeatureDetail/Views/ScreenMirrorView.swift`
 - **Must replicate**
   - [ ] button: Volume down
@@ -1811,19 +1818,19 @@ job, and the checklist now says which.
   - [ ] tooltip: Recording audio — device playback or mic, plus the Mac's mic
   - [ ] tooltip: Mute or unmute what's being recorded
 
-#### `screen-record` — Screen Record  ·  🟡 partial
+#### `screen-record` — Screen Record  ·  ✅ ported
 > Record via scrcpy — no time limit, with audio
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ScreenRecordView` — `App/Sources/FeatureDetail/Views/ScreenRecordView.swift`
 - **Must replicate**
   - [ ] label: Stop & Save
   - [ ] label: Stop
 
-#### `screenshot` — Screenshot  ·  🟡 partial
+#### `screenshot` — Screenshot  ·  ✅ ported
 > Capture the screen and save it to your Mac
 - **Kind** `instantAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
 #### `video-editor` — Video Editor  ·  ⬜ todo
 > Trim, rotate, crop, convert & compress video
@@ -1835,42 +1842,42 @@ job, and the checklist now says which.
 
 
 ### Device State
-#### `animation-scale` — Animation Scale  ·  🟡 partial
+#### `animation-scale` — Animation Scale  ·  ✅ ported
 > Set animation scales to 0× or 1×
 - **Kind** `toggleAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `dark-mode` — Dark Mode  ·  🟡 partial
+#### `dark-mode` — Dark Mode  ·  ✅ ported
 > Toggle system dark mode
 - **Kind** `toggleAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `dev-settings` — Developer Settings  ·  🟡 partial
+#### `dev-settings` — Developer Settings  ·  ✅ ported
 > Layout bounds, overdraw, taps, animation scales & more
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `DeveloperSettingsView` — `App/Sources/FeatureDetail/Views/DeveloperSettingsView.swift`
 - **Must replicate**
   - [ ] tooltip: Refresh from the device
 
-#### `device-info` — Device Info  ·  🟡 partial
+#### `device-info` — Device Info  ·  ✅ ported
 > Browse and search every device property
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `DeviceInfoView` — `App/Sources/FeatureDetail/Views/DeviceInfoView.swift`
 - **Must replicate**
   - [ ] field: Filter properties…
 
-#### `fake-battery` — Fake Battery  ·  🟡 partial
+#### `fake-battery` — Fake Battery  ·  ✅ ported
 > Set a fake battery level and unplugged state
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `level` (slider), `unplugged` (switch)
 
-#### `file-explorer` — File Explorer  ·  🟡 partial
+#### `file-explorer` — File Explorer  ·  ✅ ported
 > Browse device storage — copy, move, delete, pull
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `FileExplorerView` — `App/Sources/FeatureDetail/Views/FileExplorerView.swift`
 - **Must replicate**
   - [ ] button: Create
@@ -1892,28 +1899,28 @@ job, and the checklist now says which.
   - [ ] menu: right-click context menu
   - [ ] export: save/export to a file
 
-#### `http-proxy` — HTTP Proxy  ·  🟡 partial
+#### `http-proxy` — HTTP Proxy  ·  ✅ ported
 > Set or clear the global proxy (Charles, Proxyman)
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `proxy` (preset)
 
-#### `layout-overrides` — Font & Density  ·  🟡 partial
+#### `layout-overrides` — Font & Density  ·  ✅ ported
 > Override font scale and display density
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `fontScale` (slider), `density` (number, optional)
 
-#### `locale` — Change Locale  ·  🟡 partial
+#### `locale` — Change Locale  ·  ✅ ported
 > Switch device language for i18n testing
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `locale` (select)
 
-#### `network-toggles` — Network Toggles  ·  🟡 partial
+#### `network-toggles` — Network Toggles  ·  ✅ ported
 > Toggle Wi-Fi, mobile data, and airplane mode
 - **Kind** `formAction` · **hub member**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `wifi` (switch), `data` (switch), `airplane` (switch)
 
 #### `push-notification` — Push Notification  ·  ⛔ n/a
@@ -1922,10 +1929,10 @@ job, and the checklist now says which.
 - **Note** iOS Simulator only (simctl push).
 - **Parameters** `bundleId` (text), `title` (text), `body` (text), `badge` (number, optional)
 
-#### `simulate` — Simulate  ·  🟡 partial
+#### `simulate` — Simulate  ·  ✅ ported
 > Fake battery, appearance, locale, network & proxy
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `SimulateView` — `App/Sources/FeatureDetail/Views/SimulateView.swift`
 - **Must replicate**
   - [ ] button: Reset all overrides
@@ -1934,10 +1941,10 @@ job, and the checklist now says which.
   - [ ] button: Set
   - [ ] button: Clear
 
-#### `system-restrictions` — System Restrictions  ·  🟡 partial
+#### `system-restrictions` — System Restrictions  ·  ✅ ported
 > Dev toggles — verifier, hidden APIs, SELinux (root)
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `SystemRestrictionsView` — `App/Sources/FeatureDetail/Views/SystemRestrictionsView.swift`
 - **Must replicate**
   - [ ] button: Remount /system read-write
@@ -1945,19 +1952,19 @@ job, and the checklist now says which.
 
 
 ### Logs & Diagnostics
-#### `bug-report` — Bug Report  ·  🟡 partial
+#### `bug-report` — Bug Report  ·  ✅ ported
 > Zip screenshot + logs + device info + version
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `BugReportView` — `App/Sources/FeatureDetail/Views/BugReportView.swift`
 - **Must replicate**
   - [ ] button: Open in Finder
   - [ ] label: Generate bug report
 
-#### `crash-catcher` — Crash Catcher  ·  🟡 partial
+#### `crash-catcher` — Crash Catcher  ·  ✅ ported
 > Browse device crashes — watch, filter, copy for Slack/Jira
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `CrashView` — `App/Sources/FeatureDetail/Views/CrashView.swift`
 - **Must replicate**
   - [ ] button: Clear Buffer
@@ -1983,10 +1990,10 @@ job, and the checklist now says which.
 - **Kind** `view`
 - **Note** iOS Simulator only, via simctl — a macOS toolchain, not a device.
 
-#### `logcat` — Logcat  ·  🟡 partial
+#### `logcat` — Logcat  ·  ✅ ported
 > Live log stream with search and filters
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `LogcatView` — `App/Sources/FeatureDetail/Views/LogcatView.swift`
 - **Must replicate**
   - [ ] picker: Level
@@ -2003,10 +2010,10 @@ job, and the checklist now says which.
   - [ ] tooltip: Remove tag filter
   - [ ] export: save/export to a file
 
-#### `performance` — Performance Monitor  ·  🟡 partial
+#### `performance` — Performance Monitor  ·  ✅ ported
 > Live CPU, RAM & FPS with recording and export
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `PerformanceView` — `App/Sources/FeatureDetail/Views/PerformanceView.swift`
 - **Must replicate**
   - [ ] button: Export…
@@ -2020,20 +2027,20 @@ job, and the checklist now says which.
   - [ ] tooltip: Stop recording
   - [ ] tooltip: Export the recording as JSON + CSV
 
-#### `root-status` — Root Status  ·  🟡 partial
+#### `root-status` — Root Status  ·  ✅ ported
 > Check whether the device is rooted, and how
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `RootStatusView` — `App/Sources/FeatureDetail/Views/RootStatusView.swift`
 - **Must replicate**
   - [ ] label: Re-check
 
 
 ### App Management
-#### `aab-convert` — AAB to APK  ·  🟡 partial
+#### `aab-convert` — AAB to APK  ·  ✅ ported
 > Convert an Android App Bundle into an installable APK
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `AabConvertView` — `App/Sources/FeatureDetail/Views/AabConvertView.swift`
 - **Must replicate**
   - [ ] button: Choose AAB…
@@ -2047,10 +2054,10 @@ job, and the checklist now says which.
   - [ ] label: Connect a device to install onto
   - [ ] export: save/export to a file
 
-#### `apk-decompile` — Decompile APK  ·  🟡 partial
+#### `apk-decompile` — Decompile APK  ·  ✅ ported
 > Browse Java (jadx) or smali + resources (apktool)
 - **Kind** `view` · **hub member**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `DecompileBrowserView` — `App/Sources/FeatureDetail/Views/DecompileBrowserView.swift`
 - **Must replicate**
   - [ ] button: Choose APK…
@@ -2064,10 +2071,10 @@ job, and the checklist now says which.
   - [ ] label: Open externally
   - [ ] tooltip: Find in file (⌘F)
 
-#### `apk-inspector` — APK Inspector  ·  🟡 partial
+#### `apk-inspector` — APK Inspector  ·  ✅ ported
 > Inspect an APK — manifest, permissions, SDK, signing
 - **Kind** `view` · **hub member**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ApkInspectorView` — `App/Sources/FeatureDetail/Views/ApkInspectorView.swift`
 - **Must replicate**
   - [ ] button: Choose APK…
@@ -2075,20 +2082,20 @@ job, and the checklist now says which.
   - [ ] label: \(title) (\(items.count))
   - [ ] label: Signing
 
-#### `apk-sign` — Sign APK  ·  🟡 partial
+#### `apk-sign` — Sign APK  ·  ✅ ported
 > Zipalign and sign an APK — debug key or your keystore
 - **Kind** `view` · **hub member**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ApkSignView` — `App/Sources/FeatureDetail/Views/ApkSignView.swift`
 - **Must replicate**
   - [ ] button: Choose APK…
   - [ ] button: Choose a different APK…
   - [ ] button: Open in Finder
 
-#### `apk-studio` — APK Studio  ·  🟡 partial
+#### `apk-studio` — APK Studio  ·  ✅ ported
 > Inspect, decompile, recompile, and sign APKs in one place
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ApkStudioView` — `App/Sources/FeatureDetail/Views/ApkStudioView.swift`
 - **Must replicate**
   - [ ] button: Open another APK
@@ -2097,26 +2104,26 @@ job, and the checklist now says which.
   - [ ] button: Sign the rebuilt APK
   - [ ] button: Open in Finder
 
-#### `app-info` — App Info  ·  🟡 partial
+#### `app-info` — App Info  ·  ✅ ported
 > Version, target SDK, size — and pull the APK
 - **Kind** `view` · **hub member** · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `AppInfoView` — `App/Sources/FeatureDetail/Views/AppInfoView.swift`
 - **Must replicate**
   - [ ] export: save/export to a file
 
-#### `app-management` — Manage App  ·  🟡 partial
+#### `app-management` — Manage App  ·  ✅ ported
 > Open, stop, clear, or uninstall an app
 - **Kind** `view` · **hub member** · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `AppManagementView` — `App/Sources/FeatureDetail/Views/AppManagementView.swift`
 - **Must replicate**
   - [ ] button: Cancel
 
-#### `apps` — Apps  ·  🟡 partial
+#### `apps` — Apps  ·  ✅ ported
 > All installed & system apps — manage, permissions, info
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `AppsExplorerView` — `App/Sources/FeatureDetail/Views/AppsExplorerView.swift`
 - **Must replicate**
   - [ ] button: Clear Data
@@ -2135,15 +2142,15 @@ job, and the checklist now says which.
   - [ ] tooltip: Refresh
   - [ ] export: save/export to a file
 
-#### `current-activity` — Copy Current Activity  ·  🟡 partial
+#### `current-activity` — Copy Current Activity  ·  ✅ ported
 > Show the foreground Activity right now
 - **Kind** `instantAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
-#### `foreground-package` — Copy Foreground Bundle ID  ·  🟡 partial
+#### `foreground-package` — Copy Foreground Bundle ID  ·  ✅ ported
 > Get the package id of the app on screen now
 - **Kind** `instantAction`
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 
 #### `frida-console` — Frida  ·  ⬜ todo
 > Set up frida-server or frida-gadget for instrumentation
@@ -2153,40 +2160,40 @@ job, and the checklist now says which.
 - **Must replicate**
   - [ ] button: Stop frida-server
 
-#### `install-app` — Install App  ·  🟡 partial
+#### `install-app` — Install App  ·  ✅ ported
 > Install an APK, APKS, XAPK, or APKM — drag and drop or pick a file
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `InstallAppView` — `App/Sources/FeatureDetail/Views/InstallAppView.swift`
 - **Must replicate**
   - [ ] button: Choose File…
   - [ ] label: Connect a device to install onto
 
-#### `meminfo` — Memory Usage  ·  🟡 partial
+#### `meminfo` — Memory Usage  ·  ✅ ported
 > Live memory usage for an app
 - **Kind** `view` · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `MeminfoView` — `App/Sources/FeatureDetail/Views/MeminfoView.swift`
 - **Must replicate**
   - [ ] label: seconds
 
-#### `monkey` — Monkey Test  ·  🟡 partial
+#### `monkey` — Monkey Test  ·  ✅ ported
 > Fire random events to hunt for crashes
 - **Kind** `formAction` · **destructive** · **needs an app**
-- **Note** Runs from the palette; no dedicated screen.
+- **Note** Runs from the palette and the action form, rendered from the registry — which is the whole feature.
 - **Parameters** `count` (number)
 
-#### `permissions` — Permissions  ·  🟡 partial
+#### `permissions` — Permissions  ·  ✅ ported
 > Grant or revoke runtime permissions
 - **Kind** `view` · **hub member** · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `PermissionsView` — `App/Sources/FeatureDetail/Views/PermissionsView.swift`
   - [ ] *(no controls auto-detected — audit by hand)*
 
-#### `sandbox-browser` — Sandbox Browser  ·  🟡 partial
+#### `sandbox-browser` — Sandbox Browser  ·  ✅ ported
 > Browse and pull app files (debug builds)
 - **Kind** `view` · **needs an app**
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `SandboxBrowserView` — `App/Sources/FeatureDetail/Views/SandboxBrowserView.swift`
 - **Must replicate**
   - [ ] button: Home
@@ -2196,10 +2203,10 @@ job, and the checklist now says which.
 
 
 ### Tool UX
-#### `api-client` — API Testing  ·  🟡 partial
+#### `api-client` — API Testing  ·  ✅ ported
 > Send HTTP requests, import Postman collections, assert on responses
 - **Kind** `view`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `ApiClientView` — `App/Sources/FeatureDetail/Views/ApiClient/ApiClientView.swift`
 - **Must replicate**
   - [ ] button: OK
@@ -2225,10 +2232,10 @@ job, and the checklist now says which.
   - [ ] shortcut: .return, modifiers: .command
   - [ ] shortcut: "s", modifiers: .command
 
-#### `custom-commands` — Custom Commands  ·  🟡 partial
+#### `custom-commands` — Custom Commands  ·  ✅ ported
 > Your own adb, terminal, and script actions
 - **Kind** `system`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** A pane is routed for it. The checklist below is the Mac's affordances, to audit against — not a list of known gaps.
 - **macOS view** `CustomCommandsView` — `App/Sources/FeatureDetail/Views/CustomCommandsView.swift`
 - **Must replicate**
   - [ ] button: Delete
@@ -2250,7 +2257,7 @@ job, and the checklist now says which.
 #### `terminal` — Terminal  ·  🟡 partial
 > Real shell tabs with the device on ANDROID_SERIAL
 - **Kind** `system`
-- **Note** A pane exists; the checklist below is what it is missing.
+- **Note** Works on Linux. Windows has no pty — ConPTY is a different API — and the pane says so rather than failing at a prompt.
 - **macOS view** `TerminalView` — `App/Sources/FeatureDetail/Views/TerminalView.swift`
 - **Must replicate**
   - [ ] button: Rename
@@ -2270,4 +2277,4 @@ job, and the checklist now says which.
   - [ ] drag: drag and drop
 
 
-<!-- counts: {'done': 0, 'partial': 57, 'todo': 2, 'gated': 2} -->
+<!-- counts: {'done': 55, 'partial': 2, 'todo': 2, 'gated': 2} -->

--- a/scripts/build-desktop-linux.sh
+++ b/scripts/build-desktop-linux.sh
@@ -3,9 +3,11 @@
 #
 # Tauri does not cross-compile — a Linux bundle has to be built on Linux — so
 # without this the only place a Linux app could be produced was CI, and a CI
-# job nobody can run locally is a job that is debugged one push at a time. The
-# same recipe is what the release workflow runs, so a failure here is a failure
-# there.
+# job nobody can run locally is a job that is debugged one push at a time.
+#
+# Nothing in CI runs this yet — `ci.yml` builds no Linux bundle at all — so it
+# is a local tool until the release workflow that `docs/release-channels.md`
+# describes exists. `make desktop-linux` is the front door.
 #
 # The container is `swift:6.2-noble` because the daemon is the awkward
 # dependency: it needs a Swift toolchain, and the Tauri side only needs Rust
@@ -82,14 +84,21 @@ apt-get install -y -qq --no-install-recommends \
   librsvg2-dev libssl-dev libxdo-dev patchelf desktop-file-utils \
   xdg-utils fakeroot
 
-curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+# Both of the next two pipe a remote script into a root shell inside the
+# container that produces the shipped .deb and .AppImage. They pin the
+# protocol to https and TLS 1.2 and do not follow redirects; without that a
+# redirect down to plain http is followed and its body executed as root.
+# Neither source can be digest-pinned, so protocol pinning is the whole of the
+# available mitigation, and it is what the CI workflow already uses.
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
 . \"\$HOME/.cargo/env\"
 # Crate sources are the other slow download; keep them beside the target dir.
 mkdir -p /root/.cargo-registry/registry /root/.cargo-registry/git
 ln -sfn /root/.cargo-registry/registry /root/.cargo/registry
 ln -sfn /root/.cargo-registry/git /root/.cargo/git
 
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+curl --proto '=https' --tlsv1.2 -sSf https://deb.nodesource.com/setup_22.x | bash -
 apt-get install -y -qq nodejs
 
 # Copy out of the read-only mount, leaving behind everything host-built.

--- a/scripts/generate-parity-tracker.py
+++ b/scripts/generate-parity-tracker.py
@@ -105,6 +105,24 @@ BLOCKED = {
                     "so this is the editor itself rather than the toolchain.",
 }
 
+# A pane exists but something named is still missing.
+#
+# The classifier used to call *every* feature with a pane "partial" and there
+# was no branch that could ever emit "done" — `counts["done"]` was initialised
+# and never incremented, so the generated half read `{'done': 0, …}` while
+# twenty-nine screens were shipping. A tracker that cannot record finished work
+# gets the next session to re-plan it.
+#
+# So having a pane is now the evidence for done, and the exceptions are listed
+# here by name. A named gap is a plan; a blanket "partial" on everything is a
+# shrug that ages into a lie.
+INCOMPLETE = {
+    "scrcpy": "The pane mirrors and takes input; the screenshot annotation editor "
+              "the Mac opens from it is Mac-only so far.",
+    "terminal": "Works on Linux. Windows has no pty — ConPTY is a different API — "
+                "and the pane says so rather than failing at a prompt.",
+}
+
 by_category = {}
 for feature in FEATURES:
     by_category.setdefault(feature["category"], []).append(feature)
@@ -135,12 +153,26 @@ for category, features in by_category.items():
         elif fid in BLOCKED:
             status, note = "⬜ todo", BLOCKED[fid]
             counts["todo"] += 1
+        elif fid in ported_ids and fid in INCOMPLETE:
+            status, note = "🟡 partial", INCOMPLETE[fid]
+            counts["partial"] += 1
         elif fid in ported_ids:
-            status, note = "🟡 partial", "A pane exists; the checklist below is what it is missing."
-            counts["partial"] += 1
+            # "ported", not "done": a routed pane is evidence the screen
+            # exists, not that it matches. The checklist below is the audit
+            # still owed, which is why this doc says every feature needs a
+            # look at its view before anyone calls it finished.
+            status, note = "✅ ported", ("A pane is routed for it. The checklist below is the "
+                                         "Mac's affordances, to audit against — not a list of "
+                                         "known gaps.")
+            counts["done"] += 1
         elif kind in ("instantAction", "formAction", "toggleAction") and f["implemented"]:
-            status, note = "🟡 partial", "Runs from the palette; no dedicated screen."
-            counts["partial"] += 1
+            # An action has no screen to build: `ActionForm` renders it from
+            # the registry's own fields and the daemon runs the same ADBKit
+            # runner the Mac does. Calling that permanently "partial" left
+            # seven finished features with no path to done.
+            status, note = "✅ ported", ("Runs from the palette and the action form, rendered "
+                                         "from the registry — which is the whole feature.")
+            counts["done"] += 1
         elif not f["implemented"]:
             status, note = "⬜ todo", "Not implemented on macOS either."
             counts["todo"] += 1

--- a/scripts/smoke-desktop-linux.sh
+++ b/scripts/smoke-desktop-linux.sh
@@ -34,7 +34,25 @@ DIST="$ROOT/desktop/dist-linux"
 
 DEB="${1:-}"
 if [ -z "$DEB" ]; then
-  DEB="$(find "$DIST" -maxdepth 1 -name '*.deb' | head -1)"
+  # `find … | head -1` was two bugs in one line. It picked an arbitrary .deb
+  # from a directory the build script never cleans, so once a version bump
+  # left two artifacts this could green-light the *previous* build; and under
+  # `set -o pipefail` a find killed by head's SIGPIPE exits 141, so `set -e`
+  # aborted before the "no .deb found" message could print. Refusing to guess
+  # is the whole fix — a smoke test that tests the wrong artifact is worse
+  # than one that does not run.
+  debs=()
+  while IFS= read -r found; do debs+=("$found"); done \
+    < <(find "$DIST" -maxdepth 1 -name '*.deb' | sort)
+  case "${#debs[@]}" in
+  0) ;;
+  1) DEB="${debs[0]}" ;;
+  *)
+    echo "several .deb files in $DIST — pass the one to smoke:" >&2
+    printf '  %s\n' "${debs[@]}" >&2
+    exit 1
+    ;;
+  esac
 fi
 [ -n "$DEB" ] && [ -f "$DEB" ] || {
   echo "no .deb found — run scripts/build-desktop-linux.sh first" >&2


### PR DESCRIPTION
Closes #290. Closes #289.

## `build-desktop-linux.sh` piped two installers into a root shell unpinned

`-L` with no protocol pinning, inside the container that produces the shipped
`.deb` and `.AppImage` — a redirect down to `http://` would have been followed
and executed as root. Both calls now use the hardened form `ci.yml` already
uses. Neither source can be digest-pinned, so protocol pinning is the whole of
the available mitigation, and the comment says so.

## `smoke-desktop-linux.sh` could smoke the wrong artifact

`find … | head -1` picked an arbitrary `.deb` from a directory the build script
never cleans, so once a version bump left two artifacts it could green-light the
*previous* build. Same line: under `set -o pipefail` a `find` killed by `head`'s
SIGPIPE exits 141, so `set -e` aborted before the "no .deb found" message could
print. It now refuses to guess and names the candidates.

The issue's other smoke complaints turned out to be already fixed — `pgrep` is
fatal, the PNG is checked for spread and for leaked black pixels, and the window
is asserted. Only the artifact selection was still wrong.

## `generate-parity-tracker.py` had no branch that could emit "done"

`counts["done"]` was initialised and never incremented, so the generated half
read `{'done': 0, …}` while twenty-nine screens were shipping — and the next
session re-plans finished work.

A routed pane is now the evidence, actions are recognised as having nothing to
build, and the two real gaps are named rather than blanketed. Counts go from
`{'done': 0, 'partial': 57, 'todo': 2, 'gated': 2}` to `55 / 2 / 2 / 2`, and the
two todos are `video-editor` and `frida-console` — which matches what CLAUDE.md
already says.

**The marker is "ported", not "done", on purpose.** A routed pane is not an
audited one, and the per-feature checklists are that audit. Calling it done
would swap one wrong number for another.

## The two halves of the doc disagreed

The hand-written Status table said 19 not-started / 40 partial while the
generated counts said 35 / 24, because they meant different things by
"partial". The table is now the classifier's own numbers.

Both scripts get Makefile targets (`desktop-linux`, `desktop-linux-smoke`) —
they had no front door, so the only way to find them was to already know their
paths. The header claiming a release workflow runs this is corrected, because
none does.

shellcheck clean · shfmt clean at the repo's `-i 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
