### PR TITLE
Say "Downloading Update…" instead of greying the button out

### DIFF
--- a/ADBKit/Sources/ADBKit/Services/UpdatePolicy.swift
+++ b/ADBKit/Sources/ADBKit/Services/UpdatePolicy.swift
@@ -146,4 +146,64 @@ public enum UpdatePolicy {
         guard updateKnown else { return .idle }
         return canRelaunch ? .readyToRelaunch : .available
     }
+
+    // MARK: - The "Check for Updates…" affordance
+
+    /// Where the updater is, as far as the *button* is concerned. A pure
+    /// mirror of the App layer's `UpdatePhase`, which carries Sparkle types
+    /// and cannot come down here.
+    public enum Activity: Equatable, Sendable, CaseIterable {
+        case idle
+        case checking
+        case upToDate
+        case available
+        case downloading
+        case readyToRelaunch
+        case installing
+    }
+
+    /// What a "Check for Updates…" control should say and whether it acts.
+    public struct CheckAction: Equatable, Sendable {
+        /// The button or menu item's title.
+        public let title: String
+        /// Whether clicking does anything. False while the updater is busy
+        /// with work the user cannot influence.
+        public let isEnabled: Bool
+        /// Whether the control should show a spinner beside its title.
+        public let isBusy: Bool
+    }
+
+    /// The label and enabled state for every "Check for Updates…" control —
+    /// the menu command, Settings ▸ Updates, and About.
+    ///
+    /// All three used to render a fixed "Check for Updates…" and disable it
+    /// on Sparkle's `canCheckForUpdates`, which goes false for the whole
+    /// length of an update session. So the single most common reason the
+    /// button is dead — an update is downloading right now — looked
+    /// identical to the app being broken: a greyed-out control with no
+    /// explanation, and in About no status text anywhere near it. Saying what
+    /// is happening costs nothing and is the entire fix.
+    ///
+    /// `canCheck` is Sparkle's own gate, and it still has the final say for
+    /// the states where nothing is visibly in flight — the updater can be
+    /// busy for reasons this enum does not model.
+    public static func checkAction(for activity: Activity, canCheck: Bool) -> CheckAction {
+        switch activity {
+        case .checking:
+            return CheckAction(title: "Checking for Updates…", isEnabled: false, isBusy: true)
+        case .downloading:
+            return CheckAction(title: "Downloading Update…", isEnabled: false, isBusy: true)
+        case .installing:
+            return CheckAction(title: "Installing Update…", isEnabled: false, isBusy: true)
+        case .readyToRelaunch:
+            // Enabled on purpose, and the one busy-ish state that is: the
+            // update is staged and waiting on the user, so the control has
+            // something to do — its click points at the relaunch.
+            return CheckAction(title: "Relaunch to Update", isEnabled: true, isBusy: false)
+        case .available:
+            return CheckAction(title: "Update Now", isEnabled: canCheck, isBusy: false)
+        case .idle, .upToDate:
+            return CheckAction(title: "Check for Updates…", isEnabled: canCheck, isBusy: false)
+        }
+    }
 }

--- a/ADBKit/Tests/ADBKitTests/UpdatePolicyTests.swift
+++ b/ADBKit/Tests/ADBKitTests/UpdatePolicyTests.swift
@@ -224,3 +224,77 @@ import Testing
                 == .idle)
     }
 }
