### PR TITLE
Stop three app operations reporting something that is not true

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/AppControlService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppControlService.swift
@@ -3,6 +3,13 @@ import Foundation
 /// App-scoped operations keyed by package id: lifecycle control and the
 /// installed-package list (used by the "pick from device" bundle flow).
 public struct AppControlService: Sendable {
+    /// How long to wait for `pm clear --cache-only` before giving up on it.
+    ///
+    /// Long enough for a real clear on a slow device, short enough that the
+    /// hang some images have is a brief failure rather than half a minute of
+    /// a spinning button.
+    static let cacheClearTimeout: Duration = .seconds(10)
+
     public enum AppAction: String, Sendable, CaseIterable {
         case open
         case restart
@@ -43,7 +50,17 @@ public struct AppControlService: Sendable {
             return fromResult(result, success: "Sent to background", fallback: "Failed to minimize")
 
         case .clearCache:
-            let result = try await client.run(on: serial, ["shell", "pm", "clear", "--cache-only", shellQuote(packageId)])
+            // Bounded, unlike every other verb here. `pm clear --cache-only`
+            // never returns on some images (observed live on the API 36
+            // emulator, app running or stopped), so the default 30 s timeout
+            // meant the Apps hub's Clear Cache stalled for half a minute and
+            // then reported failure. The JS Console and Reactotron had each
+            // wrapped their own watchdog around this; the bound belongs on the
+            // command, so the hub and the panel get it too.
+            let result = try await client.run(
+                on: serial,
+                ["shell", "pm", "clear", "--cache-only", shellQuote(packageId)],
+                timeout: Self.cacheClearTimeout)
             // `pm clear` prints "Success"/"Failed" and exits 0 either way, so the
             // stdout text — not the exit code — is authoritative.
             return Self.pmClearSucceeded(result)

--- a/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
+++ b/ADBKit/Sources/ADBKit/Services/AppInspectionService.swift
@@ -206,6 +206,14 @@ public struct AppInspectionService: Sendable {
             let dest = saved.isEmpty ? base : Self.splitDestination(base: base, splitPath: path)
             let result = try await client.run(on: serial, ["pull", path, dest.path], timeout: .seconds(120))
             guard result.succeeded else {
+                // Take back what landed before rethrowing. A split app whose
+                // second pull fails would otherwise leave a lone `base.apk`
+                // at the path the user chose — which looks like the app and
+                // installs with `INSTALL_FAILED_MISSING_SPLIT` days later,
+                // long after the error message has gone. Half a bundle is
+                // worse than none.
+                for written in saved { try? FileManager.default.removeItem(at: written) }
+                try? FileManager.default.removeItem(at: dest)
                 throw PullError.failed(friendlyAdbError(result, fallback: "Failed to pull APK"))
             }
             saved.append(dest)

--- a/ADBKit/Sources/ADBKit/Services/PullProgress.swift
+++ b/ADBKit/Sources/ADBKit/Services/PullProgress.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Which files on disk make up one APK pull.
+///
+/// A split app is pulled as several files beside the one the user chose —
+/// `com.x.apk` plus `com.x.split_config.en.apk` and friends, named by
+/// `AppInspectionService.splitDestination`. The progress strip polled only the
+/// chosen file's size against `apkSizeBytes`, which is the sum of *all* of
+/// them, so the bar climbed to base/total, stalled there for the rest of the
+/// pull, and then jumped to done. On a bundle whose splits outweigh the base
+/// that is most of the wait spent looking stuck.
+///
+/// Pure and name-based: the caller does the directory read, this decides what
+/// counts.
+public enum PullProgress {
+    /// Whether `fileName`, sitting in the destination's directory, is part of
+    /// the pull that chose `destinationName`.
+    ///
+    /// The chosen file itself, or a split named after its stem. A neighbour
+    /// that merely starts with the same letters (`com.example2.apk` beside
+    /// `com.example.apk`) is excluded by requiring the separating dot.
+    public static func belongsToPull(fileName: String, destinationName: String) -> Bool {
+        if fileName == destinationName { return true }
+        let stem = (destinationName as NSString).deletingPathExtension
+        guard !stem.isEmpty else { return false }
+        let suffix = (destinationName as NSString).pathExtension
+        guard !suffix.isEmpty else { return false }
+        return fileName.hasPrefix("\(stem).") && fileName.hasSuffix(".\(suffix)")
+    }
+}

--- a/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppControlServiceTests.swift
@@ -161,6 +161,23 @@ import Testing
         ])
     }
 
+    /// The one verb here that must not wait out the default timeout: on some
+    /// images `pm clear --cache-only` never returns at all (seen live on the
+    /// API 36 emulator, app running or stopped), so the Apps hub's button sat
+    /// spinning for the full 30 s and then said it had failed.
+    @Test func clearCacheIsBoundedWhileTheOtherVerbsAreNot() async throws {
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s"], stdout: "Success")
+        let service = await makeService(runner)
+
+        _ = try await service.control(serial: "S1", packageId: "com.x", action: .clearCache)
+        #expect(runner.timeout(forArgumentsContaining: ["--cache-only"]) == .seconds(10))
+
+        _ = try await service.control(serial: "S1", packageId: "com.x", action: .clearData)
+        let dataClear = runner.timeouts.last
+        #expect(dataClear == AdbClient.defaultTimeout, "pm clear returns reliably; do not bound it")
+    }
+
     @Test func clearCacheReportsFailureWhenNoSuccessText() async throws {
         // Older devices print nothing (no --cache-only support) and exit 0.
         let runner = MockProcessRunner()

--- a/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
@@ -57,6 +57,39 @@ import Testing
         ])
     }
 
