### PR TITLE
Retry a delete Windows will not do yet, and wake the relay tests on arrival

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/DecompileService.swift
+++ b/ADBKit/Sources/ADBKit/Services/DecompileService.swift
@@ -69,7 +69,11 @@ public struct DecompileService: Sendable {
             return outDir
         }
         guard let java = await toolchain.java() else { throw DecompileError.toolMissing("Java") }
-        try? FileManager.default.removeItem(at: outDir)
+        // Retried, not swallowed: the previous run's tree is exactly what a
+        // Windows handle still holds open — `b.txt` and `AndroidManifest.xml`
+        // are the two that failed on CI — and leaving it in place would mix a
+        // stale decompile into the new one.
+        try await FileRetry.remove(outDir)
         try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
 
         let arguments: [String]

--- a/ADBKit/Sources/ADBKit/Tools/FileRetry.swift
+++ b/ADBKit/Sources/ADBKit/Tools/FileRetry.swift
@@ -27,6 +27,30 @@ enum FileRetry {
     /// `isolation` inherits the caller's actor so `body` can touch that actor's
     /// state — `ManagedToolStore`'s `fileManager` — without being sent across
     /// an isolation boundary and tripping strict concurrency.
+    /// Delete a file or tree, retrying a sharing violation.
+    ///
+    /// Deletion is the case `run` did not cover and the one CI actually trips
+    /// over: POSIX lets you unlink a file somebody still has open, Windows
+    /// does not, so a tree whose contents were just written or read fails to
+    /// go away with `NSCocoaErrorDomain 513` / Win32 32. The give-away that it
+    /// is a handle-lifetime race rather than one bad test is that a
+    /// *different* suite failed on each run.
+    ///
+    /// Missing is success, as it is for every `removeItem` caller here: they
+    /// all mean "make sure this is not there".
+    static func remove(
+        _ url: URL,
+        fileManager: FileManager = .default,
+        attempts: Int = 5,
+        isolation: isolated (any Actor)? = #isolation,
+        pause: (Int) async throws -> Void = { try await Task.sleep(for: .milliseconds(50 * $0)) }
+    ) async throws {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try await run(attempts: attempts, isolation: isolation, pause: pause) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
     static func run<T>(
         attempts: Int = 5,
         isolation: isolated (any Actor)? = #isolation,

--- a/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
+++ b/ADBKit/Sources/ADBKit/Tools/ManagedToolStore.swift
@@ -235,13 +235,13 @@ public actor ManagedToolStore {
         guard let assetURL = URL(string: asset.downloadURL) else { throw StoreError.noReleaseURL }
 
         let stagingDir = toolRoot(tool).appendingPathComponent(".staging", isDirectory: true)
-        try recreateDirectory(stagingDir)
+        try await recreateDirectory(stagingDir)
         let downloaded = stagingDir.appendingPathComponent(asset.name)
         try await http.download(from: assetURL, to: downloaded, onProgress: onProgress)
         try verifyDigest(downloaded, expected: asset.digest)
 
         let versionDir = toolRoot(tool).appendingPathComponent(sanitize(release.tagName), isDirectory: true)
-        try recreateDirectory(versionDir)
+        try await recreateDirectory(versionDir)
         try await place(asset: downloaded, spec: spec, into: versionDir)
         try? fileManager.removeItem(at: stagingDir)
 
@@ -261,7 +261,7 @@ public actor ManagedToolStore {
            !ManagedToolReleases.isNewer(version, than: installed) { return }
         guard let spec = ManagedToolSpec.hostCatalog[tool] else { throw StoreError.unsupported(tool) }
         let versionDir = toolRoot(tool).appendingPathComponent(sanitize(version), isDirectory: true)
-        try recreateDirectory(versionDir)
+        try await recreateDirectory(versionDir)
         try fileManager.copyItem(at: source, to: versionDir.appendingPathComponent(source.lastPathComponent))
         guard runnable(in: versionDir, spec: spec) != nil else { throw StoreError.runnableNotFound(tool) }
         try await markCurrent(tool, tag: version)
@@ -371,8 +371,16 @@ public actor ManagedToolStore {
         tag.replacingOccurrences(of: "/", with: "_")
     }
 
-    private func recreateDirectory(_ url: URL) throws {
-        try? fileManager.removeItem(at: url)
+    /// An empty directory at `url`, whatever was there before.
+    ///
+    /// The removal retries because this is where Windows CI failed:
+    /// `.staging` holds the jar that was just downloaded and read, and a
+    /// scanner's handle on it makes the tree undeletable for a few
+    /// milliseconds. Swallowing the failure — which `try?` did — leaves the
+    /// previous download's files inside a directory the caller was promised
+    /// is empty.
+    private func recreateDirectory(_ url: URL) async throws {
+        try await FileRetry.remove(url, fileManager: fileManager)
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
     }
 

--- a/ADBKit/Tests/ADBKitTests/FileRetryTests.swift
+++ b/ADBKit/Tests/ADBKitTests/FileRetryTests.swift
@@ -145,4 +145,71 @@ import Testing
 
         await #expect(throws: (any Error).self) { try await task.value }
     }
+
+    // MARK: - remove
+
+    /// The Windows CI failure this was added for: a delete that cannot happen
+    /// yet because something still holds the file open. Modelled with a
+    /// FileManager that refuses the first two attempts, since a real sharing
+    /// violation cannot be produced on this platform — POSIX unlinks an open
+    /// file happily, which is the whole reason the bug is Windows-only.
+    @Test func removeRetriesASharingViolation() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let locking = LockedUntil(attempts: 2)
+        var pauses = 0
+        try await FileRetry.remove(directory, fileManager: locking, pause: { _ in pauses += 1 })
+
+        #expect(locking.removeCalls == 3, "two refusals then the one that lands")
+        #expect(pauses == 2)
+    }
+
+    /// Nothing there is the outcome every caller wants, not an error — and it
+    /// must not burn the retry budget waiting for a file that will never exist.
+    @Test func removingSomethingAbsentSucceedsImmediately() async throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("absent-\(UUID().uuidString)")
+        var pauses = 0
+        try await FileRetry.remove(missing, pause: { _ in pauses += 1 })
+        #expect(pauses == 0)
+    }
+
+    @Test func removeGivesUpAndReportsTheRealError() async {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stuck-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let locking = LockedUntil(attempts: .max)
+        await #expect(throws: StillOpen.self) {
+            try await FileRetry.remove(
+                directory, fileManager: locking, attempts: 3, pause: { _ in })
+        }
+        #expect(locking.removeCalls == 3, "the budget, then the error")
+    }
+}
+
+/// A sharing violation, as this platform cannot produce a real one.
+private struct StillOpen: Error {}
+
+/// Refuses to delete anything until it has been asked `attempts` times — a
+/// stand-in for a Windows handle that is about to close.
+private final class LockedUntil: FileManager, @unchecked Sendable {
+    private let attempts: Int
+    private(set) var removeCalls = 0
+
+    init(attempts: Int) {
+        self.attempts = attempts
+        super.init()
+    }
+
+    override func fileExists(atPath path: String) -> Bool { true }
+
+    override func removeItem(at URL: URL) throws {
+        removeCalls += 1
+        if removeCalls <= attempts { throw StillOpen() }
+    }
 }

--- a/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
+++ b/droidectived/Tests/DaemonCoreTests/ReactotronRelayTests.swift
@@ -31,23 +31,60 @@ import Testing
 
     /// Collects events off the stream, so a test can wait for the one it wants
     /// without assuming how many arrive first.
+    ///
+    /// A waiter is *woken by the arrival*, not by a poll. The version this
+    /// replaces re-checked every 20 ms against a 10-second deadline, which
+    /// spends the whole budget on getting scheduled — and on a loaded
+    /// `macos-15` runner that is what
+    /// `reportsAClientThatDisconnects` intermittently ran out of, while the
+    /// same test takes 0.3 s locally. The timeout is now only a backstop
+    /// against hanging the suite, so it can be generous without costing
+    /// anything when things work.
     private actor Collected {
         private(set) var events: [ReactotronRelay.Event] = []
 
-        func add(_ event: ReactotronRelay.Event) { events.append(event) }
+        private struct Waiter {
+            let matches: @Sendable ([ReactotronRelay.Event]) -> Bool
+            let continuation: CheckedContinuation<Bool, Never>
+        }
 
-        /// Waits until `matching` finds something, or gives up. Generous,
-        /// because it is a socket round trip that normally takes milliseconds.
-        func wait(
-            timeout: Duration = .seconds(10),
-            _ matching: @Sendable ([ReactotronRelay.Event]) -> Bool
-        ) async -> Bool {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
-            while ContinuousClock.now < deadline {
-                if matching(events) { return true }
-                try? await Task.sleep(for: .milliseconds(20))
+        private var waiters: [UUID: Waiter] = [:]
+
+        func add(_ event: ReactotronRelay.Event) {
+            events.append(event)
+            for (id, waiter) in waiters where waiter.matches(events) {
+                waiters[id] = nil
+                waiter.continuation.resume(returning: true)
             }
-            return matching(events)
+        }
+
+        /// Waits until `matching` holds. The backstop returns false rather
+        /// than hanging, so a genuine failure still reports as one.
+        func wait(
+            timeout: Duration = .seconds(30),
+            _ matching: @escaping @Sendable ([ReactotronRelay.Event]) -> Bool
+        ) async -> Bool {
+            let id = UUID()
+            return await withCheckedContinuation { continuation in
+                if matching(events) {
+                    continuation.resume(returning: true)
+                    return
+                }
+                waiters[id] = Waiter(matches: matching, continuation: continuation)
+                // Started *after* registering, inside the continuation body:
+                // a timeout that fired before the waiter existed would find
+                // nothing to give up on, and the waiter registered a moment
+                // later would then never be resumed at all.
+                Task { [weak self] in
+                    try? await Task.sleep(for: timeout)
+                    await self?.giveUp(id)
+                }
+            }
+        }
+
+        private func giveUp(_ id: UUID) {
+            guard let waiter = waiters.removeValue(forKey: id) else { return }
+            waiter.continuation.resume(returning: false)
         }
     }
 


### PR DESCRIPTION
Two CI flakes, neither a product defect, both able to fail a green PR.

## Windows: `NSCocoaErrorDomain 513` / Win32 32 on teardown

A **different suite failed each run** — `ManagedToolStoreTests` on
`.staging/apktool_*.jar`, then `DecompileServiceTests` on `b.txt` and
`AndroidManifest.xml` — which is the signature of a handle-lifetime race, not
one bad test. POSIX unlinks a file somebody still has open; Windows refuses, so
a tree whose contents were just written or read is briefly undeletable.

`FileRetry` already existed for exactly this — its doc names
ERROR_SHARING_VIOLATION — but only covered moves and writes. `FileRetry.remove`
covers deletes, and the two directory recreations that failed go through it.

They were `try?` before, so the failure was swallowed and the **stale tree** was
what the next step saw. Retrying and then reporting is the honest version: a
`.staging` that would not clear left the previous download's files inside a
directory the caller was promised is empty.

## macOS: `ReactotronRelayTests.reportsAClientThatDisconnects`

`Collected.wait` polled every 20 ms against a 10-second budget, which spends
that budget on being scheduled. The test takes 0.3 s locally and ran out of it
on a loaded `macos-15` runner.

Waiters are now resumed by the arrival that satisfies them, with the timeout
demoted to a backstop against hanging — so it can be generous and costs nothing
when things work. Five consecutive local runs at 0.57 s.

## What is not verified here

**Neither can be proven on this machine.** There is no Windows and no Windows
container, and the relay flake only appears under CI load. The Windows change
is principled — retry is the standard response to a sharing violation, and this
repo already had the helper for it — but CI is the first and only place it is
exercised.

Three new `FileRetry` tests, using a `FileManager` that refuses the first N
deletes, since a real sharing violation cannot be produced on a POSIX host.

ADBKit 2128 · droidectived 408 · Mac build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