+
+/// The "Check for Updates…" affordance. All three surfaces — the menu command,
+/// Settings ▸ Updates, and About — render this, and all three used to show a
+/// fixed title greyed out for the whole length of an update session.
+@Suite struct UpdateCheckActionTests {
+    private func action(_ activity: UpdatePolicy.Activity, canCheck: Bool = false)
+        -> UpdatePolicy.CheckAction
+    {
+        UpdatePolicy.checkAction(for: activity, canCheck: canCheck)
+    }
+
+    /// The reported bug: a download makes Sparkle's gate go false, so the
+    /// control died with no explanation.
+    @Test func aDownloadSaysSoInsteadOfGoingSilentlyDead() {
+        let subject = action(.downloading)
+        #expect(subject.title == "Downloading Update…")
+        #expect(!subject.isEnabled)
+        #expect(subject.isBusy)
+    }
+
+    @Test func everyBusyStateNamesWhatItIsDoing() {
+        #expect(action(.checking).title == "Checking for Updates…")
+        #expect(action(.downloading).title == "Downloading Update…")
+        #expect(action(.installing).title == "Installing Update…")
+    }
+
+    /// A staged update is the one waiting state with something to do, so it
+    /// stays clickable and points at the relaunch rather than at a re-check.
+    @Test func aStagedUpdateOffersTheRelaunchRatherThanACheck() {
+        let subject = action(.readyToRelaunch, canCheck: false)
+        #expect(subject.title == "Relaunch to Update")
+        #expect(subject.isEnabled, "enabled even though Sparkle's own gate is shut")
+        #expect(!subject.isBusy)
+    }
+
+    @Test func anIdleUpdaterOffersAPlainCheck() {
+        let subject = action(.idle, canCheck: true)
+        #expect(subject.title == "Check for Updates…")
+        #expect(subject.isEnabled)
+        #expect(!subject.isBusy)
+    }
+
+    /// "You're up to date" is a result, not a state to sit in — the control
+    /// goes straight back to offering another check.
+    @Test func upToDateReadsTheSameAsIdle() {
+        #expect(action(.upToDate, canCheck: true) == action(.idle, canCheck: true))
+    }
+
+    @Test func aFoundUpdateOffersToInstallIt() {
+        let subject = action(.available, canCheck: true)
+        #expect(subject.title == "Update Now")
+        #expect(subject.isEnabled)
+    }
+
+    /// Sparkle's gate still has the final say wherever nothing visible is in
+    /// flight — the updater can be busy for reasons this enum does not model.
+    @Test func sparklesOwnGateStillDisablesTheQuietStates() {
+        #expect(!action(.idle, canCheck: false).isEnabled)
+        #expect(!action(.upToDate, canCheck: false).isEnabled)
+        #expect(!action(.available, canCheck: false).isEnabled)
+    }
+
+    /// A busy control is never clickable and a clickable one never spins;
+    /// every state has a non-empty title.
+    @Test func noStateIsBothBusyAndClickable() {
+        for activity in UpdatePolicy.Activity.allCases {
+            for canCheck in [true, false] {
+                let subject = action(activity, canCheck: canCheck)
+                #expect(!(subject.isBusy && subject.isEnabled), "\(activity)")
+                #expect(!subject.title.isEmpty, "\(activity)")
+            }
+        }
+    }
+}

--- a/App/Sources/FeatureDetail/Views/AboutView.swift
+++ b/App/Sources/FeatureDetail/Views/AboutView.swift
@@ -91,15 +91,20 @@ struct AboutView: View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle("Updates")
             #if !APPSTORE
+            // Title and enabled state from `UpdatePolicy`, shared with the
+            // menu command and Settings. This surface was the worst of the
+            // three: a dead "Check Now" with no status text anywhere near it,
+            // so a download in progress was indistinguishable from a bug.
+            let action = updater.checkAction
             linkRow(
                 icon: "arrow.triangle.2.circlepath",
                 title: "Check for updates",
-                detail: "Droidective checks on launch and hourly, and installs when you relaunch — you can also check right now.",
-                button: "Check Now"
-            ) { updater.checkForUpdates() }
-                // Same gate as the menu command and Settings — greyed out
-                // while a check or an update session is in flight.
-                .disabled(!updater.canCheckForUpdates)
+                detail: action.isBusy
+                    ? "An update is in progress — it installs when you relaunch."
+                    : "Droidective checks on launch and hourly, and installs when you relaunch — you can also check right now.",
+                button: action.title
+            ) { updater.performCheckAction() }
+                .disabled(!action.isEnabled)
             #endif
             linkRow(
                 icon: "shippingbox",

--- a/App/Sources/Settings/SettingsView.swift
+++ b/App/Sources/Settings/SettingsView.swift
@@ -93,15 +93,18 @@ struct GeneralSettingsView: View {
     /// Inline status beside the update button — the only place "you're up to
     /// date" appears, and it's manual-check-only by construction (background
     /// checks never enter `.checking`/`.upToDate`).
+    ///
+    /// Silent wherever the button's own title already says it. The button now
+    /// reads "Downloading Update…" rather than a greyed-out "Check for
+    /// Updates…", so a "Downloading…" label beside it would be the same
+    /// sentence twice; what is left is the version, which the button has no
+    /// room for.
     private var updateStatus: String? {
         switch updater.phase {
-        case .idle: return nil
-        case .checking: return "Checking…"
+        case .idle, .checking, .downloading, .installing: return nil
         case .upToDate: return "You're up to date."
         case .available(let info): return "Version \(info.version) is available."
-        case .downloading: return "Downloading…"
         case .readyToRelaunch(let info): return "Version \(info.version) is ready."
-        case .installing: return "Installing…"
         }
     }
     #endif
@@ -235,17 +238,15 @@ struct GeneralSettingsView: View {
                                 .font(.app(.footnote))
                                 .foregroundStyle(.textMuted)
                         }
-                        switch updater.phase {
-                        case .readyToRelaunch:
-                            Button("Relaunch to Update") { updater.relaunchNow() }
-                        case .available:
-                            Button("Update Now") { updater.installAvailableUpdate() }
-                        case .idle, .checking, .upToDate, .downloading, .installing:
-                            Button("Check for Updates…") { updater.checkForUpdates() }
-                                // Greyed out while a check or download is in
-                                // flight — same gate as the menu command.
-                                .disabled(!updater.canCheckForUpdates)
-                        }
+                        // One button whose title and enabled state come from
+                        // `UpdatePolicy`, shared with the menu command and
+                        // About — the three used to agree only by each
+                        // hard-coding the same strings, and two of them said
+                        // nothing at all while an update downloaded.
+                        let action = updater.checkAction
+                        if action.isBusy { ProgressView().controlSize(.small) }
+                        Button(action.title) { updater.performCheckAction() }
+                            .disabled(!action.isEnabled)
                     }
                 }
                 Text("Updates are delivered via Sparkle from GitHub Releases. Beta builds arrive ahead of stable releases and may be rougher; switching beta off keeps the installed build until the next stable release.")