+    /// A split app whose second pull fails used to leave a lone `base.apk` at
+    /// the path the user chose. It looks like the app and installs with
+    /// `INSTALL_FAILED_MISSING_SPLIT` days later, long after the error message
+    /// has been dismissed — so the partial set is taken back with the throw.
+    @Test func aFailedSplitPullLeavesNothingBehind() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pull-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let dest = directory.appendingPathComponent("com.x.apk")
+
+        let runner = MockProcessRunner()
+        runner.script(argsPrefix: ["-s", "S1", "shell", "pm", "path"], stdout: """
+        package:/data/app/~~a==/com.x-1/base.apk
+        package:/data/app/~~a==/com.x-1/split_config.en.apk
+        """)
+        // The base lands; the split does not. adb writes the file itself, so
+        // the base is created here to stand in for that.
+        runner.script(argsPrefix: ["-s", "S1", "pull"], stdout: "1 file pulled")
+        runner.script(
+            argsPrefix: ["-s", "S1", "pull", "/data/app/~~a==/com.x-1/split_config.en.apk"],
+            stderr: "adb: error: failed to copy", exitCode: 1)
+        FileManager.default.createFile(atPath: dest.path, contents: Data("apk".utf8))
+        let service = AppInspectionService(client: await makeTestClient(runner: runner))
+
+        await #expect(throws: AppInspectionService.PullError.self) {
+            _ = try await service.pullApk(serial: "S1", packageId: "com.x", to: dest)
+        }
+        #expect(
+            !FileManager.default.fileExists(atPath: dest.path),
+            "the base APK must not survive a failed split pull")
+    }
+
     @Test func pullApkSingleApkLandsExactlyAtTheChosenDestination() async throws {
         let runner = MockProcessRunner()
         runner.script(

--- a/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
+++ b/ADBKit/Tests/ADBKitTests/AppInspectionTests.swift
@@ -79,7 +79,11 @@ import Testing
         runner.script(
             argsPrefix: ["-s", "S1", "pull", "/data/app/~~a==/com.x-1/split_config.en.apk"],
             stderr: "adb: error: failed to copy", exitCode: 1)
-        FileManager.default.createFile(atPath: dest.path, contents: Data("apk".utf8))
+        // `Data.write`, not `FileManager.createFile`: the latter returns a Bool
+        // that is `@discardableResult` on Darwin and *not* in swift-corelibs,
+        // so ignoring it compiles here and fails the Linux and Windows jobs
+        // under warnings-as-errors.
+        try Data("apk".utf8).write(to: dest)
         let service = AppInspectionService(client: await makeTestClient(runner: runner))
 
         await #expect(throws: AppInspectionService.PullError.self) {

--- a/ADBKit/Tests/ADBKitTests/MockProcessRunner.swift
+++ b/ADBKit/Tests/ADBKitTests/MockProcessRunner.swift
@@ -12,11 +12,34 @@ final class MockProcessRunner: ProcessRunning, @unchecked Sendable {
     private let lock = NSLock()
     private var scripts: [(argsPrefix: [String], output: ProcessOutput)] = []
     private var recorded: [Invocation] = []
+    private var recordedTimeouts: [Duration] = []
 
     var invocations: [Invocation] {
         lock.lock()
         defer { lock.unlock() }
         return recorded
+    }
+
+    /// The timeout each call was given, in the same order as `invocations`.
+    ///
+    /// Kept beside them rather than on `Invocation`: a command that must be
+    /// *bounded* — `pm clear --cache-only` never returns on some images — has
+    /// no other observable difference, and widening `Invocation` would rewrite
+    /// every arg-vector assertion in the suite to say nothing new.
+    var timeouts: [Duration] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedTimeouts
+    }
+
+    /// The timeout given to the first call whose arguments contain `needle`.
+    func timeout(forArgumentsContaining needle: [String]) -> Duration? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let index = recorded.firstIndex(where: { invocation in
+            needle.allSatisfy(invocation.arguments.contains)
+        }) else { return nil }
+        return recordedTimeouts[index]
     }
 
     /// Respond to any invocation whose arguments start with `argsPrefix`.
@@ -32,14 +55,17 @@ final class MockProcessRunner: ProcessRunning, @unchecked Sendable {
     }
 
     func run(executable: String, arguments: [String], timeout: Duration, maxOutputBytes: Int) async -> ProcessOutput {
-        recordAndMatch(executable: executable, arguments: arguments)
+        recordAndMatch(executable: executable, arguments: arguments, timeout: timeout)
             ?? ProcessOutput(stdout: Data(), stderr: Data("unscripted invocation".utf8), exitCode: 1, timedOut: false)
     }
 
-    private func recordAndMatch(executable: String, arguments: [String]) -> ProcessOutput? {
+    private func recordAndMatch(
+        executable: String, arguments: [String], timeout: Duration
+    ) -> ProcessOutput? {
         lock.lock()
         defer { lock.unlock() }
         recorded.append(Invocation(executable: executable, arguments: arguments))
+        recordedTimeouts.append(timeout)
         return scripts.last { arguments.starts(with: $0.argsPrefix) }?.output
     }
 }

--- a/ADBKit/Tests/ADBKitTests/PullProgressTests.swift
+++ b/ADBKit/Tests/ADBKitTests/PullProgressTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import ADBKit
+
+/// The progress bar's idea of "how much has landed" for a split pull.
+@Suite struct PullProgressTests {
+    private func belongs(_ name: String, to destination: String = "com.x.apk") -> Bool {
+        PullProgress.belongsToPull(fileName: name, destinationName: destination)
+    }
+
+    @Test func theChosenFileCounts() {
+        #expect(belongs("com.x.apk"))
+    }
+
+    /// The names `AppInspectionService.splitDestination` produces.
+    @Test func everySplitBesideItCounts() {
+        #expect(belongs("com.x.split_config.en.apk"))
+        #expect(belongs("com.x.split_config.arm64_v8a.apk"))
+        #expect(belongs("com.x.split_config.xxhdpi.apk"))
+    }
+
+    /// The bug this guards: a neighbour sharing a prefix is a different app,
+    /// and counting it would push the bar past 100% or complete it early.
+    @Test func aPrefixNeighbourDoesNotCount() {
+        #expect(!belongs("com.x2.apk"))
+        #expect(!belongs("com.xtra.split_config.en.apk"))
+    }
+
+    @Test func anUnrelatedFileInTheSameFolderDoesNotCount() {
+        #expect(!belongs("screenshot.png"))
+        #expect(!belongs("other.apk"))
+        #expect(!belongs("com.x.split_config.en.txt"), "same stem, wrong kind")
+    }
+
+    /// A destination the user typed without an extension has no stem/suffix
+    /// pair to match splits against, so only the exact file counts — the bar
+    /// then behaves as it did before, rather than matching everything.
+    @Test func aDestinationWithNoExtensionMatchesOnlyItself() {
+        #expect(belongs("bundle", to: "bundle"))
+        #expect(!belongs("bundle.split_config.en.apk", to: "bundle"))
+    }
+
+    @Test func aDottedAppIdIsNotConfusedForAnExtension() {
+        #expect(belongs("com.foo.bar.apk", to: "com.foo.bar.apk"))
+        #expect(belongs("com.foo.bar.split_config.en.apk", to: "com.foo.bar.apk"))
+        #expect(!belongs("com.foo.baz.apk", to: "com.foo.bar.apk"))
+    }
+}

--- a/App/Sources/FeatureDetail/Views/RestartClearScope.swift
+++ b/App/Sources/FeatureDetail/Views/RestartClearScope.swift
@@ -15,29 +15,12 @@ extension AppControlService {
     /// caller's restart proceeds either way — a failed clear is reported in
     /// the toast, not fatal.
     func clear(_ scope: RestartClearScope, serial: String, package: String) async -> Bool {
-        switch scope {
-        case .cache:
-            return await clearCacheBounded(serial: serial, package: package)
-        case .data:
-            return (try? await control(serial: serial, packageId: package, action: .clearData))?.ok
-                == true
-        }
-    }
-
-    /// `pm clear --cache-only` never returns on some images (observed live on
-    /// the API 36 emulator), so the cache clear gets a bounded window —
-    /// cancelling the task kills the adb child. A full data clear doesn't need
-    /// this: `pm clear` returns reliably.
-    private func clearCacheBounded(serial: String, package: String) async -> Bool {
-        let clear = Task {
-            (try? await control(serial: serial, packageId: package, action: .clearCache))?.ok == true
-        }
-        let watchdog = Task {
-            try? await Task.sleep(for: .seconds(10))
-            clear.cancel()
-        }
-        let ok = await clear.value
-        watchdog.cancel()
-        return ok
+        // No watchdog here any more: `pm clear --cache-only` never returns on
+        // some images, and the bound for that now lives on the command itself
+        // (`AppControlService.cacheClearTimeout`) — so the Apps hub and the
+        // Quick Actions panel get it too, instead of only the two debug
+        // consoles that had each wrapped their own.
+        let action: AppControlService.AppAction = scope == .cache ? .clearCache : .clearData
+        return (try? await control(serial: serial, packageId: package, action: action))?.ok == true
     }
 }

--- a/App/Sources/State/AppState.swift
+++ b/App/Sources/State/AppState.swift
@@ -458,10 +458,9 @@ final class AppState {
                     return
                 }
                 guard !Task.isCancelled else { return }
-                let written = (try? FileManager.default.attributesOfItem(atPath: destination.path))?[.size] as? Int ?? 0
                 self?.runningOperation = OperationStatus(
                     label: label,
-                    fraction: min(1, Double(written) / Double(expectedBytes))
+                    fraction: min(1, Double(Self.bytesWritten(for: destination)) / Double(expectedBytes))
                 )
             }
         }
@@ -470,6 +469,30 @@ final class AppState {
             runningOperation = nil
         }
         return try await work()
+    }
+
+    /// How much of a pull has landed: the chosen file plus any splits written
+    /// beside it.
+    ///
+    /// A split app is pulled as several files and `expectedBytes` is the sum
+    /// of all of them, so polling only the chosen one made the bar climb to
+    /// base/total, sit there for the rest of the pull, and jump to done — most
+    /// of the wait spent looking stuck on a bundle whose splits outweigh its
+    /// base. Which names count is `PullProgress` in ADBKit, tested there; this
+    /// is the directory read.
+    private static func bytesWritten(for destination: URL) -> Int {
+        let manager = FileManager.default
+        let directory = destination.deletingLastPathComponent()
+        guard let names = try? manager.contentsOfDirectory(atPath: directory.path) else {
+            return (try? manager.attributesOfItem(atPath: destination.path))?[.size] as? Int ?? 0
+        }
+        return names.reduce(0) { total, name in
+            guard PullProgress.belongsToPull(
+                fileName: name, destinationName: destination.lastPathComponent)
+            else { return total }
+            let path = directory.appendingPathComponent(name).path
+            return total + ((try? manager.attributesOfItem(atPath: path))?[.size] as? Int ?? 0)
+        }
     }
 
     // MARK: - Save destinations