--- a/App/Sources/Updates/SparkleUpdater.swift
+++ b/App/Sources/Updates/SparkleUpdater.swift
@@ -570,6 +570,44 @@ extension UpdaterViewModel: SPUUpdaterDelegate {
     }
 }
 
+// MARK: - The "Check for Updates…" affordance
+
+extension UpdaterViewModel {
+    /// This phase as the pure enum `UpdatePolicy` reasons about. `UpdatePhase`
+    /// carries Sparkle's `SUAppcastItem` and cannot go down to ADBKit; only
+    /// the shape of the state matters to the decision.
+    var activity: UpdatePolicy.Activity {
+        switch phase {
+        case .idle: .idle
+        case .checking: .checking
+        case .upToDate: .upToDate
+        case .available: .available
+        case .downloading: .downloading
+        case .readyToRelaunch: .readyToRelaunch
+        case .installing: .installing
+        }
+    }
+
+    /// What every "Check for Updates…" control should say and whether it acts.
+    /// One source for the menu command, Settings ▸ Updates and About, so the
+    /// three cannot drift — they previously agreed only by each hard-coding
+    /// the same string.
+    var checkAction: UpdatePolicy.CheckAction {
+        UpdatePolicy.checkAction(for: activity, canCheck: canCheckForUpdates)
+    }
+
+    /// The click behind that control. The title promises a specific thing in
+    /// each state, so the action has to match it: "Relaunch to Update"
+    /// relaunches rather than starting a fresh check.
+    func performCheckAction() {
+        switch phase {
+        case .readyToRelaunch: relaunchNow()
+        case .available: installAvailableUpdate()
+        case .idle, .checking, .upToDate, .downloading, .installing: checkForUpdates()
+        }
+    }
+}
+
 /// App-wide updater. A single Sparkle updater must own update scheduling, so
 /// the menu, About view, Settings, and the sidebar pill all share this one
 /// instance.
@@ -577,14 +615,16 @@ enum SparkleUpdater {
     @MainActor static let shared = UpdaterViewModel()
 }
 
-/// The "Check for Updates…" menu command, greyed out while a check or an
-/// update session is in flight.
+/// The "Check for Updates…" menu command. Its title tracks the updater rather
+/// than staying fixed: an item greyed out under an unchanged label is how a
+/// download in progress used to look identical to a broken app.
 struct CheckForUpdatesCommand: View {
     @ObservedObject var updater: UpdaterViewModel
 
     var body: some View {
-        Button("Check for Updates…") { updater.checkForUpdates() }
-            .disabled(!updater.canCheckForUpdates)
+        let action = updater.checkAction
+        Button(action.title) { updater.performCheckAction() }
+            .disabled(!action.isEnabled)
     }
 }
 #endif


### PR DESCRIPTION
Sparkle's `canCheckForUpdates` goes false for the whole length of an update
session, and all three "Check for Updates…" surfaces disabled themselves on it
under a fixed title. So the most common reason the control is dead — an update
is downloading right now — was indistinguishable from the app being broken.

About was the worst of the three: a greyed-out "Check Now" with no status text
anywhere near it.

## One decision, three surfaces

`UpdatePolicy.checkAction` is pure and tested. The title names what is
happening — "Checking for Updates…", "Downloading Update…", "Installing
Update…" — a staged update reads "Relaunch to Update" and stays clickable
because it is the one waiting state with something to do, and Sparkle's own
gate still has the final say wherever nothing visible is in flight.

The menu command, Settings ▸ Updates and About all render it, so the three can
no longer drift. They previously agreed only by each hard-coding the same
string.

Settings drops the duplicated status wording now that the button says it, and
About's detail line follows suit. The sidebar pill and the menu bar rows
already named these states and are unchanged.

## What is not verified here

Debug builds disable Sparkle entirely (`updaterAllowed`), so the download state
is unit-tested but never rendered on this machine. Eight tests cover the
decision, including that no state is both busy and clickable.

ADBKit 2133 · AppTests 134 · Mac build warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