### PR DESCRIPTION
Three backlog bugs, each one an operation that reported something untrue.

## Clear Cache stalled for thirty seconds and then said it failed

`pm clear --cache-only` never returns on some images — seen live on the API 36
emulator, app running or stopped — so it waited out `AdbClient`'s default
timeout. The JS Console and Reactotron had each wrapped their own watchdog
`Task` around it; the bound belongs on the command, so the Apps hub, the Quick
Actions panel and the daemon get it too. Both App-layer watchdogs are gone.

`MockProcessRunner` now records the timeout each call was given, beside
`Invocation` rather than on it — widening `Invocation` would have rewritten
every arg-vector assertion in the suite to say nothing new.

## A failed split pull left a misleading `base.apk`

`pullApk` threw mid-loop with whatever had already landed still sitting at the
path the user chose. It looks like the app and installs with
`INSTALL_FAILED_MISSING_SPLIT` days later, long after the error message was
dismissed. Half a bundle is worse than none, so the partial set is taken back
with the throw.

## The pull progress bar sat still for most of a split pull

It polled the chosen file against `apkSizeBytes`, which is the sum of every
split — so it climbed to base/total, stalled there, then jumped to done. On a
bundle whose splits outweigh the base that is most of the wait spent looking
stuck.

`PullProgress` (ADBKit, pure) decides which files beside the destination belong
to the pull, including the case that would have made this worse than the bug: a
neighbour sharing a prefix (`com.example2.apk` beside `com.example.apk`) is a
different app and must not be counted.

Nine new tests. ADBKit 2133 · AppTests 134 · Mac build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
